### PR TITLE
contracts: drop FHIR Transform from the samples

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -10,16 +10,26 @@ Every contract change, dated, with the reason. Newest first.
 `enum`, so this is samples plus one prose sentence. Consumers that read `host` as an opaque string
 need no edit.
 
-**Why:** the LABDEMO production has no FHIR Transform host. It never did. The HL7→PID transform is
-a DTL applied *inside* Lab Router's process, so it produces no config item and therefore no
-`host` label in `/api/monitor/metrics`. §2 of `healthscan-api.md` says only application config
-items appear; a host that IRIS cannot emit does not belong in a sample that Dev B and Dev C mock
-against. Verified against `iris/labdemo/Production.cls`: the items are `EMR Source`, `Lab Router`,
-`Cloud API`, plus the framework-filtered `Ens.ActivityReporter`.
+**Why:** the LABDEMO production no longer has a FHIR Transform host, so IRIS cannot emit that
+`host` label. §2 of `healthscan-api.md` says only application config items appear; a host the
+production cannot produce does not belong in a sample Dev B and Dev C mock against. Verified
+against `iris/labdemo/Production.cls`: the items are `EMR Source`, `Lab Router`, `Cloud API`, plus
+the framework-filtered `Ens.ActivityReporter`.
 
-The alternative — adding a fourth component so the fixture becomes true — would be inventing a
-production host to satisfy a fixture. Nothing in the pipeline produces FHIR, and the root
-`CLAUDE.md` forbids fabricated demo data.
+**It was real when the samples were written — this is a removal, not a correction of a fabrication.**
+Worth stating plainly, because Dev B's live capture in issue #10 does show
+`host="FHIR Transform"`. It was an `EnsLib.MsgRouter.RoutingEngine` whose rule forwarded everything
+straight to CloudAPI: no DTL, and nothing FHIR, as its own class comment said. It existed to
+generate metric activity. Keren removed it in `1801a50` when the pipeline became HL7→PID, and
+PR #14 settled on the three hosts above. The samples are simply older than that change.
+
+Restoring it instead would mean re-adding a pass-through host to the production for no reason
+other than making a fixture true. Nothing in the pipeline produces FHIR — that name was aspirational
+from the start.
+
+**Dev B's instance still runs the older production definition,** so a fresh capture there will show
+four hosts until it is reloaded from `iris/labdemo/`. That is expected and breaks nothing: an extra
+host is over-coverage, and the parser reads whatever `host` labels arrive.
 
 **Changes:**
 
@@ -38,11 +48,11 @@ Verified: `node validate.mjs` passes; both samples still valid.
 
 ### Follow-up outside `contracts/`, not part of this PR
 
-`FHIR Transform` also appears in `services/detection-engine/fixtures/proxy/*.json` (8 files),
-`services/metrics-proxy/fixtures/metrics.txt`, and the four-component sentence in the root
-`CLAUDE.md`, `apps/dashboard/CLAUDE.md`, `services/detection-engine/CLAUDE.md`. Those are each in
-their owner's area. Dev A will fix the metrics-proxy fixture; the rest is on the owning developer.
-Nothing breaks meanwhile — an extra host in a fixture is over-coverage, not a failure.
+`FHIR Transform` also appears in `services/detection-engine/fixtures/proxy/*.json` (8 files) and the
+four-component sentence in the root `CLAUDE.md`, `apps/dashboard/CLAUDE.md`,
+`services/detection-engine/CLAUDE.md`. Those are each in their owner's area, so they are not touched
+here. `services/metrics-proxy/fixtures/metrics.txt` is Dev A's and is already done on the PR #13
+branch. Nothing breaks meanwhile — an extra host in a fixture is over-coverage, not a failure.
 
 ## 2026-08-09 — Schema fixes from Dev C's review (Dev B)
 

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,46 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-08-10 — `FHIR Transform` removed from the samples (Dev A)
+
+**No schema change and no field change.** `host` is `{"type": "string", "minLength": 1}` with no
+`enum`, so this is samples plus one prose sentence. Consumers that read `host` as an opaque string
+need no edit.
+
+**Why:** the LABDEMO production has no FHIR Transform host. It never did. The HL7→PID transform is
+a DTL applied *inside* Lab Router's process, so it produces no config item and therefore no
+`host` label in `/api/monitor/metrics`. §2 of `healthscan-api.md` says only application config
+items appear; a host that IRIS cannot emit does not belong in a sample that Dev B and Dev C mock
+against. Verified against `iris/labdemo/Production.cls`: the items are `EMR Source`, `Lab Router`,
+`Cloud API`, plus the framework-filtered `Ens.ActivityReporter`.
+
+The alternative — adding a fourth component so the fixture becomes true — would be inventing a
+production host to satisfy a fixture. Nothing in the pipeline produces FHIR, and the root
+`CLAUDE.md` forbids fabricated demo data.
+
+**Changes:**
+
+- `samples/hosts-response.json` — the `FHIR Transform` entry is gone. Three hosts remain, still in
+  stable alphabetical order per §1.
+- `samples/findings-response.json` — finding `f-1038` (`slow_processing`) **reassigned** to
+  `Lab Router`, not deleted. The samples carry exactly one finding per type; deleting it would
+  have zeroed `slow_processing` coverage for everyone mocking against these bytes. The reassignment
+  invents nothing: the finding cites `baselineValue: 0.08`, which is already Lab Router's measured
+  `avgProcessingTime` in `hosts-response.json`. Its `host` is now a host that exists, and its
+  baseline still agrees with that host's row — it agrees *better* than before.
+- `healthscan-api.md` §2 — "exactly four: EMR Source, Lab Router, FHIR Transform, Cloud API" →
+  "exactly three: EMR Source, Lab Router, Cloud API".
+
+Verified: `node validate.mjs` passes; both samples still valid.
+
+### Follow-up outside `contracts/`, not part of this PR
+
+`FHIR Transform` also appears in `services/detection-engine/fixtures/proxy/*.json` (8 files),
+`services/metrics-proxy/fixtures/metrics.txt`, and the four-component sentence in the root
+`CLAUDE.md`, `apps/dashboard/CLAUDE.md`, `services/detection-engine/CLAUDE.md`. Those are each in
+their owner's area. Dev A will fix the metrics-proxy fixture; the rest is on the owning developer.
+Nothing breaks meanwhile — an extra host in a fixture is over-coverage, not a failure.
+
 ## 2026-08-09 — Schema fixes from Dev C's review (Dev B)
 
 Two **schema** defects found by Dev C reviewing PR #3, both with reproductions, both confirmed

--- a/contracts/healthscan-api.md
+++ b/contracts/healthscan-api.md
@@ -47,8 +47,7 @@ Hosts are returned in stable alphabetical order by `host`.
 
 **Only application hosts appear.** The framework's own items (`Ens.MonitorService`,
 `Ens.Alarm`, `Ens.ScheduleHandler`, `EnsLib.Testing.*`, `Ens.Activity.Operation.Local`, …) are
-filtered out. For LABDEMO that means exactly four: EMR Source, Lab Router, FHIR Transform,
-Cloud API.
+filtered out. For LABDEMO that means exactly three: EMR Source, Lab Router, Cloud API.
 
 ## 2. `GET /api/healthscan/findings`
 

--- a/contracts/samples/findings-response.json
+++ b/contracts/samples/findings-response.json
@@ -31,7 +31,7 @@
   },
   {
     "id": "f-1038",
-    "host": "FHIR Transform",
+    "host": "Lab Router",
     "type": "slow_processing",
     "severity": "warning",
     "currentValue": 0.41,

--- a/contracts/samples/hosts-response.json
+++ b/contracts/samples/hosts-response.json
@@ -22,17 +22,6 @@
     "lastActivity": "2026-08-06T15:47:52Z"
   },
   {
-    "host": "FHIR Transform",
-    "type": "process",
-    "status": "OK",
-    "queued": 0,
-    "messagesPerSec": 1.2,
-    "errored": 0,
-    "avgProcessingTime": 0.08,
-    "avgQueueingTime": 0,
-    "lastActivity": "2026-08-06T15:47:52Z"
-  },
-  {
     "host": "Lab Router",
     "type": "process",
     "status": "OK",


### PR DESCRIPTION
## What

`FHIR Transform` is removed from `contracts/samples/`. Per §4 of the root `CLAUDE.md` this is its own PR, with a `contracts/CHANGELOG.md` entry, and needs all three of us.

**No schema change, no field change.** `host` is `{"type": "string", "minLength": 1}` with no `enum`, so nothing in `healthscan.schema.json` or `healthscan.d.ts` moves. If you read `host` as an opaque string — and both of you do — there is nothing to change on your side.

## Why

The LABDEMO production no longer has a `FHIR Transform` host, so IRIS cannot emit that `host` label. §2 of `healthscan-api.md` says only application config items appear — a host the production cannot produce does not belong in the bytes you two mock against.

Verified against [Production.cls](iris/labdemo/Production.cls): the items are `EMR Source`, `Lab Router`, `Cloud API`, plus `Ens.ActivityReporter`, which the framework filter drops.

### It was real — this is a removal, not a correction of a fabrication

Worth stating plainly, because @Ari-Glikman's live capture in #10 **does** show `host="FHIR Transform"`, and my first version of this PR body wrongly claimed the production never had it. Git history disagrees with me: it was an `<Item>` in `Production.cls` from the first commit until `1801a50`.

It was an `EnsLib.MsgRouter.RoutingEngine` whose rule forwarded everything straight to `CloudAPI` — no DTL, and nothing FHIR, as its own class comment said. It existed to generate metric activity. Keren removed it in `1801a50` when the pipeline became HL7→PID, and #14 settled on the three hosts above.

**So the samples aren't wrong, they're older than the pipeline change.** Restoring the host instead would mean re-adding a pass-through item to the production for no reason beyond making a fixture true. Nothing in the pipeline produces FHIR; that name was aspirational from the start.

### One consequence for @Ari-Glikman

Your instance still runs the older production definition, so a fresh capture there will show four hosts until you reload from `iris/labdemo/`. Expected, and it breaks nothing — the parser reads whatever `host` labels arrive, and an extra host is over-coverage rather than a failure.

## The one thing worth reviewing carefully

I did **not** delete the `FHIR Transform` finding. The samples carry **exactly one finding per type**, so deleting `f-1038` would have zeroed `slow_processing` coverage for anyone mocking against these bytes.

It is reassigned to `Lab Router` instead, and that costs nothing: the finding cites `baselineValue: 0.08`, which is *already* Lab Router's measured `avgProcessingTime` in `hosts-response.json`. Its `host` now names a host that exists and its baseline still agrees with that host's row — it agrees better than it did before.

## Changes

| File | Change |
|---|---|
| `samples/hosts-response.json` | `FHIR Transform` entry removed; three hosts remain, still alphabetical per §1 |
| `samples/findings-response.json` | `f-1038` `host`: `FHIR Transform` → `Lab Router` |
| `healthscan-api.md` §2 | "exactly four: …, FHIR Transform, Cloud API" → "exactly three: EMR Source, Lab Router, Cloud API" |
| `CHANGELOG.md` | entry with the reasoning above |

## Verification

```
$ node validate.mjs
ok    samples/hosts-response.json against HostsResponse
ok    samples/findings-response.json against FindingsResponse
...
all checks passed (2 samples, 4 accept, 5 reject)
```

## Follow-up outside `contracts/` — deliberately not in this PR

`FHIR Transform` also appears in each of our own areas, and I am not editing anyone else's:

- `services/detection-engine/fixtures/proxy/*.json` (8 files) and the four-component sentence in `services/detection-engine/CLAUDE.md` — @tanifgit
- the four-component sentence in `apps/dashboard/CLAUDE.md` — @Ari-Glikman
- the four-component sentence in the root `CLAUDE.md` — shared, needs its own PR; happy to open it if you both agree with this one
- `services/metrics-proxy/fixtures/metrics.txt` — mine, **already done** on the #13 branch

Nothing breaks in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
