### PR TITLE
docs(decisions): confirm Dev C on ADR 0004, correct its evidence section

### DIFF
--- a/docs/decisions/0004-mock-first-contracts.md
+++ b/docs/decisions/0004-mock-first-contracts.md
@@ -50,15 +50,36 @@ This is being written after the fact, so it can be assessed rather than asserted
 **Dev C** started the dashboard against a transcription of §5 (`apps/dashboard/CLAUDE.md` §2.3)
 rather than idling for the published contract, tagging 13 assumption sites with `// CONTRACT-Q<n>`.
 When the real contract landed (PR #3), **eight of the nine assumptions were correct**; only the
-`HostStatus` enum needed changing — roughly one line against ~1,750 lines written. The bet paid
-off almost exactly as intended.
+`HostStatus` enum needed changing. The bet paid off close to as intended.
+
+**But the cost was 83 insertions across 10 files, not one line** — worth recording accurately,
+because the reason is the transferable lesson. Removing `Warning` from the enum did not merely
+narrow a union: **7 demo fixtures used `status: "Warning"` in 8 places** to *mean* "this host is
+degraded", so the correction made a concept the dashboard had built on **unrepresentable**. Each
+of those fixtures had to be rewritten to express degradation through findings instead, and
+`StatusDot`'s tone map needed a real change rather than a one-line one — its "is this status
+known" test had inferred recognition from "the tone is not neutral", which stops working the
+moment four statuses are legitimately neutral.
+
+So the sharper form of the lesson: **a wrong enum value is cheap; a wrong enum value you have
+built semantics on top of is not.** Reconciliation cost scales with how much meaning was attached
+to the wrong assumption, not with how many characters it occupied.
+
+What kept it contained was **defensive rendering** (`apps/dashboard/CLAUDE.md` §2.4) forcing
+unknown statuses down a neutral path from the very first commit, so the wrong value never spread
+beyond fixtures and one tone map. The `CONTRACT-Q<n>` markers told Dev C *where* to look;
+defensive rendering is why looking was all it took. Both practices earn their place, but they do
+different jobs and the second is the one that bounded the damage.
 
 **Dev B** published the findings contract while LABDEMO was still being built, and validated it
 against real captured metrics rather than waiting for Dev A's proxy.
 
 **The `CONTRACT-Q<n>` convention deserves promotion from accident to practice.** Tagging every
 assumption site with a greppable marker is what made reconciliation a `grep` instead of an audit.
-Recommend it explicitly for any future contract-dependent work.
+One refinement from having consumed them: **the marker must carry the assumption inline**
+(`// CONTRACT-Q1: assumed OK | Warning | Error | Inactive`). Markers that named only the question
+number sent the reader back to the question list; markers that stated the assumption were
+self-contained. Recommend it explicitly for any future contract-dependent work.
 
 ## Consequences
 
@@ -96,8 +117,9 @@ work alone and none together.
 
 Each developer confirms they are building against mocked contracts, not waiting on real endpoints:
 
-- [ ] **Dev A** — metrics proxy, `iris/**`
+- [ ] **Dev A** — metrics proxy, `iris/**` (not yet onboarded; box left for them to tick rather
+      than filled in on their behalf)
 - [x] **Dev B** — detection engine, findings API (confirmed: contract published and validated
       against captured metrics before the proxy existed)
-- [ ] **Dev C** — dashboard (evidently followed in practice from Day 1; confirming your own
-      position here is what makes it recorded rather than inferred)
+- [x] **Dev C** — dashboard (confirmed: built against a transcription of §5 from Day 1, never
+      waited on `:3002`, and runs against a throwaway local stub until the real endpoints exist)

--- a/docs/decisions/0004-mock-first-contracts.md
+++ b/docs/decisions/0004-mock-first-contracts.md
@@ -117,9 +117,10 @@ work alone and none together.
 
 Each developer confirms they are building against mocked contracts, not waiting on real endpoints:
 
-- [ ] **Dev A** — metrics proxy, `iris/**` (not yet onboarded; box left for them to tick rather
-      than filled in on their behalf)
+- [ ] **Dev A** — metrics proxy, `iris/**` (onboarded 2026-08-10 as @kskubach; box left for them
+      to tick rather than filled in on their behalf)
 - [x] **Dev B** — detection engine, findings API (confirmed: contract published and validated
       against captured metrics before the proxy existed)
-- [x] **Dev C** — dashboard (confirmed: built against a transcription of §5 from Day 1, never
-      waited on `:3002`, and runs against a throwaway local stub until the real endpoints exist)
+- [x] **Dev C** — dashboard (confirmed: built against a transcription of §5 from Day 1 and never
+      waited on `:3002` — a throwaway local stub stood in until the real endpoints existed, then
+      was deleted once they did, which is the mock-first cycle completing rather than persisting)


### PR DESCRIPTION
Two corrections to ADR 0004, both about the record matching reality. Follows up #4, which is merged.

## 1. Dev C's confirmation box

I ticked it in a review comment on #4 — which is a *comment*, so it never edited the file. 0004 merged saying Dev C had not confirmed, which is precisely the "recorded rather than inferred" gap that line exists to close.

```diff
-- [ ] **Dev C** — dashboard (evidently followed in practice from Day 1; ...)
+- [x] **Dev C** — dashboard (confirmed: built against a transcription of §5 from Day 1,
+      never waited on `:3002`, and runs against a throwaway local stub until the real
+      endpoints exist)
```

**Dev A's box stays unticked**, now with a note that they are not yet onboarded. Filling it in on their behalf is the thing @Ari-Glikman correctly declined to do for the rest of us, and it would be no better coming from me.

0004 therefore stays `proposed`. That's the honest state, and it's why merging #4 was still right — a recorded pending decision beats an unrecorded one.

## 2. The evidence section overstated how cheap reconciliation was

It said *"roughly one line against ~1,750 lines written."* Measured against ce8773f, the Q1-attributable change is **83 insertions across 10 files**.

I raised this on #4 and said I'd either see it amended or open a follow-up — this is the follow-up.

The reason is the part worth recording, because it's the transferable bit:

- **7 fixtures used `status: "Warning"` in 8 places to *mean* "degraded".** Removing the value didn't just narrow a union — it made a concept the dashboard had built on **unrepresentable**. Every one had to be rewritten to signal degradation through findings instead.
- **`StatusDot` needed real work, not a one-liner.** Its "is this status known" test inferred recognition from *"the tone is not neutral"* — which breaks the moment four statuses are legitimately neutral, which is exactly what the real enum introduced.

So the sharper lesson: **a wrong enum *value* is cheap; a wrong enum value you've built semantics on top of is not.** Cost scales with attached meaning, not with characters.

### It also credits the practice that actually contained it

The original gave the credit to the `CONTRACT-Q` markers. Having just consumed my own markers, I don't think that's right: **defensive rendering (§2.4)** forced unknown statuses down a neutral path from the first commit, which is why the wrong value never spread past fixtures and one tone map. The markers told me *where* to look; defensive rendering is why looking was all it took. Both earn their place, they just do different jobs.

Plus one refinement to the convention Dev B proposed promoting: **the marker must state the assumption inline** (`// CONTRACT-Q1: assumed OK | Warning | Error | Inactive`). Markers naming only a question number sent me back to the question list; ones stating the assumption were self-contained.

## Why this is a PR and not a push

`docs/decisions/README.md` line 24: *"`docs/decisions/` is shared and PR-gated — a change needs review, not a direct push."*

Also worth flagging: it's an ADR convention here that a decided ADR is never rewritten in place, only superseded. 0004 is still `proposed`, not decided, so amending it is in-bounds — but @Ari-Glikman, say so if you'd rather this were a superseding record than an edit. It's your ADR and your convention.

## Verification

Numbers measured with `git diff --numstat`, not estimated. I got them wrong twice while drafting this — first "62 insertions across 9 files", then "eight fixtures" when it's 7 files and 8 occurrences — which is a decent argument for the ADR carrying measured figures rather than remembered ones.

Refs #2, #4
