### PR TITLE
docs(decisions): draft ADRs 0001-0004 (MVP §7.4)

### DIFF
--- a/docs/decisions/0001-detection-engine-location.md
+++ b/docs/decisions/0001-detection-engine-location.md
@@ -1,0 +1,82 @@
+# ADR 0001 — Where the detection engine lives
+
+- **Status:** proposed
+- **Date:** 2026-08-06
+- **Deciders:** Dev A, Dev B, Dev C
+- **Drafted by:** Dev B (implementer)
+- **Source:** §7.4 decision 1 of `production-guardian-healthscan-mvp1.docx`
+
+## Context
+
+Health Scan polls IRIS metrics, compares them to a rolling baseline, and emits findings. That
+detection work has to run somewhere. Two candidates:
+
+1. In the Node/Python service alongside the metrics proxy (Layer 3 of the §2.1 data flow)
+2. Inside IRIS as ObjectScript, reading the metrics natively
+
+The MVP doc recommends the proxy, "to keep MVP 1 free of custom IRIS code and reusable across
+environments."
+
+## Decision
+
+**The detection engine runs outside IRIS, in the `services/detection-engine/` service on port
+3002.** It consumes Dev A's proxy JSON over HTTP and never touches IRIS directly.
+
+MVP 1 ships **no custom ObjectScript for detection**.
+
+## Rationale
+
+**It uses only the built-in `/api/monitor/` API.** This is §1.2's stated reason Health Scan is
+first — lowest-risk module, no custom IRIS code required. Putting detection in ObjectScript would
+forfeit that property on day one.
+
+**Deployability is the real argument.** A customer evaluating Production Guardian can point it at
+an existing production without installing classes into their namespace. Detection in ObjectScript
+means a code deployment into a live interoperability namespace — a much harder sell, and a much
+harder rollback.
+
+**It matches the ownership split.** `iris/**` is Dev A's, `services/detection-engine/**` is Dev
+B's. An in-IRIS engine would put the engine inside Dev A's directory and make the two developers
+share a component, which is precisely what the three-way split exists to avoid.
+
+**Language freedom for the consumer.** Dev C binds to nothing language-specific — they read a base
+URL from an env var (`apps/dashboard/CLAUDE.md` §4.3). That stays true only while the engine is an
+HTTP service.
+
+## Consequences
+
+**Accepted costs:**
+
+- Every metric crosses a process boundary, so the engine sees data at proxy-poll granularity
+  (10s) rather than live. Acceptable: the bar is "updates within 10s of a change," and the
+  dashboard polls at 5s, so the proxy is the pacing item either way.
+- Baseline state lives in a process that can restart, losing warm-up. See ADR 0002.
+- Some IRIS state is not in the Prometheus text at all — `iris_interop_queued` has no `host`
+  label. Per-host queue depth comes from `Ens.Util.Statistics:EnumerateHostStatus` instead, which
+  means **the proxy must expose host status, not only parse `/metrics`.** This is a real
+  constraint on Dev A's component discovered while building LABDEMO, and the one place this
+  decision costs something concrete.
+
+**Gained:**
+
+- MVP 1 installs nothing into IRIS beyond enabling built-in metrics
+- The engine is testable against fixture JSON with no IRIS at all — which is what makes
+  mock-first (ADR 0004) work
+
+## Alternatives considered
+
+**Detection in ObjectScript inside IRIS.** Rejected for MVP 1. It has genuine advantages —
+sub-second access to host state, no serialization, direct `Ens.*` API access — and is worth
+revisiting for **Smart Resolve**, which must act on the production and will need in-IRIS presence
+anyway. But adopting it now trades away Health Scan's lowest-risk property for capability MVP 1
+does not use.
+
+**Split: detection in the proxy, host-state reads in IRIS.** Rejected as premature. It is what
+we would build if the queue-depth constraint above proves limiting, but it splits one component
+across two owners for a problem we have not yet hit.
+
+## Revisit when
+
+- Smart Resolve begins — it needs in-IRIS presence, and the engine may follow it
+- Per-host state proves unavailable through the proxy in a way that blocks a finding type
+- Sub-10s detection becomes a requirement

--- a/docs/decisions/0002-baseline-strategy.md
+++ b/docs/decisions/0002-baseline-strategy.md
@@ -1,0 +1,92 @@
+# ADR 0002 — Baseline strategy
+
+- **Status:** proposed
+- **Date:** 2026-08-06
+- **Deciders:** Dev A, Dev B, Dev C
+- **Drafted by:** Dev B (implementer)
+- **Source:** §7.4 decision 2 of `production-guardian-healthscan-mvp1.docx`
+
+## Context
+
+Every detection rule except `dead_host` and `system_alert` is comparative — "queue depth exceeds
+baseline by > X%", "throughput falls below baseline". So the engine needs a notion of normal.
+
+Two candidates: a rolling in-memory window, or persisted history in a table. The MVP doc
+recommends in-memory for MVP 1, "persistence is a later enhancement."
+
+`docs/…mvp1.docx` §6 also names baseline warm-up as a named risk: "Baseline needs warm-up time
+(no history at startup)," mitigated by seeding from the first N samples and showing a "baseline
+warming up" state.
+
+## Decision
+
+**A rolling in-memory window: a trailing 30-minute, per-host, per-metric ring buffer of samples,
+held in the engine process. Nothing is persisted.**
+
+Warm-up is explicit and visible rather than hidden:
+
+- Below the minimum sample count, a metric has **no baseline**. Comparative rules do not fire.
+- The API reports this as **`baselineValue: null`** (contract Q3) plus an advisory
+  `X-Healthscan-State: warming` header.
+- At 10s proxy polls, a 30-minute window is ~180 samples. We require **12 samples (~2 minutes)**
+  before a baseline is usable — enough to be meaningful, short enough that a demo does not stall.
+
+## Rationale
+
+**No historical trend charts are in scope.** §1.4 rules them out, and `apps/dashboard/CLAUDE.md`
+§1.1 forbids time-series graphs. Persistence exists to serve history; MVP 1 displays none. Building
+a store for data nothing reads is the definition of premature.
+
+**It keeps the engine stateless-by-restart, which is a testing advantage.** Rules are pure
+functions of (current sample, window). That is what makes the 8 rules unit-testable against
+fixtures with no database and no IRIS.
+
+**Warm-up as a first-class state is better than a seeded guess.** The doc suggests seeding the
+baseline from the first N samples. We do the stricter thing: report "no baseline yet" honestly.
+A fabricated baseline produces fabricated findings — a false `queue_buildup` at second 11 because
+the "baseline" is one sample old. `baselineValue: null` is the contract-visible truth, and Dev C
+already renders it as an em dash.
+
+**It composes with sustained-breach.** §6 requires 2+ consecutive samples before flagging. Both
+mechanisms need the same ring buffer, so there is one state structure, not two.
+
+## Consequences
+
+**Accepted costs:**
+
+- **An engine restart loses all baselines**, and the dashboard shows warming for ~2 minutes.
+  Mitigation for the demo: start the engine before the rehearsal, not during it. Worth putting on
+  the presenter cue sheet.
+- **No cross-restart or day-over-day comparison.** "Normal for a Monday morning" is not
+  expressible. Out of scope for MVP 1; it is Early Warning's problem.
+- **Memory grows with hosts × metrics.** Bounded and small: 4 hosts × 6 numeric metrics × 180
+  samples ≈ 4,300 numbers. Irrelevant at LABDEMO scale; worth revisiting at hundreds of hosts.
+
+**Gained:**
+
+- No schema, no migration, no persistence layer to build in a 5-day project
+- Rules are pure and trivially testable
+- No stale-baseline bugs, because there is no stale baseline to have
+
+## Alternatives considered
+
+**Persisted history in an IRIS or SQLite table.** Rejected for MVP 1 — it serves history, and MVP 1
+shows none. This is the obvious first enhancement, and the natural prerequisite for **Early
+Warning** (forecasting needs more than 30 minutes) and **Health Score** (trending a score over
+time).
+
+**Seed the baseline from the first sample** so rules fire immediately. Rejected: it manufactures
+false findings during warm-up, which §6 lists "too many false-positive findings" as a named risk
+against. A demo that shows three spurious criticals in its first ten seconds is worse than one
+that says "warming up."
+
+**Fixed thresholds only, no baseline.** Rejected — it is a different product. Five of the eight
+finding types are defined comparatively. But note thresholds are configurable per ADR 0003, so a
+demo *can* be forced deterministic by setting absolute floors, which is the escape hatch §6 asks
+for.
+
+## Revisit when
+
+- Early Warning begins — forecasting needs persisted history
+- Baseline warm-up after restart proves disruptive in rehearsal
+- Host count grows enough for memory to matter

--- a/docs/decisions/0003-threshold-configuration.md
+++ b/docs/decisions/0003-threshold-configuration.md
@@ -1,0 +1,110 @@
+# ADR 0003 — Threshold configuration
+
+- **Status:** proposed
+- **Date:** 2026-08-06
+- **Deciders:** Dev A, Dev B, Dev C
+- **Drafted by:** Dev B (implementer)
+- **Source:** §7.4 decision 3 of `production-guardian-healthscan-mvp1.docx`
+
+## Context
+
+Each of the eight rules needs numbers: how far above baseline is a `queue_buildup`, how long
+without activity is `stalled_host`. Fixed constants, or configurable?
+
+The MVP doc recommends "configurable via a small config file, seeded with conservative defaults,
+so the demo can be tuned without redeploying." §6 lists **"too many false-positive findings"** as
+a named risk, mitigated by conservative defaults plus configurability plus sustained-breach.
+
+## Decision
+
+**A single JSON config file, `services/detection-engine/thresholds.json`, re-read on change
+without a restart. Conservative defaults committed. Every rule's numbers live there — no
+thresholds hard-coded in rule logic.**
+
+Structure: global defaults per rule, with optional per-host overrides.
+
+```json
+{
+  "sustainedSamples": 2,
+  "minBaselineSamples": 12,
+  "rules": {
+    "queue_buildup": {
+      "baselineMultiplier": 5.0,
+      "absoluteFloor": 50,
+      "severity": { "warning": 5.0, "critical": 20.0 }
+    },
+    "stalled_host": {
+      "inactiveSeconds": 300,
+      "requiresQueued": true
+    }
+  },
+  "hostOverrides": {
+    "Cloud API": { "slow_processing": { "baselineMultiplier": 8.0 } }
+  }
+}
+```
+
+Two cross-rule keys sit at the top because they are engine-wide, not per-rule:
+`sustainedSamples` (§6's 2+ requirement) and `minBaselineSamples` (ADR 0002's warm-up gate).
+
+## Rationale
+
+**A rule needs two conditions, not one.** `queue_buildup` at `baselineMultiplier: 5.0` alone
+fires when depth goes 1 → 5, which is noise. With `absoluteFloor: 50` it must be both 5× baseline
+*and* over 50 deep. This is the single biggest false-positive lever, and it only works if both
+numbers are configurable together.
+
+**Severity is a threshold, not a rule property.** The same condition is a warning at 5× and
+critical at 20×. Putting severity bands in config means tuning demo drama without touching code.
+
+**Hot-reload matters specifically for the demo.** "Tunable without redeploying" is the doc's
+phrasing, and the reason is Day-5: if a trigger does not produce a visible finding during
+rehearsal, the fix must be a number change, not a rebuild. Reload on file-mtime change, log the
+new values, keep serving on malformed input.
+
+**Per-host overrides because hosts are not alike.** Cloud API is an outbound operation whose
+latency depends on a simulated remote call; Lab Router is in-process. One `slow_processing`
+multiplier across both guarantees a wrong answer for one of them.
+
+## Consequences
+
+**Accepted costs:**
+
+- **Config is a new failure mode.** A malformed file could silently disable detection. Mitigation:
+  validate on load, refuse to apply an invalid file, keep the last-good values, and log loudly.
+  Never fall back to zero-thresholds, which would fire everything.
+- **Defaults are guesses until LABDEMO runs under load.** They are starting points to be corrected
+  by observation, not settled values. The committed numbers should be revised once each of the
+  eight triggers has been induced.
+- **Per-host overrides can hide a real problem.** Raising Cloud API's multiplier to stop a nagging
+  warning also raises the bar for a genuine regression. Overrides should be rare and commented.
+
+**Gained:**
+
+- False-positive tuning without a deploy — the §6 mitigation, actually available
+- Demo can be made deterministic by setting absolute floors, the escape hatch §6 asks for
+- Rule code stays declarative: rules read config, they do not embed policy
+
+## Alternatives considered
+
+**Hard-coded constants.** Rejected — it makes the §6 false-positive mitigation unavailable and
+turns any Day-5 tuning into a rebuild.
+
+**Environment variables.** Rejected. Nested per-rule, per-host structure flattens badly
+(`QUEUE_BUILDUP_CLOUD_API_MULTIPLIER`), and env vars cannot hot-reload — the property we most
+want.
+
+**A settings UI in the dashboard.** Rejected, and out of scope: `apps/dashboard/CLAUDE.md` §1.1
+makes the dashboard display-only and forbids control surfaces. It would also make Dev C's
+component write to Dev B's, crossing the ownership boundary.
+
+**Thresholds in IRIS as a lookup table.** Rejected — contradicts ADR 0001's "no custom IRIS code"
+for MVP 1.
+
+## Revisit when
+
+- All eight triggers have been induced against LABDEMO and the defaults can be replaced with
+  observed values
+- Threshold tuning starts needing an audit trail (who changed what, when)
+- **Smart Resolve** begins — acting on a finding raises the cost of a false positive sharply, and
+  these numbers will deserve more rigor than a JSON file

--- a/docs/decisions/0004-mock-first-contracts.md
+++ b/docs/decisions/0004-mock-first-contracts.md
@@ -1,0 +1,103 @@
+# ADR 0004 — Mock-first contracts
+
+- **Status:** **proposed — needs explicit confirmation from all three developers**
+- **Date:** 2026-08-06
+- **Deciders:** Dev A, Dev B, Dev C
+- **Drafted by:** Dev B — see the note below on why this one is different
+- **Source:** §7.4 decision 4 of `production-guardian-healthscan-mvp1.docx`
+
+## A note on this ADR
+
+0001–0003 are technical choices with a recommended answer, drafted by the developer who will
+implement them. **This one is not a technical choice — it is an agreement between three people**,
+and §7.4 asks all three to *confirm* it rather than for one of us to decide it.
+
+It is drafted here because it was identified (issue #2) as **load-bearing without being recorded**:
+Dev C relied on it from Day 1 while building against a transcribed schema. Writing it down is
+overdue. But Dev A and Dev C should each confirm rather than inherit my summary — this stays
+`proposed` until they do.
+
+## Context
+
+§4.1's parallelization bet: all contracts are published Day 1, then Dev B builds against a mock of
+Dev A's proxy and Dev C against a mock of Dev B's findings API. "So all three work in parallel and
+only integrate at the end."
+
+This works only if everyone actually does it. One developer waiting for a real endpoint serializes
+the project and the 5-day timeline fails.
+
+## Decision
+
+**All three developers build against mocked contracts from Day 1. No developer is ever blocked on
+another's service being up.**
+
+Concretely:
+
+- **`contracts/samples/` is the handoff currency.** Dev A's `proxy-response.json` *is* Dev B's
+  mock input; Dev B's `findings-response.json` *is* Dev C's mock input. The same bytes, which is
+  what makes "works against the mock" predict "works against the real thing."
+- **Samples are captured from live IRIS wherever possible**, not invented. Real values catch
+  real problems.
+- **Mock-first is the plan, not a fallback.** Building against a mock is the intended path, not
+  what you do when the real thing is down.
+- **A contract change after Day 1** is a PR to `contracts/` with a `CHANGELOG.md` entry and a
+  heads-up to the consumer. Never an in-place edit, never silent.
+
+## Evidence it held
+
+This is being written after the fact, so it can be assessed rather than asserted:
+
+**Dev C** started the dashboard against a transcription of §5 (`apps/dashboard/CLAUDE.md` §2.3)
+rather than idling for the published contract, tagging 13 assumption sites with `// CONTRACT-Q<n>`.
+When the real contract landed (PR #3), **eight of the nine assumptions were correct**; only the
+`HostStatus` enum needed changing — roughly one line against ~1,750 lines written. The bet paid
+off almost exactly as intended.
+
+**Dev B** published the findings contract while LABDEMO was still being built, and validated it
+against real captured metrics rather than waiting for Dev A's proxy.
+
+**The `CONTRACT-Q<n>` convention deserves promotion from accident to practice.** Tagging every
+assumption site with a greppable marker is what made reconciliation a `grep` instead of an audit.
+Recommend it explicitly for any future contract-dependent work.
+
+## Consequences
+
+**Accepted costs:**
+
+- **A wrong assumption compounds silently** until the contract lands. Bounded here by the
+  `CONTRACT-Q` markers; unbounded without them.
+- **A mock can be wrong in ways the real thing is not** — this is exactly why samples must be real
+  captures. A hand-written sample encodes the author's belief about the API, so mocking against it
+  proves only self-consistency.
+- **Integration risk is deferred, not removed.** Day 5 is the first time real components meet. The
+  `contracts` CI job (validating `samples/` against the schemas) is the main defence, and it is
+  worth more than the other three CI jobs combined.
+
+**Gained:**
+
+- Three developers working genuinely in parallel at ~3.5–4 dev-days each
+- No developer idle waiting on another's environment
+- Contract disagreements surface as schema-validation failures rather than Day-5 surprises
+
+## Alternatives considered
+
+**Sequential: A finishes, then B, then C.** Rejected — it is ~10–12 person-days of work in a
+5-day window. Arithmetically impossible with three developers idling in turn.
+
+**Shared live environment from Day 1.** Rejected. It makes every developer's progress depend on
+one IRIS instance staying healthy, and inverts the risk: instead of integration risk on Day 5, you
+get environment risk every day. (A live instance is still valuable *alongside* mocks — LABDEMO
+exists and is where the real metric captures came from.)
+
+**Contract-last: build, then reconcile.** Rejected — it is how you get three components that each
+work alone and none together.
+
+## Confirmation
+
+Each developer confirms they are building against mocked contracts, not waiting on real endpoints:
+
+- [ ] **Dev A** — metrics proxy, `iris/**`
+- [x] **Dev B** — detection engine, findings API (confirmed: contract published and validated
+      against captured metrics before the proxy existed)
+- [ ] **Dev C** — dashboard (evidently followed in practice from Day 1; confirming your own
+      position here is what makes it recorded rather than inferred)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,24 @@
+# Architecture decision records
+
+The four decisions §7.4 of the MVP doc asks to settle before starting. Recorded because they are
+the questions most likely to be re-litigated on Day 4.
+
+| ADR | Decision | Status |
+|---|---|---|
+| [0001](0001-detection-engine-location.md) | Detection engine runs outside IRIS, in `services/detection-engine/` | proposed |
+| [0002](0002-baseline-strategy.md) | Rolling 30-minute in-memory window; nothing persisted | proposed |
+| [0003](0003-threshold-configuration.md) | JSON config file, hot-reloaded, conservative defaults | proposed |
+| [0004](0004-mock-first-contracts.md) | All three build against mocked contracts from Day 1 | **needs all three to confirm** |
+
+0001–0003 were drafted by Dev B, who implements them, and follow the MVP doc's recommendations.
+0004 is not a technical choice but an agreement between three people — it stays `proposed` until
+Dev A and Dev C each confirm rather than inherit someone else's summary.
+
+## Conventions
+
+- One decision per file, `NNNN-short-slug.md`, numbered in decision order.
+- **Never rewrite a decided ADR.** Supersede it with a new one and mark the old
+  `superseded by NNNN`. The point is the record of *why*, including reasoning later abandoned.
+- Every ADR carries a **Revisit when** section. A decision right for MVP 1 is often wrong for
+  Smart Resolve; naming the trigger in advance is what stops Day-4 re-litigation.
+- `docs/decisions/` is shared and PR-gated — a change needs review, not a direct push.


### PR DESCRIPTION
Addresses the ADR half of #2, which flagged **0004 as load-bearing without being recorded**.

| ADR | Decision |
|---|---|
| [0001](docs/decisions/0001-detection-engine-location.md) | Detection engine runs **outside IRIS**, in `services/detection-engine/` |
| [0002](docs/decisions/0002-baseline-strategy.md) | Rolling **30-minute in-memory** window; nothing persisted |
| [0003](docs/decisions/0003-threshold-configuration.md) | **JSON config file**, hot-reloaded, conservative defaults |
| [0004](docs/decisions/0004-mock-first-contracts.md) | **Mock-first contracts** — needs all three to confirm |

All four follow the MVP doc's recommendations. Each carries a **Revisit when** section naming the trigger that would reopen it — these are the decisions §7.4 expects to be re-litigated on Day 4, so the point is to make that a lookup rather than an argument.

## 0004 is deliberately unfinished

I drafted it but left Dev A's and Dev C's confirmation boxes **unchecked**. §7.4 asks all three of us to *confirm* mock-first, and it's an agreement between people rather than a technical choice one developer can decide. Please each check your own box rather than inherit my summary.

It does record **evidence rather than assertion**: of Dev C's nine assumptions, eight were correct, so building against a transcription instead of idling cost about one line against ~1,750 written. The bet paid off close to exactly as §4.1 intended.

It also recommends promoting Dev C's `// CONTRACT-Q<n>` convention from accident to practice — greppable assumption markers are what made reconciliation a `grep` instead of an audit.

## For Dev A — one constraint in 0001

0001 records something found while standing up LABDEMO: **`iris_interop_queued` carries no `host` label**, so per-host queue depth isn't in the Prometheus text. It *is* available from `Ens.Util.Statistics:EnumerateHostStatus` (verified: `Cloud API = 48` while disabled), which means **the proxy needs to expose host status, not only parse `/metrics`.**

No extra IRIS configuration required, and no contract change — `Host.queued` stays a required number. But it's a real requirement on your component, and 0001 is where the reasoning is written down.

## Two places I chose the stricter option

**0002 — warm-up.** The MVP doc suggests seeding the baseline from the first N samples. I propose the stricter thing: report `baselineValue: null` and let comparative rules stay silent until 12 samples (~2 min) exist. A seeded baseline manufactures false findings in the first seconds — and §6 names false positives as a risk. A demo showing three spurious criticals on startup is worse than one saying "warming up".

**0003 — two conditions per rule.** `queue_buildup` needs both a baseline multiplier *and* an absolute floor. `5× baseline` alone fires on 1 → 5, which is noise. Both numbers configurable together is the single biggest false-positive lever.

Both are open to challenge — that's what review is for.

## Review

`docs/decisions/` is shared and PR-gated per `CONTRIBUTING.md` §2, so this needs review rather than a direct push. Related: #3 (the Health Scan contract), #2 (Day-1 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
