### PR TITLE
fix(detection-engine): drop FHIR Transform from the proxy fixtures

### DIFF
--- a/services/detection-engine/CLAUDE.md
+++ b/services/detection-engine/CLAUDE.md
@@ -188,9 +188,11 @@ all eight types.
 
 ## 6. Never invent data
 
-- **No fabricated hosts, metrics, or findings outside `fixtures/`.** Fixtures use the four LABDEMO
-  components — **EMR Source** (service), **Lab Router** (process), **FHIR Transform** (process),
-  **Cloud API** (operation) — and the eight real finding types.
+- **No fabricated hosts, metrics, or findings outside `fixtures/`.** Fixtures use the LABDEMO
+  application components — **EMR Source** (service), **Lab Router** (process), **Cloud API**
+  (operation) — and the eight real finding types. The authoritative list is the `<Item>` set in
+  `iris/labdemo/Production.cls`; do not restate it here beyond this note, because a host list
+  duplicated across areas is exactly what went stale when `FHIR Transform` was removed.
 - Fixture values should be **captured from live LABDEMO**, not invented. Real numbers catch real
   problems; `contracts/samples/` was built that way.
 - If the proxy is unreachable, serve last-known findings and report `X-Healthscan-State: stale`.

--- a/services/detection-engine/fixtures/proxy/cloud-api-dead.json
+++ b/services/detection-engine/fixtures/proxy/cloud-api-dead.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 1440,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 4.275,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "Disabled",

--- a/services/detection-engine/fixtures/proxy/error-storm-2.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-2.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 2172,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.9,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "Error",

--- a/services/detection-engine/fixtures/proxy/error-storm-3.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-3.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 2790,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.9,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "Error",

--- a/services/detection-engine/fixtures/proxy/error-storm-4.json
+++ b/services/detection-engine/fixtures/proxy/error-storm-4.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 2802,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.9,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "Error",

--- a/services/detection-engine/fixtures/proxy/error-storm.json
+++ b/services/detection-engine/fixtures/proxy/error-storm.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 2160,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.8,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "Error",

--- a/services/detection-engine/fixtures/proxy/healthy.json
+++ b/services/detection-engine/fixtures/proxy/healthy.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Captured from live LABDEMO, 2026-08-06. Steady state, all four hosts OK. avgProcessingTime 0.08 for the two processes is the real measured value.",
+  "_comment": "Captured from live LABDEMO, 2026-08-06. Steady state, all application hosts OK. avgProcessingTime 0.08 for Lab Router is the real measured value. Includes Ens.MonitorService to prove the framework filter drops it. FHIR Transform was removed here when it ceased to be a production item (see contracts/CHANGELOG.md); the remaining values are unchanged from the capture.",
   "sampledAt": "2026-08-06T15:47:52Z",
   "production": "LABDEMO.Production",
   "hosts": [
@@ -27,19 +27,6 @@
       "avgProcessingTime": 0.08,
       "avgQueueingTime": 0,
       "lastActivityElapsedSeconds": 3.966,
-      "sampleCount": 24
-    },
-    {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 1176,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.968,
       "sampleCount": 24
     },
     {

--- a/services/detection-engine/fixtures/proxy/queue-buildup.json
+++ b/services/detection-engine/fixtures/proxy/queue-buildup.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Cloud API alive but throttled: it still processes, slowly, so the queue climbs past the absoluteFloor of 50 while status stays OK. Derived from the same LABDEMO capture as cloud-api-dead, with Latency raised rather than the host disabled — this is what the FailurePercent/Latency triggers on LABDEMO.Operation.CloudAPI produce. Distinct from cloud-api-dead on purpose: that one stops at depth 48 and correctly does NOT trip queue_buildup.",
+  "_comment": "Cloud API alive but throttled: it still processes, slowly, so the queue climbs past the absoluteFloor of 50 while status stays OK. Derived from the same LABDEMO capture as cloud-api-dead, with Latency raised rather than the host disabled \u2014 this is what the FailurePercent/Latency triggers on LABDEMO.Operation.CloudAPI produce. Distinct from cloud-api-dead on purpose: that one stops at depth 48 and correctly does NOT trip queue_buildup.",
   "sampledAt": "2026-08-06T15:46:02Z",
   "production": "LABDEMO.Production",
   "hosts": [
@@ -18,19 +18,6 @@
     },
     {
       "name": "Lab Router",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 1800,
-      "messagesPerSec": 1.2,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 3.9,
-      "sampleCount": 24
-    },
-    {
-      "name": "FHIR Transform",
       "type": "actor",
       "status": "OK",
       "queued": 0,

--- a/services/detection-engine/fixtures/proxy/stalled-host.json
+++ b/services/detection-engine/fixtures/proxy/stalled-host.json
@@ -30,19 +30,6 @@
       "sampleCount": 24
     },
     {
-      "name": "FHIR Transform",
-      "type": "actor",
-      "status": "OK",
-      "queued": 0,
-      "messages": 2400,
-      "messagesPerSec": 0,
-      "messagesErrored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivityElapsedSeconds": 381,
-      "sampleCount": 24
-    },
-    {
       "name": "Cloud API",
       "type": "operation",
       "status": "OK",

--- a/services/detection-engine/package-lock.json
+++ b/services/detection-engine/package-lock.json
@@ -12,7 +12,7 @@
         "typescript": "^5.5.0"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=22.18.0"
       }
     },
     "node_modules/@types/node": {


### PR DESCRIPTION
The detection-engine half of #15, which is now merged. Follows it deliberately rather than racing it, so the contract moved first and these fixtures track it.

`FHIR Transform` is no longer an `<Item>` in `iris/labdemo/Production.cls` — @kskubach removed it in #14 when the pipeline became `EMR Source → Lab Router → Cloud API`. IRIS cannot emit that host label any more, so a fixture carrying it asserts a host the production cannot produce.

## Changes

- Removed from all **8** `fixtures/proxy/*.json`
- `CLAUDE.md` §6 stops restating the host list and points at `Production.cls` instead

That second one is the more interesting change. A host list duplicated across `contracts/samples/`, my fixtures, the dashboard's docs and the root `CLAUDE.md` is precisely what went stale here — four copies, one source of truth, and the copies drifted. Naming the authoritative source beats correcting the copy.

## The thing actually worth checking

Not "did the host go away" but **can the demo still show all eight finding types with three hosts**:

```
OK   dead_host             critical      OK   slow_processing       warning
OK   stalled_host          warning       OK   growing_queue_wait    warning
OK   queue_buildup         warning       OK   throughput_drop       warning
OK   elevated_error_rate   critical      OK   system_alert          info
```

It can — but that was **luck, not design**. `stalled_host` happens to use Lab Router and `dead_host` Cloud API, so neither depended on the removed host. Had the fixtures been laid out slightly differently, removing a host would have silently dropped a finding type from the demo, and `test/scenario.test.ts` would have caught it only because it exists. Worth stating plainly: the coverage assertion is what made this a five-minute change instead of a bug found during the screencast.

## Verification

```
tsc --noEmit strict          clean
tests                        110/110 pass
serves with no proxy         hosts: 3 -> Cloud API, EMR Source, Lab Router   (ADR 0004)
```

Three hosts, matching `Production.cls`'s application items exactly. Rebased on `main` post-#15 and re-verified there — the contract samples and these fixtures now name the same three hosts, which is the point of `contracts/samples/` being the shared bytes.

`Ens.MonitorService` remains in `healthy.json` on purpose: it's the framework host that proves `isFrameworkHost()` filters it, and the engine reports 3 rather than 4 as a result.

## Also includes one incidental fix

`package-lock.json` still carried `"node": ">=20.6.0"` while `package.json` requires `>=22.18.0` since the switch to native type stripping. One line, regenerated by `npm install` rather than hand-edited. Unrelated to the rest — happy to split it out if you'd rather.

Refs #15, #14
