### PR TITLE
fix(ci): ADR 0004 step asserted an exact host count and went stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
         run: npm test
       # ADR 0004 is a promise the engine must keep: it has to start and serve with
       # Dev A's proxy absent. If this step fails, mock-first is broken.
+      #
+      # Asserts "serves at least one host", not an exact count. An earlier version
+      # hardcoded 4 and went red when FHIR Transform was legitimately removed from the
+      # production (#14) -- the engine was right and the assertion was stale. The host
+      # count belongs to iris/labdemo/Production.cls, which this job does not own;
+      # coupling CI to it makes a correct change look like a regression.
+      # Coverage of *which* hosts and findings appear is asserted properly in
+      # test/scenario.test.ts, against the fixtures, where it can be kept honest.
       - name: Serves with no proxy running (ADR 0004)
         if: steps.guard.outputs.present == 'true'
         working-directory: services/detection-engine
@@ -84,7 +92,7 @@ jobs:
           kill "$ENGINE_PID" 2>/dev/null || true
           COUNT=$(printf '%s' "$HOSTS" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).length))')
           echo "hosts served with no proxy: $COUNT"
-          test "$COUNT" -eq 4
+          test "$COUNT" -ge 1
 
   dashboard:
     name: dashboard — typecheck + build


### PR DESCRIPTION
**My CI check was wrong, not the code.** #18 went red on this, and the engine is right.

The ADR 0004 step hardcoded `test "$COUNT" -eq 4`. `FHIR Transform` was legitimately removed from the production in #14, so the engine now correctly serves **3** hosts:

```
detection-engine listening on :3002 (proxy=mock, poll=500ms)
hosts served with no proxy: 3
##[error]Process completed with exit code 1
```

## Why `-ge 1` rather than `-eq 3`

Changing 4 → 3 would just re-arm the same trap. The exact count was never what this step is for: **ADR 0004 promises the engine starts and serves with Dev A's proxy absent** — if it serves anything at all, mock-first holds. A host count belongs to `iris/labdemo/Production.cls`, which this job doesn't own, so coupling CI to it makes a correct change in @kskubach's area look like a regression in mine.

Coverage of *which* hosts and finding types appear is asserted properly in `services/detection-engine/test/scenario.test.ts`, against the fixtures, where it sits next to the data it describes.

It's the same duplication problem as the host list itself — which is what #18 and #15 were both about. Four copies of one fact, and the copies drift. Removing the copy beats updating it.

## Verification

```
YAML valid, jobs: contracts, detection-engine, dashboard, metrics-proxy
hosts served with no proxy: 3
ADR 0004 STEP: PASS          # step replicated verbatim, locally
```

**#18 stays red until this merges** — it's the only failure there, and the fixture change itself is green (110/110 tests, tsc clean).

Small and mechanical; merge whenever. Refs #18, #14
