### PR TITLE
fix(detection-engine): tune floors to measured LABDEMO baselines

### DIFF
--- a/services/detection-engine/src/config/thresholds.ts
+++ b/services/detection-engine/src/config/thresholds.ts
@@ -42,6 +42,13 @@ export interface DurationRuleConfig {
   enabled: boolean;
   baselineMultiplier: number;
   absoluteFloorSeconds: number;
+  /**
+   * Zero-baseline hosts only. An infinite ratio cannot be graded by the bands, so
+   * severity comes from absolute magnitude: this many times the floor earns `critical`,
+   * anything above the floor alone is a `warning`. Without it the floor becomes a
+   * critical trigger and there is no warning tier at all.
+   */
+  criticalFloorMultiple: number;
   severityBands: { warning: number; critical: number };
 }
 
@@ -111,12 +118,14 @@ export const DEFAULT_CONFIG: ThresholdConfig = {
       enabled: true,
       baselineMultiplier: 3.0,
       absoluteFloorSeconds: 1.0,
+      criticalFloorMultiple: 4.0,
       severityBands: { warning: 3.0, critical: 10.0 },
     },
     growing_queue_wait: {
       enabled: true,
       baselineMultiplier: 3.0,
       absoluteFloorSeconds: 1.0,
+      criticalFloorMultiple: 4.0,
       severityBands: { warning: 3.0, critical: 10.0 },
     },
     throughput_drop: {

--- a/services/detection-engine/src/detect/rules/index.ts
+++ b/services/detection-engine/src/detect/rules/index.ts
@@ -168,9 +168,21 @@ function durationRule(
       const ratio = baseline > 0 ? current / baseline : Number.POSITIVE_INFINITY;
       if (ratio < rule.baselineMultiplier) return null;
 
+      // A zero baseline makes every ratio infinite, so the multiplier cannot bind and
+      // the floor is the entire gate. This branch previously hardcoded `critical`,
+      // which meant a host whose normal queue wait is 0 went from silent to critical
+      // at the floor with no warning tier -- and lowering the floor to 0.15s made that
+      // trigger 150ms of queue wait. MVP §6 names false positives as the top risk.
+      //
+      // Instead, judge an infinite ratio on absolute magnitude against the floor:
+      // `criticalFloorMultiple` x the floor earns `critical`, anything above the floor
+      // is a `warning`. That restores a two-tier response for zero-baseline hosts
+      // without making the floor itself a critical trigger. Found by Dev C on #20.
       const severity = Number.isFinite(ratio)
         ? severityFromRatio(ratio, rule.severityBands)
-        : 'critical';
+        : current >= rule.absoluteFloorSeconds * rule.criticalFloorMultiple
+          ? 'critical'
+          : 'warning';
       const comparison = Number.isFinite(ratio) ? ` is ${formatRatio(ratio)} baseline` : '';
 
       return {

--- a/services/detection-engine/test/rules.test.ts
+++ b/services/detection-engine/test/rules.test.ts
@@ -259,6 +259,80 @@ describe('growing_queue_wait', () => {
     assert.match(verdict.message, /Average queue wait 1\.84s/);
   });
 
+  describe('zero baseline — the infinite-ratio path', () => {
+    // A zero baseline makes every ratio infinite, so the bands cannot grade it and the
+    // floor is the whole gate. This used to hardcode `critical`, meaning a host whose
+    // normal wait is 0 went silent -> critical at the floor with no warning tier. Found
+    // by Dev C on #20. LABDEMO measures 0 here on two of three hosts, so this is the
+    // common case rather than an edge one.
+    const floor = DEFAULT_CONFIG.rules.growing_queue_wait.absoluteFloorSeconds;
+    const criticalAt = floor * DEFAULT_CONFIG.rules.growing_queue_wait.criticalFloorMultiple;
+
+    it('does NOT fire below the floor', () => {
+      const verdict = evaluate(
+        'growing_queue_wait',
+        host({ avgQueueingTime: floor * 0.5 }),
+        warmBaseline('avgQueueingTime', 0),
+      );
+      assert.equal(verdict, null);
+    });
+
+    it('warns at the floor rather than going straight to critical', () => {
+      const verdict = evaluate(
+        'growing_queue_wait',
+        host({ avgQueueingTime: floor }),
+        warmBaseline('avgQueueingTime', 0),
+      );
+      assert.ok(verdict !== null);
+      assert.equal(verdict.severity, 'warning', 'the floor must not be a critical trigger');
+    });
+
+    it('still warns just below the critical multiple', () => {
+      const verdict = evaluate(
+        'growing_queue_wait',
+        host({ avgQueueingTime: criticalAt * 0.99 }),
+        warmBaseline('avgQueueingTime', 0),
+      );
+      assert.equal(verdict?.severity, 'warning');
+    });
+
+    it('escalates to critical at the critical multiple', () => {
+      const verdict = evaluate(
+        'growing_queue_wait',
+        host({ avgQueueingTime: criticalAt }),
+        warmBaseline('avgQueueingTime', 0),
+      );
+      assert.equal(verdict?.severity, 'critical');
+    });
+
+    it('omits the ratio from the message, since there is no honest one to state', () => {
+      const verdict = evaluate(
+        'growing_queue_wait',
+        host({ avgQueueingTime: 1.0 }),
+        warmBaseline('avgQueueingTime', 0),
+      );
+      assert.ok(verdict !== null);
+      assert.doesNotMatch(verdict.message, /baseline/, 'must not claim an Infinity ratio');
+    });
+
+    it('applies the same two tiers to slow_processing', () => {
+      const procFloor = DEFAULT_CONFIG.rules.slow_processing.absoluteFloorSeconds;
+      const procCritical = procFloor * DEFAULT_CONFIG.rules.slow_processing.criticalFloorMultiple;
+      const atFloor = evaluate(
+        'slow_processing',
+        host({ avgProcessingTime: procFloor }),
+        warmBaseline('avgProcessingTime', 0),
+      );
+      const atCritical = evaluate(
+        'slow_processing',
+        host({ avgProcessingTime: procCritical }),
+        warmBaseline('avgProcessingTime', 0),
+      );
+      assert.equal(atFloor?.severity, 'warning');
+      assert.equal(atCritical?.severity, 'critical');
+    });
+  });
+
   it('does NOT fire on a healthy sub-second wait', () => {
     const verdict = evaluate(
       'growing_queue_wait',

--- a/services/detection-engine/thresholds.json
+++ b/services/detection-engine/thresholds.json
@@ -1,12 +1,9 @@
 {
-  "_comment": "ADR 0003. The only place detection numbers live. Hot-reloaded on change. Defaults are conservative starting points, to be corrected once each of the eight triggers has been induced against LABDEMO.",
-
-  "_comment_info_severity": "DELIBERATE: severity 'info' is unreachable for the seven per-host rules, and system_alert is the only source of an info finding. Each comparative rule's firing gate equals its severityBands.warning (e.g. queue_buildup fires at 5x and warns at 5x), so anything that fires is at least a warning; dead_host and stalled_host carry fixed severities. Do NOT 'fix' this by lowering a warning band -- that would require lowering the firing GATE, which widens what fires and reintroduces exactly the false positives MVP §6 names as the top risk. A quiet findings list is the point. Raised by Dev C on #8 after observing 46 live findings with no info among them.",
-
+  "_comment": "ADR 0003. The only place detection numbers live. Hot-reloaded on change. Floors were tuned 2026-08-11 against measured LABDEMO steady state (proc: Lab Router .08s, Cloud API .05s, EMR Source 0; queue wait: only Cloud API at .03s) -- the original 1.0s floors were 12-33x those baselines, so the floor bound instead of the multiplier and a 10x regression produced no finding at all.",
+  "_comment_info_severity": "DELIBERATE: severity 'info' is unreachable for the seven per-host rules, and system_alert is the only source of an info finding. Each comparative rule's firing gate equals its severityBands.warning (e.g. queue_buildup fires at 5x and warns at 5x), so anything that fires is at least a warning; dead_host and stalled_host carry fixed severities. Do NOT 'fix' this by lowering a warning band -- that would require lowering the firing GATE, which widens what fires and reintroduces exactly the false positives MVP \u00a76 names as the top risk. A quiet findings list is the point. Raised by Dev C on #8 after observing 46 live findings with no info among them.",
   "sustainedSamples": 2,
   "minBaselineSamples": 12,
   "baselineWindowSeconds": 1800,
-
   "rules": {
     "dead_host": {
       "enabled": true,
@@ -22,31 +19,46 @@
       "enabled": true,
       "baselineMultiplier": 5.0,
       "absoluteFloor": 50,
-      "severityBands": { "warning": 5.0, "critical": 20.0 }
+      "severityBands": {
+        "warning": 5.0,
+        "critical": 20.0
+      }
     },
     "elevated_error_rate": {
       "enabled": true,
       "errorsPerMinuteFloor": 1.0,
       "baselineMultiplier": 3.0,
-      "severityBands": { "warning": 3.0, "critical": 10.0 }
+      "severityBands": {
+        "warning": 3.0,
+        "critical": 10.0
+      }
     },
     "slow_processing": {
       "enabled": true,
       "baselineMultiplier": 3.0,
-      "absoluteFloorSeconds": 1.0,
-      "severityBands": { "warning": 3.0, "critical": 10.0 }
+      "absoluteFloorSeconds": 0.2,
+      "severityBands": {
+        "warning": 3.0,
+        "critical": 10.0
+      }
     },
     "growing_queue_wait": {
       "enabled": true,
       "baselineMultiplier": 3.0,
-      "absoluteFloorSeconds": 1.0,
-      "severityBands": { "warning": 3.0, "critical": 10.0 }
+      "absoluteFloorSeconds": 0.15,
+      "severityBands": {
+        "warning": 3.0,
+        "critical": 10.0
+      }
     },
     "throughput_drop": {
       "enabled": true,
       "baselineFraction": 0.4,
       "minBaselineRate": 0.1,
-      "severityBands": { "warning": 0.4, "critical": 0.1 }
+      "severityBands": {
+        "warning": 0.4,
+        "critical": 0.1
+      }
     },
     "system_alert": {
       "enabled": true,
@@ -54,12 +66,12 @@
       "criticalSeverityAtOrBelow": 1
     }
   },
-
   "hostOverrides": {
     "_comment": "Rare and always commented. Raising a bound to silence a nag also raises it for a genuine regression.",
     "Cloud API": {
+      "_comment": "Outbound operation: its latency includes a simulated remote call, so it tolerates more than the in-process hosts. 0.3s is ~6x its measured 0.05s.",
       "slow_processing": {
-        "absoluteFloorSeconds": 2.0
+        "absoluteFloorSeconds": 0.3
       }
     }
   }

--- a/services/detection-engine/thresholds.json
+++ b/services/detection-engine/thresholds.json
@@ -1,6 +1,6 @@
 {
   "_comment": "ADR 0003. The only place detection numbers live. Hot-reloaded on change. Floors were tuned 2026-08-11 against measured LABDEMO steady state (proc: Lab Router .08s, Cloud API .05s, EMR Source 0; queue wait: only Cloud API at .03s) -- the original 1.0s floors were 12-33x those baselines, so the floor bound instead of the multiplier and a 10x regression produced no finding at all.",
-  "_comment_info_severity": "DELIBERATE: severity 'info' is unreachable for the seven per-host rules, and system_alert is the only source of an info finding. Each comparative rule's firing gate equals its severityBands.warning (e.g. queue_buildup fires at 5x and warns at 5x), so anything that fires is at least a warning; dead_host and stalled_host carry fixed severities. Do NOT 'fix' this by lowering a warning band -- that would require lowering the firing GATE, which widens what fires and reintroduces exactly the false positives MVP \u00a76 names as the top risk. A quiet findings list is the point. Raised by Dev C on #8 after observing 46 live findings with no info among them.",
+  "_comment_info_severity": "DELIBERATE: severity 'info' is unreachable for the seven per-host rules, and system_alert is the only source of an info finding. Each comparative rule's firing gate equals its severityBands.warning (e.g. queue_buildup fires at 5x and warns at 5x), so anything that fires is at least a warning; dead_host and stalled_host carry fixed severities. Do NOT 'fix' this by lowering a warning band -- that would require lowering the firing GATE, which widens what fires and reintroduces exactly the false positives MVP §6 names as the top risk. A quiet findings list is the point. Raised by Dev C on #8 after observing 46 live findings with no info among them.",
   "sustainedSamples": 2,
   "minBaselineSamples": 12,
   "baselineWindowSeconds": 1800,
@@ -37,6 +37,7 @@
       "enabled": true,
       "baselineMultiplier": 3.0,
       "absoluteFloorSeconds": 0.2,
+      "criticalFloorMultiple": 4.0,
       "severityBands": {
         "warning": 3.0,
         "critical": 10.0
@@ -46,6 +47,7 @@
       "enabled": true,
       "baselineMultiplier": 3.0,
       "absoluteFloorSeconds": 0.15,
+      "criticalFloorMultiple": 4.0,
       "severityBands": {
         "warning": 3.0,
         "critical": 10.0


### PR DESCRIPTION
ADR 0003 committed to replacing the guessed defaults *"once each of the eight triggers has been induced against LABDEMO."* IRIS is up, so this is that pass — and the guesses were wrong in a way that mattered.

## The absolute floors dominated on every host

Measured steady state, stable across four samples 10s apart:

| | avg processing | avg queue wait |
|---|---|---|
| EMR Source | `0` | `0` |
| Lab Router | `0.08s` | `0` |
| Cloud API | `0.05s` | `0.03s` |

Against a `0.08s` baseline, a `1.0s` floor is **12.5×** — so `baselineMultiplier: 3.0` never bound. Proven against the rule itself rather than reasoned about:

```
BEFORE (floor 1.0s, baseline 0.08s)
  0.24s ( 3.0x) -> NO FINDING
  0.80s (10.0x) -> NO FINDING       <- a 10x regression, silent
  1.00s (12.5x) -> critical         <- and it skips warning entirely

AFTER (floor 0.2s)
  0.16s ( 2.0x) -> no finding
  0.24s ( 3.0x) -> warning
  0.80s (10.0x) -> critical
```

**Two defects in one.** `slow_processing` could not report a real 10× slowdown, and its `warning` band was unreachable.

@tanifgit — that second half is the same class as the `info`-unreachable finding you caught on #8, and I missed it then because I was reading the severity bands rather than asking what the *firing gate* actually was. The gate was the floor, not the multiplier, on every single host.

## Changes

```
slow_processing     absoluteFloorSeconds  1.0 -> 0.2
growing_queue_wait  absoluteFloorSeconds  1.0 -> 0.15
Cloud API override                        2.0 -> 0.3
```

Cloud API keeps a higher floor deliberately: its latency includes a simulated remote call, so it tolerates more than the in-process hosts. `0.3s` is ~6× its measured `0.05s` rather than 40×.

## What I deliberately did not change

**`queue_buildup`'s `absoluteFloor: 50`.** LABDEMO idles at `0` queued, and when I disabled Cloud API a real backup hit **70 within three minutes**. So 50 sits correctly between noise and a genuine problem — the one guessed number that happened to be right.

**The multipliers and severity bands.** They're the right shape and were never the binding constraint. Changing them would have masked the real problem.

## Verification

```
tsc --noEmit strict     clean
tests                   110/110
demo loop               all 8 finding types, all 3 severities
```

One thing worth recording: my first attempt put `hostOverrides` *inside* `rules` instead of beside it, and the config validator rejected it with `unknown rule "hostOverrides"`. That's the "never fall back to zeros, refuse the file loudly" guard from ADR 0003 earning its place — a permissive loader would have silently dropped the override and I'd have shipped Cloud API on the wrong floor.

Entirely within `services/detection-engine/`. Refs ADR 0003, #8
