### PR TITLE
chore(ci): real handle for Dev A, and stop reporting green on nothing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,12 @@
 # Ownership, enforced mechanically rather than promised. CONTRIBUTING.md §4.
 #
-# Handles are placeholders where a developer is not yet onboarded. GitHub silently
-# ignores an unknown handle rather than erroring, so an unresolved name means reviews
-# are NOT requested for that path -- fix the handle, do not assume it works.
+# GitHub silently ignores an unknown handle rather than erroring, so an unresolved name
+# means reviews are NOT requested for that path. Verify a handle resolves before
+# trusting it -- a typo here looks identical to working config.
 
 # ---- Dev A -- IRIS and metrics ingestion ----
-# TODO: replace @devA with the real handle once Dev A is onboarded.
-/iris/                        @devA
-/services/metrics-proxy/      @devA
+/iris/                        @kskubach
+/services/metrics-proxy/      @kskubach
 
 # ---- Dev B -- detection engine and findings API ----
 /services/detection-engine/   @Ari-Glikman
@@ -20,18 +19,18 @@
 # A contract change needs all three. That sounds heavy and is the point: a silent
 # contract change is the failure mode that breaks the Day-5 integration, and the
 # review takes 30 seconds.
-/contracts/                   @devA @Ari-Glikman @tanifgit
+/contracts/                   @kskubach @Ari-Glikman @tanifgit
 
 # ADRs record decisions nobody should change unilaterally.
-/docs/decisions/              @devA @Ari-Glikman @tanifgit
+/docs/decisions/              @kskubach @Ari-Glikman @tanifgit
 
 # Root config, tooling, CI.
-/tools/                       @devA @Ari-Glikman @tanifgit
-/.github/                     @devA @Ari-Glikman @tanifgit
+/tools/                       @kskubach @Ari-Glikman @tanifgit
+/.github/                     @kskubach @Ari-Glikman @tanifgit
 
 # Source material is read-only after Day 1 -- any change here wants three pairs of eyes.
-/docs/production-guardian-healthscan-mvp1.docx  @devA @Ari-Glikman @tanifgit
-/docs/production-guardian-demo.html             @devA @Ari-Glikman @tanifgit
+/docs/production-guardian-healthscan-mvp1.docx  @kskubach @Ari-Glikman @tanifgit
+/docs/production-guardian-demo.html             @kskubach @Ari-Glikman @tanifgit
 
 # Catch-all for anything not matched above.
-*                             @devA @Ari-Glikman @tanifgit
+*                             @kskubach @Ari-Glikman @tanifgit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,18 +122,23 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      # Dev A's component does not exist yet, so this job is a no-op placeholder
-      # rather than a failure. It exists so the fourth per-path job from
-      # CONTRIBUTING.md §4 is present, and starts working the moment they land code.
       - name: Skip if the service is absent
         id: guard
         run: |
           if [ -f services/metrics-proxy/package.json ]; then echo "present=true" >> "$GITHUB_OUTPUT"
           else echo "present=false" >> "$GITHUB_OUTPUT"; echo "services/metrics-proxy not present yet — skipping"; fi
+      # `npm ci` requires a committed lockfile; metrics-proxy has none yet, so prefer it
+      # when available and fall back quietly rather than printing a wall of npm errors
+      # into a passing job — noise in a green log trains people to stop reading it.
       - name: Install
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
-        run: npm ci || npm install
+        run: |
+          if [ -f package-lock.json ]; then npm ci
+          else echo "no package-lock.json — using npm install (ask Dev A to commit one)"; npm install; fi
+      # --if-present means a missing script is a silent pass. That is right for typecheck
+      # (metrics-proxy is plain JS and has none) but NOT for tests: a component with no
+      # test script should say so out loud rather than report green.
       - name: Typecheck
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
@@ -141,4 +146,6 @@ jobs:
       - name: Test
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
-        run: npm test --if-present
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then npm test
+          else echo "::warning::metrics-proxy defines no test script — nothing was verified"; fi


### PR DESCRIPTION
Three fixes from watching the **first real CI run** on `main` after #9 merged. I read the step logs rather than the job conclusions, which is how two of these surfaced.

## 1. CODEOWNERS was requesting no review at all for Dev A's paths

`@devA` was a placeholder and doesn't exist. GitHub **silently ignores** an unknown owner, so `/iris/` and `/services/metrics-proxy/` were configured to request nobody while looking correct.

Now `@kskubach` — and I verified it rather than assuming, since that's the entire failure mode:

```
$ gh api users/kskubach --jq '{login,type}'
{"login":"kskubach","type":"User"}

$ gh api .../collaborators --jq '.[].login'
tanifgit, kskubach, Ari-Glikman, InterSystems-Israel
```

## 2. A wall of npm errors inside a passing job

`npm ci || npm install` fails loudly first when there's no lockfile, and `services/metrics-proxy` has none:

```
metrics-proxy  Install  npm error code EUSAGE
metrics-proxy  Install  npm error The `npm ci` command can only install with an existing package-lock.json
```

The job passed via the fallback, so this was pure noise — and noise in a green log trains people to stop reading it. It now checks for the lockfile and says which path it took.

@kskubach — committing a `package-lock.json` for `services/metrics-proxy` would let CI use `npm ci` and get reproducible installs. Not urgent.

## 3. `npm test --if-present` reports green when there is no test script

This is the one worth flagging: it's **the same failure Dev C found in `-c ajv-formats`** (#3) — a check that silently gets weaker instead of failing — reproduced in my own CI a day after I wrote the README warning about it.

The step now emits a GitHub warning annotation when a component defines no test script, so *"nothing was verified"* is visible rather than indistinguishable from success.

Kept `--if-present` for **typecheck**, because `metrics-proxy` is plain JS and legitimately has no such script — a missing one there is correct, not suspicious.

## What the first run actually proved

Worth recording, since three of four jobs skipped their real work (their directories aren't all on `main` yet):

| Job | What really happened |
|---|---|
| `contracts` | **genuinely validated** — 11/11 checks, the job Dev C called most valuable |
| `metrics-proxy` | **genuinely ran Dev A's 123 lines of parser tests**, all passing |
| `detection-engine` | skipped — not on `main` until #8 |
| `dashboard` | skipped — not on `main` until #5 |

So CI works. Verified: YAML parses, all four jobs present.

Refs #9
