### PR TITLE
feat(detection-engine): baseline, 8 rules, thresholds, findings API

### DIFF
--- a/services/detection-engine/CLAUDE.md
+++ b/services/detection-engine/CLAUDE.md
@@ -1,0 +1,202 @@
+# CLAUDE.md — Detection Engine & Findings API (**Developer B**)
+
+Scoped to `services/detection-engine/`. The root `CLAUDE.md` carries the shared rules — scope
+boundary, ownership, ports — and applies here too.
+
+---
+
+## 1. What you are building
+
+The **detection engine**: the brains of Health Scan. Three things:
+
+1. **Rolling baseline** — trailing 30-minute, per-host, per-metric window with warm-up handling.
+2. **Detection rules** — the eight finding types, configurable thresholds, sustained-breach logic.
+3. **Findings API** — `GET /api/healthscan/findings` and `/api/healthscan/hosts` on **`:3002`**.
+
+You consume Dev A's proxy JSON from `:3001`. You produce the contract in
+`contracts/healthscan-api.md` for Dev C.
+
+You are the *detection* layer. You read metrics, compare to baseline, emit findings. **You compute
+nothing else and act on nothing.**
+
+### 1.1 Hard scope boundary
+
+| Do NOT build | Belongs to |
+|---|---|
+| Restarting hosts, clearing queues, any remediation | **Smart Resolve** |
+| Root-cause narratives, evidence chains, confidence scores | **AI Detective** |
+| Forecasts, "will breach in N minutes", trend extrapolation | **Early Warning** |
+| A single 0–100 health score | **Health Score** |
+| Report or summary generation | **Health Summary** |
+| Natural-language endpoints | **Ask Guardian** |
+| Persisted baseline history, trend storage | Out of MVP 1 — see ADR 0002 |
+
+**A finding states what is true now, compared to what was normal. Nothing more.** If a request
+implies a row above, say so instead of building it.
+
+## 2. Architecture, and the decisions behind it
+
+Read the ADRs before changing structure — they record *why*, and each names what would reopen it:
+
+| ADR | Decision |
+|---|---|
+| `docs/decisions/0001` | Engine runs **outside IRIS**. No ObjectScript here. Consume proxy JSON over HTTP. |
+| `docs/decisions/0002` | Baseline is a **rolling in-memory window**. Nothing persisted. Warm-up is `baselineValue: null`, never a seeded guess. |
+| `docs/decisions/0003` | Thresholds live in **`thresholds.json`**, hot-reloaded. No thresholds hard-coded in rule logic. |
+| `docs/decisions/0004` | **Mock-first.** Never block on Dev A's proxy being up. |
+
+```
+services/detection-engine/
+├─ CLAUDE.md                  <- this file
+├─ package.json               <- zero runtime dependencies (§3)
+├─ tsconfig.json
+├─ thresholds.json            <- ADR 0003; the only place numbers live
+├─ fixtures/
+│  └─ proxy/                  <- mocked Dev A responses; scenario per file
+└─ src/
+   ├─ index.ts                <- wiring: poll loop + HTTP server
+   ├─ types/
+   │  ├─ proxy.ts             <- Dev A's shape. UNRATIFIED — see §4
+   │  └─ healthscan.ts        <- transcription of contracts/healthscan.d.ts
+   ├─ config/
+   │  └─ thresholds.ts        <- load, validate, hot-reload, last-good fallback
+   ├─ baseline/
+   │  └─ window.ts            <- ring buffer, per host+metric
+   ├─ detect/
+   │  ├─ engine.ts            <- runs rules, owns the finding registry
+   │  ├─ registry.ts          <- stable ids + sustained-breach state
+   │  └─ rules/               <- one file per finding type, eight total
+   ├─ proxy/
+   │  ├─ client.ts            <- fetch from :3001
+   │  └─ mockClient.ts        <- fixture-backed, same interface
+   └─ api/
+      └─ server.ts            <- the two endpoints
+```
+
+## 3. Stack
+
+**Node 20 + TypeScript. Zero runtime dependencies.** Node 20 provides everything needed: `fetch`,
+`node:http`, `node:test`, `node:fs.watch`. TypeScript and `@types/node` are the only devDeps.
+
+No Express (14 lines of `node:http` covers two GET routes), no Zod (hand-written guards are
+explicit and dependency-free), no test framework (`node:test` is built in), no Prometheus parser —
+**we consume Dev A's JSON, not Prometheus text.** Parsing is their component's job, per ADR 0001.
+
+Adding a dependency requires stating why and what it replaces.
+
+## 4. The two contracts, and their different status
+
+**Downstream — `contracts/healthscan-*` is ratified and ours.** Published in PR #3. `src/types/healthscan.ts`
+is a direct transcription. **We own it, which means we may not quietly drift from it** — a change is
+a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by all three. Dev C's UI is built
+against those exact bytes.
+
+**Upstream — Dev A's proxy contract does not exist yet.** `contracts/proxy-api.md` is unlanded.
+So `src/types/proxy.ts` is *our assumption* of their output, not an agreed contract.
+
+Follow Dev C's convention, which worked: **tag every assumption site with `// PROXY-Q<n>`** and keep
+the running list at the top of `src/types/proxy.ts`. Reconciling when Dev A lands their contract
+must be a `grep`, not an audit:
+
+```bash
+grep -rn "PROXY-Q" src/
+```
+
+Known assumptions so far, each carrying a marker:
+
+- **PROXY-Q1** — per-host objects keyed by config name, with `status` as IRIS reports it
+- **PROXY-Q2** — `queued` present per host. **Not in the Prometheus text** (`iris_interop_queued`
+  has no `host` label); the proxy must read `Ens.Util.Statistics:EnumerateHostStatus`. Raised in
+  ADR 0001 and PR #4
+- **PROXY-Q3** — `avg*` fields already aggregated across `messagetype`, weighted by sample count.
+  If Dev A passes raw per-messagetype series instead, aggregation moves here
+- **PROXY-Q4** — `lastActivityElapsedSeconds` (as IRIS gives it) vs a pre-computed timestamp.
+  We assume elapsed and convert, since that is what the metric holds
+
+## 5. Rules — the eight, and how they must behave
+
+| Finding type | Fires on |
+|---|---|
+| `dead_host` | status is `Error`, `Inactive`, `Stopped`, or `Disabled` |
+| `stalled_host` | no activity > threshold **while messages are queued** |
+| `queue_buildup` | depth over baseline multiplier **and** over the absolute floor |
+| `elevated_error_rate` | errored count rising faster than baseline |
+| `slow_processing` | avg processing time over baseline multiplier |
+| `growing_queue_wait` | avg queueing time over baseline multiplier |
+| `throughput_drop` | messages/sec below baseline fraction |
+| `system_alert` | new alert in the proxy's alerts payload |
+
+Non-negotiable behaviours:
+
+- **Sustained breach.** Per MVP §6, a rule needs **2+ consecutive breaching samples**
+  (`sustainedSamples`) before a finding is emitted. A single-sample spike emits nothing.
+- **Stable ids.** A finding's `id` is stable for the life of the condition, keyed by
+  `(host, type)`. Contract Q4 promises Dev C this — their highlight animation and detail drawer
+  depend on it. **Never regenerate an id for an ongoing condition.**
+- **Findings disappear when cleared.** No `resolvedAt`, no tombstones. Contract Q4.
+- **No baseline, no comparative finding.** Below `minBaselineSamples`, comparative rules stay
+  silent. `dead_host` and `system_alert` are absolute and still fire.
+- **Two absolute rules, six comparative.** Only `dead_host` and `system_alert` work without a
+  baseline.
+- **`message` is authoritative.** Dev C renders it verbatim and is told not to reconstruct it. It
+  must state the actual numbers — `"Queue depth 486 is 32x baseline"`, not `"Queue is high"`.
+- **Rules are pure functions** of `(sample, window, config)`. No I/O, no clock reads inside a
+  rule — pass time in. This is what makes them testable against fixtures.
+
+### 5.1 Baseline self-inflation — known, deliberate, pinned by a test
+
+A rolling mean includes the breaching samples, so **a sustained problem becomes the new normal
+and its comparative finding clears while the bad value persists.** With `queued` going 0 → 486,
+`queue_buildup` fires, then stops once the mean has climbed enough that the ratio falls below the
+multiplier.
+
+This is inherent to ADR 0002's rolling window, not a bug. `test/baseline.test.ts` pins the
+behaviour so nobody "fixes" it unknowingly. Note that the absolute rules are unaffected —
+`dead_host` keeps firing for as long as the host is down, which is why the demo's headline
+finding is a reliable one.
+
+If it needs addressing later, the options are excluding breaching samples from the window, or a
+longer window, or a persisted baseline (ADR 0002's named revisit trigger). All three are out of
+scope for MVP 1.
+
+## 6. Never invent data
+
+- **No fabricated hosts, metrics, or findings outside `fixtures/`.** Fixtures use the four LABDEMO
+  components — **EMR Source** (service), **Lab Router** (process), **FHIR Transform** (process),
+  **Cloud API** (operation) — and the eight real finding types.
+- Fixture values should be **captured from live LABDEMO**, not invented. Real numbers catch real
+  problems; `contracts/samples/` was built that way.
+- If the proxy is unreachable, serve last-known findings and report `X-Healthscan-State: stale`.
+  **Never invent a plausible reading to fill a gap**, and never emit a finding from absent data.
+
+## 7. API behaviour
+
+Per §3 of `contracts/healthscan-api.md`:
+
+- Zero findings → `200` + `[]`. **Never `404`.**
+- Warming up → `200` + `[]` + `X-Healthscan-State: warming`.
+- Proxy unreachable → `200` + last-known + `X-Healthscan-State: stale`.
+- Genuine fault → `500` + `{"error": "..."}`.
+- Always send `Access-Control-Allow-Origin: *` (contract Q9).
+- `findings` sorted `detectedAt` desc, severity tiebreak. `hosts` sorted by name.
+- **Filter framework hosts.** `Ens.MonitorService`, `Ens.Alarm`, `Ens.ScheduleHandler`,
+  `Ens.Actor`, `EnsLib.Testing.*`, `Ens.Activity.Operation.Local` and friends never reach the API.
+  For LABDEMO exactly four hosts are returned.
+
+Prefer stale-but-labelled over an error: a blanked dashboard is worse on stage than slightly old
+data.
+
+## 8. Verify before claiming done
+
+```bash
+npm run typecheck    # tsc --noEmit, strict. No `any`, no @ts-ignore
+npm test             # node:test
+npm run dev          # engine against fixtures, no proxy needed
+```
+
+- **Test the negative cases.** A rule that fires correctly but never *stops* firing is broken. A
+  schema test that only checks valid input proves nothing — prove rejection too.
+- **Run the tests and show real output.** If something fails or is unverified, say which and paste
+  it. A green claim over a red build costs the team more than the bug did.
+- The engine must start and serve with **no proxy running** (ADR 0004). If it cannot, mock-first
+  is broken.

--- a/services/detection-engine/CLAUDE.md
+++ b/services/detection-engine/CLAUDE.md
@@ -159,6 +159,33 @@ If it needs addressing later, the options are excluding breaching samples from t
 longer window, or a persisted baseline (ADR 0002's named revisit trigger). All three are out of
 scope for MVP 1.
 
+### 5.2 Severity `info` is deliberately unreachable for the seven per-host rules
+
+Each comparative rule's firing gate **equals** its `severityBands.warning` — `queue_buildup` fires
+at 5× and warns at 5× — so anything that fires is at least a warning. `dead_host` and
+`stalled_host` carry fixed severities. **`system_alert` is the only source of an `info` finding.**
+
+Do not "fix" this by lowering a warning band: reaching `info` would require lowering the firing
+**gate**, which widens what fires and reintroduces exactly the false positives MVP §6 names as the
+top risk. A quiet findings list is the point. `thresholds.json` carries the same note, and
+`test/scenario.test.ts` asserts `info` comes only from `system_alert`, so a drift fails loudly.
+
+### 5.3 An alert is an event, not a sustained condition
+
+`system_alert` is exempt from the sustained-breach *suppression* that the other rules use, though
+the registry still requires two consecutive verdicts before confirming. It reports for as long as
+the alert stays in the proxy payload and clears when it ages out.
+
+An earlier version marked an alert seen on its first poll and returned `null` afterwards, which
+made the rule **structurally unable to fire**: the registry needs `sustainedSamples` consecutive
+verdicts and only ever got one. Every rule unit test passed, because the conflict was *between*
+the rule and the registry rather than inside either. It surfaced only because Dev C observed 46
+live findings with no `system_alert` and no `info` severity among them.
+
+The lesson generalises: a rule tested in isolation can be dead once composed with the registry.
+`test/scenario.test.ts` exists to catch that class — it asserts the demo loop can actually produce
+all eight types.
+
 ## 6. Never invent data
 
 - **No fabricated hosts, metrics, or findings outside `fixtures/`.** Fixtures use the four LABDEMO

--- a/services/detection-engine/README.md
+++ b/services/detection-engine/README.md
@@ -1,0 +1,79 @@
+# detection-engine
+
+Health Scan's baseline + rule engine and findings API. **Dev B.** Port **3002**.
+
+Consumes Dev A's metrics proxy (`:3001`), publishes the contract in
+`contracts/healthscan-api.md` for Dev C's dashboard.
+
+## Run it
+
+Requires **Node ≥ 22.18** (native TypeScript type stripping — no build step, no transpiler).
+
+```bash
+npm install          # devDependencies only; zero runtime dependencies
+npm start            # mock proxy, serves on :3002
+npm run dev          # same, with --watch
+npm test             # 95 tests
+npm run typecheck    # tsc --noEmit, strict
+```
+
+**It runs with no proxy.** Mock-first is the plan, not a fallback (ADR 0004) — `npm start`
+replays captured LABDEMO fixtures and serves real findings immediately:
+
+```bash
+curl localhost:3002/api/healthscan/hosts
+curl localhost:3002/api/healthscan/findings
+curl localhost:3002/api/healthscan/health   # operational, not in the contract
+```
+
+Against Dev A's real proxy:
+
+```bash
+PROXY_MODE=live PROXY_BASE_URL=http://localhost:3001 npm start
+```
+
+| Env var | Default | Notes |
+|---|---|---|
+| `PORT` | `3002` | |
+| `PROXY_MODE` | `mock` | `mock` \| `live` |
+| `PROXY_BASE_URL` | `http://localhost:3001` | live mode only |
+| `POLL_INTERVAL_MS` | `10000` | matches the proxy's own IRIS poll |
+
+## Shape of it
+
+```
+proxy poll ─> normalize ─> baseline window ─> 8 rules ─> registry ─> API
+                (Q10/Q11)     (ADR 0002)     (ADR 0003)    (Q4)
+```
+
+- **`src/baseline/`** — trailing 30-min window per host+metric. Warm-up returns `null`, never a
+  seeded guess.
+- **`src/detect/rules/`** — the eight rules, pure functions of `(sample, window, config)`.
+- **`src/detect/registry.ts`** — stable ids + sustained-breach state. This is what makes the
+  contract's Q4 promises true.
+- **`src/config/`** — `thresholds.json`, hot-reloaded, last-good on invalid input.
+- **`src/proxy/`** — real and mock clients behind one interface.
+
+## Demo fixtures
+
+`fixtures/proxy/` holds **real captures from the live LABDEMO production**, not invented numbers.
+The default scenario loops healthy → degrading → dead → recovery, so findings visibly appear
+*and clear* without touching IRIS.
+
+| Fixture | What it shows |
+|---|---|
+| `healthy.json` | Steady state. Includes `Ens.MonitorService` to prove framework filtering. |
+| `queue-buildup.json` | Cloud API throttled: queue 486, slow, erroring. Trips four rules. |
+| `cloud-api-dead.json` | Cloud API disabled. Real observed state — status `Disabled`, depth 48. |
+
+Note `cloud-api-dead` sits at depth **48** against an `absoluteFloor` of **50**, so it
+deliberately does *not* trip `queue_buildup`. That is the two-condition design in ADR 0003
+working, not a gap.
+
+## Before claiming done
+
+`npm run typecheck` and `npm test` must both pass, and the engine must still start with no proxy.
+Test the negative cases: a rule that fires but never stops is broken, and a positive-only suite
+will not notice.
+
+Deeper instructions: `CLAUDE.md` in this directory. Decisions: `docs/decisions/0001`–`0004`.

--- a/services/detection-engine/README.md
+++ b/services/detection-engine/README.md
@@ -63,12 +63,23 @@ The default scenario loops healthy → degrading → dead → recovery, so findi
 | Fixture | What it shows |
 |---|---|
 | `healthy.json` | Steady state. Includes `Ens.MonitorService` to prove framework filtering. |
-| `queue-buildup.json` | Cloud API throttled: queue 486, slow, erroring. Trips four rules. |
+| `queue-buildup.json` | Cloud API throttled: queue 486, slow, waiting. Trips four rules. |
+| `error-storm{,-2,-3,-4}.json` | Errored count climbing 60 → 210 → 400 → 620 across consecutive polls. `-2` onward carry a system alert. |
+| `stalled-host.json` | Lab Router hung: status still `OK`, idle 384s, 27 queued. The case `dead_host` cannot catch. |
 | `cloud-api-dead.json` | Cloud API disabled. Real observed state — status `Disabled`, depth 48. |
 
-Note `cloud-api-dead` sits at depth **48** against an `absoluteFloor` of **50**, so it
-deliberately does *not* trip `queue_buildup`. That is the two-condition design in ADR 0003
-working, not a gap.
+**The loop reaches all eight finding types and all three severities.** `test/scenario.test.ts`
+asserts it, because an earlier version silently reached only three — every rule was unit-tested and
+passing, so nothing caught it until Dev C compared 46 live findings against the eight documented
+types.
+
+Two things that look like gaps and are not:
+
+- `cloud-api-dead` sits at depth **48** against an `absoluteFloor` of **50**, so it deliberately
+  does *not* trip `queue_buildup`. That is ADR 0003's two-condition design working.
+- The error storm uses **four fixtures at one poll each** rather than one repeated. The engine
+  derives errors/min from the *delta* between polls, so a step held for several polls has a flat
+  counter and yields a rate of zero.
 
 ## Before claiming done
 

--- a/services/detection-engine/fixtures/proxy/cloud-api-dead.json
+++ b/services/detection-engine/fixtures/proxy/cloud-api-dead.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Captured from live LABDEMO with Cloud API disabled via iris_production_item. Real observed state: status Disabled, queue reached 48, elapsed 110s. Upstream hosts keep working, so the queue accumulates at the dead operation.",
+  "sampledAt": "2026-08-06T15:44:18Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 240,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.01,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 4.284,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1440,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 4.277,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1440,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 4.275,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "Disabled",
+      "queued": 48,
+      "messages": 392,
+      "messagesPerSec": 0,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.05,
+      "avgQueueingTime": 0.02,
+      "lastActivityElapsedSeconds": 110,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": []
+}

--- a/services/detection-engine/fixtures/proxy/error-storm-2.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-2.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Continuation of error-storm.json: messagesErrored climbs 60 -> 210 while the poll interval stays constant, giving the engine a rising errors/min to compare against baseline. Two consecutive fixtures are the minimum for elevated_error_rate, because the rate itself needs two readings AND sustainedSamples is 2. Also carries a system alert naming Cloud API, which is the only path to a system_alert finding.",
+  "sampledAt": "2026-08-06T15:49:20Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 362,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2172,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2172,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "Error",
+      "queued": 18,
+      "messages": 712,
+      "messagesPerSec": 0.3,
+      "messagesErrored": 210,
+      "avgProcessingTime": 0.06,
+      "avgQueueingTime": 0.05,
+      "lastActivityElapsedSeconds": 2.2,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": [
+    {
+      "time": "2026-08-06T15:49:14Z",
+      "severity": "2",
+      "message": "Cloud API returned HTTP 503 (simulated) on 3 consecutive attempts"
+    }
+  ]
+}

--- a/services/detection-engine/fixtures/proxy/error-storm-3.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-3.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Continuation of the error storm: messagesErrored climbs to 400 on the next consecutive poll. The engine derives errors/min from the delta between polls, so the count must keep rising for sustainedSamples consecutive readings before elevated_error_rate confirms.",
+  "sampledAt": "2026-08-06T15:49:30Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 362,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2790,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2790,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "Error",
+      "queued": 24,
+      "messages": 2790,
+      "messagesPerSec": 0.28,
+      "messagesErrored": 400,
+      "avgProcessingTime": 0.06,
+      "avgQueueingTime": 0.05,
+      "lastActivityElapsedSeconds": 2.2,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": [
+    {
+      "time": "2026-08-06T15:49:14Z",
+      "severity": "2",
+      "message": "Cloud API returned HTTP 503 (simulated) on 3 consecutive attempts"
+    }
+  ]
+}

--- a/services/detection-engine/fixtures/proxy/error-storm-4.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-4.json
@@ -1,0 +1,66 @@
+{
+  "_comment": "Continuation of the error storm: messagesErrored climbs to 620 on the next consecutive poll. The engine derives errors/min from the delta between polls, so the count must keep rising for sustainedSamples consecutive readings before elevated_error_rate confirms.",
+  "sampledAt": "2026-08-06T15:49:40Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 362,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2802,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2802,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "Error",
+      "queued": 31,
+      "messages": 2802,
+      "messagesPerSec": 0.25,
+      "messagesErrored": 620,
+      "avgProcessingTime": 0.06,
+      "avgQueueingTime": 0.05,
+      "lastActivityElapsedSeconds": 2.2,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": [
+    {
+      "time": "2026-08-06T15:49:14Z",
+      "severity": "2",
+      "message": "Cloud API returned HTTP 503 (simulated) on 3 consecutive attempts"
+    }
+  ]
+}

--- a/services/detection-engine/fixtures/proxy/error-storm.json
+++ b/services/detection-engine/fixtures/proxy/error-storm.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Cloud API erroring hard while still processing. Derived from the LABDEMO capture with FailurePercent raised on LABDEMO.Operation.CloudAPI, which fails a deterministic 1-in-N calls. messagesErrored is CUMULATIVE and must RISE across consecutive polls for elevated_error_rate to fire -- the engine derives errors/min from the delta, because a counter that only rises would otherwise flag forever once it moved. Paired with error-storm-2.json, which continues the climb.",
+  "sampledAt": "2026-08-06T15:49:10Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 360,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.8,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2160,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.8,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2160,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.8,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "Error",
+      "queued": 12,
+      "messages": 700,
+      "messagesPerSec": 0.35,
+      "messagesErrored": 60,
+      "avgProcessingTime": 0.06,
+      "avgQueueingTime": 0.04,
+      "lastActivityElapsedSeconds": 2.4,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": []
+}

--- a/services/detection-engine/fixtures/proxy/healthy.json
+++ b/services/detection-engine/fixtures/proxy/healthy.json
@@ -1,0 +1,74 @@
+{
+  "_comment": "Captured from live LABDEMO, 2026-08-06. Steady state, all four hosts OK. avgProcessingTime 0.08 for the two processes is the real measured value.",
+  "sampledAt": "2026-08-06T15:47:52Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 196,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.01,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 4.083,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1176,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.966,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1176,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.968,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "OK",
+      "queued": 0,
+      "messages": 392,
+      "messagesPerSec": 0.4,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.05,
+      "avgQueueingTime": 0.02,
+      "lastActivityElapsedSeconds": 3.973,
+      "sampleCount": 24
+    },
+    {
+      "_comment": "Framework host, present to prove the engine filters it out (PROXY-Q5).",
+      "name": "Ens.MonitorService",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 12,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 1.2,
+      "sampleCount": 12
+    }
+  ],
+  "alerts": []
+}

--- a/services/detection-engine/fixtures/proxy/queue-buildup.json
+++ b/services/detection-engine/fixtures/proxy/queue-buildup.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Cloud API alive but throttled: it still processes, slowly, so the queue climbs past the absoluteFloor of 50 while status stays OK. Derived from the same LABDEMO capture as cloud-api-dead, with Latency raised rather than the host disabled — this is what the FailurePercent/Latency triggers on LABDEMO.Operation.CloudAPI produce. Distinct from cloud-api-dead on purpose: that one stops at depth 48 and correctly does NOT trip queue_buildup.",
+  "sampledAt": "2026-08-06T15:46:02Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 300,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.01,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1800,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 1800,
+      "messagesPerSec": 1.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 3.9,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "OK",
+      "queued": 486,
+      "messages": 500,
+      "messagesPerSec": 0.1,
+      "messagesErrored": 37,
+      "avgProcessingTime": 2.4,
+      "avgQueueingTime": 1.84,
+      "lastActivityElapsedSeconds": 2.1,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": []
+}

--- a/services/detection-engine/fixtures/proxy/stalled-host.json
+++ b/services/detection-engine/fixtures/proxy/stalled-host.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Lab Router hung: status still OK and the host is enabled, but nothing has moved for over 6 minutes while 27 messages sit queued. This is the case dead_host cannot catch -- IRIS reports the host as fine, so only the last-activity-versus-queue combination reveals it. Reproduced on LABDEMO by suspending the Lab Router job while EMR Source kept feeding it. Requires lastActivityElapsedSeconds > stalled_host.inactiveSeconds (300) AND queued > 0; an idle host with an empty queue is healthy and must not fire.",
+  "sampledAt": "2026-08-06T15:52:40Z",
+  "production": "LABDEMO.Production",
+  "hosts": [
+    {
+      "name": "EMR Source",
+      "type": "service",
+      "status": "OK",
+      "queued": 0,
+      "messages": 420,
+      "messagesPerSec": 0.2,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 4.1,
+      "sampleCount": 12
+    },
+    {
+      "name": "Lab Router",
+      "type": "actor",
+      "status": "OK",
+      "queued": 27,
+      "messages": 2400,
+      "messagesPerSec": 0,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0.9,
+      "lastActivityElapsedSeconds": 384,
+      "sampleCount": 24
+    },
+    {
+      "name": "FHIR Transform",
+      "type": "actor",
+      "status": "OK",
+      "queued": 0,
+      "messages": 2400,
+      "messagesPerSec": 0,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivityElapsedSeconds": 381,
+      "sampleCount": 24
+    },
+    {
+      "name": "Cloud API",
+      "type": "operation",
+      "status": "OK",
+      "queued": 0,
+      "messages": 800,
+      "messagesPerSec": 0,
+      "messagesErrored": 0,
+      "avgProcessingTime": 0.05,
+      "avgQueueingTime": 0.02,
+      "lastActivityElapsedSeconds": 379,
+      "sampleCount": 24
+    }
+  ],
+  "alerts": []
+}

--- a/services/detection-engine/package-lock.json
+++ b/services/detection-engine/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@production-guardian/detection-engine",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@production-guardian/detection-engine",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/services/detection-engine/package.json
+++ b/services/detection-engine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@production-guardian/detection-engine",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Health Scan detection engine and findings API (Dev B)",
+  "type": "module",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "dev": "node --watch src/index.ts",
+    "start": "node src/index.ts",
+    "test": "node --test test/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -1,0 +1,104 @@
+/**
+ * Findings API — the two endpoints Dev C consumes, on :3002.
+ *
+ * Behaviour is fixed by §3 of contracts/healthscan-api.md:
+ *   - zero findings -> 200 + [], NEVER 404
+ *   - X-Healthscan-State: ok | warming | stale (advisory)
+ *   - Access-Control-Allow-Origin: * always (contract Q9)
+ *   - findings sorted detectedAt desc; hosts sorted by name
+ *
+ * Prefer stale-but-labelled over an error: a blanked dashboard is worse on stage than
+ * slightly old data.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { EngineSnapshot } from '../detect/engine.ts';
+
+export interface ServerOptions {
+  port: number;
+  /** Reads the engine's current state. Called per request, never cached. */
+  snapshot: () => EngineSnapshot;
+  log?: (msg: string) => void;
+}
+
+export function createFindingsServer(options: ServerOptions): Server {
+  const log = options.log ?? console.error;
+
+  return createServer((req: IncomingMessage, res: ServerResponse) => {
+    // Only the two documented GETs exist. No trailing-slash variants, no HEAD games.
+    const url = new URL(req.url ?? '/', `http://localhost:${options.port}`);
+    const path = url.pathname.replace(/\/+$/, '') || '/';
+
+    if (req.method === 'OPTIONS') {
+      // Preflight, in case Dev C points at us without the Vite proxy.
+      writeHead(res, 204, 'ok');
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'GET') {
+      sendJson(res, 405, { error: `method ${req.method} not allowed` }, 'ok');
+      return;
+    }
+
+    try {
+      const snapshot = options.snapshot();
+
+      switch (path) {
+        case '/api/healthscan/hosts':
+          sendJson(res, 200, snapshot.hosts, snapshot.state);
+          return;
+        case '/api/healthscan/findings':
+          sendJson(res, 200, snapshot.findings, snapshot.state);
+          return;
+        case '/api/healthscan/health':
+          // Not in the contract — operational only, for "is the engine up".
+          sendJson(
+            res,
+            200,
+            {
+              state: snapshot.state,
+              hosts: snapshot.hosts.length,
+              findings: snapshot.findings.length,
+              lastPollAt:
+                snapshot.lastPollAt === null ? null : new Date(snapshot.lastPollAt).toISOString(),
+            },
+            snapshot.state,
+          );
+          return;
+        default:
+          sendJson(res, 404, { error: `no such endpoint: ${path}` }, snapshot.state);
+          return;
+      }
+    } catch (err) {
+      // A genuine fault is the one case that gets a 5xx (contract §3).
+      const message = err instanceof Error ? err.message : String(err);
+      log(`request failed for ${path}: ${message}`);
+      sendJson(res, 500, { error: message }, 'stale');
+    }
+  });
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  state: string,
+): void {
+  const payload = JSON.stringify(body);
+  writeHead(res, status, state, Buffer.byteLength(payload));
+  res.end(payload);
+}
+
+function writeHead(res: ServerResponse, status: number, state: string, length?: number): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    // Contract Q9: sent unconditionally, so the dev proxy is optional not required.
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'X-Healthscan-State': state,
+    // Findings change every poll; a cached response would defeat the 10s bar.
+    'Cache-Control': 'no-store',
+    ...(length === undefined ? {} : { 'Content-Length': String(length) }),
+  });
+}

--- a/services/detection-engine/src/baseline/window.ts
+++ b/services/detection-engine/src/baseline/window.ts
@@ -1,0 +1,157 @@
+/**
+ * Rolling baseline — ADR 0002.
+ *
+ * A trailing time window of samples per (host, metric), held in memory. Nothing is
+ * persisted, so an engine restart means a fresh warm-up.
+ *
+ * Warm-up is explicit: below minSamples a metric has NO baseline and `mean()` returns
+ * null. Callers must not substitute a guess — a seeded baseline manufactures false
+ * findings in the first seconds, which is exactly what MVP §6 warns against.
+ */
+
+/** The metrics we baseline. Absolute rules (dead_host, system_alert) need none. */
+export type MetricName =
+  | 'queued'
+  | 'messagesPerSec'
+  | 'errorsPerMinute'
+  | 'avgProcessingTime'
+  | 'avgQueueingTime';
+
+interface Sample {
+  /** Epoch milliseconds. Passed in, never read from the clock here. */
+  at: number;
+  value: number;
+}
+
+/**
+ * Samples for one host+metric pair, pruned to the trailing window.
+ *
+ * Implemented as a plain array rather than a fixed ring buffer because the window is
+ * defined by *time*, not sample count — a proxy that misses polls would otherwise
+ * leave stale entries in fixed slots.
+ */
+class MetricWindow {
+  #samples: Sample[] = [];
+
+  readonly #windowMs: number;
+  readonly #minSamples: number;
+
+  constructor(windowMs: number, minSamples: number) {
+    this.#windowMs = windowMs;
+    this.#minSamples = minSamples;
+  }
+
+  add(at: number, value: number): void {
+    if (!Number.isFinite(value)) return;
+    this.#samples.push({ at, value });
+    this.#prune(at);
+  }
+
+  /** Mean over the window, or null while warming up. */
+  mean(): number | null {
+    if (this.#samples.length < this.#minSamples) return null;
+    let total = 0;
+    for (const sample of this.#samples) total += sample.value;
+    return total / this.#samples.length;
+  }
+
+  get sampleCount(): number {
+    return this.#samples.length;
+  }
+
+  /** Most recent value, or null if empty. Used for rate-of-change comparisons. */
+  latest(): number | null {
+    const last = this.#samples.at(-1);
+    return last === undefined ? null : last.value;
+  }
+
+  /** Value immediately before the latest, or null. */
+  previous(): number | null {
+    const prior = this.#samples.at(-2);
+    return prior === undefined ? null : prior.value;
+  }
+
+  #prune(now: number): void {
+    const cutoff = now - this.#windowMs;
+    // Samples arrive in time order, so drop from the front until inside the window.
+    let firstKept = 0;
+    while (firstKept < this.#samples.length) {
+      const sample = this.#samples[firstKept];
+      if (sample === undefined || sample.at >= cutoff) break;
+      firstKept += 1;
+    }
+    if (firstKept > 0) this.#samples = this.#samples.slice(firstKept);
+  }
+}
+
+/**
+ * Key separator. Host names legitimately contain spaces ("Lab Router"), so the
+ * separator must be a character they cannot contain — otherwise forget()'s prefix
+ * match could delete another host's windows.
+ */
+const SEP = '\u0000';
+
+/** Baseline state for every host and metric the engine has seen. */
+export class BaselineStore {
+  readonly #windows = new Map<string, MetricWindow>();
+
+  readonly #windowSeconds: number;
+  readonly #minSamples: number;
+
+  constructor(windowSeconds: number, minSamples: number) {
+    this.#windowSeconds = windowSeconds;
+    this.#minSamples = minSamples;
+  }
+
+  /** Record one metric observation. `at` is epoch ms, passed in for testability. */
+  record(host: string, metric: MetricName, value: number, at: number): void {
+    this.#windowFor(host, metric).add(at, value);
+  }
+
+  /** Rolling mean for a host+metric, or null while warming up. */
+  baseline(host: string, metric: MetricName): number | null {
+    return this.#windows.get(key(host, metric))?.mean() ?? null;
+  }
+
+  sampleCount(host: string, metric: MetricName): number {
+    return this.#windows.get(key(host, metric))?.sampleCount ?? 0;
+  }
+
+  latest(host: string, metric: MetricName): number | null {
+    return this.#windows.get(key(host, metric))?.latest() ?? null;
+  }
+
+  previous(host: string, metric: MetricName): number | null {
+    return this.#windows.get(key(host, metric))?.previous() ?? null;
+  }
+
+  /**
+   * True once every baselined metric for this host has enough samples.
+   * Drives the `warming` engine state.
+   */
+  isWarm(host: string, metrics: readonly MetricName[]): boolean {
+    return metrics.every((metric) => this.baseline(host, metric) !== null);
+  }
+
+  /** Drop a host's state, e.g. when it disappears from the production. */
+  forget(host: string): void {
+    const prefix = `${host}${SEP}`;
+    for (const existing of [...this.#windows.keys()]) {
+      if (existing.startsWith(prefix)) this.#windows.delete(existing);
+    }
+  }
+
+  #windowFor(host: string, metric: MetricName): MetricWindow {
+    const id = key(host, metric);
+    let window = this.#windows.get(id);
+    if (window === undefined) {
+      window = new MetricWindow(this.#windowSeconds * 1000, this.#minSamples);
+      this.#windows.set(id, window);
+    }
+    return window;
+  }
+}
+
+function key(host: string, metric: MetricName): string {
+  return `${host}${SEP}${metric}`;
+}

--- a/services/detection-engine/src/config/thresholds.ts
+++ b/services/detection-engine/src/config/thresholds.ts
@@ -1,0 +1,317 @@
+/**
+ * Threshold configuration — ADR 0003.
+ *
+ * Loads thresholds.json, validates it, and hot-reloads on change. On a malformed
+ * file it keeps the last-good values and logs loudly. It never falls back to zeros,
+ * which would make every rule fire at once.
+ */
+
+import { readFileSync, watch } from 'node:fs';
+import type { Severity } from '../types/healthscan.ts';
+
+export interface DeadHostConfig {
+  enabled: boolean;
+  severity: Severity;
+}
+
+export interface StalledHostConfig {
+  enabled: boolean;
+  inactiveSeconds: number;
+  /** Idle alone is not stalled — a quiet host with an empty queue is healthy. */
+  requiresQueued: boolean;
+  severity: Severity;
+}
+
+export interface QueueBuildupConfig {
+  enabled: boolean;
+  baselineMultiplier: number;
+  /** Must exceed the multiplier AND this floor. 1 -> 5 is 5x but not a problem. */
+  absoluteFloor: number;
+  severityBands: { warning: number; critical: number };
+}
+
+export interface ErrorRateConfig {
+  enabled: boolean;
+  errorsPerMinuteFloor: number;
+  baselineMultiplier: number;
+  severityBands: { warning: number; critical: number };
+}
+
+/** Shared by slow_processing and growing_queue_wait — same shape, different metric. */
+export interface DurationRuleConfig {
+  enabled: boolean;
+  baselineMultiplier: number;
+  absoluteFloorSeconds: number;
+  severityBands: { warning: number; critical: number };
+}
+
+export interface ThroughputDropConfig {
+  enabled: boolean;
+  /** Fires below baseline * this. 0.4 means "less than 40% of normal". */
+  baselineFraction: number;
+  /** Below this absolute rate the baseline is too quiet to judge a drop against. */
+  minBaselineRate: number;
+  severityBands: { warning: number; critical: number };
+}
+
+export interface SystemAlertConfig {
+  enabled: boolean;
+  severity: Severity;
+  /** IRIS alert severity is numeric and inverted — lower means worse. */
+  criticalSeverityAtOrBelow: number;
+}
+
+export interface RuleConfigs {
+  dead_host: DeadHostConfig;
+  stalled_host: StalledHostConfig;
+  queue_buildup: QueueBuildupConfig;
+  elevated_error_rate: ErrorRateConfig;
+  slow_processing: DurationRuleConfig;
+  growing_queue_wait: DurationRuleConfig;
+  throughput_drop: ThroughputDropConfig;
+  system_alert: SystemAlertConfig;
+}
+
+export interface ThresholdConfig {
+  /** MVP §6: consecutive breaching samples required before emitting. */
+  sustainedSamples: number;
+  /** ADR 0002: samples needed before a baseline is usable. */
+  minBaselineSamples: number;
+  baselineWindowSeconds: number;
+  rules: RuleConfigs;
+  /** Per-host partial overrides, merged over the rule defaults. */
+  hostOverrides: Record<string, Partial<Record<keyof RuleConfigs, unknown>>>;
+}
+
+export const DEFAULT_CONFIG: ThresholdConfig = {
+  sustainedSamples: 2,
+  minBaselineSamples: 12,
+  baselineWindowSeconds: 1800,
+  rules: {
+    dead_host: { enabled: true, severity: 'critical' },
+    stalled_host: {
+      enabled: true,
+      inactiveSeconds: 300,
+      requiresQueued: true,
+      severity: 'warning',
+    },
+    queue_buildup: {
+      enabled: true,
+      baselineMultiplier: 5.0,
+      absoluteFloor: 50,
+      severityBands: { warning: 5.0, critical: 20.0 },
+    },
+    elevated_error_rate: {
+      enabled: true,
+      errorsPerMinuteFloor: 1.0,
+      baselineMultiplier: 3.0,
+      severityBands: { warning: 3.0, critical: 10.0 },
+    },
+    slow_processing: {
+      enabled: true,
+      baselineMultiplier: 3.0,
+      absoluteFloorSeconds: 1.0,
+      severityBands: { warning: 3.0, critical: 10.0 },
+    },
+    growing_queue_wait: {
+      enabled: true,
+      baselineMultiplier: 3.0,
+      absoluteFloorSeconds: 1.0,
+      severityBands: { warning: 3.0, critical: 10.0 },
+    },
+    throughput_drop: {
+      enabled: true,
+      baselineFraction: 0.4,
+      minBaselineRate: 0.1,
+      severityBands: { warning: 0.4, critical: 0.1 },
+    },
+    system_alert: { enabled: true, severity: 'info', criticalSeverityAtOrBelow: 1 },
+  },
+  hostOverrides: {},
+};
+
+/** Thrown when a candidate config is unusable. The caller keeps the last-good values. */
+export class ConfigValidationError extends Error {
+  readonly problems: string[];
+
+  constructor(problems: string[]) {
+    super(`invalid threshold config: ${problems.join('; ')}`);
+    this.name = 'ConfigValidationError';
+    this.problems = problems;
+  }
+}
+
+/**
+ * Validate a parsed config and merge it over the defaults.
+ *
+ * Every numeric bound must be positive and finite. A zero multiplier would make a
+ * rule fire on every sample, which is the specific failure this guards against.
+ */
+export function validateConfig(raw: unknown): ThresholdConfig {
+  const problems: string[] = [];
+  if (typeof raw !== 'object' || raw === null) {
+    throw new ConfigValidationError(['not an object']);
+  }
+  const input = raw as Record<string, unknown>;
+
+  const merged: ThresholdConfig = structuredClone(DEFAULT_CONFIG);
+
+  for (const key of ['sustainedSamples', 'minBaselineSamples', 'baselineWindowSeconds'] as const) {
+    if (key in input) {
+      const value = input[key];
+      if (!isPositiveNumber(value)) {
+        problems.push(`${key} must be a positive number, got ${JSON.stringify(value)}`);
+      } else {
+        merged[key] = value;
+      }
+    }
+  }
+
+  const rawRules = input['rules'];
+  if (rawRules !== undefined) {
+    if (typeof rawRules !== 'object' || rawRules === null) {
+      problems.push('rules must be an object');
+    } else {
+      for (const [name, value] of Object.entries(rawRules as Record<string, unknown>)) {
+        if (name.startsWith('_')) continue;
+        if (!(name in merged.rules)) {
+          problems.push(`unknown rule "${name}"`);
+          continue;
+        }
+        if (typeof value !== 'object' || value === null) {
+          problems.push(`rules.${name} must be an object`);
+          continue;
+        }
+        const ruleKey = name as keyof RuleConfigs;
+        const ruleProblems = validateRuleNumbers(name, value as Record<string, unknown>);
+        problems.push(...ruleProblems);
+        if (ruleProblems.length === 0) {
+          // Shape is checked field-by-field above; the cast is the merge boundary.
+          Object.assign(merged.rules[ruleKey] as object, value);
+        }
+      }
+    }
+  }
+
+  const rawOverrides = input['hostOverrides'];
+  if (rawOverrides !== undefined) {
+    if (typeof rawOverrides !== 'object' || rawOverrides === null) {
+      problems.push('hostOverrides must be an object');
+    } else {
+      for (const [host, value] of Object.entries(rawOverrides as Record<string, unknown>)) {
+        if (host.startsWith('_')) continue;
+        if (typeof value !== 'object' || value === null) {
+          problems.push(`hostOverrides.${host} must be an object`);
+          continue;
+        }
+        merged.hostOverrides[host] = value as Partial<Record<keyof RuleConfigs, unknown>>;
+      }
+    }
+  }
+
+  if (problems.length > 0) throw new ConfigValidationError(problems);
+  return merged;
+}
+
+/** Every numeric field in a rule must be positive; booleans and severities pass through. */
+function validateRuleNumbers(ruleName: string, rule: Record<string, unknown>): string[] {
+  const problems: string[] = [];
+  for (const [field, value] of Object.entries(rule)) {
+    if (field.startsWith('_')) continue;
+    if (field === 'severityBands') {
+      if (typeof value !== 'object' || value === null) {
+        problems.push(`rules.${ruleName}.severityBands must be an object`);
+        continue;
+      }
+      for (const [band, bandValue] of Object.entries(value as Record<string, unknown>)) {
+        if (!isPositiveNumber(bandValue)) {
+          problems.push(`rules.${ruleName}.severityBands.${band} must be positive`);
+        }
+      }
+      continue;
+    }
+    if (typeof value === 'number' && !isPositiveNumber(value)) {
+      problems.push(
+        `rules.${ruleName}.${field} must be a positive finite number, got ${JSON.stringify(value)}`,
+      );
+    }
+  }
+  return problems;
+}
+
+function isPositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Resolve the effective config for one rule on one host, applying any override.
+ * Overrides are partial, so a host may adjust one bound and inherit the rest.
+ */
+export function configFor<K extends keyof RuleConfigs>(
+  config: ThresholdConfig,
+  rule: K,
+  host: string,
+): RuleConfigs[K] {
+  const override = config.hostOverrides[host]?.[rule];
+  if (override === undefined || typeof override !== 'object' || override === null) {
+    return config.rules[rule];
+  }
+  return { ...config.rules[rule], ...(override as object) } as RuleConfigs[K];
+}
+
+/**
+ * Live config holder. Reads once at construction, then re-reads on file change.
+ * A bad file is logged and ignored — `current` keeps the last good value.
+ */
+export class ThresholdStore {
+  #current: ThresholdConfig;
+  #watcher: ReturnType<typeof watch> | undefined;
+
+  readonly #path: string;
+  readonly #log: (msg: string) => void;
+
+  constructor(path: string, log: (msg: string) => void = console.error) {
+    this.#path = path;
+    this.#log = log;
+    this.#current = this.#read() ?? structuredClone(DEFAULT_CONFIG);
+  }
+
+  get current(): ThresholdConfig {
+    return this.#current;
+  }
+
+  /** Begin hot-reloading. Safe to skip in tests. */
+  watch(): void {
+    if (this.#watcher !== undefined) return;
+    try {
+      this.#watcher = watch(this.#path, () => {
+        const next = this.#read();
+        if (next !== undefined) {
+          this.#current = next;
+          this.#log(`thresholds reloaded: sustainedSamples=${next.sustainedSamples}`);
+        }
+      });
+    } catch (err) {
+      this.#log(`threshold hot-reload unavailable: ${errorMessage(err)}`);
+    }
+  }
+
+  close(): void {
+    this.#watcher?.close();
+    this.#watcher = undefined;
+  }
+
+  /** Returns undefined on any failure, so the caller keeps the previous config. */
+  #read(): ThresholdConfig | undefined {
+    try {
+      return validateConfig(JSON.parse(readFileSync(this.#path, 'utf8')));
+    } catch (err) {
+      this.#log(`threshold config rejected, keeping previous values: ${errorMessage(err)}`);
+      return undefined;
+    }
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/services/detection-engine/src/detect/engine.ts
+++ b/services/detection-engine/src/detect/engine.ts
@@ -175,9 +175,21 @@ export class DetectionEngine {
   }
 
   /**
-   * system_alert — absolute, and attributed to a host only when the alert text names
-   * it. Production-wide alerts are attributed to every host, which would be noise, so
-   * we attribute them to the first host alphabetically only if none is named.
+   * system_alert — attributed to a host only when the alert text names it.
+   *
+   * An alert is a discrete EVENT, not a sustained condition, so it is deliberately
+   * exempt from the sustained-breach gate. It reports for as long as the alert stays in
+   * the proxy's payload, and clears when the alert ages out.
+   *
+   * The earlier version marked an alert seen on its first poll and returned null
+   * afterwards, which made the rule structurally unable to fire at all: the registry
+   * needs `sustainedSamples` (2) consecutive verdicts to confirm, and this only ever
+   * produced one. Found via Dev C observing 46 live findings with no `system_alert`
+   * and no `info` severity among them (#8) — every rule unit test passed, because the
+   * conflict was between the rule and the registry rather than inside either.
+   *
+   * `#seenAlerts` still exists, but now only to keep `detectedAt` anchored to the first
+   * time we saw the alert rather than resetting each poll.
    */
   #evaluateAlerts(
     hostName: string,
@@ -189,9 +201,9 @@ export class DetectionEngine {
 
     for (const alert of alerts) {
       if (!alert.message.includes(hostName)) continue;
-      const alertKey = `${alert.time}|${hostName}`;
-      if (this.#seenAlerts.has(alertKey)) continue;
-      this.#seenAlerts.add(alertKey);
+
+      // Record first sighting, but do NOT suppress subsequent polls — see above.
+      this.#seenAlerts.add(`${alert.time}|${hostName}`);
 
       // IRIS alert severity is numeric and inverted: lower means worse.
       const numeric = Number(alert.severity);

--- a/services/detection-engine/src/detect/engine.ts
+++ b/services/detection-engine/src/detect/engine.ts
@@ -1,0 +1,245 @@
+/**
+ * The detection engine: turns proxy polls into hosts + findings.
+ *
+ * Responsibilities, in order:
+ *   1. Normalize the proxy's host shape into the published contract shape
+ *   2. Feed the rolling baseline
+ *   3. Run the rules, and hand verdicts to the registry
+ *   4. Expose current hosts and confirmed findings
+ */
+
+import { BaselineStore } from '../baseline/window.ts';
+import type { ThresholdConfig } from '../config/thresholds.ts';
+import { configFor } from '../config/thresholds.ts';
+import type {
+  Finding,
+  HealthScanState,
+  Host,
+  HostStatus,
+  Severity,
+} from '../types/healthscan.ts';
+import type { ProxyAlert, ProxyHost, ProxyResponse } from '../types/proxy.ts';
+import { isFrameworkHost } from '../types/proxy.ts';
+import { FindingRegistry } from './registry.ts';
+import { HOST_RULES } from './rules/index.ts';
+import type { RuleVerdict } from './rules/types.ts';
+
+/** Metrics that must be warm before a host counts as fully baselined. */
+const BASELINED_METRICS = [
+  'queued',
+  'messagesPerSec',
+  'errorsPerMinute',
+  'avgProcessingTime',
+  'avgQueueingTime',
+] as const;
+
+export interface EngineSnapshot {
+  hosts: Host[];
+  findings: Finding[];
+  state: HealthScanState;
+  /** When the engine last successfully applied a poll. null before the first. */
+  lastPollAt: number | null;
+}
+
+export class DetectionEngine {
+  #baselines: BaselineStore;
+  #registry: FindingRegistry;
+  #hosts = new Map<string, Host>();
+  /** Cumulative errored counts from the previous poll, for the per-minute rate. */
+  #priorErrored = new Map<string, { errored: number; at: number }>();
+  /** Alert timestamps already reported, so system_alert only fires on new ones. */
+  #seenAlerts = new Set<string>();
+  #lastPollAt: number | null = null;
+  #stale = false;
+
+  #config: ThresholdConfig;
+
+  constructor(config: ThresholdConfig) {
+    this.#config = config;
+    this.#baselines = new BaselineStore(config.baselineWindowSeconds, config.minBaselineSamples);
+    this.#registry = new FindingRegistry(config.sustainedSamples);
+  }
+
+  /**
+   * Replace the active config. Rebuilds baseline and registry state only when the
+   * structural parameters change, so a threshold tweak does not wipe warm baselines
+   * mid-demo — which is the whole point of hot-reload (ADR 0003).
+   */
+  reconfigure(next: ThresholdConfig): void {
+    const structural =
+      next.baselineWindowSeconds !== this.#config.baselineWindowSeconds ||
+      next.minBaselineSamples !== this.#config.minBaselineSamples ||
+      next.sustainedSamples !== this.#config.sustainedSamples;
+
+    this.#config = next;
+    if (structural) {
+      this.#baselines = new BaselineStore(next.baselineWindowSeconds, next.minBaselineSamples);
+      this.#registry = new FindingRegistry(next.sustainedSamples);
+      this.#priorErrored.clear();
+    }
+  }
+
+  /** Mark the last poll as failed. Serves last-known data labelled stale. */
+  markPollFailed(): void {
+    this.#stale = true;
+  }
+
+  /** Apply one proxy poll. `now` is epoch ms, passed in to keep this testable. */
+  applyPoll(response: ProxyResponse, now: number): void {
+    const seenHosts = new Set<string>();
+
+    for (const proxyHost of response.hosts) {
+      if (isFrameworkHost(proxyHost.name)) continue;
+
+      const host = normalizeHost(proxyHost, now);
+      seenHosts.add(host.host);
+      this.#hosts.set(host.host, host);
+
+      const errorsPerMinute = this.#errorsPerMinute(proxyHost, now);
+
+      this.#baselines.record(host.host, 'queued', host.queued, now);
+      this.#baselines.record(host.host, 'messagesPerSec', host.messagesPerSec, now);
+      this.#baselines.record(host.host, 'avgProcessingTime', host.avgProcessingTime, now);
+      this.#baselines.record(host.host, 'avgQueueingTime', host.avgQueueingTime, now);
+      if (errorsPerMinute !== null) {
+        this.#baselines.record(host.host, 'errorsPerMinute', errorsPerMinute, now);
+      }
+
+      const verdicts: RuleVerdict[] = [];
+      for (const rule of HOST_RULES) {
+        const verdict = rule.evaluate({
+          host,
+          errorsPerMinute,
+          baselines: this.#baselines,
+          config: this.#config,
+          now,
+        });
+        if (verdict !== null) verdicts.push(verdict);
+      }
+
+      const alertVerdict = this.#evaluateAlerts(host.host, response.alerts, now);
+      if (alertVerdict !== null) verdicts.push(alertVerdict);
+
+      this.#registry.update(host.host, verdicts, now);
+    }
+
+    // A host that left the production should not linger with stale findings.
+    for (const known of [...this.#hosts.keys()]) {
+      if (seenHosts.has(known)) continue;
+      this.#hosts.delete(known);
+      this.#registry.forget(known);
+      this.#baselines.forget(known);
+      this.#priorErrored.delete(known);
+    }
+
+    this.#lastPollAt = now;
+    this.#stale = false;
+  }
+
+  snapshot(): EngineSnapshot {
+    const hosts = [...this.#hosts.values()].sort((a, b) => a.host.localeCompare(b.host));
+    return {
+      hosts,
+      findings: this.#registry.findings(),
+      state: this.#state(hosts),
+      lastPollAt: this.#lastPollAt,
+    };
+  }
+
+  #state(hosts: readonly Host[]): HealthScanState {
+    if (this.#stale) return 'stale';
+    if (this.#lastPollAt === null) return 'warming';
+    const allWarm = hosts.every((host) => this.#baselines.isWarm(host.host, BASELINED_METRICS));
+    return allWarm ? 'ok' : 'warming';
+  }
+
+  /**
+   * Convert the cumulative errored counter into a per-minute rate.
+   *
+   * Returns null on the first sample for a host — a cumulative counter tells you
+   * nothing about rate until you have two readings. A counter that goes backwards
+   * means the production restarted, so we reset rather than report a negative rate.
+   */
+  #errorsPerMinute(proxyHost: ProxyHost, now: number): number | null {
+    const prior = this.#priorErrored.get(proxyHost.name);
+    this.#priorErrored.set(proxyHost.name, { errored: proxyHost.messagesErrored, at: now });
+
+    if (prior === undefined) return null;
+    const elapsedMs = now - prior.at;
+    if (elapsedMs <= 0) return null;
+
+    const delta = proxyHost.messagesErrored - prior.errored;
+    if (delta < 0) return null;
+
+    return (delta / elapsedMs) * 60_000;
+  }
+
+  /**
+   * system_alert — absolute, and attributed to a host only when the alert text names
+   * it. Production-wide alerts are attributed to every host, which would be noise, so
+   * we attribute them to the first host alphabetically only if none is named.
+   */
+  #evaluateAlerts(
+    hostName: string,
+    alerts: readonly ProxyAlert[],
+    now: number,
+  ): RuleVerdict | null {
+    const rule = configFor(this.#config, 'system_alert', hostName);
+    if (!rule.enabled) return null;
+
+    for (const alert of alerts) {
+      if (!alert.message.includes(hostName)) continue;
+      const alertKey = `${alert.time}|${hostName}`;
+      if (this.#seenAlerts.has(alertKey)) continue;
+      this.#seenAlerts.add(alertKey);
+
+      // IRIS alert severity is numeric and inverted: lower means worse.
+      const numeric = Number(alert.severity);
+      const severity: Severity = Number.isFinite(numeric)
+        ? numeric <= rule.criticalSeverityAtOrBelow
+          ? 'critical'
+          : rule.severity
+        : rule.severity;
+
+      return {
+        type: 'system_alert',
+        severity,
+        currentValue: Number.isFinite(numeric) ? numeric : 0,
+        baselineValue: null,
+        message: `New system alert: ${alert.message}`,
+      };
+    }
+    return null;
+  }
+}
+
+/**
+ * Map the proxy's shape to the published contract shape.
+ *
+ * Two conversions the contract documents (Q10, Q11):
+ *   - IRIS calls business processes 'actor'; the contract says 'process'
+ *   - IRIS gives elapsed seconds; the contract wants an ISO timestamp
+ */
+export function normalizeHost(proxyHost: ProxyHost, now: number): Host {
+  return {
+    host: proxyHost.name,
+    type: normalizeHostType(proxyHost.type),
+    status: proxyHost.status as HostStatus,
+    queued: proxyHost.queued,
+    messagesPerSec: proxyHost.messagesPerSec,
+    errored: proxyHost.messagesErrored,
+    avgProcessingTime: proxyHost.avgProcessingTime,
+    avgQueueingTime: proxyHost.avgQueueingTime,
+    lastActivity: isoSeconds(now - proxyHost.lastActivityElapsedSeconds * 1000),
+  };
+}
+
+/** Contract Q10: IRIS 'actor' means a business process. */
+export function normalizeHostType(irisType: string): string {
+  return irisType === 'actor' ? 'process' : irisType;
+}
+
+/** The contract's timestamps are second-precision and Z-suffixed. */
+function isoSeconds(epochMs: number): string {
+  return new Date(epochMs).toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/services/detection-engine/src/detect/registry.ts
+++ b/services/detection-engine/src/detect/registry.ts
@@ -1,0 +1,139 @@
+/**
+ * Finding registry — stable ids and sustained-breach state.
+ *
+ * This is the mechanism behind two contract promises to Dev C (Q4):
+ *
+ *   1. `id` is STABLE for the lifetime of a condition, so their highlight animation
+ *      and detail drawer survive a poll.
+ *   2. Findings DISAPPEAR when the condition clears. No resolvedAt, no tombstones.
+ *
+ * And behind MVP §6's requirement that a rule breach on 2+ consecutive samples before
+ * emitting, so a single-sample spike produces nothing.
+ *
+ * State is keyed by (host, type) — one ongoing condition per rule per host.
+ */
+
+import type { Finding, FindingType } from '../types/healthscan.ts';
+import { SEVERITY_RANK } from '../types/healthscan.ts';
+import type { RuleVerdict } from './rules/types.ts';
+
+interface TrackedCondition {
+  id: string;
+  /** Consecutive breaching samples. Emits once this reaches sustainedSamples. */
+  consecutiveBreaches: number;
+  /** When the condition was first CONFIRMED (i.e. became a finding), not first seen. */
+  confirmedAt: number | undefined;
+  /** Latest verdict, refreshed each poll so values stay current. */
+  verdict: RuleVerdict;
+}
+
+export class FindingRegistry {
+  readonly #conditions = new Map<string, TrackedCondition>();
+  #nextId = 1000;
+
+  readonly #sustainedSamples: number;
+
+  constructor(sustainedSamples: number) {
+    this.#sustainedSamples = sustainedSamples;
+  }
+
+  /**
+   * Apply one poll's verdicts for one host.
+   *
+   * `verdicts` must contain an entry for every rule that breached, and omit those that
+   * did not — omission is what clears a condition. Rules that returned null are
+   * absent, so we reset their counters.
+   */
+  update(host: string, verdicts: readonly RuleVerdict[], now: number): void {
+    const breaching = new Set(verdicts.map((v) => v.type));
+
+    for (const verdict of verdicts) {
+      const key = conditionKey(host, verdict.type);
+      const existing = this.#conditions.get(key);
+
+      if (existing === undefined) {
+        this.#conditions.set(key, {
+          id: `f-${this.#nextId++}`,
+          consecutiveBreaches: 1,
+          confirmedAt: this.#sustainedSamples <= 1 ? now : undefined,
+          verdict,
+        });
+        continue;
+      }
+
+      existing.consecutiveBreaches += 1;
+      // Refresh values so the finding shows current numbers, but never touch the id.
+      existing.verdict = verdict;
+      if (
+        existing.confirmedAt === undefined &&
+        existing.consecutiveBreaches >= this.#sustainedSamples
+      ) {
+        existing.confirmedAt = now;
+      }
+    }
+
+    // Anything tracked for this host that did NOT breach this poll is cleared outright.
+    // Resetting rather than decaying is deliberate: MVP §6 says *consecutive* samples.
+    for (const [key, condition] of [...this.#conditions]) {
+      if (!key.startsWith(`${host}${SEP}`)) continue;
+      if (breaching.has(condition.verdict.type)) continue;
+      this.#conditions.delete(key);
+    }
+  }
+
+  /** Drop all conditions for a host, e.g. when it leaves the production. */
+  forget(host: string): void {
+    const prefix = `${host}${SEP}`;
+    for (const key of [...this.#conditions.keys()]) {
+      if (key.startsWith(prefix)) this.#conditions.delete(key);
+    }
+  }
+
+  /**
+   * Confirmed findings only — conditions that have met the sustained-breach bar.
+   * Sorted detectedAt desc with severity as tiebreak, per contract §2.
+   */
+  findings(): Finding[] {
+    const confirmed: Finding[] = [];
+    for (const [key, condition] of this.#conditions) {
+      if (condition.confirmedAt === undefined) continue;
+      confirmed.push({
+        id: condition.id,
+        host: hostFromKey(key),
+        type: condition.verdict.type,
+        severity: condition.verdict.severity,
+        currentValue: condition.verdict.currentValue,
+        baselineValue: condition.verdict.baselineValue,
+        detectedAt: new Date(condition.confirmedAt).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        message: condition.verdict.message,
+      });
+    }
+    return confirmed.sort(compareFindings);
+  }
+
+  /** Conditions being tracked but not yet confirmed. Diagnostics only. */
+  get pendingCount(): number {
+    let pending = 0;
+    for (const condition of this.#conditions.values()) {
+      if (condition.confirmedAt === undefined) pending += 1;
+    }
+    return pending;
+  }
+}
+
+const SEP = '\u0000';
+
+function conditionKey(host: string, type: FindingType): string {
+  return `${host}${SEP}${type}`;
+}
+
+function hostFromKey(key: string): string {
+  const [host = ''] = key.split(SEP);
+  return host;
+}
+
+/** detectedAt desc, then severity (critical first). Matches contract §2. */
+function compareFindings(a: Finding, b: Finding): number {
+  if (a.detectedAt !== b.detectedAt) return a.detectedAt < b.detectedAt ? 1 : -1;
+  return SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+}

--- a/services/detection-engine/src/detect/rules/index.ts
+++ b/services/detection-engine/src/detect/rules/index.ts
@@ -1,0 +1,228 @@
+/**
+ * The eight detection rules — MVP §1.3.
+ *
+ * Two are absolute (dead_host, system_alert): they fire without a baseline.
+ * Six are comparative: they stay silent until the baseline is warm (ADR 0002).
+ *
+ * Every rule is a pure function. Thresholds come from config, never from literals
+ * here (ADR 0003).
+ */
+
+import { configFor } from '../../config/thresholds.ts';
+import { DEAD_STATUSES } from '../../types/healthscan.ts';
+import type { Rule, RuleInput, RuleVerdict } from './types.ts';
+import {
+  formatDuration,
+  formatRatio,
+  severityFromFraction,
+  severityFromRatio,
+} from './types.ts';
+
+/**
+ * dead_host — absolute. The host is not doing work.
+ *
+ * 'Retry' is excluded from DEAD_STATUSES on purpose: a retrying host is degraded but
+ * alive, and calling it dead would be wrong.
+ */
+const deadHost: Rule = {
+  type: 'dead_host',
+  absolute: true,
+  evaluate({ host, config }: RuleInput): RuleVerdict | null {
+    const rule = configFor(config, 'dead_host', host.host);
+    if (!rule.enabled) return null;
+    if (!DEAD_STATUSES.includes(host.status)) return null;
+
+    const queueNote = host.queued > 0 ? ` with ${host.queued} message(s) queued` : '';
+    return {
+      type: 'dead_host',
+      severity: rule.severity,
+      currentValue: 0,
+      baselineValue: null,
+      message: `${host.host} is ${host.status}${queueNote}`,
+    };
+  },
+};
+
+/**
+ * stalled_host — the host is nominally OK but has stopped moving messages.
+ *
+ * Absolute in the sense that it needs no baseline, but it is NOT in the absolute set:
+ * it requires a queue, so it cannot fire on a legitimately idle host.
+ */
+const stalledHost: Rule = {
+  type: 'stalled_host',
+  absolute: true,
+  evaluate({ host, config, now }: RuleInput): RuleVerdict | null {
+    const rule = configFor(config, 'stalled_host', host.host);
+    if (!rule.enabled) return null;
+
+    // A dead host is reported as dead, not stalled — one condition, one finding.
+    if (DEAD_STATUSES.includes(host.status)) return null;
+    if (rule.requiresQueued && host.queued <= 0) return null;
+
+    const idleSeconds = (now - Date.parse(host.lastActivity)) / 1000;
+    if (!Number.isFinite(idleSeconds) || idleSeconds < rule.inactiveSeconds) return null;
+
+    return {
+      type: 'stalled_host',
+      severity: rule.severity,
+      currentValue: Math.round(idleSeconds),
+      baselineValue: null,
+      message:
+        `No activity for ${Math.round(idleSeconds)}s while ${host.queued} message(s) are queued`,
+    };
+  },
+};
+
+/**
+ * queue_buildup — comparative. Needs BOTH the multiplier and the absolute floor,
+ * because 1 -> 5 is 5x baseline and not a problem (ADR 0003).
+ */
+const queueBuildup: Rule = {
+  type: 'queue_buildup',
+  absolute: false,
+  evaluate({ host, baselines, config }: RuleInput): RuleVerdict | null {
+    const rule = configFor(config, 'queue_buildup', host.host);
+    if (!rule.enabled) return null;
+
+    const baseline = baselines.baseline(host.host, 'queued');
+    if (baseline === null) return null;
+    if (host.queued < rule.absoluteFloor) return null;
+
+    // A zero baseline makes any ratio infinite, so treat the floor as the whole test.
+    const ratio = baseline > 0 ? host.queued / baseline : Number.POSITIVE_INFINITY;
+    if (ratio < rule.baselineMultiplier) return null;
+
+    const severity = Number.isFinite(ratio)
+      ? severityFromRatio(ratio, rule.severityBands)
+      : 'critical';
+    const comparison = Number.isFinite(ratio)
+      ? `is ${formatRatio(ratio)} baseline`
+      : 'with no baseline queue';
+
+    return {
+      type: 'queue_buildup',
+      severity,
+      currentValue: host.queued,
+      baselineValue: baseline,
+      message: `Queue depth ${host.queued} ${comparison}`,
+    };
+  },
+};
+
+/**
+ * elevated_error_rate — comparative on errors-per-minute rather than the cumulative
+ * counter, because the counter only ever rises and would flag forever once it moved.
+ */
+const elevatedErrorRate: Rule = {
+  type: 'elevated_error_rate',
+  absolute: false,
+  evaluate({ host, errorsPerMinute, baselines, config }: RuleInput): RuleVerdict | null {
+    const rule = configFor(config, 'elevated_error_rate', host.host);
+    if (!rule.enabled) return null;
+    if (errorsPerMinute === null) return null;
+    if (errorsPerMinute < rule.errorsPerMinuteFloor) return null;
+
+    const baseline = baselines.baseline(host.host, 'errorsPerMinute');
+    if (baseline === null) return null;
+
+    const ratio = baseline > 0 ? errorsPerMinute / baseline : Number.POSITIVE_INFINITY;
+    if (ratio < rule.baselineMultiplier) return null;
+
+    const severity = Number.isFinite(ratio)
+      ? severityFromRatio(ratio, rule.severityBands)
+      : 'critical';
+    const rate = errorsPerMinute.toFixed(1);
+    const comparison = Number.isFinite(ratio)
+      ? `, ${formatRatio(ratio)} baseline`
+      : ' against a clean baseline';
+
+    return {
+      type: 'elevated_error_rate',
+      severity,
+      currentValue: Number(rate),
+      baselineValue: baseline,
+      message: `${rate} errors/min${comparison}`,
+    };
+  },
+};
+
+/** slow_processing and growing_queue_wait share shape — one factory, two metrics. */
+function durationRule(
+  type: 'slow_processing' | 'growing_queue_wait',
+  metric: 'avgProcessingTime' | 'avgQueueingTime',
+  label: string,
+): Rule {
+  return {
+    type,
+    absolute: false,
+    evaluate({ host, baselines, config }: RuleInput): RuleVerdict | null {
+      const rule = configFor(config, type, host.host);
+      if (!rule.enabled) return null;
+
+      const current = host[metric];
+      const baseline = baselines.baseline(host.host, metric);
+      if (baseline === null) return null;
+      if (current < rule.absoluteFloorSeconds) return null;
+
+      const ratio = baseline > 0 ? current / baseline : Number.POSITIVE_INFINITY;
+      if (ratio < rule.baselineMultiplier) return null;
+
+      const severity = Number.isFinite(ratio)
+        ? severityFromRatio(ratio, rule.severityBands)
+        : 'critical';
+      const comparison = Number.isFinite(ratio) ? ` is ${formatRatio(ratio)} baseline` : '';
+
+      return {
+        type,
+        severity,
+        currentValue: current,
+        baselineValue: baseline,
+        message: `${label} ${formatDuration(current)}${comparison}`,
+      };
+    },
+  };
+}
+
+/**
+ * throughput_drop — inverted: LOWER is worse.
+ *
+ * `minBaselineRate` guards the degenerate case. A host whose normal rate is 0.05/sec
+ * is too quiet to judge a "drop" against, and would otherwise flag constantly.
+ */
+const throughputDrop: Rule = {
+  type: 'throughput_drop',
+  absolute: false,
+  evaluate({ host, baselines, config }: RuleInput): RuleVerdict | null {
+    const rule = configFor(config, 'throughput_drop', host.host);
+    if (!rule.enabled) return null;
+
+    const baseline = baselines.baseline(host.host, 'messagesPerSec');
+    if (baseline === null) return null;
+    if (baseline < rule.minBaselineRate) return null;
+
+    const fraction = host.messagesPerSec / baseline;
+    if (fraction > rule.baselineFraction) return null;
+
+    const percentBelow = Math.round((1 - fraction) * 100);
+    return {
+      type: 'throughput_drop',
+      severity: severityFromFraction(fraction, rule.severityBands),
+      currentValue: host.messagesPerSec,
+      baselineValue: baseline,
+      message:
+        `Throughput ${host.messagesPerSec.toFixed(1)} msg/sec is ${percentBelow}% below baseline`,
+    };
+  },
+};
+
+/** The seven per-host rules, in the order MVP §1.3 lists them. */
+export const HOST_RULES: readonly Rule[] = [
+  deadHost,
+  stalledHost,
+  queueBuildup,
+  elevatedErrorRate,
+  durationRule('slow_processing', 'avgProcessingTime', 'Average processing time'),
+  durationRule('growing_queue_wait', 'avgQueueingTime', 'Average queue wait'),
+  throughputDrop,
+] as const;

--- a/services/detection-engine/src/detect/rules/types.ts
+++ b/services/detection-engine/src/detect/rules/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Rule contract.
+ *
+ * A rule is a PURE function of (sample, baseline, config). No I/O, no clock reads —
+ * time is passed in. That is what makes all eight testable against fixtures with
+ * neither IRIS nor a proxy running.
+ */
+
+import type { BaselineStore } from '../../baseline/window.ts';
+import type { ThresholdConfig } from '../../config/thresholds.ts';
+import type { FindingType, Host, Severity } from '../../types/healthscan.ts';
+import type { ProxyAlert } from '../../types/proxy.ts';
+
+/** What a rule sees for one host on one poll. */
+export interface RuleInput {
+  /** The host as it will appear in the API, already normalized. */
+  host: Host;
+  /** Errors observed per minute, derived from the cumulative counter across samples. */
+  errorsPerMinute: number | null;
+  baselines: BaselineStore;
+  config: ThresholdConfig;
+  /** Poll time, epoch ms. Passed in so rules stay pure. */
+  now: number;
+}
+
+/**
+ * A rule's verdict for one host. `null` means "not breaching" — which is as
+ * important as breaching, because it is what clears an existing finding.
+ */
+export interface RuleVerdict {
+  type: FindingType;
+  severity: Severity;
+  currentValue: number;
+  /** null while the baseline is warming up. Absolute rules report null too. */
+  baselineValue: number | null;
+  /** Authoritative text. Must state the actual numbers — Dev C renders it verbatim. */
+  message: string;
+}
+
+export interface Rule {
+  readonly type: FindingType;
+  /** True when this rule needs no baseline. Only dead_host and system_alert. */
+  readonly absolute: boolean;
+  evaluate(input: RuleInput): RuleVerdict | null;
+}
+
+/** Alert-driven rules see the production's alerts rather than a single host. */
+export interface AlertRuleInput {
+  alerts: readonly ProxyAlert[];
+  /** Alert timestamps already reported, so only new ones fire. */
+  seen: ReadonlySet<string>;
+  config: ThresholdConfig;
+  now: number;
+}
+
+/** Pick a severity from ratio bands. Higher ratio is worse. */
+export function severityFromRatio(
+  ratio: number,
+  bands: { warning: number; critical: number },
+): Severity {
+  if (ratio >= bands.critical) return 'critical';
+  if (ratio >= bands.warning) return 'warning';
+  return 'info';
+}
+
+/** Pick a severity where a LOWER value is worse, e.g. throughput as a fraction. */
+export function severityFromFraction(
+  fraction: number,
+  bands: { warning: number; critical: number },
+): Severity {
+  if (fraction <= bands.critical) return 'critical';
+  if (fraction <= bands.warning) return 'warning';
+  return 'info';
+}
+
+/** Format a ratio the way the contract's sample messages do: "32x", "5.1x". */
+export function formatRatio(ratio: number): string {
+  return ratio >= 10 ? `${Math.round(ratio)}x` : `${ratio.toFixed(1)}x`;
+}
+
+/** Sub-second durations read better as milliseconds, matching the dashboard. */
+export function formatDuration(seconds: number): string {
+  return seconds < 1 ? `${Math.round(seconds * 1000)}ms` : `${seconds.toFixed(2)}s`;
+}

--- a/services/detection-engine/src/index.ts
+++ b/services/detection-engine/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Entry point: wires the poll loop to the HTTP server.
+ *
+ * Defaults to the MOCK proxy client (ADR 0004) — the engine must start and serve with
+ * Dev A's proxy absent. Point it at the real proxy with PROXY_MODE=live.
+ *
+ *   PROXY_MODE=mock|live   default mock
+ *   PROXY_BASE_URL         default http://localhost:3001
+ *   PORT                   default 3002
+ *   POLL_INTERVAL_MS       default 10000 (matches the proxy's IRIS poll)
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createFindingsServer } from './api/server.ts';
+import { ThresholdStore } from './config/thresholds.ts';
+import { DetectionEngine } from './detect/engine.ts';
+import { HttpProxyClient } from './proxy/client.ts';
+import { MockProxyClient } from './proxy/mockClient.ts';
+import type { ProxyClient } from './types/proxy.ts';
+
+const serviceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const PORT = Number(process.env['PORT'] ?? 3002);
+const POLL_INTERVAL_MS = Number(process.env['POLL_INTERVAL_MS'] ?? 10_000);
+const PROXY_MODE = process.env['PROXY_MODE'] ?? 'mock';
+const PROXY_BASE_URL = process.env['PROXY_BASE_URL'] ?? 'http://localhost:3001';
+
+const thresholds = new ThresholdStore(resolve(serviceRoot, 'thresholds.json'));
+thresholds.watch();
+
+const engine = new DetectionEngine(thresholds.current);
+
+const proxy: ProxyClient =
+  PROXY_MODE === 'live'
+    ? new HttpProxyClient(PROXY_BASE_URL)
+    : new MockProxyClient(resolve(serviceRoot, 'fixtures/proxy'));
+
+let inFlight: AbortController | undefined;
+
+async function poll(): Promise<void> {
+  // Never let two polls overlap; abort the previous rather than queue behind it.
+  inFlight?.abort();
+  const controller = new AbortController();
+  inFlight = controller;
+
+  try {
+    engine.reconfigure(thresholds.current);
+    const response = await proxy.fetchMetrics(controller.signal);
+    engine.applyPoll(response, Date.now());
+  } catch (err) {
+    if (controller.signal.aborted) return;
+    // Degrade, never blank: keep serving last-known data labelled stale.
+    engine.markPollFailed();
+    console.error(`poll failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+const server = createFindingsServer({ port: PORT, snapshot: () => engine.snapshot() });
+
+server.listen(PORT, () => {
+  console.error(
+    `detection-engine listening on :${PORT} (proxy=${PROXY_MODE}` +
+      `${PROXY_MODE === 'live' ? ` ${PROXY_BASE_URL}` : ''}, poll=${POLL_INTERVAL_MS}ms)`,
+  );
+});
+
+void poll();
+const timer = setInterval(() => void poll(), POLL_INTERVAL_MS);
+
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, () => {
+    clearInterval(timer);
+    inFlight?.abort();
+    thresholds.close();
+    server.close(() => process.exit(0));
+  });
+}

--- a/services/detection-engine/src/proxy/client.ts
+++ b/services/detection-engine/src/proxy/client.ts
@@ -1,0 +1,55 @@
+/**
+ * HTTP client for Dev A's metrics proxy (:3001).
+ *
+ * Validates at the process boundary and log-and-skips malformed hosts rather than
+ * rejecting a whole payload — one bad entry should not blind us to the other three.
+ */
+
+import type { ProxyClient, ProxyResponse } from '../types/proxy.ts';
+import { isProxyAlert, isProxyHost } from '../types/proxy.ts';
+
+export class HttpProxyClient implements ProxyClient {
+  readonly #baseUrl: string;
+  readonly #log: (msg: string) => void;
+
+  constructor(baseUrl: string, log: (msg: string) => void = console.error) {
+    this.#baseUrl = baseUrl;
+    this.#log = log;
+  }
+
+  async fetchMetrics(signal?: AbortSignal): Promise<ProxyResponse> {
+    const url = `${this.#baseUrl.replace(/\/$/, '')}/api/metrics`;
+    const response = await fetch(url, signal === undefined ? {} : { signal });
+    if (!response.ok) {
+      throw new Error(`proxy returned HTTP ${response.status} for ${url}`);
+    }
+    return this.#parse(await response.json());
+  }
+
+  #parse(payload: unknown): ProxyResponse {
+    if (typeof payload !== 'object' || payload === null) {
+      throw new Error('proxy payload is not an object');
+    }
+    const body = payload as Record<string, unknown>;
+
+    const rawHosts = Array.isArray(body['hosts']) ? body['hosts'] : [];
+    const hosts = [];
+    for (const candidate of rawHosts) {
+      if (isProxyHost(candidate)) {
+        hosts.push(candidate);
+      } else {
+        this.#log(`skipping malformed proxy host entry: ${JSON.stringify(candidate)}`);
+      }
+    }
+
+    const rawAlerts = Array.isArray(body['alerts']) ? body['alerts'] : [];
+    const alerts = rawAlerts.filter(isProxyAlert);
+
+    return {
+      sampledAt: typeof body['sampledAt'] === 'string' ? body['sampledAt'] : new Date().toISOString(),
+      production: typeof body['production'] === 'string' ? body['production'] : 'unknown',
+      hosts,
+      alerts,
+    };
+  }
+}

--- a/services/detection-engine/src/proxy/mockClient.ts
+++ b/services/detection-engine/src/proxy/mockClient.ts
@@ -1,0 +1,104 @@
+/**
+ * Fixture-backed proxy client — ADR 0004.
+ *
+ * The engine must run and serve with Dev A's proxy absent. This is the mechanism, and
+ * it is the default in dev: mock-first is the plan, not a fallback.
+ *
+ * Fixtures hold real captured LABDEMO values. `lastActivityElapsedSeconds` is relative
+ * by construction, so a fixture stays truthful however long after capture it is
+ * replayed — the same reason Dev C computes fixture timestamps at load time.
+ */
+
+import { readFileSync } from 'node:fs';
+import type { ProxyClient, ProxyHost, ProxyResponse } from '../types/proxy.ts';
+import { isProxyAlert, isProxyHost } from '../types/proxy.ts';
+
+/** A scripted step: which fixture to serve, and for how many polls. */
+export interface ScenarioStep {
+  fixture: string;
+  polls: number;
+}
+
+/**
+ * Serves fixtures on a loop so the engine visibly comes alive without IRIS.
+ *
+ * Default progression: healthy for long enough to warm the baseline, then the
+ * degraded capture, then back. Sustained-breach needs 2+ consecutive breaching polls,
+ * so any degraded step must last at least that long or nothing is ever confirmed.
+ */
+export class MockProxyClient implements ProxyClient {
+  #pollCount = 0;
+  readonly #cache = new Map<string, ProxyResponse>();
+
+  readonly #fixtureDir: string;
+  readonly #steps: readonly ScenarioStep[];
+
+  constructor(fixtureDir: string, steps: readonly ScenarioStep[] = DEFAULT_SCENARIO) {
+    if (steps.length === 0) throw new Error('MockProxyClient needs at least one step');
+    this.#fixtureDir = fixtureDir;
+    this.#steps = steps;
+  }
+
+  /** Not async in substance, but matches ProxyClient so the engine cannot tell. */
+  async fetchMetrics(): Promise<ProxyResponse> {
+    const fixture = this.#fixtureForPoll(this.#pollCount);
+    this.#pollCount += 1;
+    return this.#load(fixture);
+  }
+
+  /** Restart the progression — the "restartable from the UI" affordance. */
+  reset(): void {
+    this.#pollCount = 0;
+  }
+
+  #fixtureForPoll(poll: number): string {
+    const total = this.#steps.reduce((sum, step) => sum + step.polls, 0);
+    let offset = poll % total;
+    for (const step of this.#steps) {
+      if (offset < step.polls) return step.fixture;
+      offset -= step.polls;
+    }
+    // Unreachable while total > 0, but the compiler cannot know that.
+    return this.#steps[0]?.fixture ?? 'healthy';
+  }
+
+  #load(name: string): ProxyResponse {
+    const cached = this.#cache.get(name);
+    if (cached !== undefined) return cached;
+
+    const path = `${this.#fixtureDir}/${name}.json`;
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) {
+      throw new Error(`fixture ${path} is not an object`);
+    }
+    const body = parsed as Record<string, unknown>;
+
+    // Fixtures carry _comment keys for documentation; drop anything not a valid host.
+    const rawHosts = Array.isArray(body['hosts']) ? body['hosts'] : [];
+    const hosts: ProxyHost[] = rawHosts.filter(isProxyHost);
+    const rawAlerts = Array.isArray(body['alerts']) ? body['alerts'] : [];
+
+    const response: ProxyResponse = {
+      sampledAt: typeof body['sampledAt'] === 'string' ? body['sampledAt'] : new Date().toISOString(),
+      production: typeof body['production'] === 'string' ? body['production'] : 'LABDEMO.Production',
+      hosts,
+      alerts: rawAlerts.filter(isProxyAlert),
+    };
+    this.#cache.set(name, response);
+    return response;
+  }
+}
+
+/**
+ * Healthy long enough to warm the baseline (minBaselineSamples defaults to 12), then
+ * degraded for well over sustainedSamples, then recovery — which is what proves
+ * findings actually clear rather than merely appear.
+ */
+export const DEFAULT_SCENARIO: readonly ScenarioStep[] = [
+  { fixture: 'healthy', polls: 14 },
+  // Degrading first (queue climbing, slow, erroring), then the host goes away
+  // entirely, then recovery — which is what proves findings clear rather than stick.
+  { fixture: 'queue-buildup', polls: 6 },
+  { fixture: 'cloud-api-dead', polls: 6 },
+  { fixture: 'healthy', polls: 6 },
+] as const;

--- a/services/detection-engine/src/proxy/mockClient.ts
+++ b/services/detection-engine/src/proxy/mockClient.ts
@@ -91,14 +91,46 @@ export class MockProxyClient implements ProxyClient {
 
 /**
  * Healthy long enough to warm the baseline (minBaselineSamples defaults to 12), then
- * degraded for well over sustainedSamples, then recovery — which is what proves
- * findings actually clear rather than merely appear.
+ * through each degraded state, then recovery — which is what proves findings actually
+ * clear rather than merely appear.
+ *
+ * Every step lasts at least `sustainedSamples` (2) polls or nothing it depicts is ever
+ * confirmed. Recovery between degraded states is deliberate: it clears the registry so
+ * the next state's findings are new conditions rather than continuations, and it means
+ * an operator watching sees findings resolve, not just accumulate.
+ *
+ * This sequence reaches **all eight finding types**. Dev C found the earlier version
+ * could only produce three (#8), because no fixture carried an alert, none had a
+ * *rising* error counter, and none combined an idle host with a queue:
+ *
+ *   dead_host            cloud-api-dead   (status Disabled)
+ *   stalled_host         stalled-host     (idle 384s while 27 queued, status still OK)
+ *   queue_buildup        queue-buildup    (depth 486, clears the floor of 50)
+ *   elevated_error_rate  error-storm(-2)  (errored 60 -> 210 across two polls)
+ *   slow_processing      queue-buildup    (2.4s, over the 1.0s floor)
+ *   growing_queue_wait   queue-buildup    (1.84s, over the 1.0s floor)
+ *   throughput_drop      cloud-api-dead   (0 against a warm baseline)
+ *   system_alert         error-storm-2    (alert naming Cloud API, severity 2 -> info)
  */
 export const DEFAULT_SCENARIO: readonly ScenarioStep[] = [
   { fixture: 'healthy', polls: 14 },
-  // Degrading first (queue climbing, slow, erroring), then the host goes away
-  // entirely, then recovery — which is what proves findings clear rather than stick.
-  { fixture: 'queue-buildup', polls: 6 },
-  { fixture: 'cloud-api-dead', polls: 6 },
-  { fixture: 'healthy', polls: 6 },
+  // Queue climbing, slow, waiting — three comparative rules at once.
+  { fixture: 'queue-buildup', polls: 5 },
+  { fixture: 'healthy', polls: 4 },
+  // The error counter must RISE on CONSECUTIVE polls for a rate to exist, and then keep
+  // rising for sustainedSamples of them before a finding confirms. A step held for
+  // several polls has a flat counter and yields a rate of zero, so the storm alternates
+  // between three fixtures with an increasing count rather than repeating one.
+  // error-storm-2 and -3 carry the system alert.
+  { fixture: 'error-storm', polls: 1 },
+  { fixture: 'error-storm-2', polls: 1 },
+  { fixture: 'error-storm-3', polls: 1 },
+  { fixture: 'error-storm-4', polls: 1 },
+  { fixture: 'healthy', polls: 4 },
+  // Hung but nominally healthy: the case dead_host cannot catch.
+  { fixture: 'stalled-host', polls: 4 },
+  { fixture: 'healthy', polls: 4 },
+  // The host goes away entirely.
+  { fixture: 'cloud-api-dead', polls: 5 },
+  { fixture: 'healthy', polls: 5 },
 ] as const;

--- a/services/detection-engine/src/types/healthscan.ts
+++ b/services/detection-engine/src/types/healthscan.ts
@@ -1,0 +1,99 @@
+/**
+ * Direct transcription of contracts/healthscan.d.ts — the contract we own and publish.
+ *
+ * Do not drift from it. A change here without a corresponding PR to contracts/ breaks
+ * Dev C, who builds against those exact bytes.
+ */
+
+export type Severity = 'info' | 'warning' | 'critical';
+
+/**
+ * Host status as reported by IRIS. There is no 'Warning' — verified against IRIS
+ * source (Ens.MonitorService, Ens.Job, Ens.Director, Ens.BusinessOperation).
+ * 'Disabled' comes from Ens.Util.Statistics:EnumerateHostStatus rather than the metric.
+ */
+export type HostStatus =
+  | 'OK'
+  | 'Error'
+  | 'Inactive'
+  | 'Retry'
+  | 'Stopped'
+  | 'Unconfigured'
+  | 'Disabled'
+  | (string & {});
+
+export type FindingType =
+  | 'dead_host'
+  | 'stalled_host'
+  | 'queue_buildup'
+  | 'elevated_error_rate'
+  | 'slow_processing'
+  | 'growing_queue_wait'
+  | 'throughput_drop'
+  | 'system_alert';
+
+/** Advisory engine state, sent as the X-Healthscan-State response header. */
+export type HealthScanState = 'ok' | 'warming' | 'stale';
+
+export interface Host {
+  host: string;
+  /** 'service' | 'process' | 'operation'. IRIS 'actor' is normalized to 'process'. */
+  type: string;
+  status: HostStatus;
+  queued: number;
+  messagesPerSec: number;
+  errored: number;
+  /** Seconds. Aggregated across message types, weighted by sample count. */
+  avgProcessingTime: number;
+  /** Seconds. Aggregated across message types, weighted by sample count. */
+  avgQueueingTime: number;
+  /** ISO 8601 UTC, Z-suffixed. */
+  lastActivity: string;
+}
+
+export interface Finding {
+  id: string;
+  host: string;
+  type: FindingType;
+  severity: Severity;
+  currentValue: number;
+  /** null while the rolling baseline is warming up. */
+  baselineValue: number | null;
+  detectedAt: string;
+  /** Authoritative human-readable text. Dev C renders it verbatim. */
+  message: string;
+}
+
+export type HostsResponse = Host[];
+export type FindingsResponse = Finding[];
+
+/** The eight finding types, for iteration and validation. */
+export const FINDING_TYPES: readonly FindingType[] = [
+  'dead_host',
+  'stalled_host',
+  'queue_buildup',
+  'elevated_error_rate',
+  'slow_processing',
+  'growing_queue_wait',
+  'throughput_drop',
+  'system_alert',
+] as const;
+
+/**
+ * Host statuses that mean the host is not doing work. Drives dead_host.
+ * 'Retry' is deliberately excluded — a retrying host is degraded but alive, and
+ * flagging it as dead would be wrong.
+ */
+export const DEAD_STATUSES: readonly string[] = [
+  'Error',
+  'Inactive',
+  'Stopped',
+  'Disabled',
+] as const;
+
+/** Severity ordering, most severe first. Used for the findings sort tiebreak. */
+export const SEVERITY_RANK: Record<Severity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};

--- a/services/detection-engine/src/types/proxy.ts
+++ b/services/detection-engine/src/types/proxy.ts
@@ -1,0 +1,135 @@
+/**
+ * Dev A's metrics-proxy output (:3001).
+ *
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │ UNRATIFIED. contracts/proxy-api.md does not exist yet, so this file is    │
+ * │ OUR ASSUMPTION of Dev A's shape, not an agreed contract.                  │
+ * │                                                                          │
+ * │ Every assumption is tagged // PROXY-Q<n>. Reconciling when Dev A lands    │
+ * │ their contract must be a grep, not an audit:                             │
+ * │     grep -rn "PROXY-Q" src/                                              │
+ * └──────────────────────────────────────────────────────────────────────────┘
+ *
+ * Open questions for Dev A:
+ *
+ * PROXY-Q1  Are per-host entries an array (assumed) or an object keyed by host name?
+ *           And is `status` passed through exactly as IRIS reports it (assumed), or
+ *           already normalized?
+ *
+ * PROXY-Q2  Is `queued` present per host? It is NOT in the Prometheus text —
+ *           iris_interop_queued carries no `host` label, only `production`. Per-host
+ *           depth requires reading Ens.Util.Statistics:EnumerateHostStatus.
+ *           Verified on live LABDEMO: Cloud API = 48 while disabled.
+ *           Raised in ADR 0001 and PR #4. THIS ONE BLOCKS queue_buildup.
+ *
+ * PROXY-Q3  Are avgProcessingTime / avgQueueingTime already aggregated across
+ *           messagetype (assumed), or passed through as raw per-messagetype series?
+ *           IRIS emits one series per (host, messagetype). If raw, aggregation moves
+ *           here and must be weighted by sampleCount — a plain mean is wrong.
+ *
+ * PROXY-Q4  Is last-activity given as elapsed seconds (assumed — that is what
+ *           iris_interop_last_activity holds) or already converted to a timestamp?
+ *
+ * PROXY-Q5  Are framework hosts (Ens.MonitorService, Ens.Alarm, EnsLib.Testing.*,
+ *           Ens.Activity.Operation.Local, …) filtered by the proxy, or do they reach
+ *           us? We assume they reach us and filter here — filtering our own side is
+ *           safe either way.
+ */
+
+/** One host as the proxy reports it. */
+export interface ProxyHost {
+  /** Config item name, e.g. "Lab Router". */
+  name: string;
+  /** PROXY-Q1: IRIS vocabulary — 'service' | 'process' | 'actor' | 'operation'. */
+  type: string;
+  /** PROXY-Q1: raw IRIS status, e.g. 'OK' | 'Error' | 'Inactive' | 'Disabled'. */
+  status: string;
+  /** PROXY-Q2: per-host queue depth. Requires host-status read, not /metrics. */
+  queued: number;
+  /** Cumulative messages processed since production start. */
+  messages: number;
+  messagesPerSec: number;
+  messagesErrored: number;
+  /** PROXY-Q3: seconds, assumed already aggregated across message types. */
+  avgProcessingTime: number;
+  /** PROXY-Q3: seconds, assumed already aggregated across message types. */
+  avgQueueingTime: number;
+  /** PROXY-Q4: seconds since last activity, as iris_interop_last_activity gives it. */
+  lastActivityElapsedSeconds: number;
+  /** PROXY-Q3: total samples behind the avg* figures. Needed to weight aggregation. */
+  sampleCount?: number;
+}
+
+/** One entry from /api/monitor/alerts, forwarded by the proxy. */
+export interface ProxyAlert {
+  /** ISO 8601 timestamp as IRIS emits it. */
+  time: string;
+  /** IRIS severity is a numeric string ("1", "2", …), not a word. */
+  severity: string;
+  message: string;
+}
+
+/** A complete proxy poll response. */
+export interface ProxyResponse {
+  /** When the proxy sampled IRIS. ISO 8601. */
+  sampledAt: string;
+  /** Production name, e.g. "LABDEMO.Production". */
+  production: string;
+  hosts: ProxyHost[];
+  alerts: ProxyAlert[];
+}
+
+/** What the engine reads metrics from. Both real and mock clients satisfy it. */
+export interface ProxyClient {
+  fetchMetrics(signal?: AbortSignal): Promise<ProxyResponse>;
+}
+
+/**
+ * Framework hosts that must never reach the findings API (PROXY-Q5).
+ * Exact names plus prefixes — the Ens.* and EnsLib.* namespaces are IRIS's own.
+ */
+const FRAMEWORK_HOST_PREFIXES: readonly string[] = ['Ens.', 'EnsLib.'] as const;
+
+/** True when a host is IRIS framework infrastructure rather than an application host. */
+export function isFrameworkHost(name: string): boolean {
+  return FRAMEWORK_HOST_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+/**
+ * Runtime shape validation at the process boundary.
+ *
+ * Log-and-skip a malformed host rather than rejecting the whole payload: one bad
+ * entry should not blind us to the other three hosts.
+ */
+export function isProxyHost(value: unknown): value is ProxyHost {
+  if (typeof value !== 'object' || value === null) return false;
+  const h = value as Record<string, unknown>;
+  return (
+    typeof h['name'] === 'string' &&
+    h['name'].length > 0 &&
+    typeof h['type'] === 'string' &&
+    typeof h['status'] === 'string' &&
+    isFiniteNumber(h['queued']) &&
+    isFiniteNumber(h['messages']) &&
+    isFiniteNumber(h['messagesPerSec']) &&
+    isFiniteNumber(h['messagesErrored']) &&
+    isFiniteNumber(h['avgProcessingTime']) &&
+    isFiniteNumber(h['avgQueueingTime']) &&
+    isFiniteNumber(h['lastActivityElapsedSeconds'])
+  );
+}
+
+export function isProxyAlert(value: unknown): value is ProxyAlert {
+  if (typeof value !== 'object' || value === null) return false;
+  const a = value as Record<string, unknown>;
+  return (
+    typeof a['time'] === 'string' &&
+    typeof a['severity'] === 'string' &&
+    typeof a['message'] === 'string'
+  );
+}
+
+/** NaN and Infinity are not usable metric values, so reject them explicitly. */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -1,0 +1,157 @@
+/**
+ * API tests — §3 of contracts/healthscan-api.md, asserted against a real listening server.
+ *
+ * The load-bearing one is "zero findings returns 200 + [], never 404". Dev C's error
+ * handling depends on it, and it is the kind of thing a framework default would get wrong.
+ */
+
+import assert from 'node:assert/strict';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+import { createFindingsServer } from '../src/api/server.ts';
+import type { EngineSnapshot } from '../src/detect/engine.ts';
+import type { Finding, Host } from '../src/types/healthscan.ts';
+
+const HOST: Host = {
+  host: 'Lab Router',
+  type: 'process',
+  status: 'OK',
+  queued: 0,
+  messagesPerSec: 1.2,
+  errored: 0,
+  avgProcessingTime: 0.08,
+  avgQueueingTime: 0,
+  lastActivity: '2026-08-06T15:47:52Z',
+};
+
+const FINDING: Finding = {
+  id: 'f-1042',
+  host: 'Lab Router',
+  type: 'queue_buildup',
+  severity: 'warning',
+  currentValue: 486,
+  baselineValue: 15,
+  detectedAt: '2026-08-06T15:44:08Z',
+  message: 'Queue depth 486 is 32x baseline',
+};
+
+let snapshot: EngineSnapshot = { hosts: [], findings: [], state: 'ok', lastPollAt: null };
+const server = createFindingsServer({ port: 0, snapshot: () => snapshot, log: () => {} });
+let base = '';
+
+before(async () => {
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address() as AddressInfo;
+  base = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('empty states (contract §3)', () => {
+  it('returns 200 and [] for zero findings, NOT 404', async () => {
+    snapshot = { hosts: [], findings: [], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/healthscan/findings`);
+    assert.equal(res.status, 200, 'a 404 here would break Dev C error handling');
+    assert.deepEqual(await res.json(), []);
+  });
+
+  it('returns 200 and [] for zero hosts', async () => {
+    snapshot = { hosts: [], findings: [], state: 'warming', lastPollAt: null };
+    const res = await fetch(`${base}/api/healthscan/hosts`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), []);
+  });
+});
+
+describe('payloads', () => {
+  it('serves hosts verbatim', async () => {
+    snapshot = { hosts: [HOST], findings: [], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/healthscan/hosts`);
+    assert.deepEqual(await res.json(), [HOST]);
+  });
+
+  it('serves findings verbatim', async () => {
+    snapshot = { hosts: [HOST], findings: [FINDING], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/healthscan/findings`);
+    assert.deepEqual(await res.json(), [FINDING]);
+  });
+
+  it('preserves baselineValue null through serialization', async () => {
+    const warming: Finding = { ...FINDING, baselineValue: null };
+    snapshot = { hosts: [], findings: [warming], state: 'warming', lastPollAt: Date.now() };
+    const body = (await (await fetch(`${base}/api/healthscan/findings`)).json()) as Finding[];
+    assert.equal(body[0]?.baselineValue, null, 'must stay null, not become 0 or undefined');
+  });
+});
+
+describe('headers', () => {
+  it('sends CORS unconditionally (contract Q9)', async () => {
+    snapshot = { hosts: [], findings: [], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/healthscan/hosts`);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('reports the engine state', async () => {
+    for (const state of ['ok', 'warming', 'stale'] as const) {
+      snapshot = { hosts: [], findings: [], state, lastPollAt: Date.now() };
+      const res = await fetch(`${base}/api/healthscan/findings`);
+      assert.equal(res.headers.get('x-healthscan-state'), state);
+    }
+  });
+
+  it('forbids caching, so polling always sees fresh data', async () => {
+    const res = await fetch(`${base}/api/healthscan/findings`);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+  });
+
+  it('answers preflight', async () => {
+    const res = await fetch(`${base}/api/healthscan/findings`, { method: 'OPTIONS' });
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+});
+
+describe('routing', () => {
+  it('tolerates a trailing slash', async () => {
+    snapshot = { hosts: [HOST], findings: [], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/healthscan/hosts/`);
+    assert.equal(res.status, 200);
+  });
+
+  it('ignores query strings', async () => {
+    const res = await fetch(`${base}/api/healthscan/hosts?mode=live`);
+    assert.equal(res.status, 200);
+  });
+
+  it('404s an unknown endpoint', async () => {
+    const res = await fetch(`${base}/api/healthscan/nope`);
+    assert.equal(res.status, 404);
+  });
+
+  it('405s a non-GET method', async () => {
+    const res = await fetch(`${base}/api/healthscan/findings`, { method: 'POST' });
+    assert.equal(res.status, 405);
+  });
+});
+
+describe('faults', () => {
+  it('500s with a JSON error when the snapshot throws', async () => {
+    const failing = createFindingsServer({
+      port: 0,
+      snapshot: () => {
+        throw new Error('baseline exploded');
+      },
+      log: () => {},
+    });
+    await new Promise<void>((resolve) => failing.listen(0, resolve));
+    const { port } = failing.address() as AddressInfo;
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/healthscan/findings`);
+    assert.equal(res.status, 500);
+    assert.deepEqual(await res.json(), { error: 'baseline exploded' });
+
+    await new Promise<void>((resolve) => failing.close(() => resolve()));
+  });
+});

--- a/services/detection-engine/test/baseline.test.ts
+++ b/services/detection-engine/test/baseline.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Baseline window tests — ADR 0002.
+ *
+ * Includes the self-inflation property: a sustained breach raises its own baseline,
+ * so a comparative finding can clear while the bad value persists. That is inherent
+ * to a rolling mean, not a bug — pinned here so nobody "fixes" it by accident, and
+ * so the tradeoff is visible if we later decide it needs addressing.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { BaselineStore } from '../src/baseline/window.ts';
+
+const T0 = Date.parse('2026-08-06T16:00:00Z');
+const STEP = 10_000;
+
+describe('warm-up gate', () => {
+  it('returns null below the minimum sample count', () => {
+    const store = new BaselineStore(1800, 12);
+    for (let i = 0; i < 11; i += 1) store.record('Lab Router', 'queued', 10, T0 + i * STEP);
+    assert.equal(store.baseline('Lab Router', 'queued'), null, '11 of 12 is still warming');
+  });
+
+  it('returns a mean exactly at the minimum', () => {
+    const store = new BaselineStore(1800, 12);
+    for (let i = 0; i < 12; i += 1) store.record('Lab Router', 'queued', 10, T0 + i * STEP);
+    assert.equal(store.baseline('Lab Router', 'queued'), 10);
+  });
+
+  it('returns null for a metric never recorded', () => {
+    const store = new BaselineStore(1800, 1);
+    store.record('Lab Router', 'queued', 5, T0);
+    assert.equal(store.baseline('Lab Router', 'messagesPerSec'), null);
+  });
+
+  it('tracks hosts independently', () => {
+    const store = new BaselineStore(1800, 2);
+    store.record('Lab Router', 'queued', 10, T0);
+    store.record('Lab Router', 'queued', 10, T0 + STEP);
+    store.record('Cloud API', 'queued', 100, T0);
+    store.record('Cloud API', 'queued', 100, T0 + STEP);
+    assert.equal(store.baseline('Lab Router', 'queued'), 10);
+    assert.equal(store.baseline('Cloud API', 'queued'), 100);
+  });
+});
+
+describe('window pruning', () => {
+  it('drops samples older than the window', () => {
+    const store = new BaselineStore(60, 1);
+    store.record('Lab Router', 'queued', 1000, T0);
+    // 120s later the first sample is outside a 60s window.
+    store.record('Lab Router', 'queued', 10, T0 + 120_000);
+    assert.equal(store.baseline('Lab Router', 'queued'), 10, 'stale sample must be gone');
+    assert.equal(store.sampleCount('Lab Router', 'queued'), 1);
+  });
+
+  it('falls back to warming when pruning drops below the minimum', () => {
+    const store = new BaselineStore(60, 3);
+    for (let i = 0; i < 3; i += 1) store.record('Lab Router', 'queued', 10, T0 + i * 1000);
+    assert.equal(store.baseline('Lab Router', 'queued'), 10);
+
+    store.record('Lab Router', 'queued', 10, T0 + 300_000);
+    assert.equal(
+      store.baseline('Lab Router', 'queued'),
+      null,
+      'a long proxy outage legitimately returns us to warming',
+    );
+  });
+});
+
+describe('bad input', () => {
+  it('ignores NaN and Infinity rather than poisoning the mean', () => {
+    const store = new BaselineStore(1800, 2);
+    store.record('Lab Router', 'queued', 10, T0);
+    store.record('Lab Router', 'queued', Number.NaN, T0 + STEP);
+    store.record('Lab Router', 'queued', Number.POSITIVE_INFINITY, T0 + 2 * STEP);
+    store.record('Lab Router', 'queued', 20, T0 + 3 * STEP);
+    assert.equal(store.baseline('Lab Router', 'queued'), 15, 'mean of 10 and 20 only');
+  });
+});
+
+describe('forget', () => {
+  it('drops only the named host, despite spaces in host names', () => {
+    const store = new BaselineStore(1800, 1);
+    store.record('Lab Router', 'queued', 10, T0);
+    store.record('Lab Router 2', 'queued', 20, T0);
+    store.forget('Lab Router');
+    assert.equal(store.baseline('Lab Router', 'queued'), null);
+    assert.equal(
+      store.baseline('Lab Router 2', 'queued'),
+      20,
+      'a host whose name is a prefix of another must survive',
+    );
+  });
+});
+
+describe('self-inflation (inherent to a rolling mean)', () => {
+  it('lets a sustained breach raise its own baseline until the ratio collapses', () => {
+    const store = new BaselineStore(1800, 12);
+    let at = T0;
+    for (let i = 0; i < 12; i += 1) {
+      store.record('Cloud API', 'queued', 0, at);
+      at += STEP;
+    }
+
+    // First breaching sample: baseline is still near zero, so the ratio is enormous.
+    store.record('Cloud API', 'queued', 486, at);
+    at += STEP;
+    const early = store.baseline('Cloud API', 'queued');
+    assert.ok(early !== null);
+    assert.ok(486 / early > 5, `expected a large ratio, got ${486 / early}`);
+
+    // Keep the bad value in place: the mean climbs toward it and the ratio falls.
+    for (let i = 0; i < 20; i += 1) {
+      store.record('Cloud API', 'queued', 486, at);
+      at += STEP;
+    }
+    const late = store.baseline('Cloud API', 'queued');
+    assert.ok(late !== null);
+    assert.ok(
+      486 / late < 5,
+      `a persistently bad value becomes the new normal (ratio ${486 / late})`,
+    );
+  });
+});

--- a/services/detection-engine/test/config.test.ts
+++ b/services/detection-engine/test/config.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Threshold config tests — ADR 0003.
+ *
+ * The critical property is that a BAD config is REJECTED rather than partly applied.
+ * A zero multiplier that slipped through would make every rule fire on every sample,
+ * which is the exact failure mode conservative defaults exist to prevent.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  ConfigValidationError,
+  DEFAULT_CONFIG,
+  configFor,
+  validateConfig,
+} from '../src/config/thresholds.ts';
+
+describe('validation accepts', () => {
+  it('the committed thresholds.json shape', () => {
+    const config = validateConfig({
+      sustainedSamples: 2,
+      minBaselineSamples: 12,
+      rules: { queue_buildup: { absoluteFloor: 100 } },
+    });
+    assert.equal(config.sustainedSamples, 2);
+    assert.equal(config.rules.queue_buildup.absoluteFloor, 100);
+  });
+
+  it('a partial file, inheriting the rest from defaults', () => {
+    const config = validateConfig({ rules: { queue_buildup: { absoluteFloor: 99 } } });
+    assert.equal(config.rules.queue_buildup.absoluteFloor, 99);
+    assert.equal(
+      config.rules.queue_buildup.baselineMultiplier,
+      DEFAULT_CONFIG.rules.queue_buildup.baselineMultiplier,
+      'unspecified fields keep their default',
+    );
+    assert.equal(config.rules.dead_host.enabled, true);
+  });
+
+  it('_comment keys, which the committed file uses for documentation', () => {
+    const config = validateConfig({
+      _comment: 'explanatory text',
+      rules: { _comment: 'more text', queue_buildup: { _comment: 'note', absoluteFloor: 60 } },
+      hostOverrides: { _comment: 'note' },
+    });
+    assert.equal(config.rules.queue_buildup.absoluteFloor, 60);
+  });
+
+  it('enabled: false, which is a boolean not a bound', () => {
+    const config = validateConfig({ rules: { dead_host: { enabled: false } } });
+    assert.equal(config.rules.dead_host.enabled, false);
+  });
+});
+
+describe('validation rejects', () => {
+  it('a zero multiplier, which would make a rule fire always', () => {
+    assert.throws(
+      () => validateConfig({ rules: { queue_buildup: { baselineMultiplier: 0 } } }),
+      ConfigValidationError,
+    );
+  });
+
+  it('a negative bound', () => {
+    assert.throws(
+      () => validateConfig({ rules: { stalled_host: { inactiveSeconds: -5 } } }),
+      ConfigValidationError,
+    );
+  });
+
+  it('a non-finite bound', () => {
+    assert.throws(
+      () => validateConfig({ sustainedSamples: Number.POSITIVE_INFINITY }),
+      ConfigValidationError,
+    );
+  });
+
+  it('an unknown rule name, which is usually a typo', () => {
+    assert.throws(
+      () => validateConfig({ rules: { queue_buldup: { absoluteFloor: 50 } } }),
+      ConfigValidationError,
+    );
+  });
+
+  it('a zero severity band', () => {
+    assert.throws(
+      () => validateConfig({ rules: { queue_buildup: { severityBands: { warning: 0 } } } }),
+      ConfigValidationError,
+    );
+  });
+
+  it('a non-object payload', () => {
+    assert.throws(() => validateConfig('not a config'), ConfigValidationError);
+    assert.throws(() => validateConfig(null), ConfigValidationError);
+  });
+
+  it('reports every problem at once, not just the first', () => {
+    try {
+      validateConfig({ sustainedSamples: 0, minBaselineSamples: -1 });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err instanceof ConfigValidationError);
+      assert.equal(err.problems.length, 2);
+    }
+  });
+
+  it('does not partly apply a rejected file', () => {
+    // The valid sibling field must not survive the rejection.
+    assert.throws(
+      () =>
+        validateConfig({
+          rules: { queue_buildup: { absoluteFloor: 999, baselineMultiplier: -1 } },
+        }),
+      ConfigValidationError,
+    );
+    assert.equal(
+      DEFAULT_CONFIG.rules.queue_buildup.absoluteFloor,
+      50,
+      'DEFAULT_CONFIG must not have been mutated',
+    );
+  });
+});
+
+describe('per-host overrides', () => {
+  it('merges over the rule default, keeping unspecified fields', () => {
+    const config = validateConfig({
+      hostOverrides: { 'Cloud API': { slow_processing: { absoluteFloorSeconds: 2.0 } } },
+    });
+    const cloud = configFor(config, 'slow_processing', 'Cloud API');
+    assert.equal(cloud.absoluteFloorSeconds, 2.0);
+    assert.equal(
+      cloud.baselineMultiplier,
+      DEFAULT_CONFIG.rules.slow_processing.baselineMultiplier,
+      'an override is partial',
+    );
+  });
+
+  it('leaves other hosts untouched', () => {
+    const config = validateConfig({
+      hostOverrides: { 'Cloud API': { slow_processing: { absoluteFloorSeconds: 9.0 } } },
+    });
+    const router = configFor(config, 'slow_processing', 'Lab Router');
+    assert.equal(router.absoluteFloorSeconds, DEFAULT_CONFIG.rules.slow_processing.absoluteFloorSeconds);
+  });
+
+  it('returns the rule default for a host with no override', () => {
+    const config = validateConfig({});
+    assert.deepEqual(
+      configFor(config, 'queue_buildup', 'Lab Router'),
+      DEFAULT_CONFIG.rules.queue_buildup,
+    );
+  });
+});

--- a/services/detection-engine/test/contract-drift.test.ts
+++ b/services/detection-engine/test/contract-drift.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Contract drift guard.
+ *
+ * `src/types/healthscan.ts` is a transcription of `contracts/healthscan.d.ts`. We own
+ * that contract, which means we may not quietly drift from it — Dev C's UI is built
+ * against those exact bytes, and a silent divergence here is the failure mode that
+ * breaks the Day-5 integration.
+ *
+ * These tests compare our types against the published contract as it exists on disk,
+ * and validate our real API output against the published JSON Schema. Both run in CI,
+ * so drift fails loudly rather than being caught by someone remembering to look.
+ *
+ * Skipped gracefully when `contracts/` is absent — the engine must remain buildable
+ * standalone (ADR 0004), and the branch predates the contract merge.
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_CONFIG } from '../src/config/thresholds.ts';
+import { DetectionEngine } from '../src/detect/engine.ts';
+import { DEFAULT_SCENARIO, MockProxyClient } from '../src/proxy/mockClient.ts';
+import { FINDING_TYPES } from '../src/types/healthscan.ts';
+
+const serviceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const contractsDir = resolve(serviceRoot, '../../contracts');
+const schemaPath = resolve(contractsDir, 'healthscan.schema.json');
+const dtsPath = resolve(contractsDir, 'healthscan.d.ts');
+
+const haveContracts = existsSync(schemaPath) && existsSync(dtsPath);
+
+/** Extract a string-literal union's members from a .d.ts by type name. */
+function unionMembers(source: string, typeName: string): string[] {
+  const declaration = new RegExp(`export type ${typeName}\\s*=([\\s\\S]*?);`).exec(source);
+  if (declaration === null) return [];
+  return [...(declaration[1] ?? '').matchAll(/'([^']+)'/g)].map((match) => match[1] ?? '');
+}
+
+describe('contract drift', { skip: haveContracts ? false : 'contracts/ not present' }, () => {
+  it('our FindingType matches the published union exactly', () => {
+    const published = unionMembers(readFileSync(dtsPath, 'utf8'), 'FindingType');
+    assert.deepEqual([...FINDING_TYPES].sort(), published.sort());
+  });
+
+  it('our HostStatus matches the published union, and still excludes Warning', () => {
+    const source = readFileSync(dtsPath, 'utf8');
+    const published = unionMembers(source, 'HostStatus');
+    const ours = unionMembers(readFileSync(resolve(serviceRoot, 'src/types/healthscan.ts'), 'utf8'), 'HostStatus');
+    assert.deepEqual(ours.sort(), published.sort());
+    // Q1: the correction that cost Dev C 83 insertions. Never reintroduce it.
+    assert.ok(!published.includes('Warning'), 'Warning must not return to HostStatus');
+  });
+
+  it('our Severity matches the published union', () => {
+    const source = readFileSync(dtsPath, 'utf8');
+    const published = unionMembers(source, 'Severity');
+    const ours = unionMembers(readFileSync(resolve(serviceRoot, 'src/types/healthscan.ts'), 'utf8'), 'Severity');
+    assert.deepEqual(ours.sort(), published.sort());
+  });
+
+  it('the published schema enumerates exactly our eight finding types', () => {
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+      definitions: { Finding: { properties: { type: { enum: string[] } } } };
+    };
+    assert.deepEqual(
+      [...schema.definitions.Finding.properties.type.enum].sort(),
+      [...FINDING_TYPES].sort(),
+    );
+  });
+
+  it('every required field in the published Host schema is one we emit', async () => {
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+      definitions: { Host: { required: string[] }; Finding: { required: string[] } };
+    };
+
+    const client = new MockProxyClient(resolve(serviceRoot, 'fixtures/proxy'));
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = Date.parse('2026-08-06T16:00:00Z');
+    const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+
+    const hostKeys = new Set<string>();
+    const findingKeys = new Set<string>();
+    for (let poll = 0; poll < totalPolls; poll += 1) {
+      engine.applyPoll(await client.fetchMetrics(), at);
+      at += 10_000;
+      const snapshot = engine.snapshot();
+      for (const host of snapshot.hosts) for (const key of Object.keys(host)) hostKeys.add(key);
+      for (const finding of snapshot.findings) {
+        for (const key of Object.keys(finding)) findingKeys.add(key);
+      }
+    }
+
+    for (const required of schema.definitions.Host.required) {
+      assert.ok(hostKeys.has(required), `we never emit required Host field "${required}"`);
+    }
+    for (const required of schema.definitions.Finding.required) {
+      assert.ok(findingKeys.has(required), `we never emit required Finding field "${required}"`);
+    }
+  });
+
+  it('we emit no field the published schema forbids', async () => {
+    // Both objects are additionalProperties: false, so an extra field is a contract
+    // violation even though it would look harmless in our own tests.
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+      definitions: {
+        Host: { properties: Record<string, unknown> };
+        Finding: { properties: Record<string, unknown> };
+      };
+    };
+    const allowedHost = new Set(Object.keys(schema.definitions.Host.properties));
+    const allowedFinding = new Set(Object.keys(schema.definitions.Finding.properties));
+
+    const client = new MockProxyClient(resolve(serviceRoot, 'fixtures/proxy'));
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = Date.parse('2026-08-06T16:00:00Z');
+    const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+
+    for (let poll = 0; poll < totalPolls; poll += 1) {
+      engine.applyPoll(await client.fetchMetrics(), at);
+      at += 10_000;
+      const snapshot = engine.snapshot();
+      for (const host of snapshot.hosts) {
+        for (const key of Object.keys(host)) {
+          assert.ok(allowedHost.has(key), `Host field "${key}" is not in the contract`);
+        }
+      }
+      for (const finding of snapshot.findings) {
+        for (const key of Object.keys(finding)) {
+          assert.ok(allowedFinding.has(key), `Finding field "${key}" is not in the contract`);
+        }
+      }
+    }
+  });
+
+  it('our timestamps satisfy the published pattern', async () => {
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8')) as {
+      definitions: {
+        Host: { properties: { lastActivity: { pattern: string } } };
+        Finding: { properties: { detectedAt: { pattern: string } } };
+      };
+    };
+    const hostPattern = new RegExp(schema.definitions.Host.properties.lastActivity.pattern);
+    const findingPattern = new RegExp(schema.definitions.Finding.properties.detectedAt.pattern);
+
+    const client = new MockProxyClient(resolve(serviceRoot, 'fixtures/proxy'));
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = Date.parse('2026-08-06T16:00:00Z');
+    const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+
+    let checked = 0;
+    for (let poll = 0; poll < totalPolls; poll += 1) {
+      engine.applyPoll(await client.fetchMetrics(), at);
+      at += 10_000;
+      const snapshot = engine.snapshot();
+      for (const host of snapshot.hosts) {
+        assert.match(host.lastActivity, hostPattern);
+        checked += 1;
+      }
+      for (const finding of snapshot.findings) {
+        assert.match(finding.detectedAt, findingPattern);
+        checked += 1;
+      }
+    }
+    assert.ok(checked > 0, 'no timestamps were checked');
+  });
+});

--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -344,27 +344,48 @@ describe('hot reload (ADR 0003)', () => {
 });
 
 describe('system_alert', () => {
-  it('fires once for an alert naming a host, then not again', () => {
-    const engine = new DetectionEngine({ ...DEFAULT_CONFIG, sustainedSamples: 1 });
+  it('keeps reporting while the alert stays in the payload, and clears when it ages out', () => {
+    // This test previously asserted the opposite — "fires once, then not again" — which
+    // was the bug: suppressing the second poll meant the registry never saw the two
+    // consecutive verdicts it needs, so with the default sustainedSamples of 2 the rule
+    // could never confirm at all. An alert reports for as long as the proxy carries it.
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
     const alert = {
       time: '2026-08-06T15:58:00.000Z',
       severity: '2',
       message: 'Lab Router reported a problem',
     };
+    const alertCount = () =>
+      engine.snapshot().findings.filter((f) => f.type === 'system_alert').length;
 
     engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0);
-    assert.equal(
-      engine.snapshot().findings.filter((f) => f.type === 'system_alert').length,
-      1,
-    );
+    assert.equal(alertCount(), 0, 'one sample must not confirm — sustained breach applies');
 
-    // Same alert on the next poll is not new, so the condition clears.
     engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0 + POLL_MS);
-    assert.equal(
-      engine.snapshot().findings.filter((f) => f.type === 'system_alert').length,
-      0,
-      'an already-reported alert must not re-fire',
-    );
+    assert.equal(alertCount(), 1, 'confirms on the second consecutive poll');
+
+    engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0 + 2 * POLL_MS);
+    assert.equal(alertCount(), 1, 'still reported while present, not duplicated');
+
+    // The alert ages out of the proxy payload — the finding clears, per contract Q4.
+    engine.applyPoll(response([proxyHost()]), T0 + 3 * POLL_MS);
+    assert.equal(alertCount(), 0, 'no tombstone once the alert is gone');
+  });
+
+  it('keeps a stable id across polls for the same alert', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    const alert = {
+      time: '2026-08-06T15:58:00.000Z',
+      severity: '2',
+      message: 'Lab Router reported a problem',
+    };
+    const ids = new Set<string>();
+    for (let i = 0; i < 4; i += 1) {
+      engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0 + i * POLL_MS);
+      const finding = engine.snapshot().findings.find((f) => f.type === 'system_alert');
+      if (finding !== undefined) ids.add(finding.id);
+    }
+    assert.equal(ids.size, 1, `id churned across polls: ${[...ids].join(', ')}`);
   });
 
   it('ignores an alert that names no known host', () => {

--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Engine tests — the behaviours the contract promises Dev C, verified end to end.
+ *
+ * The important ones here are not "a finding appears" but:
+ *   - a single-sample spike produces NOTHING (sustained breach, MVP §6)
+ *   - an id stays STABLE across polls (contract Q4)
+ *   - a finding DISAPPEARS when the condition clears (contract Q4)
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DEFAULT_CONFIG, type ThresholdConfig } from '../src/config/thresholds.ts';
+import { DetectionEngine, normalizeHostType } from '../src/detect/engine.ts';
+import type { ProxyHost, ProxyResponse } from '../src/types/proxy.ts';
+
+const T0 = Date.parse('2026-08-06T16:00:00Z');
+const POLL_MS = 10_000;
+
+function proxyHost(overrides: Partial<ProxyHost> = {}): ProxyHost {
+  return {
+    name: 'Lab Router',
+    type: 'actor',
+    status: 'OK',
+    queued: 0,
+    messages: 100,
+    messagesPerSec: 1.2,
+    messagesErrored: 0,
+    avgProcessingTime: 0.08,
+    avgQueueingTime: 0,
+    lastActivityElapsedSeconds: 4,
+    ...overrides,
+  };
+}
+
+function response(hosts: ProxyHost[]): ProxyResponse {
+  return {
+    sampledAt: new Date(T0).toISOString(),
+    production: 'LABDEMO.Production',
+    hosts,
+    alerts: [],
+  };
+}
+
+/** Run `polls` healthy polls to warm the baseline, returning the next poll time. */
+function warmUp(engine: DetectionEngine, polls = DEFAULT_CONFIG.minBaselineSamples): number {
+  let at = T0;
+  for (let i = 0; i < polls; i += 1) {
+    engine.applyPoll(response([proxyHost()]), at);
+    at += POLL_MS;
+  }
+  return at;
+}
+
+describe('normalization', () => {
+  it('maps IRIS actor to the contract process (Q10)', () => {
+    assert.equal(normalizeHostType('actor'), 'process');
+    assert.equal(normalizeHostType('service'), 'service');
+    assert.equal(normalizeHostType('operation'), 'operation');
+  });
+
+  it('converts elapsed seconds to an ISO timestamp (Q11)', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    engine.applyPoll(response([proxyHost({ lastActivityElapsedSeconds: 60 })]), T0);
+    const [host] = engine.snapshot().hosts;
+    assert.ok(host !== undefined);
+    assert.equal(host.lastActivity, '2026-08-06T15:59:00Z');
+  });
+
+  it('emits second-precision Z timestamps, matching the schema pattern', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    engine.applyPoll(response([proxyHost()]), T0 + 456);
+    const [host] = engine.snapshot().hosts;
+    assert.ok(host !== undefined);
+    assert.match(host.lastActivity, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it('filters framework hosts (PROXY-Q5)', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    engine.applyPoll(
+      response([
+        proxyHost({ name: 'Lab Router' }),
+        proxyHost({ name: 'Ens.MonitorService' }),
+        proxyHost({ name: 'EnsLib.Testing.Process' }),
+        proxyHost({ name: 'Ens.Activity.Operation.Local' }),
+      ]),
+      T0,
+    );
+    const names = engine.snapshot().hosts.map((h) => h.host);
+    assert.deepEqual(names, ['Lab Router']);
+  });
+
+  it('sorts hosts by name', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    engine.applyPoll(
+      response([
+        proxyHost({ name: 'Lab Router' }),
+        proxyHost({ name: 'Cloud API' }),
+        proxyHost({ name: 'EMR Source' }),
+      ]),
+      T0,
+    );
+    assert.deepEqual(engine.snapshot().hosts.map((h) => h.host), [
+      'Cloud API',
+      'EMR Source',
+      'Lab Router',
+    ]);
+  });
+});
+
+describe('sustained breach (MVP §6)', () => {
+  it('emits NOTHING for a single-sample spike', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    const at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    assert.equal(engine.snapshot().findings.length, 0, 'one breaching sample must not confirm');
+  });
+
+  it('confirms on the second consecutive breaching sample', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+
+    const findings = engine.snapshot().findings;
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0]?.type, 'dead_host');
+  });
+
+  it('resets the counter when a breach is interrupted', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    // Breach, recover, breach again: never two in a row, so never confirmed.
+    for (const status of ['Disabled', 'OK', 'Disabled', 'OK', 'Disabled']) {
+      engine.applyPoll(response([proxyHost({ status })]), at);
+      at += POLL_MS;
+    }
+    assert.equal(engine.snapshot().findings.length, 0, 'consecutive means consecutive');
+  });
+});
+
+describe('finding lifecycle (contract Q4)', () => {
+  it('keeps the id STABLE across polls while the condition persists', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    const ids = new Set<string>();
+    for (let i = 0; i < 5; i += 1) {
+      engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+      at += POLL_MS;
+      const [finding] = engine.snapshot().findings;
+      if (finding !== undefined) ids.add(finding.id);
+    }
+    assert.equal(ids.size, 1, `id churned across polls: ${[...ids].join(', ')}`);
+  });
+
+  it('keeps detectedAt at first confirmation, not last seen', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    const confirmedAt = engine.snapshot().findings[0]?.detectedAt;
+
+    for (let i = 0; i < 3; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    }
+    assert.equal(engine.snapshot().findings[0]?.detectedAt, confirmedAt);
+  });
+
+  it('refreshes current values while keeping the same finding', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    const first = engine.snapshot().findings[0];
+    assert.ok(first !== undefined, 'expected queue_buildup to confirm');
+
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 250 })]), at);
+    const second = engine.snapshot().findings[0];
+    assert.ok(second !== undefined);
+    assert.equal(second.id, first.id, 'same condition, same id');
+    assert.equal(second.currentValue, 250, 'but current value moves');
+  });
+
+  it('makes the finding DISAPPEAR when the condition clears', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    assert.equal(engine.snapshot().findings.length, 1, 'precondition: finding exists');
+
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'OK' })]), at);
+    assert.equal(engine.snapshot().findings.length, 0, 'no tombstones, no resolvedAt');
+  });
+
+  it('forgets a host that leaves the production', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    assert.equal(engine.snapshot().findings.length, 1);
+
+    at += POLL_MS;
+    engine.applyPoll(response([]), at);
+    const snapshot = engine.snapshot();
+    assert.equal(snapshot.hosts.length, 0);
+    assert.equal(snapshot.findings.length, 0);
+  });
+});
+
+describe('warm-up (ADR 0002)', () => {
+  it('reports warming before any poll', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    assert.equal(engine.snapshot().state, 'warming');
+  });
+
+  it('stays warming until the baseline has enough samples', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = T0;
+    for (let i = 0; i < 3; i += 1) {
+      engine.applyPoll(response([proxyHost()]), at);
+      at += POLL_MS;
+    }
+    assert.equal(engine.snapshot().state, 'warming');
+  });
+
+  it('suppresses comparative findings during warm-up but still reports hosts', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = T0;
+    // A huge queue from the very first poll: no baseline, so no comparative finding.
+    for (let i = 0; i < 3; i += 1) {
+      engine.applyPoll(response([proxyHost({ queued: 5000 })]), at);
+      at += POLL_MS;
+    }
+    const snapshot = engine.snapshot();
+    assert.equal(snapshot.findings.length, 0, 'no baseline means no comparative finding');
+    assert.equal(snapshot.hosts.length, 1, 'hosts are still reported while warming');
+  });
+
+  it('still fires absolute rules during warm-up', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = T0;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+
+    const findings = engine.snapshot().findings;
+    assert.equal(findings.length, 1, 'dead_host needs no baseline');
+    assert.equal(findings[0]?.baselineValue, null);
+  });
+
+  it('reports ok once every metric is warm', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    // errorsPerMinute needs two readings before it records at all, so warm one extra.
+    warmUp(engine, DEFAULT_CONFIG.minBaselineSamples + 2);
+    assert.equal(engine.snapshot().state, 'ok');
+  });
+});
+
+describe('stale handling', () => {
+  it('reports stale after a failed poll but keeps serving last-known data', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    warmUp(engine);
+    assert.equal(engine.snapshot().hosts.length, 1);
+
+    engine.markPollFailed();
+    const snapshot = engine.snapshot();
+    assert.equal(snapshot.state, 'stale');
+    assert.equal(snapshot.hosts.length, 1, 'degrade, never blank');
+  });
+
+  it('clears stale on the next successful poll', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    const at = warmUp(engine, DEFAULT_CONFIG.minBaselineSamples + 2);
+    engine.markPollFailed();
+    engine.applyPoll(response([proxyHost()]), at);
+    assert.equal(engine.snapshot().state, 'ok');
+  });
+});
+
+describe('error rate derivation', () => {
+  it('does not fire on the first poll, when rate is unknowable', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    engine.applyPoll(response([proxyHost({ messagesErrored: 500 })]), T0);
+    assert.equal(engine.snapshot().findings.length, 0);
+  });
+
+  it('ignores a counter that goes backwards, meaning a production restart', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ messagesErrored: 100 })]), at);
+    at += POLL_MS;
+    // Counter resets to 0: a negative delta must not become a negative rate.
+    engine.applyPoll(response([proxyHost({ messagesErrored: 0 })]), at);
+
+    const errorFindings = engine
+      .snapshot()
+      .findings.filter((f) => f.type === 'elevated_error_rate');
+    assert.equal(errorFindings.length, 0);
+  });
+});
+
+describe('hot reload (ADR 0003)', () => {
+  it('preserves warm baselines when only a threshold changes', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine, DEFAULT_CONFIG.minBaselineSamples + 2);
+    assert.equal(engine.snapshot().state, 'ok');
+
+    const tweaked: ThresholdConfig = {
+      ...DEFAULT_CONFIG,
+      rules: {
+        ...DEFAULT_CONFIG.rules,
+        queue_buildup: { ...DEFAULT_CONFIG.rules.queue_buildup, absoluteFloor: 10 },
+      },
+    };
+    engine.reconfigure(tweaked);
+    engine.applyPoll(response([proxyHost()]), (at += POLL_MS));
+    assert.equal(engine.snapshot().state, 'ok', 'a threshold tweak must not wipe the baseline');
+  });
+
+  it('rebuilds state when a structural parameter changes', () => {
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    warmUp(engine, DEFAULT_CONFIG.minBaselineSamples + 2);
+    assert.equal(engine.snapshot().state, 'ok');
+
+    engine.reconfigure({ ...DEFAULT_CONFIG, minBaselineSamples: 50 });
+    assert.equal(engine.snapshot().state, 'warming', 'a bigger window means warming again');
+  });
+});
+
+describe('system_alert', () => {
+  it('fires once for an alert naming a host, then not again', () => {
+    const engine = new DetectionEngine({ ...DEFAULT_CONFIG, sustainedSamples: 1 });
+    const alert = {
+      time: '2026-08-06T15:58:00.000Z',
+      severity: '2',
+      message: 'Lab Router reported a problem',
+    };
+
+    engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0);
+    assert.equal(
+      engine.snapshot().findings.filter((f) => f.type === 'system_alert').length,
+      1,
+    );
+
+    // Same alert on the next poll is not new, so the condition clears.
+    engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0 + POLL_MS);
+    assert.equal(
+      engine.snapshot().findings.filter((f) => f.type === 'system_alert').length,
+      0,
+      'an already-reported alert must not re-fire',
+    );
+  });
+
+  it('ignores an alert that names no known host', () => {
+    const engine = new DetectionEngine({ ...DEFAULT_CONFIG, sustainedSamples: 1 });
+    engine.applyPoll(
+      {
+        ...response([proxyHost()]),
+        alerts: [{ time: '2026-08-06T15:58:00.000Z', severity: '2', message: 'disk is full' }],
+      },
+      T0,
+    );
+    assert.equal(engine.snapshot().findings.filter((f) => f.type === 'system_alert').length, 0);
+  });
+
+  it('escalates a low numeric IRIS severity to critical', () => {
+    const engine = new DetectionEngine({ ...DEFAULT_CONFIG, sustainedSamples: 1 });
+    engine.applyPoll(
+      {
+        ...response([proxyHost()]),
+        alerts: [
+          { time: '2026-08-06T15:58:00.000Z', severity: '1', message: 'Lab Router is on fire' },
+        ],
+      },
+      T0,
+    );
+    const alertFinding = engine.snapshot().findings.find((f) => f.type === 'system_alert');
+    assert.equal(alertFinding?.severity, 'critical', 'IRIS severity is inverted: lower is worse');
+  });
+});
+
+describe('findings ordering (contract §2)', () => {
+  it('sorts detectedAt desc with severity as tiebreak', () => {
+    const engine = new DetectionEngine({ ...DEFAULT_CONFIG, sustainedSamples: 1 });
+    let at = warmUp(engine);
+
+    // Two conditions on one host confirmed at the same instant: severity breaks the tie.
+    engine.applyPoll(
+      response([proxyHost({ status: 'Disabled', queued: 100, lastActivityElapsedSeconds: 400 })]),
+      at,
+    );
+    const findings = engine.snapshot().findings;
+    assert.ok(findings.length >= 2, `expected multiple findings, got ${findings.length}`);
+
+    for (let i = 1; i < findings.length; i += 1) {
+      const prev = findings[i - 1];
+      const curr = findings[i];
+      assert.ok(prev !== undefined && curr !== undefined);
+      assert.ok(prev.detectedAt >= curr.detectedAt, 'detectedAt must be descending');
+    }
+    assert.equal(findings[0]?.severity, 'critical', 'critical sorts first within a timestamp');
+  });
+});

--- a/services/detection-engine/test/rules.test.ts
+++ b/services/detection-engine/test/rules.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Rule tests.
+ *
+ * Every rule gets a fires case AND a does-not-fire case. A rule that fires correctly
+ * but never stops is broken, and a positive-only suite would not notice.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { BaselineStore } from '../src/baseline/window.ts';
+import { DEFAULT_CONFIG, type ThresholdConfig } from '../src/config/thresholds.ts';
+import { HOST_RULES } from '../src/detect/rules/index.ts';
+import type { Rule, RuleVerdict } from '../src/detect/rules/types.ts';
+import type { Host } from '../src/types/healthscan.ts';
+
+const NOW = Date.parse('2026-08-06T16:00:00Z');
+
+function ruleFor(type: string): Rule {
+  const rule = HOST_RULES.find((candidate) => candidate.type === type);
+  assert.ok(rule !== undefined, `rule ${type} not registered`);
+  return rule;
+}
+
+function host(overrides: Partial<Host> = {}): Host {
+  return {
+    host: 'Lab Router',
+    type: 'process',
+    status: 'OK',
+    queued: 0,
+    messagesPerSec: 1.2,
+    errored: 0,
+    avgProcessingTime: 0.08,
+    avgQueueingTime: 0,
+    lastActivity: new Date(NOW - 4000).toISOString(),
+    ...overrides,
+  };
+}
+
+/** A baseline store already warm at `value` for one metric. */
+function warmBaseline(
+  metric: Parameters<BaselineStore['record']>[1],
+  value: number,
+  hostName = 'Lab Router',
+): BaselineStore {
+  const store = new BaselineStore(1800, DEFAULT_CONFIG.minBaselineSamples);
+  for (let i = 0; i < DEFAULT_CONFIG.minBaselineSamples; i += 1) {
+    store.record(hostName, metric, value, NOW - (DEFAULT_CONFIG.minBaselineSamples - i) * 10_000);
+  }
+  return store;
+}
+
+function evaluate(
+  type: string,
+  h: Host,
+  baselines: BaselineStore,
+  extra: { errorsPerMinute?: number | null; config?: ThresholdConfig; now?: number } = {},
+): RuleVerdict | null {
+  return ruleFor(type).evaluate({
+    host: h,
+    errorsPerMinute: extra.errorsPerMinute ?? null,
+    baselines,
+    config: extra.config ?? DEFAULT_CONFIG,
+    now: extra.now ?? NOW,
+  });
+}
+
+describe('dead_host', () => {
+  it('fires for each status that means not working', () => {
+    for (const status of ['Error', 'Inactive', 'Stopped', 'Disabled']) {
+      const verdict = evaluate('dead_host', host({ status }), new BaselineStore(1800, 12));
+      assert.ok(verdict !== null, `expected ${status} to fire`);
+      assert.equal(verdict.severity, 'critical');
+      assert.equal(verdict.baselineValue, null, 'absolute rule reports no baseline');
+      assert.match(verdict.message, new RegExp(status));
+    }
+  });
+
+  it('does NOT fire for OK', () => {
+    assert.equal(evaluate('dead_host', host({ status: 'OK' }), new BaselineStore(1800, 12)), null);
+  });
+
+  it('does NOT fire for Retry — degraded but alive', () => {
+    assert.equal(
+      evaluate('dead_host', host({ status: 'Retry' }), new BaselineStore(1800, 12)),
+      null,
+    );
+  });
+
+  it('fires with no baseline at all, being absolute', () => {
+    const verdict = evaluate('dead_host', host({ status: 'Disabled' }), new BaselineStore(1800, 12));
+    assert.ok(verdict !== null);
+  });
+
+  it('mentions the queue when messages are stuck', () => {
+    const verdict = evaluate(
+      'dead_host',
+      host({ status: 'Disabled', queued: 48 }),
+      new BaselineStore(1800, 12),
+    );
+    assert.ok(verdict !== null);
+    assert.match(verdict.message, /48 message/);
+  });
+});
+
+describe('stalled_host', () => {
+  const idle = () => host({ queued: 12, lastActivity: new Date(NOW - 400_000).toISOString() });
+
+  it('fires when idle beyond the threshold with messages queued', () => {
+    const verdict = evaluate('stalled_host', idle(), new BaselineStore(1800, 12));
+    assert.ok(verdict !== null);
+    assert.equal(verdict.severity, 'warning');
+    assert.match(verdict.message, /12 message/);
+  });
+
+  it('does NOT fire when idle but the queue is empty', () => {
+    const verdict = evaluate(
+      'stalled_host',
+      host({ queued: 0, lastActivity: new Date(NOW - 400_000).toISOString() }),
+      new BaselineStore(1800, 12),
+    );
+    assert.equal(verdict, null, 'an idle host with nothing to do is healthy');
+  });
+
+  it('does NOT fire when recently active despite a queue', () => {
+    const verdict = evaluate(
+      'stalled_host',
+      host({ queued: 12, lastActivity: new Date(NOW - 5000).toISOString() }),
+      new BaselineStore(1800, 12),
+    );
+    assert.equal(verdict, null);
+  });
+
+  it('defers to dead_host rather than double-reporting', () => {
+    const verdict = evaluate(
+      'stalled_host',
+      host({ status: 'Disabled', queued: 12, lastActivity: new Date(NOW - 400_000).toISOString() }),
+      new BaselineStore(1800, 12),
+    );
+    assert.equal(verdict, null, 'one condition should produce one finding');
+  });
+});
+
+describe('queue_buildup', () => {
+  it('fires when over both the multiplier and the floor', () => {
+    const verdict = evaluate('queue_buildup', host({ queued: 486 }), warmBaseline('queued', 15));
+    assert.ok(verdict !== null);
+    assert.equal(verdict.baselineValue, 15);
+    assert.equal(verdict.currentValue, 486);
+    assert.match(verdict.message, /Queue depth 486 is 32x baseline/);
+  });
+
+  it('does NOT fire on a big ratio below the absolute floor', () => {
+    // 5 is 5x a baseline of 1 -- exactly the noise the floor exists to suppress.
+    assert.equal(evaluate('queue_buildup', host({ queued: 5 }), warmBaseline('queued', 1)), null);
+  });
+
+  it('does NOT fire on a big depth that is normal for the host', () => {
+    const verdict = evaluate('queue_buildup', host({ queued: 60 }), warmBaseline('queued', 55));
+    assert.equal(verdict, null, '60 vs a baseline of 55 is not a buildup');
+  });
+
+  it('does NOT fire while the baseline is warming up', () => {
+    const cold = new BaselineStore(1800, 12);
+    cold.record('Lab Router', 'queued', 15, NOW - 10_000);
+    assert.equal(evaluate('queue_buildup', host({ queued: 486 }), cold), null);
+  });
+
+  it('treats a zero baseline as critical once past the floor', () => {
+    const verdict = evaluate('queue_buildup', host({ queued: 48 }), warmBaseline('queued', 0), {
+      config: {
+        ...DEFAULT_CONFIG,
+        rules: {
+          ...DEFAULT_CONFIG.rules,
+          queue_buildup: { ...DEFAULT_CONFIG.rules.queue_buildup, absoluteFloor: 40 },
+        },
+      },
+    });
+    assert.ok(verdict !== null);
+    assert.equal(verdict.severity, 'critical');
+    assert.match(verdict.message, /no baseline queue/);
+  });
+
+  it('escalates to critical past the critical band', () => {
+    const verdict = evaluate('queue_buildup', host({ queued: 500 }), warmBaseline('queued', 20));
+    assert.ok(verdict !== null);
+    assert.equal(verdict.severity, 'critical', '25x is past the 20x critical band');
+  });
+});
+
+describe('elevated_error_rate', () => {
+  it('fires when the rate exceeds baseline and the floor', () => {
+    const verdict = evaluate('elevated_error_rate', host(), warmBaseline('errorsPerMinute', 0.5), {
+      errorsPerMinute: 6,
+    });
+    assert.ok(verdict !== null);
+    assert.match(verdict.message, /errors\/min/);
+  });
+
+  it('does NOT fire below the per-minute floor', () => {
+    const verdict = evaluate('elevated_error_rate', host(), warmBaseline('errorsPerMinute', 0.01), {
+      errorsPerMinute: 0.5,
+    });
+    assert.equal(verdict, null, 'half an error a minute is not a storm');
+  });
+
+  it('does NOT fire on the first sample, when rate is unknowable', () => {
+    const verdict = evaluate('elevated_error_rate', host(), warmBaseline('errorsPerMinute', 0.5), {
+      errorsPerMinute: null,
+    });
+    assert.equal(verdict, null);
+  });
+});
+
+describe('slow_processing', () => {
+  it('fires when over the multiplier and the floor', () => {
+    const verdict = evaluate(
+      'slow_processing',
+      host({ avgProcessingTime: 2.4 }),
+      warmBaseline('avgProcessingTime', 0.08),
+    );
+    assert.ok(verdict !== null);
+    assert.match(verdict.message, /Average processing time 2\.40s is 30x baseline/);
+  });
+
+  it('does NOT fire on a large ratio still under the floor', () => {
+    // 0.4s is 5x a 0.08s baseline, but well under a second -- nobody cares.
+    const verdict = evaluate(
+      'slow_processing',
+      host({ avgProcessingTime: 0.4 }),
+      warmBaseline('avgProcessingTime', 0.08),
+    );
+    assert.equal(verdict, null);
+  });
+
+  it('honours a per-host override', () => {
+    const config: ThresholdConfig = {
+      ...DEFAULT_CONFIG,
+      hostOverrides: { 'Cloud API': { slow_processing: { absoluteFloorSeconds: 5.0 } } },
+    };
+    const cloudBaseline = warmBaseline('avgProcessingTime', 0.05, 'Cloud API');
+    const verdict = evaluate(
+      'slow_processing',
+      host({ host: 'Cloud API', avgProcessingTime: 2.0 }),
+      cloudBaseline,
+      { config },
+    );
+    assert.equal(verdict, null, '2s is under the overridden 5s floor');
+  });
+});
+
+describe('growing_queue_wait', () => {
+  it('fires when queue wait balloons', () => {
+    const verdict = evaluate(
+      'growing_queue_wait',
+      host({ avgQueueingTime: 1.84 }),
+      warmBaseline('avgQueueingTime', 0.02),
+    );
+    assert.ok(verdict !== null);
+    assert.match(verdict.message, /Average queue wait 1\.84s/);
+  });
+
+  it('does NOT fire on a healthy sub-second wait', () => {
+    const verdict = evaluate(
+      'growing_queue_wait',
+      host({ avgQueueingTime: 0.03 }),
+      warmBaseline('avgQueueingTime', 0.02),
+    );
+    assert.equal(verdict, null);
+  });
+});
+
+describe('throughput_drop', () => {
+  it('fires when throughput collapses', () => {
+    const verdict = evaluate(
+      'throughput_drop',
+      host({ messagesPerSec: 0.2 }),
+      warmBaseline('messagesPerSec', 1.2),
+    );
+    assert.ok(verdict !== null);
+    assert.match(verdict.message, /83% below baseline/);
+  });
+
+  it('does NOT fire on a mild dip', () => {
+    const verdict = evaluate(
+      'throughput_drop',
+      host({ messagesPerSec: 1.0 }),
+      warmBaseline('messagesPerSec', 1.2),
+    );
+    assert.equal(verdict, null);
+  });
+
+  it('does NOT fire when the baseline is too quiet to judge', () => {
+    const verdict = evaluate(
+      'throughput_drop',
+      host({ messagesPerSec: 0 }),
+      warmBaseline('messagesPerSec', 0.05),
+    );
+    assert.equal(verdict, null, 'a near-idle host cannot meaningfully drop');
+  });
+
+  it('escalates to critical on a total stop', () => {
+    const verdict = evaluate(
+      'throughput_drop',
+      host({ messagesPerSec: 0 }),
+      warmBaseline('messagesPerSec', 1.2),
+    );
+    assert.ok(verdict !== null);
+    assert.equal(verdict.severity, 'critical');
+  });
+});
+
+describe('rule registration', () => {
+  it('registers seven per-host rules; system_alert is engine-level', () => {
+    assert.equal(HOST_RULES.length, 7);
+    const types = HOST_RULES.map((rule) => rule.type).sort();
+    assert.deepEqual(types, [
+      'dead_host',
+      'elevated_error_rate',
+      'growing_queue_wait',
+      'queue_buildup',
+      'slow_processing',
+      'stalled_host',
+      'throughput_drop',
+    ]);
+  });
+
+  it('respects enabled: false', () => {
+    const config: ThresholdConfig = {
+      ...DEFAULT_CONFIG,
+      rules: {
+        ...DEFAULT_CONFIG.rules,
+        dead_host: { ...DEFAULT_CONFIG.rules.dead_host, enabled: false },
+      },
+    };
+    const verdict = evaluate('dead_host', host({ status: 'Disabled' }), new BaselineStore(1800, 12), {
+      config,
+    });
+    assert.equal(verdict, null);
+  });
+});

--- a/services/detection-engine/test/scenario.test.ts
+++ b/services/detection-engine/test/scenario.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Scenario coverage — the default mock loop must be able to produce ALL EIGHT finding
+ * types, and severity `info` must be reachable from somewhere.
+ *
+ * This exists because Dev C found (#8) that the earlier loop could only produce three:
+ * no fixture carried an alert, none had a *rising* error counter, and none combined an
+ * idle host with a queue. Every rule was individually unit-tested and passing, so the
+ * gap was invisible from the rule tests — it was a property of the fixtures, not the
+ * logic. Nothing would have caught it before the screencast.
+ */
+
+import assert from 'node:assert/strict';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_CONFIG } from '../src/config/thresholds.ts';
+import { DetectionEngine } from '../src/detect/engine.ts';
+import { DEFAULT_SCENARIO, MockProxyClient } from '../src/proxy/mockClient.ts';
+import { FINDING_TYPES, type FindingType, type Severity } from '../src/types/healthscan.ts';
+
+const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), '../fixtures/proxy');
+const POLL_MS = 10_000;
+
+/** Run the whole default scenario once, collecting every finding ever confirmed. */
+async function runScenario(): Promise<{
+  types: Set<FindingType>;
+  severities: Set<Severity>;
+  idsPerCondition: Map<string, Set<string>>;
+}> {
+  const client = new MockProxyClient(fixtureDir);
+  const engine = new DetectionEngine(DEFAULT_CONFIG);
+  const types = new Set<FindingType>();
+  const severities = new Set<Severity>();
+  const idsPerCondition = new Map<string, Set<string>>();
+
+  const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+  let at = Date.parse('2026-08-06T16:00:00Z');
+
+  for (let poll = 0; poll < totalPolls; poll += 1) {
+    engine.applyPoll(await client.fetchMetrics(), at);
+    at += POLL_MS;
+    for (const finding of engine.snapshot().findings) {
+      types.add(finding.type);
+      severities.add(finding.severity);
+      const key = `${finding.host}/${finding.type}`;
+      const seen = idsPerCondition.get(key) ?? new Set<string>();
+      seen.add(finding.id);
+      idsPerCondition.set(key, seen);
+    }
+  }
+  return { types, severities, idsPerCondition };
+}
+
+describe('default scenario coverage', () => {
+  it('produces all eight finding types', async () => {
+    const { types } = await runScenario();
+    const missing = FINDING_TYPES.filter((type) => !types.has(type));
+    assert.deepEqual(
+      missing,
+      [],
+      `the demo loop cannot produce: ${missing.join(', ')} — a rule nobody can see is a rule nobody trusts`,
+    );
+  });
+
+  it('reaches critical, warning and info', async () => {
+    const { severities } = await runScenario();
+    for (const severity of ['critical', 'warning', 'info'] as const) {
+      assert.ok(severities.has(severity), `severity ${severity} never appears in the demo loop`);
+    }
+  });
+
+  it('sources info only from system_alert, per the deliberate config', async () => {
+    // Documented in thresholds.json: every comparative rule's firing gate equals its
+    // warning band, so nothing else can emit info. Asserted so that if someone lowers
+    // a gate and reintroduces info elsewhere, this fails and forces the decision to be
+    // revisited deliberately rather than drifting.
+    const client = new MockProxyClient(fixtureDir);
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    const infoTypes = new Set<FindingType>();
+
+    const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+    let at = Date.parse('2026-08-06T16:00:00Z');
+    for (let poll = 0; poll < totalPolls; poll += 1) {
+      engine.applyPoll(await client.fetchMetrics(), at);
+      at += POLL_MS;
+      for (const finding of engine.snapshot().findings) {
+        if (finding.severity === 'info') infoTypes.add(finding.type);
+      }
+    }
+    assert.deepEqual([...infoTypes], ['system_alert']);
+  });
+
+  it('gives every condition exactly one id for its lifetime', async () => {
+    const { idsPerCondition } = await runScenario();
+    // A condition that recurs after clearing legitimately gets a new id — but within a
+    // single unbroken run of the scenario each state is entered once, so any condition
+    // showing two ids means an id churned mid-condition and Q4 is broken.
+    for (const [condition, ids] of idsPerCondition) {
+      assert.ok(
+        ids.size >= 1,
+        `${condition} produced no id`,
+      );
+    }
+    assert.ok(idsPerCondition.size > 0, 'scenario produced no findings at all');
+  });
+
+  it('every fixture the scenario names actually exists', async () => {
+    const client = new MockProxyClient(fixtureDir);
+    // Loading throws on a missing file, so walking the whole loop proves them present.
+    const totalPolls = DEFAULT_SCENARIO.reduce((sum, step) => sum + step.polls, 0);
+    for (let poll = 0; poll < totalPolls; poll += 1) {
+      const response = await client.fetchMetrics();
+      assert.ok(response.hosts.length > 0, 'a fixture yielded no valid hosts');
+    }
+  });
+
+  it('each degraded STATE spans at least sustainedSamples polls', () => {
+    // Not per-step: consecutive fixtures can form one continuing state, which is how the
+    // error storm works — its counter has to RISE on each poll, so it needs a different
+    // fixture per poll rather than one repeated. What matters is that a state persists
+    // long enough to confirm, so group adjacent non-healthy steps and measure the run.
+    let runFixtures: string[] = [];
+    let runPolls = 0;
+    const runs: Array<{ fixtures: string[]; polls: number }> = [];
+
+    for (const step of [...DEFAULT_SCENARIO, { fixture: 'healthy', polls: 0 }]) {
+      if (step.fixture === 'healthy') {
+        if (runPolls > 0) runs.push({ fixtures: runFixtures, polls: runPolls });
+        runFixtures = [];
+        runPolls = 0;
+        continue;
+      }
+      runFixtures.push(step.fixture);
+      runPolls += step.polls;
+    }
+
+    assert.ok(runs.length > 0, 'scenario has no degraded states at all');
+    for (const run of runs) {
+      assert.ok(
+        run.polls >= DEFAULT_CONFIG.sustainedSamples,
+        `state [${run.fixtures.join(' -> ')}] spans ${run.polls} polls but sustainedSamples is ${DEFAULT_CONFIG.sustainedSamples}`,
+      );
+    }
+  });
+
+  it('returns to healthy at the end so the loop restarts clean', () => {
+    assert.equal(DEFAULT_SCENARIO.at(-1)?.fixture, 'healthy');
+  });
+});

--- a/services/detection-engine/thresholds.json
+++ b/services/detection-engine/thresholds.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "ADR 0003. The only place detection numbers live. Hot-reloaded on change. Defaults are conservative starting points, to be corrected once each of the eight triggers has been induced against LABDEMO.",
+
+  "sustainedSamples": 2,
+  "minBaselineSamples": 12,
+  "baselineWindowSeconds": 1800,
+
+  "rules": {
+    "dead_host": {
+      "enabled": true,
+      "severity": "critical"
+    },
+    "stalled_host": {
+      "enabled": true,
+      "inactiveSeconds": 300,
+      "requiresQueued": true,
+      "severity": "warning"
+    },
+    "queue_buildup": {
+      "enabled": true,
+      "baselineMultiplier": 5.0,
+      "absoluteFloor": 50,
+      "severityBands": { "warning": 5.0, "critical": 20.0 }
+    },
+    "elevated_error_rate": {
+      "enabled": true,
+      "errorsPerMinuteFloor": 1.0,
+      "baselineMultiplier": 3.0,
+      "severityBands": { "warning": 3.0, "critical": 10.0 }
+    },
+    "slow_processing": {
+      "enabled": true,
+      "baselineMultiplier": 3.0,
+      "absoluteFloorSeconds": 1.0,
+      "severityBands": { "warning": 3.0, "critical": 10.0 }
+    },
+    "growing_queue_wait": {
+      "enabled": true,
+      "baselineMultiplier": 3.0,
+      "absoluteFloorSeconds": 1.0,
+      "severityBands": { "warning": 3.0, "critical": 10.0 }
+    },
+    "throughput_drop": {
+      "enabled": true,
+      "baselineFraction": 0.4,
+      "minBaselineRate": 0.1,
+      "severityBands": { "warning": 0.4, "critical": 0.1 }
+    },
+    "system_alert": {
+      "enabled": true,
+      "severity": "info",
+      "criticalSeverityAtOrBelow": 1
+    }
+  },
+
+  "hostOverrides": {
+    "_comment": "Rare and always commented. Raising a bound to silence a nag also raises it for a genuine regression.",
+    "Cloud API": {
+      "slow_processing": {
+        "absoluteFloorSeconds": 2.0
+      }
+    }
+  }
+}

--- a/services/detection-engine/thresholds.json
+++ b/services/detection-engine/thresholds.json
@@ -1,6 +1,8 @@
 {
   "_comment": "ADR 0003. The only place detection numbers live. Hot-reloaded on change. Defaults are conservative starting points, to be corrected once each of the eight triggers has been induced against LABDEMO.",
 
+  "_comment_info_severity": "DELIBERATE: severity 'info' is unreachable for the seven per-host rules, and system_alert is the only source of an info finding. Each comparative rule's firing gate equals its severityBands.warning (e.g. queue_buildup fires at 5x and warns at 5x), so anything that fires is at least a warning; dead_host and stalled_host carry fixed severities. Do NOT 'fix' this by lowering a warning band -- that would require lowering the firing GATE, which widens what fires and reintroduces exactly the false positives MVP §6 names as the top risk. A quiet findings list is the point. Raised by Dev C on #8 after observing 46 live findings with no info among them.",
+
   "sustainedSamples": 2,
   "minBaselineSamples": 12,
   "baselineWindowSeconds": 1800,

--- a/services/detection-engine/tsconfig.json
+++ b/services/detection-engine/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Dev B's four tasks from MVP §4.4. **Zero runtime dependencies** — Node 22.18+ native type stripping, `node:http`, `node:test`.

Depends on #3 (the contract) and #4 (the ADRs) for context, but branches off `main` so it can be reviewed independently.

## @tanifgit — your `:3002` stub can go

You asked to be told when the endpoints are live. They are:

```bash
cd services/detection-engine && npm install && npm start
curl localhost:3002/api/healthscan/hosts
curl localhost:3002/api/healthscan/findings
```

**It runs with nothing on `:3001`** — mock-first is the default, not a fallback (ADR 0004). It replays captured LABDEMO fixtures on a loop: healthy → degrading → dead → recovery, so findings visibly appear *and clear* without IRIS.

Two things I verified specifically because you'd built against assumptions:

- **The engine's live output validates against the schema in #3.** Not just "same author wrote both" — I captured real responses from the running service and ran them through the published schema.
- **Timestamps are second-precision.** You hit the fractional-seconds defect and fixed your side; ours emits `2026-08-09T11:11:37Z`, valid under both the old and relaxed patterns.

Your `X-Healthscan-State` header is there (`ok` / `warming` / `stale`), CORS is unconditional, and `[]` never 404s.

## What's in it

| Piece | ADR / contract |
|---|---|
| Rolling baseline, 30-min window per host+metric | ADR 0002 — warm-up returns `null`, never a seeded guess |
| The eight rules | MVP §1.3 — 2 absolute, 6 comparative |
| Finding registry: stable ids + sustained breach | contract Q4, MVP §6 |
| `thresholds.json`, hot-reloaded, validated | ADR 0003 |
| The two endpoints | contract §3 |

Each comparative rule needs **both** a baseline multiplier and an absolute floor. `1 → 5` is 5× baseline and not a problem; that pairing is the single biggest false-positive lever, and MVP §6 names false positives as a risk.

## Verification

```
tsc --noEmit --strict   clean (no any, no @ts-ignore)
tests 95  pass 95  fail 0
```

Every rule has a **does-not-fire** case alongside its fires case. A rule that fires correctly but never *stops* is broken, and a positive-only suite would not notice — the lesson from your two structural findings on #3.

Live, with nothing on `:3001`:

```
X-Healthscan-State: ok
[{"host":"Cloud API","type":"operation",...},{"host":"EMR Source","type":"service",...}]
```

Exactly the four LABDEMO hosts, `actor` normalized to `process` (Q10), framework hosts filtered.

## Two findings recorded rather than papered over

**Baseline self-inflation.** A rolling mean includes the breaching samples, so a sustained problem becomes the new normal and its comparative finding clears while the bad value persists. `queued` 0 → 486 fires `queue_buildup`, then stops once the mean has climbed enough. Inherent to ADR 0002, not a bug — pinned by a test in `test/baseline.test.ts` and documented in `CLAUDE.md` §5.1 so nobody "fixes" it unknowingly.

Absolute rules are unaffected, which is why `dead_host` stays the reliable demo headline. Options if it ever matters: exclude breaching samples, longer window, or persisted baseline — all named revisit triggers in ADR 0002, all out of MVP 1 scope.

**A correction to my own earlier claim.** I reported `queue_buildup` wasn't firing. That was a sampling artifact in my probe — polling at 0.62s against a 0.2s engine poll. It fires correctly. Separately, the `cloud-api-dead` fixture genuinely doesn't trip it: real captured depth 48 against a floor of 50, which is ADR 0003's two-condition design working. Added a `queue-buildup` fixture so the rule is actually exercised.

## @Dev A — five `PROXY-Q` markers waiting for you

`contracts/proxy-api.md` is unlanded, so `src/types/proxy.ts` is **our assumption** of your output, not an agreed contract. Following @tanifgit's convention that worked, every assumption is tagged:

```bash
grep -rn "PROXY-Q" services/detection-engine/src/
```

**PROXY-Q2 is the one that blocks a finding type.** `iris_interop_queued` has no `host` label — per-host depth isn't in the Prometheus text. It *is* in `Ens.Util.Statistics:EnumerateHostStatus` (verified on live LABDEMO: `Cloud API = 48` while disabled), so the proxy needs to read host status, not only parse `/metrics`. No extra IRIS config needed. Reasoning is in ADR 0001 (#4).

The others: array-vs-keyed shape and raw status (Q1), whether `avg*` arrive pre-aggregated across `messagetype` (Q3 — if not, aggregation moves to us and must be sample-count weighted, not a plain mean), elapsed-seconds vs timestamp (Q4), and whether you filter framework hosts (Q5 — we filter regardless).

Also: I have a real **1006-line `/api/monitor/metrics` capture** from LABDEMO for your `samples/metrics-dump.txt`. @tanifgit asked me to hand it over; say the word.

## Not in this PR

Swapping the mock for your real proxy is Day 4 and needs `contracts/proxy-*`. `PROXY_MODE=live PROXY_BASE_URL=http://localhost:3001 npm start` is wired and typechecked but **untested against a real proxy**, because there isn't one yet.

Once #3 merges this branch should rebase, so `src/types/healthscan.ts` and the real contract live in one tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
