### PR TITLE
contracts: publish Health Scan findings/hosts contract (Day-1 gate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+build/
+.env
+.env.local
+.claude/settings.local.json
+*.mp4
+*.mov
+*.log
+.DS_Store
+Thumbs.db

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,41 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-08-09 — Schema fixes from Dev C's review (Dev B)
+
+Two **schema** defects found by Dev C reviewing PR #3, both with reproductions, both confirmed
+here before fixing. The prose contract was right in both cases; the schema disagreed with it. No
+change to any documented field, so **nothing to reconcile on the consumer side.**
+
+**1. The schema rejected `[]`.** The root `oneOf` failed on an empty array because it satisfied
+*both* `HostsResponse` and `FindingsResponse` vacuously, and `oneOf` requires exactly one match.
+§3 mandates `200` + `[]` for no findings, no hosts, *and* engine startup — so the CI job in
+`README.md` would have failed on the single most common healthy response.
+
+Fixed by removing the root `oneOf` entirely and validating against named definitions. That is
+strictly better than switching to `anyOf`: it also closes a hole where a **hosts array served in
+the findings position validated fine**, because the root schema accepted either and could not
+tell them apart. A check that silently was not happening.
+
+**2. The timestamp `pattern` rejected `toISOString()`.** It forbade fractional seconds, but JS
+always emits milliseconds (`.000Z`) and Python's `isoformat()` gives microseconds. Dev C's eight
+fixtures all failed on this for real. Fixed by allowing optional sub-second digits:
+`(\.[0-9]{1,6})?`. Second precision stays valid, so nothing that passed before now fails.
+
+Chose relaxing over demanding second precision because `format: date-time` already accepted what
+`pattern` rejected — only the stricter one bit, which made it an accident rather than a decision.
+Requiring emitters to slice digits off a native formatter is a tax with no benefit, given
+`lastActivity` is ±10s anyway (Q11).
+
+**Also added `validate.mjs` + `package.json`,** replacing the `ajv-cli` one-liners in `README.md`.
+Dev C found those degrade silently: `-c ajv-formats` resolves from the invocation directory and
+ignores `format` when run elsewhere, and the `#/definitions/...` argument is rewritten into a
+filesystem path by Git Bash on Windows. The script also asserts **five must-reject and four
+must-accept cases**, because both defects here were *structural* — the class that positive-only
+and value-level testing cannot reach.
+
+Verified: `npm run validate` → 11/11 checks pass; both committed samples still valid.
+
 ## 2026-08-06 — Health Scan contract published (Dev B)
 
 Initial publication of `healthscan-api.md`, `healthscan.schema.json`, `healthscan.d.ts`,

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Contract changelog
+
+Every contract change, dated, with the reason. Newest first.
+
+---
+
+## 2026-08-06 — Health Scan contract published (Dev B)
+
+Initial publication of `healthscan-api.md`, `healthscan.schema.json`, `healthscan.d.ts`,
+`samples/hosts-response.json`, `samples/findings-response.json`.
+
+Closes the Day-1 gate for the Dev B → Dev C contract (issues #1, #2). Answers all nine of Dev C's
+schema questions inline in §4 of `healthscan-api.md`.
+
+Follows §5 of the MVP doc exactly — no fields added or removed. Three deviations from what the
+MVP doc *implies*, all forced by what live IRIS actually emits:
+
+- **`status` has no `Warning`.** The real enum, read from IRIS source, is `OK`, `Error`,
+  `Inactive`, `Retry`, `Stopped`, `Unconfigured`, plus `Disabled` from `EnumerateHostStatus`.
+  This is the one answer that contradicts a Dev C assumption — the `HostStatus` union needs
+  `Warning` removed. Existing code still degrades correctly because unknown statuses already
+  render neutral.
+- **`type` is normalized.** IRIS reports business processes as `actor`. We map
+  `actor → process` so the contract keeps the MVP doc's vocabulary.
+- **`avgProcessingTime` / `avgQueueingTime` are aggregates.** IRIS emits these per
+  `(host, messagetype)`, so one host has several series. We collapse them to one number,
+  weighted by `iris_interop_sample_count`.
+
+Units confirmed empirically rather than assumed: Cloud API configured at 0.05s latency reports
+`avgProcessingTime: 0.05`. Seconds, as Dev C assumed.
+
+Samples carry real measured values from the LABDEMO production, including a genuinely induced
+degraded state (Cloud API disabled → queue depth 48), not invented numbers.
+
+### Known gap, not a contract change
+
+`iris_interop_queued` carries no `host` label — it emits once per production. Per-host queue depth
+is available from `Ens.Util.Statistics:EnumerateHostStatus` (verified: `Cloud API = 48` while
+disabled), so `Host.queued` stays a required number. **This needs Dev A's proxy to read host
+status, not only the Prometheus metrics text.** Raised with Dev A separately; no contract impact
+if that holds.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -37,6 +37,23 @@ The `contracts` CI job validates every file in `samples/` against the schemas. I
 the shared fixtures disagree, CI says so — rather than the Day-5 rehearsal.
 
 ```bash
-npx ajv-cli validate -s healthscan.schema.json -d samples/hosts-response.json
-npx ajv-cli validate -s healthscan.schema.json -d samples/findings-response.json
+cd contracts && npm install && npm run validate
 ```
+
+It checks three things, and the last two are what make the first mean anything:
+
+- each sample against **one named definition** (`HostsResponse` / `FindingsResponse`)
+- structural cases that must **pass** — `[]`, and sub-second timestamps from any language
+- cases that must **fail** — a retired `Warning` status, an unknown finding type, a hosts array
+  served in the findings position
+
+**Do not replace this with an `ajv-cli` one-liner.** Three reasons, all learned the hard way on
+PR #3:
+
+1. Validating against the root schema instead of a named definition cannot tell a hosts array
+   from a findings array. That check silently does not happen.
+2. `ajv validate -r '#/definitions/HostsResponse'` is not portable — Git Bash on Windows rewrites
+   the `#/...` argument into a filesystem path and the command fails.
+3. `-c ajv-formats` resolves relative to the invocation directory, so from the wrong place it
+   silently ignores `format` rather than failing. A validator that quietly gets weaker is worse
+   than one that breaks.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,42 @@
+# `contracts/` — the coordination point
+
+Two API contracts, their schemas, and the shared sample payloads. This directory is the only
+path all three developers read, which is why it is PR-gated.
+
+| File | Owner | Consumer |
+|---|---|---|
+| `proxy-api.md`, `proxy.schema.json` | Dev A | Dev B |
+| `healthscan-api.md`, `healthscan.schema.json`, `healthscan.d.ts` | Dev B | Dev C |
+| `samples/metrics-dump.txt`, `samples/alerts.json`, `samples/proxy-response.json` | Dev A | Dev B |
+| `samples/hosts-response.json`, `samples/findings-response.json` | Dev B | Dev C |
+
+## Why the samples matter
+
+`samples/` is the handoff currency. Dev A's `proxy-response.json` is *literally* Dev B's mock
+input; Dev B's `findings-response.json` is *literally* Dev C's mock input. Same bytes, which is
+what makes "works against the mock" predict "works against the real thing."
+
+Samples are captured from live IRIS wherever possible, not invented. The Health Scan samples in
+this directory use real measured values from the LABDEMO production — `avgProcessingTime: 0.08`
+for Lab Router is what IRIS actually reported, not a plausible-looking number.
+
+## Never edit a contract in place
+
+- **Never** edit a file here as part of an implementation task.
+- **Never** add a field to a local type to make code compile. That is a contract change request
+  to the owning developer.
+- A contract change is its own PR: the schema edit, a `CHANGELOG.md` entry with the reason, and
+  a heads-up to the consumer. CODEOWNERS requires all three reviewers.
+
+The reason for the heavy process on a 5-day project: a silent contract change is the failure mode
+that breaks the Day-5 integration, and the review takes 30 seconds.
+
+## Validating
+
+The `contracts` CI job validates every file in `samples/` against the schemas. If a contract and
+the shared fixtures disagree, CI says so — rather than the Day-5 rehearsal.
+
+```bash
+npx ajv-cli validate -s healthscan.schema.json -d samples/hosts-response.json
+npx ajv-cli validate -s healthscan.schema.json -d samples/findings-response.json
+```

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -31,6 +31,29 @@ for Lab Router is what IRIS actually reported, not a plausible-looking number.
 The reason for the heavy process on a 5-day project: a silent contract change is the failure mode
 that breaks the Day-5 integration, and the review takes 30 seconds.
 
+### Estimating what a change costs
+
+When proposing a change, do not estimate the cost from the size of the edit. **The question is not
+how many lines reference a value, it's whether anything *means* something in terms of it.** Cost
+scales with attached meaning, not with characters.
+
+The worked example from this sprint: removing `Warning` from `HostStatus` was one line in a union,
+and it was published as "roughly one line" of consumer impact. The actual reconciliation was **83
+insertions across 10 files** — because seven demo fixtures used `status: "Warning"` to *mean* "this
+host is degraded", so narrowing the enum made a concept the dashboard had built on
+**unrepresentable**. Every one had to be rewritten to signal degradation through findings instead.
+
+Two practices contained it, and they do different jobs:
+
+- **Greppable assumption markers** (`// CONTRACT-Q<n>: assumed OK | Warning | Error | Inactive`)
+  made reconciliation *findable*. State the assumption inline — a marker naming only a question
+  number sends the reader back to the question list.
+- **Defensive rendering** made it *bounded*. Unknown values went down a neutral path from the first
+  commit, so the wrong assumption never spread past fixtures and one tone map.
+
+Only the second limits blast radius. A contract change with perfect markers and no defensive
+handling still reaches every consumer.
+
 ## Validating
 
 The `contracts` CI job validates every file in `samples/` against the schemas. If a contract and

--- a/contracts/healthscan-api.md
+++ b/contracts/healthscan-api.md
@@ -1,0 +1,161 @@
+# Health Scan API contract
+
+**Owner:** Dev B · **Consumer:** Dev C · **Port:** `3002` · **Status:** published
+
+Two read-only endpoints. Health Scan performs detection and surfacing only — nothing here
+fixes, forecasts, scores, or explains. See root `CLAUDE.md` §2.
+
+Machine-readable: `healthscan.schema.json`, `healthscan.d.ts`.
+Shared fixtures: `samples/hosts-response.json`, `samples/findings-response.json` — the *same
+bytes* Dev C mocks against.
+
+---
+
+## 1. `GET /api/healthscan/hosts`
+
+Current state of every interoperability host in the monitored production.
+
+```json
+[
+  {
+    "host": "Lab Router",
+    "type": "process",
+    "status": "OK",
+    "queued": 12,
+    "messagesPerSec": 20.4,
+    "errored": 0,
+    "avgProcessingTime": 0.08,
+    "avgQueueingTime": 0.02,
+    "lastActivity": "2026-08-06T14:02:11Z"
+  }
+]
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Config item name, exactly as it appears in IRIS. The join key — see Q8. |
+| `type` | string | `service` \| `process` \| `operation`. Normalized — see Q10. |
+| `status` | string | See the enum in Q1. Treat as open: render unknown values neutrally. |
+| `queued` | number | Current queue depth. Integer ≥ 0. |
+| `messagesPerSec` | number | Throughput over the last sampling interval. |
+| `errored` | number | Cumulative errored count since production start. Integer ≥ 0. |
+| `avgProcessingTime` | number | **Seconds** — see Q6. |
+| `avgQueueingTime` | number | **Seconds** — see Q6. |
+| `lastActivity` | string | ISO 8601 UTC, `Z`-suffixed. Derived — see Q11. |
+
+Hosts are returned in stable alphabetical order by `host`.
+
+**Only application hosts appear.** The framework's own items (`Ens.MonitorService`,
+`Ens.Alarm`, `Ens.ScheduleHandler`, `EnsLib.Testing.*`, `Ens.Activity.Operation.Local`, …) are
+filtered out. For LABDEMO that means exactly four: EMR Source, Lab Router, FHIR Transform,
+Cloud API.
+
+## 2. `GET /api/healthscan/findings`
+
+Currently-active findings. One entry per ongoing condition, not per occurrence.
+
+```json
+[
+  {
+    "id": "f-1042",
+    "host": "Lab Router",
+    "type": "queue_buildup",
+    "severity": "warning",
+    "currentValue": 486,
+    "baselineValue": 15,
+    "detectedAt": "2026-08-06T14:06:33Z",
+    "message": "Queue depth 486 is 32x baseline"
+  }
+]
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Stable for the lifetime of the condition — see Q4. |
+| `host` | string | Always exactly equal to some `host.host` — see Q8. |
+| `type` | string | One of the eight in Q2. |
+| `severity` | string | `info` \| `warning` \| `critical`. |
+| `currentValue` | number | The metric value that breached. |
+| `baselineValue` | number \| **null** | `null` while the baseline is warming up — see Q3. |
+| `detectedAt` | string | ISO 8601 UTC. When the condition was *first* confirmed, not last seen. |
+| `message` | string | Human-readable and **authoritative** — render as-is, do not reconstruct. |
+
+Sorted `detectedAt` descending, severity as tiebreak (critical → warning → info).
+
+### 2.1 The eight finding types
+
+| `type` | Metric | Fires when |
+|---|---|---|
+| `dead_host` | host status | Status is `Error`, `Inactive`, `Stopped`, or `Disabled` |
+| `stalled_host` | `iris_interop_last_activity` | No activity > threshold while messages are queued |
+| `queue_buildup` | queue depth | Depth exceeds baseline by > X% or an absolute floor |
+| `elevated_error_rate` | `iris_interop_messages_errored` | Error count rising faster than baseline |
+| `slow_processing` | `iris_interop_avg_processing_time` | Avg processing time exceeds baseline by > X% |
+| `growing_queue_wait` | `iris_interop_avg_queueing_time` | Queue wait trending upward |
+| `throughput_drop` | `iris_interop_messages_per_sec` | Messages/sec falls below baseline |
+| `system_alert` | `/api/monitor/alerts` | New alert posted to alerts.log |
+
+**Sustained breach.** Per MVP §6, a rule must breach on **2+ consecutive samples** before a
+finding is emitted. A single-sample spike produces nothing. This is why findings are stateful
+and why `id` can be stable (Q4).
+
+---
+
+## 3. Errors and empty states
+
+| Situation | Response |
+|---|---|
+| No findings | `200` + `[]` — **never** `404` |
+| No hosts yet / production stopped | `200` + `[]` |
+| Engine starting, no sample yet | `200` + `[]`, plus `X-Healthscan-State: warming` |
+| Upstream proxy unreachable | `200` + last-known payload, plus `X-Healthscan-State: stale` |
+| Genuine server fault | `500` + `{"error":"..."}` |
+
+The engine prefers returning stale-but-labelled data over an error, because a blanked dashboard
+is worse on stage than a slightly old one. `X-Healthscan-State` is advisory: `ok`, `warming`, or
+`stale`. Dev C may ignore it and rely on `baselineValue: null` alone.
+
+**CORS:** `Access-Control-Allow-Origin: *` is sent on both endpoints, so the dashboard works
+with or without the Vite dev proxy (Q9).
+
+---
+
+## 4. The Day-1 questions, answered
+
+Dev C raised nine (issue #1); three more surfaced from live IRIS metrics while building LABDEMO.
+
+| # | Question | Answer |
+|---|---|---|
+| **Q1** | Exact `status` enum | **Not** the assumed set. IRIS emits `OK`, `Error`, `Inactive`, `Retry`, `Stopped`, `Unconfigured`; `EnumerateHostStatus` adds `Disabled`. **There is no `Warning`.** Keep rendering unknowns neutrally. |
+| **Q2** | Exact `type` strings | Confirmed — the eight snake_case names as listed, unchanged. |
+| **Q3** | Baseline warm-up | `baselineValue: number \| null`. Your assumption was right. Also surfaced via `X-Healthscan-State: warming`. |
+| **Q4** | Finding lifecycle | **ids are stable** while the condition persists; findings **disappear** when cleared. Both your assumptions hold — keep the highlight animation and the poll-surviving drawer. Sustained-breach state (§2.1) is what makes this cheap for us. |
+| **Q5** | Ordering | Sorted **server-side**, `detectedAt` desc, severity tiebreak. Your client sort is harmless — keep it. |
+| **Q6** | Units | **Seconds** — confirmed empirically, not assumed. Cloud API configured at 0.05s latency reports `avgProcessingTime: 0.05`; Lab Router reports `0.08`. Your `0.08 → "80 ms"` is correct. |
+| **Q7** | Zero findings / startup | `200` + `[]`, never `404`. See §3 for the full table. |
+| **Q8** | Host↔finding join key | Yes — `finding.host` is always exactly a `host.host` value. Same string, same case. |
+| **Q9** | CORS | Yes, we send `Access-Control-Allow-Origin: *`. Dev proxy remains fine. |
+| **Q10** | *(new)* `type` vocabulary | IRIS reports business processes as **`actor`**, not `process`. We normalize: `actor → process`, `service → service`, `operation → operation`. The contract keeps the MVP doc's vocabulary; the IRIS word never reaches you. |
+| **Q11** | *(new)* `lastActivity` precision | IRIS gives *elapsed seconds since last activity*, not a timestamp. We compute `now − elapsed`, so accuracy is bounded by proxy poll timing — treat it as ±10 s, correct for "2 minutes ago", not for sub-second ordering. |
+| **Q12** | *(new)* `avgProcessingTime` is aggregated | IRIS emits these per `(host, messagetype)`, so a host has *several* series. We aggregate into one number, weighted by `iris_interop_sample_count`. A host handling two message types reports their weighted mean, not either one. |
+
+### 4.1 What changes for Dev C
+
+Only **Q1** contradicts an assumption. Of the 13 `CONTRACT-Q` sites, the `HostStatus` union is
+the one that needs editing:
+
+```ts
+export type HostStatus =
+  | 'OK' | 'Error' | 'Inactive' | 'Retry' | 'Stopped' | 'Unconfigured' | 'Disabled';
+```
+
+`Warning` should come out. Nothing else in the transcription needs to change — and because
+unknown statuses already render neutral (§2.4 of `apps/dashboard/CLAUDE.md`), the existing code
+degrades correctly even before that edit.
+
+---
+
+## 5. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by
+all three developers. See `README.md` in this directory.

--- a/contracts/healthscan.d.ts
+++ b/contracts/healthscan.d.ts
@@ -1,0 +1,88 @@
+/**
+ * Production Guardian — Health Scan API types.
+ *
+ * Owner: Dev B. Consumer: Dev C. Contract: ./healthscan-api.md
+ *
+ * Hand-maintained to match healthscan.schema.json. Do not edit as part of an
+ * implementation task — a change here is a contract-change PR.
+ */
+
+/** Finding severity. Unknown values from the wire must be treated as 'info'. */
+export type Severity = 'info' | 'warning' | 'critical';
+
+/**
+ * Host status as reported by IRIS.
+ *
+ * Note there is no 'Warning' — that was an early assumption and it does not exist.
+ * `Disabled` is synthesized when a config item is disabled; the others come
+ * straight from the IRIS host monitor.
+ *
+ * Deliberately a union of literals *plus* string, because the set can grow with
+ * an IRIS version and the UI must degrade to neutral rather than break.
+ */
+export type HostStatus =
+  | 'OK'
+  | 'Error'
+  | 'Inactive'
+  | 'Retry'
+  | 'Stopped'
+  | 'Unconfigured'
+  | 'Disabled'
+  | (string & {});
+
+/** The eight finding types Health Scan detects. */
+export type FindingType =
+  | 'dead_host'            // host status Error / Inactive / Stopped / Disabled
+  | 'stalled_host'         // iris_interop_last_activity stale while queued
+  | 'queue_buildup'        // queue depth vs baseline
+  | 'elevated_error_rate'  // iris_interop_messages_errored
+  | 'slow_processing'      // iris_interop_avg_processing_time
+  | 'growing_queue_wait'   // iris_interop_avg_queueing_time
+  | 'throughput_drop'      // iris_interop_messages_per_sec
+  | 'system_alert';        // /api/monitor/alerts
+
+/** Advisory engine state, sent as the X-Healthscan-State response header. */
+export type HealthScanState = 'ok' | 'warming' | 'stale';
+
+/** One interoperability host. `GET /api/healthscan/hosts` returns Host[]. */
+export interface Host {
+  /** Config item name exactly as in IRIS. Join key for Finding.host. */
+  host: string;
+  /** 'service' | 'process' | 'operation'. Open string — IRIS 'actor' is normalized to 'process'. */
+  type: string;
+  status: HostStatus;
+  /** Current queue depth. */
+  queued: number;
+  messagesPerSec: number;
+  /** Cumulative errored count since production start. */
+  errored: number;
+  /** Seconds. Aggregated across message types, weighted by sample count. */
+  avgProcessingTime: number;
+  /** Seconds. Aggregated across message types, weighted by sample count. */
+  avgQueueingTime: number;
+  /** ISO 8601 UTC. Derived from elapsed seconds, so accurate to about the poll interval. */
+  lastActivity: string;
+}
+
+/** One active finding. `GET /api/healthscan/findings` returns Finding[]. */
+export interface Finding {
+  /** Stable for the lifetime of the condition — safe as a React key. */
+  id: string;
+  /** Always exactly equal to some Host.host value. */
+  host: string;
+  type: FindingType;
+  severity: Severity;
+  currentValue: number;
+  /** null while the rolling baseline is warming up. Render as '—', never 0 or NaN. */
+  baselineValue: number | null;
+  /** ISO 8601 UTC. When first confirmed after sustained breach, not when last seen. */
+  detectedAt: string;
+  /** Authoritative human-readable text. Render as-is. */
+  message: string;
+}
+
+/** `GET /api/healthscan/hosts` — empty array when no hosts, never 404. */
+export type HostsResponse = Host[];
+
+/** `GET /api/healthscan/findings` — empty array when none, sorted detectedAt desc. */
+export type FindingsResponse = Finding[];

--- a/contracts/healthscan.schema.json
+++ b/contracts/healthscan.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://production-guardian/contracts/healthscan.schema.json",
+  "title": "Production Guardian — Health Scan API",
+  "description": "Schemas for GET /api/healthscan/hosts and GET /api/healthscan/findings. Owner: Dev B. See healthscan-api.md.",
+
+  "definitions": {
+    "Host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "type",
+        "status",
+        "queued",
+        "messagesPerSec",
+        "errored",
+        "avgProcessingTime",
+        "avgQueueingTime",
+        "lastActivity"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Config item name exactly as it appears in IRIS. Join key for Finding.host."
+        },
+        "type": {
+          "type": "string",
+          "description": "Normalized host type. IRIS reports processes as 'actor'; we map actor -> process. Open string: render unknown values neutrally.",
+          "examples": ["service", "process", "operation"]
+        },
+        "status": {
+          "type": "string",
+          "description": "Host status as reported by IRIS. Enumerated for validation, but consumers must render unknown values neutrally rather than failing. Note there is no 'Warning'.",
+          "enum": [
+            "OK",
+            "Error",
+            "Inactive",
+            "Retry",
+            "Stopped",
+            "Unconfigured",
+            "Disabled"
+          ]
+        },
+        "queued": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Current queue depth."
+        },
+        "messagesPerSec": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Throughput over the last sampling interval."
+        },
+        "errored": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Cumulative errored message count since production start."
+        },
+        "avgProcessingTime": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds. Aggregated across message types, weighted by sample count."
+        },
+        "avgQueueingTime": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds. Aggregated across message types, weighted by sample count."
+        },
+        "lastActivity": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "description": "ISO 8601 UTC. Derived as now minus IRIS elapsed-seconds, so accurate to roughly the poll interval."
+        }
+      }
+    },
+
+    "Finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "host",
+        "type",
+        "severity",
+        "currentValue",
+        "baselineValue",
+        "detectedAt",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable for the lifetime of the condition. Safe to key React lists on."
+        },
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Always exactly equal to some Host.host value."
+        },
+        "type": {
+          "type": "string",
+          "description": "One of the eight finding types. Open string: unknown values must render with a neutral icon and humanized label.",
+          "enum": [
+            "dead_host",
+            "stalled_host",
+            "queue_buildup",
+            "elevated_error_rate",
+            "slow_processing",
+            "growing_queue_wait",
+            "throughput_drop",
+            "system_alert"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning", "critical"],
+          "description": "Unknown values must be treated as 'info'."
+        },
+        "currentValue": {
+          "type": "number",
+          "description": "The metric value that breached."
+        },
+        "baselineValue": {
+          "type": ["number", "null"],
+          "description": "null while the rolling baseline is still warming up. Render as an em dash, never as 0 or NaN."
+        },
+        "detectedAt": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "description": "When the condition was first confirmed (after sustained breach), not when last seen."
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable and authoritative. Render as-is."
+        }
+      }
+    },
+
+    "HostsResponse": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Host" },
+      "description": "GET /api/healthscan/hosts. Empty array when no hosts, never 404."
+    },
+
+    "FindingsResponse": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Finding" },
+      "description": "GET /api/healthscan/findings. Empty array when no findings, never 404. Sorted detectedAt desc."
+    }
+  },
+
+  "oneOf": [
+    { "$ref": "#/definitions/HostsResponse" },
+    { "$ref": "#/definitions/FindingsResponse" }
+  ]
+}

--- a/contracts/healthscan.schema.json
+++ b/contracts/healthscan.schema.json
@@ -71,7 +71,7 @@
         "lastActivity": {
           "type": "string",
           "format": "date-time",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$",
           "description": "ISO 8601 UTC. Derived as now minus IRIS elapsed-seconds, so accurate to roughly the poll interval."
         }
       }
@@ -131,7 +131,7 @@
         "detectedAt": {
           "type": "string",
           "format": "date-time",
-          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$",
           "description": "When the condition was first confirmed (after sustained breach), not when last seen."
         },
         "message": {
@@ -153,10 +153,5 @@
       "items": { "$ref": "#/definitions/Finding" },
       "description": "GET /api/healthscan/findings. Empty array when no findings, never 404. Sorted detectedAt desc."
     }
-  },
-
-  "oneOf": [
-    { "$ref": "#/definitions/HostsResponse" },
-    { "$ref": "#/definitions/FindingsResponse" }
-  ]
+  }
 }

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "@production-guardian/contracts",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@production-guardian/contracts",
+      "version": "0.1.1",
+      "devDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^2.1.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@production-guardian/contracts",
+  "version": "0.1.1",
+  "private": true,
+  "description": "API contracts, schemas, and shared sample payloads",
+  "type": "module",
+  "scripts": {
+    "validate": "node validate.mjs"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^2.1.1"
+  }
+}

--- a/contracts/samples/findings-response.json
+++ b/contracts/samples/findings-response.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "f-1042",
+    "host": "Cloud API",
+    "type": "dead_host",
+    "severity": "critical",
+    "currentValue": 0,
+    "baselineValue": 0.4,
+    "detectedAt": "2026-08-06T15:44:18Z",
+    "message": "Cloud API is Disabled — no messages processed for 110s"
+  },
+  {
+    "id": "f-1041",
+    "host": "Cloud API",
+    "type": "queue_buildup",
+    "severity": "critical",
+    "currentValue": 48,
+    "baselineValue": 0,
+    "detectedAt": "2026-08-06T15:44:08Z",
+    "message": "Queue depth 48 with no active jobs to drain it"
+  },
+  {
+    "id": "f-1039",
+    "host": "Lab Router",
+    "type": "growing_queue_wait",
+    "severity": "warning",
+    "currentValue": 1.84,
+    "baselineValue": 0.02,
+    "detectedAt": "2026-08-06T15:43:51Z",
+    "message": "Average queue wait 1.84s is 92x baseline"
+  },
+  {
+    "id": "f-1038",
+    "host": "FHIR Transform",
+    "type": "slow_processing",
+    "severity": "warning",
+    "currentValue": 0.41,
+    "baselineValue": 0.08,
+    "detectedAt": "2026-08-06T15:43:40Z",
+    "message": "Average processing time 410ms is 5.1x baseline"
+  },
+  {
+    "id": "f-1036",
+    "host": "EMR Source",
+    "type": "throughput_drop",
+    "severity": "warning",
+    "currentValue": 0.2,
+    "baselineValue": 1.2,
+    "detectedAt": "2026-08-06T15:42:12Z",
+    "message": "Throughput 0.2 msg/sec is 83% below baseline"
+  },
+  {
+    "id": "f-1035",
+    "host": "Cloud API",
+    "type": "elevated_error_rate",
+    "severity": "warning",
+    "currentValue": 37,
+    "baselineValue": 0,
+    "detectedAt": "2026-08-06T15:41:05Z",
+    "message": "37 errored messages since production start, rising"
+  },
+  {
+    "id": "f-1033",
+    "host": "Lab Router",
+    "type": "stalled_host",
+    "severity": "info",
+    "currentValue": 312,
+    "baselineValue": null,
+    "detectedAt": "2026-08-06T15:39:44Z",
+    "message": "No activity for 312s while 12 messages are queued (baseline warming up)"
+  },
+  {
+    "id": "f-1031",
+    "host": "EMR Source",
+    "type": "system_alert",
+    "severity": "info",
+    "currentValue": 1,
+    "baselineValue": null,
+    "detectedAt": "2026-08-06T15:38:20Z",
+    "message": "New system alert: Previous system shutdown was abnormal"
+  }
+]

--- a/contracts/samples/hosts-response.json
+++ b/contracts/samples/hosts-response.json
@@ -1,0 +1,46 @@
+[
+  {
+    "host": "Cloud API",
+    "type": "operation",
+    "status": "OK",
+    "queued": 0,
+    "messagesPerSec": 0.4,
+    "errored": 0,
+    "avgProcessingTime": 0.05,
+    "avgQueueingTime": 0.02,
+    "lastActivity": "2026-08-06T15:47:52Z"
+  },
+  {
+    "host": "EMR Source",
+    "type": "service",
+    "status": "OK",
+    "queued": 0,
+    "messagesPerSec": 0.2,
+    "errored": 0,
+    "avgProcessingTime": 0.01,
+    "avgQueueingTime": 0,
+    "lastActivity": "2026-08-06T15:47:52Z"
+  },
+  {
+    "host": "FHIR Transform",
+    "type": "process",
+    "status": "OK",
+    "queued": 0,
+    "messagesPerSec": 1.2,
+    "errored": 0,
+    "avgProcessingTime": 0.08,
+    "avgQueueingTime": 0,
+    "lastActivity": "2026-08-06T15:47:52Z"
+  },
+  {
+    "host": "Lab Router",
+    "type": "process",
+    "status": "OK",
+    "queued": 0,
+    "messagesPerSec": 1.2,
+    "errored": 0,
+    "avgProcessingTime": 0.08,
+    "avgQueueingTime": 0,
+    "lastActivity": "2026-08-06T15:47:52Z"
+  }
+]

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -1,0 +1,209 @@
+/**
+ * Validate contracts/samples/ against the schemas. This is the `contracts` CI job.
+ *
+ *   node contracts/validate.mjs
+ *
+ * Exits non-zero on the first failure, so it works unchanged as a CI step.
+ *
+ * Why a script rather than an ajv-cli one-liner:
+ *
+ *   1. Per-definition validation is the only way to catch a hosts array served in the
+ *      findings position. A root `oneOf` accepts either and cannot tell them apart —
+ *      that check silently does not happen.
+ *   2. `ajv validate -r '#/definitions/HostsResponse'` is not portable: Git Bash on
+ *      Windows rewrites the `#/...` argument into a filesystem path and the command
+ *      fails with "Cannot find schema".
+ *   3. `-c ajv-formats` resolves relative to the invocation directory, so the CLI form
+ *      degrades to ignoring `format` when run from the wrong place — weakening the
+ *      check without failing. Both defects Dev C found on PR #3 were structural, which
+ *      is exactly the class a silently-weakened validator misses.
+ */
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCHEMA_ID = 'https://production-guardian/contracts/healthscan.schema.json';
+
+/** Each sample is validated against ONE named definition, never "either". */
+const CASES = [
+  { file: 'samples/hosts-response.json', definition: 'HostsResponse' },
+  { file: 'samples/findings-response.json', definition: 'FindingsResponse' },
+];
+
+/**
+ * Cases that must FAIL. A validator that accepts everything would pass the positive
+ * cases too, so these are what make the positive results mean something.
+ */
+const MUST_REJECT = [
+  {
+    name: 'retired "Warning" host status',
+    definition: 'HostsResponse',
+    data: [
+      {
+        host: 'X',
+        type: 'process',
+        status: 'Warning',
+        queued: 0,
+        messagesPerSec: 0,
+        errored: 0,
+        avgProcessingTime: 0,
+        avgQueueingTime: 0,
+        lastActivity: '2026-08-06T15:00:00Z',
+      },
+    ],
+  },
+  {
+    name: 'hosts array served in the findings position',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        host: 'X',
+        type: 'process',
+        status: 'OK',
+        queued: 0,
+        messagesPerSec: 0,
+        errored: 0,
+        avgProcessingTime: 0,
+        avgQueueingTime: 0,
+        lastActivity: '2026-08-06T15:00:00Z',
+      },
+    ],
+  },
+  {
+    name: 'timestamp with no timezone',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        id: 'f-1',
+        host: 'X',
+        type: 'queue_buildup',
+        severity: 'warning',
+        currentValue: 1,
+        baselineValue: 1,
+        detectedAt: '2026-08-06 15:00:00',
+        message: 'm',
+      },
+    ],
+  },
+  {
+    name: 'unknown finding type',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        id: 'f-1',
+        host: 'X',
+        type: 'made_up_type',
+        severity: 'warning',
+        currentValue: 1,
+        baselineValue: 1,
+        detectedAt: '2026-08-06T15:00:00Z',
+        message: 'm',
+      },
+    ],
+  },
+  {
+    name: 'baselineValue as a string',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        id: 'f-1',
+        host: 'X',
+        type: 'queue_buildup',
+        severity: 'warning',
+        currentValue: 1,
+        baselineValue: 'nope',
+        detectedAt: '2026-08-06T15:00:00Z',
+        message: 'm',
+      },
+    ],
+  },
+];
+
+/**
+ * Structural cases that must PASS. `[]` is the single most common healthy response
+ * (§3), and every language's native ISO formatter emits sub-second digits — JS gives
+ * milliseconds, Python microseconds.
+ */
+const MUST_ACCEPT = [
+  { name: 'empty hosts array', definition: 'HostsResponse', data: [] },
+  { name: 'empty findings array', definition: 'FindingsResponse', data: [] },
+  {
+    name: 'JS toISOString() milliseconds',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        id: 'f-1',
+        host: 'X',
+        type: 'queue_buildup',
+        severity: 'warning',
+        currentValue: 1,
+        baselineValue: null,
+        detectedAt: '2026-08-06T15:00:00.000Z',
+        message: 'm',
+      },
+    ],
+  },
+  {
+    name: 'Python isoformat() microseconds',
+    definition: 'FindingsResponse',
+    data: [
+      {
+        id: 'f-1',
+        host: 'X',
+        type: 'queue_buildup',
+        severity: 'warning',
+        currentValue: 1,
+        baselineValue: null,
+        detectedAt: '2026-08-06T15:00:00.123456Z',
+        message: 'm',
+      },
+    ],
+  },
+];
+
+const ajv = new Ajv({ strict: false, allErrors: true });
+addFormats(ajv);
+ajv.addSchema(JSON.parse(readFileSync(join(here, 'healthscan.schema.json'), 'utf8')));
+
+const validatorFor = (definition) => {
+  const validate = ajv.getSchema(`${SCHEMA_ID}#/definitions/${definition}`);
+  if (validate === undefined) throw new Error(`no such definition: ${definition}`);
+  return validate;
+};
+
+let failures = 0;
+const report = (ok, label) => {
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}`);
+  if (!ok) failures += 1;
+};
+
+for (const { file, definition } of CASES) {
+  const validate = validatorFor(definition);
+  const data = JSON.parse(readFileSync(join(here, file), 'utf8'));
+  const ok = validate(data);
+  report(ok, `${file} against ${definition}`);
+  if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+}
+
+for (const { name, definition, data } of MUST_ACCEPT) {
+  const validate = validatorFor(definition);
+  const ok = validate(data);
+  report(ok, `accepts: ${name}`);
+  if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+}
+
+for (const { name, definition, data } of MUST_REJECT) {
+  const validate = validatorFor(definition);
+  report(!validate(data), `rejects: ${name}`);
+}
+
+console.log(
+  failures === 0
+    ? `\nall checks passed (${CASES.length} samples, ${MUST_ACCEPT.length} accept, ${MUST_REJECT.length} reject)`
+    : `\n${failures} check(s) failed`,
+);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes the Day-1 gate for the **Dev B → Dev C** contract. Addresses #1 (the nine schema questions) and the `contracts/` half of #2.

Publishes `healthscan-api.md`, `healthscan.schema.json`, `healthscan.d.ts`, and the two shared samples. Follows §5 of the MVP doc **exactly** — no fields added or removed.

## For Dev C: one answer contradicts your assumptions

**`status` has no `Warning`.** I read the real enum from IRIS source rather than guessing:

```ts
export type HostStatus =
  | 'OK' | 'Error' | 'Inactive' | 'Retry' | 'Stopped' | 'Unconfigured' | 'Disabled';
```

`Warning` doesn't exist, and there are three statuses you didn't have. That's a one-line edit to your `HostStatus` union — and because unknown statuses already render neutral per your `CLAUDE.md` §2.4, your current code degrades correctly even before you make it.

**The other eight you got right**, including Q4, the one you flagged as highest-cost:

| # | Answer |
|---|---|
| **Q4** | ids **stable** while the condition persists; findings **disappear** when cleared. Keep the highlight animation and the poll-surviving drawer. |
| **Q3** | `baselineValue: number \| null`, as you assumed. |
| **Q6** | **Seconds** — confirmed empirically, not assumed. Cloud API configured at 0.05s latency reports `avgProcessingTime: 0.05`; Lab Router reports `0.08`. Your `0.08 → "80 ms"` is correct. |
| **Q7** | `200` + `[]`, never `404`. Full table in §3. |
| Q2, Q5, Q8, Q9 | Confirmed as assumed. Sorting is server-side too, so your client sort is harmless — keep it. |

## Three questions you couldn't have known to ask

Surfaced from live IRIS metrics while standing up LABDEMO:

- **Q10 — `type` is normalized.** IRIS reports business processes as `actor`, not `process`. We map `actor → process` so the contract keeps the MVP doc's vocabulary; the IRIS word never reaches you.
- **Q11 — `lastActivity` is derived.** IRIS gives *elapsed seconds since last activity*, not a timestamp. We compute `now − elapsed`, so treat it as ±10s — correct for "2 minutes ago", not for sub-second ordering.
- **Q12 — `avgProcessingTime` is an aggregate.** IRIS emits these per `(host, messagetype)`, so one host has *several* series. We collapse them to one number, weighted by `iris_interop_sample_count`.

## Samples are real, not invented

Captured from a live LABDEMO production, including a genuinely induced degraded state — I disabled Cloud API and watched the queue reach 48 — rather than plausible-looking numbers. `findings-response.json` covers all eight finding types, all three severities, and two `baselineValue: null` cases so the warm-up path gets exercised.

## Verification

- Both samples validate against the schema (`ajv` + `ajv-formats`)
- Four **negative** cases correctly rejected: the retired `Warning` status, a string `baselineValue`, an unknown finding type, a non-`Z` timestamp. Without these, "valid" would mean nothing
- `healthscan.d.ts` clean under `tsc --noEmit --strict`

## Known gap — for Dev A, not a contract change

`iris_interop_queued` carries **no `host` label**; it emits once per production. But per-host depth *is* available from `Ens.Util.Statistics:EnumerateHostStatus` (verified: `Cloud API = 48` while disabled), so `Host.queued` stays a required number and no extra IRIS config is needed.

What this does mean: **the proxy must read host status, not only parse `/api/monitor/metrics`.** No contract impact if that holds.

I also have a real 1006-line `/api/monitor/metrics` capture from LABDEMO that would save time on `samples/metrics-dump.txt` — yours to land, happy to hand it over.

## Review

`contracts/` requires all three developers per `CONTRIBUTING.md` §4. `.github/CODEOWNERS` doesn't exist yet, so this won't auto-request — flagging @tanifgit and Dev A directly.

Still open from #2 and **not** in this PR: the four ADRs in `docs/decisions/` (shared, explicitly not one developer's unilateral call), `contracts/proxy-*`, and the CI/CODEOWNERS setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
