### PR TITLE
fix(dashboard): drop FHIR Transform from the demo fixtures

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -305,7 +305,7 @@ Going through the dev proxy means **CORS is never your problem** and Dev B can b
 
 Demo mode is a **first-class deliverable**, not a stub — it is the Day-5 fallback and the screencast source.
 
-- Fixtures use the LABDEMO production's four real components, so demo and live look continuous: **EMR Source** (service), **Lab Router** (process), **FHIR Transform** (process), **Cloud API** (operation).
+- Fixtures use the LABDEMO production's three real components, so demo and live look continuous: **EMR Source** (service), **Lab Router** (process), **Cloud API** (operation). There was a fourth, `FHIR Transform`, until `contracts/` PR #15 dropped it — a real pass-through routing item that left the production when the pipeline became HL7→PID.
 - Fixture files are plain JSON matching the contract exactly — the same guards run over them. If a fixture fails validation, the contract transcription is wrong.
 - Each fixture is a scenario file containing `{ hosts: Host[], findings: Finding[] }`. `scenario-healthy.json` has zero findings — that exercises the empty state, which is easy to forget and looks bad if broken on stage.
 - `mockClient` supports a **scripted progression**: healthy → degrading → findings appear, advancing on each poll so the dashboard visibly comes alive during the demo without anyone touching IRIS. Make it loop, and make it restartable from the UI.
@@ -415,7 +415,7 @@ From §4.5 of the MVP plan, in order:
 
 | # | Task | Est. | Done when |
 |---|---|---|---|
-| 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders all four LABDEMO hosts and all fixture findings; every state designed; `tsc` clean |
+| 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders all three LABDEMO hosts and all fixture findings; every state designed; `tsc` clean |
 | 2 | Live polling + demo/live toggle (`?mode=live`) | 0.75 d | Visible change reflected within 10 s; API failure degrades to last-good + banner, never blanks |
 | 3 | Finding detail view | 0.5 d | Click a finding → current vs. baseline, metric, timestamp; keyboard accessible; drawer survives polls |
 | 4 | Screencast + static fallback | 0.5 d | `dist/index.html` opens from `file://` in demo mode; screencast recorded |
@@ -431,7 +431,7 @@ Sequencing note: tasks 1–3 need only the contract, so they proceed regardless 
 
 - **Ask before widening scope.** If a request implies any module from §1.1, say so instead of building it.
 - **The contract is upstream of you.** Never edit `contracts/`. Never add a field to a type to make a component work — surface it as a contract question.
-- **Never invent data.** No placeholder hosts, no made-up metrics, no fabricated findings outside `fixtures/`. Fixtures use the four LABDEMO components and the eight real finding types.
+- **Never invent data.** No placeholder hosts, no made-up metrics, no fabricated findings outside `fixtures/`. Fixtures use the three LABDEMO components and the eight real finding types.
 - **No new dependencies** without stating why and what it replaces.
 - **No `fetch` outside `src/api/`.** No component talks to the network.
 - **No hard-coded colors, spacing, or radii.** Use the tokens in §7.1. If a token is missing, add it to `tokens.css` rather than inlining a value.

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -29,12 +29,12 @@ Every scenario is reachable by URL, which is also how you grab screenshots.
 | URL | What you should see |
 |---|---|
 | `/` | Scripted progression — advances one fixture per refresh, then loops |
-| `/?scenario=healthy` | All four hosts OK, zero counts, the designed empty state |
-| `/?scenario=queue-buildup` | Lab Router queue at 486, two warnings |
-| `/?scenario=dead-host` | Cloud API grey `Inactive` dot, two criticals, red left borders |
+| `/?scenario=healthy` | All three hosts OK, zero counts, the designed empty state |
+| `/?scenario=queue-buildup` | Lab Router queue at 486, two criticals |
+| `/?scenario=dead-host` | Cloud API grey `Disabled` dot, three criticals and a warning, red left borders |
 | `/?scenario=error-storm` | Cloud API in `Error`, 218 errored messages |
-| `/?scenario=slow-processing` | FHIR Transform at 1.86 s per message |
-| `/?scenario=throughput-drop` | EMR Source intake collapsed to 1.8 msg/sec |
+| `/?scenario=slow-processing` | Lab Router at 1.86 s per message |
+| `/?scenario=throughput-drop` | EMR Source intake collapsed to 0 msg/sec, the drop reaching all three hosts |
 | `/?scenario=system-alert` | An alert from `/api/monitor/alerts` |
 | `/?scenario=baseline-warming` | `baselineValue: null` — comparisons render `—`, never `NaN` |
 

--- a/apps/dashboard/fixtures/README.md
+++ b/apps/dashboard/fixtures/README.md
@@ -5,17 +5,19 @@ the screencast source (`apps/dashboard/CLAUDE.md` §5).
 
 ## Rules these files follow
 
-- **The four LABDEMO components only** — `EMR Source` (service), `Lab Router`
-  (process), `FHIR Transform` (process), `Cloud API` (operation). Demo and live
-  must look continuous, so no invented hosts.
+- **The three LABDEMO components only** — `EMR Source` (service), `Lab Router`
+  (process), `Cloud API` (operation). Demo and live must look continuous, so no
+  invented hosts. `FHIR Transform` was a fourth until `contracts/` PR #15: it was
+  a real pass-through routing item, removed from the production when the pipeline
+  became HL7→PID, so the samples were older than the production rather than wrong.
 - **Numbers are anchored to measured LABDEMO values, never invented** (issue #6).
   The healthy steady state is the capture Dev B re-measured over three samples:
-  `EMR Source 0.2` msg/sec, `Lab Router` and `FHIR Transform 1.2`, `Cloud API
-  0.4`; `avgProcessingTime` `0`/`0.08`/`0.08`/`0.05`; `avgQueueingTime` **0 except
-  Cloud API** at `0.02`, because only the terminal operation ever waits. Every
-  other scenario is a departure from those numbers. The topology matters as much
-  as the magnitude — service lowest, processes highest, operation between — since
-  four hosts reporting the same rate is what made the old set read as synthetic.
+  `EMR Source 0.2` msg/sec, `Lab Router 1.2`, `Cloud API 0.4`;
+  `avgProcessingTime` `0`/`0.08`/`0.05`; `avgQueueingTime` **0 except Cloud API**
+  at `0.02`, because only the terminal operation ever waits. Every other scenario
+  is a departure from those numbers. The topology matters as much as the
+  magnitude — service lowest, process highest, operation between — since hosts
+  reporting the same rate is what made the old set read as synthetic.
 - **The eight real finding types only** — the snake_case names in the contract.
 - **Timestamps are relative**, stored as `lastActivitySecondsAgo` /
   `detectedSecondsAgo`. `mockClient` resolves them against load time into ISO
@@ -82,19 +84,27 @@ npm run validate:fixtures:strict   # a missing contract or thresholds file FAILS
 |---|---|
 | `scenario-healthy.json` | Zero findings — exercises the empty state, which looks bad if it breaks on stage. Also the measured baseline every other file departs from |
 | `scenario-queue-buildup.json` | Lab Router's queue climbing behind a slowed Cloud API |
-| `scenario-dead-host.json` | Cloud API `Disabled`, plus the stall and throughput collapse it causes upstream |
-| `scenario-error-storm.json` | Cloud API in `Error`, rejecting messages while FHIR Transform retries |
-| `scenario-slow-processing.json` | FHIR Transform processing time inflated, queue climbing behind it |
-| `scenario-throughput-drop.json` | EMR Source intake stopped, the drop propagating downstream |
+| `scenario-dead-host.json` | Cloud API `Disabled`, plus the stall and throughput collapse it causes on Lab Router upstream |
+| `scenario-error-storm.json` | Cloud API in `Error`, rejecting messages while Lab Router retries |
+| `scenario-slow-processing.json` | Lab Router processing time inflated, queue climbing behind it |
+| `scenario-throughput-drop.json` | EMR Source intake stopped, the drop propagating through all three hosts |
 | `scenario-system-alert.json` | Alert posted to alerts.log |
 | `scenario-baseline-warming.json` | `baselineValue: null` — the warm-up state (contract §4 Q3), so only the absolute rules appear |
 
 Two notes on reading these, both learned from checking them against the real engine:
 
 - **A zero baseline is normal, not a bug.** LABDEMO idles at `queued: 0` and
-  `avgQueueingTime: 0` on three of four hosts, so a real buildup has no ratio to
-  quote. The engine treats its absolute floor as the whole test there and says
+  `avgQueueingTime: 0` on two of the three hosts, so a real buildup has no ratio
+  to quote. The engine treats its absolute floor as the whole test there and says
   "with no baseline queue" rather than "∞x baseline".
+- **A rolling baseline is not the steady-state table.** `scenario-slow-processing`
+  gives Lab Router a `growing_queue_wait` baseline of `0.02` even though the
+  measured table has its `avgQueueingTime` at `0`. That is deliberate: the engine's
+  baseline is a 30-minute rolling mean (ADR 0002), so a host that idles at zero
+  still carries a small non-zero mean if anything queued during the window. The
+  value came from the finding this scenario used to hang on `FHIR Transform`, and
+  it is kept rather than zeroed because a zero baseline changes the engine's own
+  message to the "no baseline" wording, which a fixture may not invent.
 - **`elevated_error_rate` compares a rate, not the counter.** `host.errored` is
   IRIS's cumulative count, but the finding's `currentValue` is errors/min — a
   cumulative counter only ever rises and would flag forever once it moved. The two

--- a/apps/dashboard/fixtures/scenario-baseline-warming.json
+++ b/apps/dashboard/fixtures/scenario-baseline-warming.json
@@ -18,17 +18,6 @@
       "host": "Lab Router",
       "type": "process",
       "status": "OK",
-      "queued": 0,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivitySecondsAgo": 1
-    },
-    {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
       "queued": 12,
       "messagesPerSec": 0,
       "errored": 0,
@@ -61,7 +50,7 @@
     },
     {
       "id": "f-1661",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "stalled_host",
       "severity": "warning",
       "currentValue": 312,

--- a/apps/dashboard/fixtures/scenario-dead-host.json
+++ b/apps/dashboard/fixtures/scenario-dead-host.json
@@ -1,7 +1,7 @@
 {
   "id": "dead-host",
   "label": "Dead host",
-  "note": "Cloud API is Disabled. Nothing drains downstream, so FHIR Transform stalls behind it — the critical scenario and the demo headline. dead_host is absolute, so it stays trustworthy even as the rolling baseline drifts (engine CLAUDE.md §5.1).",
+  "note": "Cloud API is Disabled. Nothing drains downstream, so Lab Router stalls behind it — the critical scenario and the demo headline. EMR Source keeps accepting at its measured 0.2 msg/sec, which is where Lab Router's 212 queued came from. dead_host is absolute, so it stays trustworthy even as the rolling baseline drifts (engine CLAUDE.md §5.1).",
   "hosts": [
     {
       "host": "EMR Source",
@@ -19,17 +19,6 @@
       "type": "process",
       "status": "OK",
       "queued": 212,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 2.1,
-      "lastActivitySecondsAgo": 3
-    },
-    {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
-      "queued": 338,
       "messagesPerSec": 0,
       "errored": 0,
       "avgProcessingTime": 0.08,
@@ -61,7 +50,7 @@
     },
     {
       "id": "f-1104",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "throughput_drop",
       "severity": "critical",
       "currentValue": 0,
@@ -71,13 +60,13 @@
     },
     {
       "id": "f-1102",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "stalled_host",
       "severity": "warning",
       "currentValue": 402,
       "baselineValue": null,
       "detectedSecondsAgo": 60,
-      "message": "No activity for 402s while 338 message(s) are queued"
+      "message": "No activity for 402s while 212 message(s) are queued"
     },
     {
       "id": "f-1103",

--- a/apps/dashboard/fixtures/scenario-error-storm.json
+++ b/apps/dashboard/fixtures/scenario-error-storm.json
@@ -1,7 +1,7 @@
 {
   "id": "error-storm",
   "label": "Error storm",
-  "note": "Cloud API is rejecting messages and FHIR Transform is retrying behind it. host.errored stays the cumulative count IRIS reports, while the finding's currentValue is errors/min — the engine compares a rate, because a cumulative counter only ever rises and would flag forever once it moved.",
+  "note": "Cloud API is rejecting messages and Lab Router is retrying into it. host.errored stays the cumulative count IRIS reports, while the finding's currentValue is errors/min — the engine compares a rate, because a cumulative counter only ever rises and would flag forever once it moved. Lab Router's finding is the only elevated_error_rate in the set with a non-zero baseline, so it is the one that exercises the ratio path rather than the clean-baseline path.",
   "hosts": [
     {
       "host": "EMR Source",
@@ -16,17 +16,6 @@
     },
     {
       "host": "Lab Router",
-      "type": "process",
-      "status": "OK",
-      "queued": 2,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0.03,
-      "lastActivitySecondsAgo": 2
-    },
-    {
-      "host": "FHIR Transform",
       "type": "process",
       "status": "Retry",
       "queued": 22,
@@ -81,7 +70,7 @@
     },
     {
       "id": "f-1211",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "elevated_error_rate",
       "severity": "warning",
       "currentValue": 4.2,

--- a/apps/dashboard/fixtures/scenario-healthy.json
+++ b/apps/dashboard/fixtures/scenario-healthy.json
@@ -1,7 +1,7 @@
 {
   "id": "healthy",
   "label": "Healthy",
-  "note": "Everything within baseline. Zero findings — the empty state. These four rows are the measured LABDEMO steady state, so every other scenario is a departure from real numbers rather than from invented ones.",
+  "note": "Everything within baseline. Zero findings — the empty state. These three rows are the measured LABDEMO steady state, so every other scenario is a departure from real numbers rather than from invented ones.",
   "hosts": [
     {
       "host": "EMR Source",
@@ -24,17 +24,6 @@
       "avgProcessingTime": 0.08,
       "avgQueueingTime": 0,
       "lastActivitySecondsAgo": 2
-    },
-    {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
-      "queued": 0,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivitySecondsAgo": 4
     },
     {
       "host": "Cloud API",

--- a/apps/dashboard/fixtures/scenario-queue-buildup.json
+++ b/apps/dashboard/fixtures/scenario-queue-buildup.json
@@ -26,17 +26,6 @@
       "lastActivitySecondsAgo": 1
     },
     {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
-      "queued": 4,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0.05,
-      "lastActivitySecondsAgo": 3
-    },
-    {
       "host": "Cloud API",
       "type": "operation",
       "status": "OK",

--- a/apps/dashboard/fixtures/scenario-slow-processing.json
+++ b/apps/dashboard/fixtures/scenario-slow-processing.json
@@ -1,7 +1,7 @@
 {
   "id": "slow-processing",
   "label": "Slow processing",
-  "note": "FHIR Transform is taking far longer per message than baseline, and the queue is climbing behind it. Nothing is failing yet — this is the early signal. Against a measured 80ms baseline the same 1.86s is a far starker multiple than it was against the old invented 0.21s.",
+  "note": "Lab Router is taking far longer per message than baseline, and the queue is climbing behind it. Nothing is failing yet — this is the early signal. Against a measured 80ms baseline the same 1.86s is a far starker multiple than it was against the old invented 0.21s. Throughput at 0.5 against a 1.2 baseline is a fraction of 0.42, just above the engine's 0.4 firing gate, so throughput_drop stays silent here on purpose — slow is not yet stopped.",
   "hosts": [
     {
       "host": "EMR Source",
@@ -16,17 +16,6 @@
     },
     {
       "host": "Lab Router",
-      "type": "process",
-      "status": "OK",
-      "queued": 3,
-      "messagesPerSec": 1.2,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0.04,
-      "lastActivitySecondsAgo": 1
-    },
-    {
-      "host": "FHIR Transform",
       "type": "process",
       "status": "OK",
       "queued": 96,
@@ -51,7 +40,7 @@
   "findings": [
     {
       "id": "f-1330",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "slow_processing",
       "severity": "critical",
       "currentValue": 1.86,
@@ -61,7 +50,7 @@
     },
     {
       "id": "f-1332",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "growing_queue_wait",
       "severity": "critical",
       "currentValue": 1.24,
@@ -71,7 +60,7 @@
     },
     {
       "id": "f-1331",
-      "host": "FHIR Transform",
+      "host": "Lab Router",
       "type": "queue_buildup",
       "severity": "critical",
       "currentValue": 96,

--- a/apps/dashboard/fixtures/scenario-system-alert.json
+++ b/apps/dashboard/fixtures/scenario-system-alert.json
@@ -26,17 +26,6 @@
       "lastActivitySecondsAgo": 3
     },
     {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
-      "queued": 1,
-      "messagesPerSec": 1.2,
-      "errored": 2,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0.01,
-      "lastActivitySecondsAgo": 2
-    },
-    {
       "host": "Cloud API",
       "type": "operation",
       "status": "Retry",

--- a/apps/dashboard/fixtures/scenario-throughput-drop.json
+++ b/apps/dashboard/fixtures/scenario-throughput-drop.json
@@ -1,7 +1,7 @@
 {
   "id": "throughput-drop",
   "label": "Throughput drop",
-  "note": "EMR Source intake has collapsed and the drop propagates downstream. Queues are draining, which looks healthy until you notice nothing is arriving. Every collapsed value here is below the measured healthy rate — the whole point of the rescale, since the old fixture's 'collapsed' 1.8 msg/sec was above LABDEMO's real 1.2.",
+  "note": "EMR Source intake has collapsed and the drop propagates the full length of the pipeline — 0.2 to 0, then 1.2 to 0.4, then 0.4 to 0.1. Queues are draining, which looks healthy until you notice nothing is arriving. Every collapsed value here is below the measured healthy rate — the whole point of the rescale, since the old fixture's 'collapsed' 1.8 msg/sec was above LABDEMO's real 1.2. Only EMR Source reaches critical: the two downstream fractions are 0.33 and 0.25, and the engine's critical band is at or below 0.1.",
   "hosts": [
     {
       "host": "EMR Source",
@@ -24,17 +24,6 @@
       "avgProcessingTime": 0.08,
       "avgQueueingTime": 0,
       "lastActivitySecondsAgo": 29
-    },
-    {
-      "host": "FHIR Transform",
-      "type": "process",
-      "status": "OK",
-      "queued": 0,
-      "messagesPerSec": 0.1,
-      "errored": 0,
-      "avgProcessingTime": 0.08,
-      "avgQueueingTime": 0,
-      "lastActivitySecondsAgo": 31
     },
     {
       "host": "Cloud API",
@@ -60,24 +49,24 @@
       "message": "Throughput 0.0 msg/sec is 100% below baseline"
     },
     {
-      "id": "f-1442",
-      "host": "FHIR Transform",
-      "type": "throughput_drop",
-      "severity": "critical",
-      "currentValue": 0.1,
-      "baselineValue": 1.2,
-      "detectedSecondsAgo": 58,
-      "message": "Throughput 0.1 msg/sec is 92% below baseline"
-    },
-    {
       "id": "f-1441",
       "host": "Lab Router",
       "type": "throughput_drop",
       "severity": "warning",
       "currentValue": 0.4,
       "baselineValue": 1.2,
-      "detectedSecondsAgo": 54,
+      "detectedSecondsAgo": 58,
       "message": "Throughput 0.4 msg/sec is 67% below baseline"
+    },
+    {
+      "id": "f-1442",
+      "host": "Cloud API",
+      "type": "throughput_drop",
+      "severity": "warning",
+      "currentValue": 0.1,
+      "baselineValue": 0.4,
+      "detectedSecondsAgo": 54,
+      "message": "Throughput 0.1 msg/sec is 75% below baseline"
     }
   ]
 }

--- a/apps/dashboard/src/components/HostGrid.tsx
+++ b/apps/dashboard/src/components/HostGrid.tsx
@@ -49,12 +49,12 @@ function HostSkeleton(): JSX.Element {
 }
 
 export function HostGrid({ hosts, findings, now, loading }: HostGridProps): JSX.Element {
-  // Skeletons, not spinners (§7.3) — four, matching the LABDEMO host count, so
+  // Skeletons, not spinners (§7.3) — three, matching the LABDEMO host count, so
   // the layout does not jump when real data lands.
   if (loading && hosts.length === 0) {
     return (
       <div className="pg-grid">
-        {[0, 1, 2, 3].map((index) => (
+        {[0, 1, 2].map((index) => (
           <HostSkeleton key={index} />
         ))}
       </div>


### PR DESCRIPTION
## What and why

Follows @kskubach's #15, which removed `FHIR Transform` from `contracts/samples/`. This is the dashboard's side of it — the third and last of the three areas, after #15 and @Ari-Glikman's #18.

Refs #15. No `contracts/` file touched.

The host left the LABDEMO production when the pipeline became HL7→PID, so as #15's CHANGELOG entry puts it, **the fixtures were older than the production rather than wrong.** I kept that distinction in `fixtures/README.md` and `CLAUDE.md` §5 rather than just deleting the name, because "we removed a fabricated host" and "a real host left the production" lead a future reader to different conclusions.

## The two that needed re-telling, not a deleted row

I flagged in my #15 review that this would not be a find-and-replace. Two scenarios used `FHIR Transform` as a narrative participant:

**`dead-host`** — it was the host that stalled behind a `Disabled` Cloud API, which is the demo headline. **Lab Router takes that role**: keeps its own queue depth of 212, inherits the stall characteristics (`messagesPerSec` 0, `avgQueueingTime` 41.6, idle 402 s). All four findings survive — `dead_host` on Cloud API, and `throughput_drop` + `stalled_host` + `queue_buildup` on Lab Router. The `stalled_host` message moves from "338 message(s) are queued" to 212, so it agrees with the row it describes.

**`throughput-drop`** — the drop propagated through three hosts, and dropping one would have left a two-stage story. Cloud API's row **already** asserted `messagesPerSec: 0.1` against its measured `0.4` baseline, so I added the finding that row was already implying rather than inventing a value. Full-length propagation again: 0.2→0, 1.2→0.4, 0.4→0.1.

Note the severities there: only EMR Source is `critical`. The two downstream fractions are 0.33 and 0.25, and `throughput_drop`'s critical band is at or below 0.1. That is in the scenario `note` now so nobody "fixes" it later.

## The thing worth reviewing carefully

**Both `stalled_host` findings in the entire set were on `FHIR Transform`** — `dead-host` and `baseline-warming`. A straight row-and-finding delete would have zeroed that type's coverage for anyone reading these fixtures, the same trap @kskubach avoided with `f-1038` and `slow_processing` in #15. Both are reassigned to Lab Router instead.

Same shape in `error-storm`: its Lab Router finding (was FHIR Transform) is the **only `elevated_error_rate` in the set with a non-zero baseline**, so it is the only one exercising the ratio path rather than the clean-baseline path. `4.2 / 1.1 = 3.8x`, unchanged.

Straight row deletions only in `healthy`, `queue-buildup` and `system-alert`, where the host carried no findings.

## One judgement call I did not silently make

`slow-processing` keeps a `growing_queue_wait` **baseline of 0.02** on Lab Router, where the measured steady-state table reads `0`. That number came from the finding this scenario used to hang on `FHIR Transform`, and it did not match FHIR Transform's measured `0` either — so it is inherited, not introduced.

I kept it rather than zeroing it, and documented why in `fixtures/README.md`: the engine's baseline is a rolling 30-minute mean (ADR 0002), so a host that idles at zero still carries a small non-zero mean if anything queued during the window. Zeroing it would change the engine's own message to the "no baseline" wording, and a fixture may not invent that string. Happy to be told this should be a `0` and the finding dropped instead.

## Also in here

- `HostGrid` loading skeletons **4 → 3**, with the comment updated. This was the only code change; nothing in `src/` hardcodes a host name, as I confirmed on #15.
- The four-component sentences in `apps/dashboard/CLAUDE.md` §5, §8 and §9, and in `fixtures/README.md`.
- **Three rows of the README scenario table that were stale for unrelated reasons.** It claimed `queue-buildup` shows two warnings (it is two criticals), `dead-host` shows an `Inactive` dot and two criticals (it is `Disabled`, three criticals and a warning), and `throughput-drop` collapses to `1.8 msg/sec` — left over from the issue #6 rescale, where the real value is now `0`. Adjacent to my edits and false as written, so I corrected them. Flagging because it is outside the stated scope of this PR.

## Verification

```
$ npm run validate:fixtures:strict
ok    scenario-baseline-warming.json
ok    scenario-dead-host.json
ok    scenario-error-storm.json
ok    scenario-healthy.json
ok    scenario-queue-buildup.json
ok    scenario-slow-processing.json
ok    scenario-system-alert.json
ok    scenario-throughput-drop.json
All fixtures match the published contract.
All fixture findings are self-consistent and engine-emittable.

$ npx tsc --noEmit
(clean)

$ npm run build
dist/index.html  199.53 kB | gzip: 61.33 kB   built in 459ms

hosts across all fixtures:  Cloud API | EMR Source | Lab Router
all 8 finding types still covered  (scripted check, every fixture)
```

**Rendered and checked in a browser, not just built** — a fixture set can validate perfectly and still look wrong:

- `?scenario=dead-host` → 3 critical / 1 warning / 0 info, "Hosts OK (of 3)" = 2, Lab Router showing 212 queued / 0 msg/sec / 41.6 s / "7 minutes ago" with **3 active findings**, Cloud API a grey `Disabled` dot with 1.
- `?scenario=throughput-drop` → three-stage propagation, one finding per host, EMR Source red-bordered and the two downstream cards amber.
- `?mode=live` against the engine on `:3002` → renders real findings, including an `info` from `system_alert`, which is the only rule that can produce one.

## One consequence for @Ari-Glikman, and it is not blocking this PR

Your #20 lowers `growing_queue_wait`'s floor from `1.0s` to `0.15s`. I checked this branch against your actual thresholds file and **my findings all still validate** — lowering a floor cannot invalidate a finding that already cleared a higher one, so 8/8 passes either way. Merge order between us does not matter.

But the other direction bites. **Four host rows in these fixtures would be flagged by your retuned engine and carry no finding:**

```
NEW after #20   error-storm     Cloud API   avgQueueingTime 0.84s vs baseline 0.02
NEW after #20   queue-buildup   Lab Router  avgQueueingTime 0.62s vs baseline 0
NEW after #20   system-alert    Cloud API   avgQueueingTime 0.21s vs baseline 0.02
PRE-EXISTING    dead-host       Lab Router  avgQueueingTime 41.6s vs baseline 0
```

`scenario-healthy` stays clean under the new floors — I checked that specifically, since a healthy fixture that starts producing findings would be the damaging case. `baseline-warming`'s `0.31s` is safe because comparative rules cannot fire with a null baseline.

**And my own validator is structurally blind to this.** `validate-fixture-claims.mjs` walks the findings and asks "would the engine emit this?" It never walks the hosts and asks "is there a finding the engine *would* emit that is missing?" That is the same failure mode you named twice this week — a check that gets quietly weaker instead of failing — sitting in the tool I wrote to catch exactly that. The `dead-host` row proves it, since that one was already above the old `1.0s` floor and slipped through anyway.

Both are mine and both are follow-ups, not this PR: a reverse check in `validate-fixture-claims.mjs`, then the four rows once the check can prove the fix. Your #20 is right on the merits and I will say so on it properly.

## Checklist

- [x] Stayed inside my own area (`CONTRIBUTING.md` §2) — `apps/dashboard/**` only
- [x] No `contracts/` file edited as part of an implementation task
- [x] Ran my area's typecheck / build / tests, and pasted the output above
- [x] No invented data outside a declared fixtures directory — the one added finding uses a value the fixture's own host row already asserted
- [x] No new dependency

## Scope

- [x] Adds no capability from a later module — detection and surfacing only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
