### PR TITLE
chore(ci): CODEOWNERS, PR template, and the four per-path CI jobs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# Ownership, enforced mechanically rather than promised. CONTRIBUTING.md §4.
+#
+# Handles are placeholders where a developer is not yet onboarded. GitHub silently
+# ignores an unknown handle rather than erroring, so an unresolved name means reviews
+# are NOT requested for that path -- fix the handle, do not assume it works.
+
+# ---- Dev A -- IRIS and metrics ingestion ----
+# TODO: replace @devA with the real handle once Dev A is onboarded.
+/iris/                        @devA
+/services/metrics-proxy/      @devA
+
+# ---- Dev B -- detection engine and findings API ----
+/services/detection-engine/   @Ari-Glikman
+
+# ---- Dev C -- dashboard and demo ----
+/apps/dashboard/              @tanifgit
+/docs/demo/                   @tanifgit
+
+# ---- Shared, PR-gated ----
+# A contract change needs all three. That sounds heavy and is the point: a silent
+# contract change is the failure mode that breaks the Day-5 integration, and the
+# review takes 30 seconds.
+/contracts/                   @devA @Ari-Glikman @tanifgit
+
+# ADRs record decisions nobody should change unilaterally.
+/docs/decisions/              @devA @Ari-Glikman @tanifgit
+
+# Root config, tooling, CI.
+/tools/                       @devA @Ari-Glikman @tanifgit
+/.github/                     @devA @Ari-Glikman @tanifgit
+
+# Source material is read-only after Day 1 -- any change here wants three pairs of eyes.
+/docs/production-guardian-healthscan-mvp1.docx  @devA @Ari-Glikman @tanifgit
+/docs/production-guardian-demo.html             @devA @Ari-Glikman @tanifgit
+
+# Catch-all for anything not matched above.
+*                             @devA @Ari-Glikman @tanifgit

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+Keep this short. The checklist exists to catch the three things that have actually
+cost this project time, not to be ceremony.
+-->
+
+## What and why
+
+<!-- One or two sentences. Link the issue or ADR if there is one. -->
+
+## Verification
+
+<!--
+Paste the actual output, not a claim. "tests pass" is not evidence; the summary line
+is. If something is unverified or failing, say which -- a green claim over a red build
+costs the team more than the bug did.
+-->
+
+```
+```
+
+## Checklist
+
+- [ ] Stayed inside my own area (`CONTRIBUTING.md` §2), or flagged the crossing explicitly
+- [ ] No `contracts/` file edited as part of an implementation task
+- [ ] Ran my area's typecheck / build / tests, and pasted the output above
+- [ ] No invented data outside a declared fixtures directory
+- [ ] No new dependency, or stated why and what it replaces
+
+## If this touches `contracts/`
+
+- [ ] `contracts/CHANGELOG.md` entry, dated, with the reason
+- [ ] Consumer told what changes for them — and what does **not**
+- [ ] `cd contracts && npm run validate` passes
+- [ ] All three developers on the review (CODEOWNERS asks automatically)
+
+## Scope
+
+- [ ] Adds no capability from a later module — no fixing, root-cause, forecasting,
+      single health score, report generation, or chat (root `CLAUDE.md` §2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,144 @@
+name: CI
+
+# Per-path jobs so one developer's push never goes red because another's area is
+# mid-refactor (CONTRIBUTING.md §4). Each job only runs when its own paths change.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # The job worth more than the other three combined: it validates every file in
+  # contracts/samples/ against the schemas, so a contract and the shared fixtures
+  # disagreeing is caught here rather than at the Day-5 rehearsal.
+  contracts:
+    name: contracts — samples vs schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Skip if contracts/ is absent
+        id: guard
+        run: |
+          if [ -d contracts ]; then echo "present=true" >> "$GITHUB_OUTPUT"
+          else echo "present=false" >> "$GITHUB_OUTPUT"; echo "contracts/ not present yet — skipping"; fi
+      # `npm ci` needs a lockfile; fall back to `npm install` before one is committed.
+      - name: Install
+        if: steps.guard.outputs.present == 'true'
+        working-directory: contracts
+        run: npm ci || npm install
+      # Deliberately not an ajv-cli one-liner. Three reasons, all found on PR #3:
+      #   1. validating against the root schema cannot distinguish a hosts array from
+      #      a findings array, so that check silently does not happen
+      #   2. `-r '#/definitions/...'` is rewritten into a filesystem path by Git Bash
+      #   3. `-c ajv-formats` resolves from the invocation directory and silently
+      #      ignores `format` when run elsewhere — a validator that quietly weakens
+      - name: Validate samples
+        if: steps.guard.outputs.present == 'true'
+        working-directory: contracts
+        run: npm run validate
+
+  detection-engine:
+    name: detection-engine — typecheck + tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Skip if the service is absent
+        id: guard
+        run: |
+          if [ -d services/detection-engine ]; then echo "present=true" >> "$GITHUB_OUTPUT"
+          else echo "present=false" >> "$GITHUB_OUTPUT"; echo "services/detection-engine not present yet — skipping"; fi
+      - name: Install
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/detection-engine
+        run: npm ci || npm install
+      - name: Typecheck
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/detection-engine
+        run: npm run typecheck
+      - name: Test
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/detection-engine
+        run: npm test
+      # ADR 0004 is a promise the engine must keep: it has to start and serve with
+      # Dev A's proxy absent. If this step fails, mock-first is broken.
+      - name: Serves with no proxy running (ADR 0004)
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/detection-engine
+        run: |
+          PORT=3002 POLL_INTERVAL_MS=500 node src/index.ts &
+          ENGINE_PID=$!
+          for i in $(seq 1 20); do
+            if curl -fsS http://127.0.0.1:3002/api/healthscan/hosts >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          HOSTS=$(curl -fsS http://127.0.0.1:3002/api/healthscan/hosts)
+          kill "$ENGINE_PID" 2>/dev/null || true
+          COUNT=$(printf '%s' "$HOSTS" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).length))')
+          echo "hosts served with no proxy: $COUNT"
+          test "$COUNT" -eq 4
+
+  dashboard:
+    name: dashboard — typecheck + build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Skip if the app is absent
+        id: guard
+        run: |
+          if [ -f apps/dashboard/package.json ]; then echo "present=true" >> "$GITHUB_OUTPUT"
+          else echo "present=false" >> "$GITHUB_OUTPUT"; echo "apps/dashboard not present yet — skipping"; fi
+      - name: Install
+        if: steps.guard.outputs.present == 'true'
+        working-directory: apps/dashboard
+        run: npm ci || npm install
+      - name: Build (runs tsc --noEmit first)
+        if: steps.guard.outputs.present == 'true'
+        working-directory: apps/dashboard
+        run: npm run build
+      # Dev C's own fixture validator, if present — keeps demo fixtures honest
+      # against the published schema.
+      - name: Validate fixtures
+        if: steps.guard.outputs.present == 'true'
+        working-directory: apps/dashboard
+        run: npm run validate:fixtures --if-present
+
+  metrics-proxy:
+    name: metrics-proxy — typecheck + tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # Dev A's component does not exist yet, so this job is a no-op placeholder
+      # rather than a failure. It exists so the fourth per-path job from
+      # CONTRIBUTING.md §4 is present, and starts working the moment they land code.
+      - name: Skip if the service is absent
+        id: guard
+        run: |
+          if [ -f services/metrics-proxy/package.json ]; then echo "present=true" >> "$GITHUB_OUTPUT"
+          else echo "present=false" >> "$GITHUB_OUTPUT"; echo "services/metrics-proxy not present yet — skipping"; fi
+      - name: Install
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/metrics-proxy
+        run: npm ci || npm install
+      - name: Typecheck
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/metrics-proxy
+        run: npm run typecheck --if-present
+      - name: Test
+        if: steps.guard.outputs.present == 'true'
+        working-directory: services/metrics-proxy
+        run: npm test --if-present


### PR DESCRIPTION
Closes the `.github/` items from the §8 checklist in #2 — the last things on that list nobody had picked up. Shared and PR-gated, so review rather than a push.

Doing this now because it's the useful work available **while waiting on Dev A**, and it blocks nothing of theirs.

## The four per-path jobs

Per `CONTRIBUTING.md` §4, so one developer's push never goes red because another's area is mid-refactor.

| Job | Runs |
|---|---|
| `contracts` | `npm run validate` — samples vs schema |
| `detection-engine` | typecheck, tests, **and the ADR 0004 assertion** |
| `dashboard` | `npm run build` (which runs `tsc --noEmit`), plus `validate:fixtures` if present |
| `metrics-proxy` | placeholder — no-op until Dev A lands code |

**Every job guards on its own directory existing** and skips cleanly otherwise. That matters right now: two of the four components are still on unmerged branches and `services/metrics-proxy/` doesn't exist at all, so without the guards this workflow would be red on `main` from the moment it landed.

## Two jobs worth explaining

**`contracts` runs `validate.mjs`, not an `ajv-cli` one-liner.** @tanifgit found three ways the CLI form degrades (#3): validating against the root schema can't distinguish a hosts array from a findings array, Git Bash rewrites the `#/definitions/...` argument into a filesystem path, and `-c ajv-formats` silently ignores `format` when resolved from the wrong directory. A validator that quietly gets weaker is worse than one that breaks. The `README.md` records why, so nobody "simplifies" it back.

**`detection-engine` asserts ADR 0004 directly** — the engine must start and serve four hosts with **nothing on `:3001`**. If that step ever fails, mock-first is broken, and that's the promise the entire three-way parallel split rests on. Seemed worth a CI assertion rather than trusting it stays true.

## @Dev A — CODEOWNERS has a placeholder for you

`@devA` is not a real handle. GitHub **silently ignores** an unknown owner rather than erroring, so an unresolved name means reviews are quietly *not* requested for those paths — which is worse than an empty file, because it looks like it works. The file says so in a comment; swap it for the real handle when you're onboarded.

Paths currently pointing at the placeholder: `/iris/`, `/services/metrics-proxy/`, plus your third of `/contracts/`, `/docs/decisions/`, `/.github/`, and the catch-all.

## Verification

Run from clean worktree checkouts, not just eyeballed:

```
YAML valid. jobs: contracts, detection-engine, dashboard, metrics-proxy

$ # the ADR 0004 step, verbatim from ci.yml
hosts served with no proxy: 4
ADR 0004 CI STEP: PASS

$ # the contracts job, verbatim
all checks passed (2 samples, 4 accept, 5 reject)
CONTRACTS_JOB_EXIT=0
```

**Not verified:** none of this has run on GitHub Actions, only locally. The first PR after merge is the real test, and the `metrics-proxy` job is an untested placeholder that only becomes meaningful when Dev A lands code.

## On the PR template

Deliberately short. The verification section asks for **pasted output rather than a claim**, because "tests pass" isn't evidence and this project has already had one case of me reporting a green result from an `echo` rather than the tool I thought I'd run.

Refs #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
