### PR TITLE
fix(dashboard): sweep for findings the engine would emit but a fixture omits

### DIFF
--- a/apps/dashboard/fixtures/README.md
+++ b/apps/dashboard/fixtures/README.md
@@ -68,6 +68,30 @@ engine would never have produced. Reproducing the engine's logic means it drifts
 Dev B retunes — which is the point, since a fixture that silently stops matching the
 engine is exactly what is being guarded against.
 
+It also sweeps the **reverse** direction, which is a different mistake: a host row
+the engine *would* flag, with no finding for it. A fixture like that understates the
+product — the grid shows a host quietly breaching a rule while the findings list says
+nothing. That gap found four omissions in this set, two of them on `Cloud API` in
+`scenario-dead-host`, where a `Disabled` host with 154 queued produces `dead_host`,
+`queue_buildup` **and** `throughput_drop` rather than just the first.
+
+Two things about that sweep worth knowing:
+
+- **Baselines come from `scenario-healthy.json`**, since that file is already declared
+  above as the measured steady state everything else departs from. Deriving them beats
+  a table of host names in the tool — a duplicated host list is what went stale when
+  `FHIR Transform` was removed.
+- **It covers six of the eight rules.** `elevated_error_rate` compares
+  errors-per-*minute* derived across consecutive polls, and one host row cannot yield a
+  rate; `system_alert` comes from the proxy's alerts payload, which a scenario file does
+  not carry. The tool prints both exclusions on every run rather than letting "no
+  missing findings" imply a sweep it did not do.
+
+`scenario-baseline-warming.json` carries `"baselineWarming": true`, which is what
+silences the comparative half of the sweep for it — without the flag, two hosts at
+`0 msg/sec` read as unreported `throughput_drop`s. The flag is cross-checked: if it is
+set while any finding carries a non-null baseline, that fails too.
+
 Both checks **skip cleanly** when the thing they need is absent: `contracts/` and
 `services/detection-engine/` each land via their own PR, so neither may fail a
 dashboard branch that simply predates them. That leniency is wrong for CI, where a
@@ -97,6 +121,14 @@ Two notes on reading these, both learned from checking them against the real eng
   `avgQueueingTime: 0` on two of the three hosts, so a real buildup has no ratio
   to quote. The engine treats its absolute floor as the whole test there and says
   "with no baseline queue" rather than "∞x baseline".
+- **The two rule families grade a zero baseline differently**, so a fixture cannot
+  assume "no baseline means critical". `queue_buildup` still reaches straight for
+  `critical`, which is fair where its floor is 50 queued messages. The two duration
+  rules instead judge absolute magnitude — `criticalFloorMultiple` (4.0) × the floor
+  earns `critical`, anything merely above the floor is a `warning`. That landed in
+  Dev B's `fbb34da` after the review on #20, because 150 ms of queue wait reaching
+  for `critical` was not a claim worth making. `scenario-queue-buildup`'s Lab Router
+  finding sits 20 ms above that bound and is the set's most fragile severity.
 - **A rolling baseline is not the steady-state table.** `scenario-slow-processing`
   gives Lab Router a `growing_queue_wait` baseline of `0.02` even though the
   measured table has its `avgQueueingTime` at `0`. That is deliberate: the engine's

--- a/apps/dashboard/fixtures/scenario-baseline-warming.json
+++ b/apps/dashboard/fixtures/scenario-baseline-warming.json
@@ -1,7 +1,8 @@
 {
   "id": "baseline-warming",
   "label": "Baseline warming up",
-  "note": "The engine has just started, so there is no rolling baseline and comparisons render as absent rather than as zero. Only the absolute rules can fire in this state: every comparative rule returns nothing while its baseline is null, so a warm-up fixture showing queue_buildup or slow_processing would be unproducible by the real engine.",
+  "baselineWarming": true,
+  "note": "The engine has just started, so there is no rolling baseline and comparisons render as absent rather than as zero. Only the absolute rules can fire in this state: every comparative rule returns nothing while its baseline is null, so a warm-up fixture showing queue_buildup or slow_processing would be unproducible by the real engine. The baselineWarming flag above is what tells validate-fixture-claims.mjs to silence its comparative sweep here — without it, Lab Router and Cloud API sitting at 0 msg/sec read as unreported throughput_drops.",
   "hosts": [
     {
       "host": "EMR Source",

--- a/apps/dashboard/fixtures/scenario-dead-host.json
+++ b/apps/dashboard/fixtures/scenario-dead-host.json
@@ -49,6 +49,26 @@
       "message": "Cloud API is Disabled with 154 message(s) queued"
     },
     {
+      "id": "f-1107",
+      "host": "Cloud API",
+      "type": "throughput_drop",
+      "severity": "critical",
+      "currentValue": 0,
+      "baselineValue": 0.4,
+      "detectedSecondsAgo": 90,
+      "message": "Throughput 0.0 msg/sec is 100% below baseline"
+    },
+    {
+      "id": "f-1106",
+      "host": "Cloud API",
+      "type": "queue_buildup",
+      "severity": "critical",
+      "currentValue": 154,
+      "baselineValue": 0,
+      "detectedSecondsAgo": 88,
+      "message": "Queue depth 154 with no baseline queue"
+    },
+    {
       "id": "f-1104",
       "host": "Lab Router",
       "type": "throughput_drop",
@@ -67,6 +87,16 @@
       "baselineValue": null,
       "detectedSecondsAgo": 60,
       "message": "No activity for 402s while 212 message(s) are queued"
+    },
+    {
+      "id": "f-1105",
+      "host": "Lab Router",
+      "type": "growing_queue_wait",
+      "severity": "critical",
+      "currentValue": 41.6,
+      "baselineValue": 0,
+      "detectedSecondsAgo": 50,
+      "message": "Average queue wait 41.60s"
     },
     {
       "id": "f-1103",

--- a/apps/dashboard/fixtures/scenario-error-storm.json
+++ b/apps/dashboard/fixtures/scenario-error-storm.json
@@ -59,6 +59,16 @@
       "message": "Cloud API is Error with 61 message(s) queued"
     },
     {
+      "id": "f-1214",
+      "host": "Cloud API",
+      "type": "queue_buildup",
+      "severity": "critical",
+      "currentValue": 61,
+      "baselineValue": 0,
+      "detectedSecondsAgo": 60,
+      "message": "Queue depth 61 with no baseline queue"
+    },
+    {
       "id": "f-1212",
       "host": "Cloud API",
       "type": "throughput_drop",
@@ -67,6 +77,16 @@
       "baselineValue": 0.4,
       "detectedSecondsAgo": 25,
       "message": "Throughput 0.1 msg/sec is 75% below baseline"
+    },
+    {
+      "id": "f-1215",
+      "host": "Cloud API",
+      "type": "growing_queue_wait",
+      "severity": "critical",
+      "currentValue": 0.84,
+      "baselineValue": 0.02,
+      "detectedSecondsAgo": 48,
+      "message": "Average queue wait 840ms is 42x baseline"
     },
     {
       "id": "f-1211",

--- a/apps/dashboard/fixtures/scenario-queue-buildup.json
+++ b/apps/dashboard/fixtures/scenario-queue-buildup.json
@@ -1,7 +1,7 @@
 {
   "id": "queue-buildup",
   "label": "Queue buildup",
-  "note": "Cloud API has slowed, so Lab Router's queue climbs behind it while throughput holds — the classic downstream bottleneck. LABDEMO's measured queue baseline is 0, so the buildup has no ratio to quote and the absolute depth is the whole signal.",
+  "note": "Cloud API has slowed, so Lab Router's queue climbs behind it while throughput holds — the classic downstream bottleneck. LABDEMO's measured queue baseline is 0, so the buildup has no ratio to quote and the absolute depth is the whole signal. Lab Router's 620ms queue wait sits just 20ms above the critical bound for a zero-baseline duration rule (growing_queue_wait's 0.15s floor x criticalFloorMultiple 4.0 = 0.6s), so this finding is the closest in the set to flipping severity if Dev B retunes. validate-fixture-claims.mjs is what will catch that rather than a reader noticing.",
   "hosts": [
     {
       "host": "EMR Source",
@@ -47,6 +47,16 @@
       "baselineValue": 0,
       "detectedSecondsAgo": 45,
       "message": "Queue depth 486 with no baseline queue"
+    },
+    {
+      "id": "f-1044",
+      "host": "Lab Router",
+      "type": "growing_queue_wait",
+      "severity": "critical",
+      "currentValue": 0.62,
+      "baselineValue": 0,
+      "detectedSecondsAgo": 38,
+      "message": "Average queue wait 620ms"
     },
     {
       "id": "f-1043",

--- a/apps/dashboard/fixtures/scenario-system-alert.json
+++ b/apps/dashboard/fixtures/scenario-system-alert.json
@@ -59,6 +59,16 @@
       "message": "Average processing time 2.40s is 48x baseline"
     },
     {
+      "id": "f-1553",
+      "host": "Cloud API",
+      "type": "growing_queue_wait",
+      "severity": "critical",
+      "currentValue": 0.21,
+      "baselineValue": 0.02,
+      "detectedSecondsAgo": 10,
+      "message": "Average queue wait 210ms is 11x baseline"
+    },
+    {
       "id": "f-1552",
       "host": "Lab Router",
       "type": "system_alert",

--- a/apps/dashboard/tools/validate-fixture-claims.mjs
+++ b/apps/dashboard/tools/validate-fixture-claims.mjs
@@ -122,7 +122,27 @@ function checkEmittable(finding) {
   const { currentValue: current, baselineValue: baseline, severity } = finding;
   const infinite = typeof baseline !== 'number' || baseline === 0;
   const ratio = infinite ? Number.POSITIVE_INFINITY : current / baseline;
-  const expectRatio = () => (Number.isFinite(ratio) ? fromRatio(ratio, rule.severityBands) : 'critical');
+
+  /*
+   * An infinite ratio cannot be graded by a ratio band, and the two rule families
+   * resolve it differently — so this cannot be one shared expression.
+   *
+   * The duration rules judge absolute magnitude against the floor:
+   * `criticalFloorMultiple` x floor earns critical, above the floor alone is a
+   * warning (Dev B's fbb34da, from the review on #20). `queue_buildup` still
+   * hardcodes critical on that branch, which is defensible where the duration
+   * version was not — a floor of 50 queued messages is a meaningful absolute
+   * quantity, whereas 150ms of queue wait is not.
+   */
+  const expectRatio = () => {
+    if (Number.isFinite(ratio)) return fromRatio(ratio, rule.severityBands);
+    if (finding.type === 'slow_processing' || finding.type === 'growing_queue_wait') {
+      return current >= rule.absoluteFloorSeconds * rule.criticalFloorMultiple
+        ? 'critical'
+        : 'warning';
+    }
+    return 'critical';
+  };
 
   switch (finding.type) {
     case 'queue_buildup':
@@ -208,6 +228,115 @@ function checkWarmUp(finding) {
   return [`${finding.type} is comparative, so it cannot fire with baselineValue null`];
 }
 
+/* ── The reverse direction ───────────────────────────────────────────────────────
+ *
+ * Everything above walks the FINDINGS and asks "would the engine emit this?". That
+ * misses the opposite error: a host row the engine WOULD flag, with no finding for
+ * it. A fixture like that understates the product — the grid shows a host quietly
+ * breaching a rule and the findings list says nothing.
+ *
+ * It is the same class as the two checks Dev B added upstream: a check that gets
+ * quietly weaker rather than failing. It went unnoticed because `dead-host`'s
+ * 41.6s queue wait was already far above the old 1.0s floor and slipped through
+ * anyway, so this was never really about the #20 retune.
+ *
+ * Baselines come from `scenario-healthy.json`, which `fixtures/README.md` declares
+ * as the measured LABDEMO steady state every other scenario departs from. Deriving
+ * them beats a table of host names in here — #19 removed a hardcoded host count for
+ * exactly that reason, and a fourth copy of the host list is what went stale when
+ * FHIR Transform was removed.
+ */
+
+/** Statuses `stalled_host` defers on, since a dead host is reported as dead. */
+const RULES_REVERSE_CHECKED = [
+  'dead_host',
+  'stalled_host',
+  'queue_buildup',
+  'slow_processing',
+  'growing_queue_wait',
+  'throughput_drop',
+];
+
+/* Two rules cannot be judged from a single host row, and saying so beats implying
+   coverage this does not have. `elevated_error_rate` compares errors-per-MINUTE
+   derived across consecutive polls; `host.errored` is a cumulative counter and one
+   snapshot cannot yield a rate. `system_alert` comes from the proxy's alerts
+   payload, which a scenario file does not carry at all. */
+const RULES_NOT_REVERSE_CHECKABLE = ['elevated_error_rate', 'system_alert'];
+
+/** The healthy fixture IS the baseline, so its own rows must never breach. */
+function baselineHosts() {
+  const healthy = JSON.parse(readFileSync(join(FIXTURES, 'scenario-healthy.json'), 'utf8'));
+  return new Map(healthy.hosts.map((host) => [host.host, host]));
+}
+
+/**
+ * Which rules would fire for this host row — mirroring each rule's branches in
+ * `detect/rules/index.ts`, in the same order, including the early returns.
+ */
+function wouldEmit(host, base, warming) {
+  const hit = [];
+  const rule = (type) => ruleFor(type, host.host);
+
+  const deadHost = rule('dead_host');
+  if (deadHost?.enabled !== false && DEAD_STATUSES.includes(host.status)) hit.push('dead_host');
+
+  // stalled_host defers to dead_host — one condition, one finding.
+  const stalled = rule('stalled_host');
+  if (
+    stalled?.enabled !== false &&
+    !DEAD_STATUSES.includes(host.status) &&
+    !(stalled.requiresQueued && host.queued <= 0) &&
+    host.lastActivitySecondsAgo >= stalled.inactiveSeconds
+  ) {
+    hit.push('stalled_host');
+  }
+
+  // Everything below is comparative, so a warming baseline silences all of it.
+  if (warming || base === undefined) return hit;
+
+  /** Both gates, in the engine's order: the floor first, then the multiplier. */
+  const overBoth = (current, baseline, floor, multiplier) => {
+    if (current < floor) return false;
+    const ratio = baseline > 0 ? current / baseline : Number.POSITIVE_INFINITY;
+    return ratio >= multiplier;
+  };
+
+  const queue = rule('queue_buildup');
+  if (
+    queue?.enabled !== false &&
+    overBoth(host.queued, base.queued, queue.absoluteFloor, queue.baselineMultiplier)
+  ) {
+    hit.push('queue_buildup');
+  }
+
+  for (const [type, metric] of [
+    ['slow_processing', 'avgProcessingTime'],
+    ['growing_queue_wait', 'avgQueueingTime'],
+  ]) {
+    const duration = rule(type);
+    if (
+      duration?.enabled !== false &&
+      overBoth(host[metric], base[metric], duration.absoluteFloorSeconds, duration.baselineMultiplier)
+    ) {
+      hit.push(type);
+    }
+  }
+
+  const throughput = rule('throughput_drop');
+  if (
+    throughput?.enabled !== false &&
+    base.messagesPerSec >= throughput.minBaselineRate &&
+    host.messagesPerSec / base.messagesPerSec <= throughput.baselineFraction
+  ) {
+    hit.push('throughput_drop');
+  }
+
+  return hit;
+}
+
+const BASELINE = baselineHosts();
+
 let failures = 0;
 for (const file of readdirSync(FIXTURES).filter((f) => f.startsWith('scenario-'))) {
   const scenario = JSON.parse(readFileSync(join(FIXTURES, file), 'utf8'));
@@ -228,6 +357,36 @@ for (const file of readdirSync(FIXTURES).filter((f) => f.startsWith('scenario-')
       for (const problem of problems) console.error(`        ${problem}`);
     }
   }
+
+  // A fixture that declares itself warming must mean it — the reverse check silences
+  // every comparative rule on the strength of this flag, so a wrong flag would hide
+  // real omissions rather than report them.
+  const warming = scenario.baselineWarming === true;
+  if (warming) {
+    const dated = scenario.findings.filter((f) => f.baselineValue !== null);
+    if (dated.length > 0) {
+      failures += 1;
+      console.error(`FAIL  ${file} — baselineWarming is true but these carry a baseline:`);
+      for (const f of dated) console.error(`        ${f.id} ${f.type} baselineValue ${f.baselineValue}`);
+    }
+  }
+
+  if (thresholds !== null) {
+    for (const host of scenario.hosts) {
+      const present = new Set(
+        scenario.findings.filter((f) => f.host === host.host).map((f) => f.type),
+      );
+      const missing = wouldEmit(host, BASELINE.get(host.host), warming).filter(
+        (type) => !present.has(type),
+      );
+
+      if (missing.length > 0) {
+        failures += 1;
+        console.error(`FAIL  ${file} — ${host.host} breaches a rule with no finding to show it`);
+        for (const type of missing) console.error(`        ${type} would fire, but no finding of that type names this host`);
+      }
+    }
+  }
 }
 
 if (failures > 0) {
@@ -235,10 +394,17 @@ if (failures > 0) {
   process.exit(1);
 }
 
-/* Say which checks actually ran. Claiming "engine-emittable" when thresholds.json
-   was absent would report a check that did not happen as a pass. */
-console.log(
-  thresholds === null
-    ? 'All fixture findings are self-consistent.\nnote  no services/detection-engine/ checkout — the engine-emittable checks did NOT run'
-    : 'All fixture findings are self-consistent and engine-emittable.',
-);
+/* Say which checks actually ran, and which rules the reverse direction cannot judge.
+   Claiming "engine-emittable" when thresholds.json was absent would report a check
+   that did not happen as a pass — and so would letting "no missing findings" imply
+   all eight rules were swept when two of them cannot be. */
+if (thresholds === null) {
+  console.log('All fixture findings are self-consistent.');
+  console.log('note  no services/detection-engine/ checkout — the engine-emittable checks did NOT run');
+  console.log('note  the missing-finding sweep did NOT run either; it needs the same thresholds');
+} else {
+  console.log('All fixture findings are self-consistent and engine-emittable.');
+  console.log(`      no host breaches a rule silently, across ${RULES_REVERSE_CHECKED.length} of the 8 rules`);
+  console.log(`note  ${RULES_NOT_REVERSE_CHECKABLE.join(' and ')} are NOT swept — neither is derivable`);
+  console.log('      from a single host row, so a fixture could omit one and this would not say so');
+}


### PR DESCRIPTION
**Stacked on #21** — based on `devC/drop-fhir-transform`, so the diff here is only the new work. GitHub will retarget it to `main` when #21 merges.

This is the follow-up I committed to in #21 and in my review on #20.

## The gap

`validate-fixture-claims.mjs` walked the findings and asked *"would the engine emit this?"* It never walked the hosts and asked the reverse: **"is there a finding the engine would emit that is missing?"**

A fixture can therefore understate the product — the host grid shows a host quietly breaching a rule while the findings list says nothing about it. That is the same class as the two defects @Ari-Glikman found upstream (`npm test --if-present` reporting green on nothing, and `slow_processing`'s unreachable warning band): a check that gets quietly weaker instead of failing. Sitting, in this case, inside the tool I wrote to catch exactly that.

**It is not a consequence of #20.** `dead-host`'s `41.6s` queue wait was already far above the *old* `1.0s` floor and slipped through anyway. The retune only made me look.

## Four omissions found

```
dead-host    Cloud API   queue_buildup       154 queued, no baseline queue
dead-host    Cloud API   throughput_drop     0 against a 0.4 baseline
dead-host    Lab Router  growing_queue_wait  41.60s
error-storm  Cloud API   queue_buildup       61 queued, no baseline queue
```

Two of those are the interesting kind, and I had missed both by hand: **a `Disabled` Cloud API holding 154 messages produces `dead_host`, `queue_buildup` *and* `throughput_drop`**, not just the first. I had only been looking at the duration rules when I reported four rows on #20 — the tool found strictly more than I did, which is rather the point of writing it.

`dead-host` now carries **7 findings from one root cause**. That is what the engine genuinely does, and I decided against trimming it: correlating findings to a single cause is AI Detective's job, not Health Scan's (root `CLAUDE.md` §2). It also makes the demo headline more honest about what an operator actually sees.

## How the sweep works

Mirrors each rule's branches from `detect/rules/index.ts` in the same order, including the early returns — notably that `stalled_host` defers to `dead_host` ("one condition, one finding"), and that a zero baseline makes the ratio infinite so the **floor becomes the entire gate**.

**Baselines are derived from `scenario-healthy.json`** rather than hardcoded. That file is already declared in `fixtures/README.md` as the measured steady state every other scenario departs from, so it is the natural source. A table of host names inside the tool would be a fourth copy of a fact that already went stale once — the same duplication @Ari-Glikman removed in #19.

**It covers six of the eight rules, and prints which two it cannot on every run:**

```
      no host breaches a rule silently, across 6 of the 8 rules
note  elevated_error_rate and system_alert are NOT swept — neither is derivable
      from a single host row, so a fixture could omit one and this would not say so
```

`elevated_error_rate` compares errors-per-**minute** derived across consecutive polls, and `host.errored` is a cumulative counter — one snapshot cannot yield a rate. `system_alert` comes from the proxy's alerts payload, which a scenario file does not carry at all. Letting "no missing findings" imply a sweep of all eight would be precisely the failure this check exists to prevent.

## `baselineWarming`

`scenario-baseline-warming.json` gains `"baselineWarming": true`. Without it, its two hosts sitting at `0 msg/sec` read as unreported `throughput_drop`s — they are not, because comparative rules return early on a null baseline.

The flag is **cross-checked rather than trusted**: setting it while any finding carries a non-null baseline is itself a failure. A wrong flag would silence the comparative sweep and hide real omissions, so it needed to be unable to lie.

## One thing for @Ari-Glikman, non-blocking

`queueBuildup` appends `with no baseline queue` for the infinite-ratio case ([index.ts:99-101](services/detection-engine/src/detect/rules/index.ts#L99-L101)), but `durationRule` appends an empty string ([index.ts:174](services/detection-engine/src/detect/rules/index.ts#L174)). So the same situation reads two ways, and in `dead-host` they now land two rows apart on screen:

```
Critical  Queue buildup       · Lab Router   Queue depth 212 with no baseline queue
Critical  Growing queue wait  · Lab Router   Average queue wait 41.60s
```

The second doesn't say *why* there's no ratio. Entirely your call and I have not touched it — I used the engine's real string rather than the nicer one, because a fixture may not invent wording the engine doesn't produce.

## Verification

```
$ npm run validate:fixtures:strict
ok    (all 8 scenarios)
All fixtures match the published contract.
All fixture findings are self-consistent and engine-emittable.
      no host breaches a rule silently, across 6 of the 8 rules
note  elevated_error_rate and system_alert are NOT swept — neither is derivable
      from a single host row, so a fixture could omit one and this would not say so

$ npx tsc --noEmit
(clean)

$ npm run build
dist/index.html  200.47 kB | gzip: 61.51 kB

25 findings across 8 scenarios; all 8 finding types still covered
?scenario=dead-host  all 7 render, 6 critical + 1 warning,
                     Lab Router 4 active findings, Cloud API 3
```

Rendered from `dist/index.html` over `file://` rather than the dev server, so that also re-checks the §6 static fallback.

**Evidence the check works** — before the fixture fixes, on the unmodified set:

```
FAIL  scenario-dead-host.json — Lab Router breaches a rule with no finding to show it
        growing_queue_wait would fire, but no finding of that type names this host
FAIL  scenario-dead-host.json — Cloud API breaches a rule with no finding to show it
        queue_buildup would fire, but no finding of that type names this host
        throughput_drop would fire, but no finding of that type names this host
FAIL  scenario-error-storm.json — Cloud API breaches a rule with no finding to show it
        queue_buildup would fire, but no finding of that type names this host
```

## Merge ordering — a correction to my #20 review

On #20 I said *"merge order between us doesn't matter."* **That was true of the forward check and is not true of this one.** Correcting it here as well as on #20.

Three further omissions appear only once #20's floors land:

```
error-storm     Cloud API   growing_queue_wait  0.84s vs 0.02  ratio 42
queue-buildup   Lab Router  growing_queue_wait  0.62s, no baseline
system-alert    Cloud API   growing_queue_wait  0.21s vs 0.02  ratio 11
```

**And they cannot be pre-fixed.** Under today's `1.0s` floor the emittable check correctly rejects the very same findings:

```
FAIL  scenario-queue-buildup.json — f-1044 growing_queue_wait @ Lab Router
        0.62s is below absoluteFloorSeconds 1 — would not fire
```

So the two directions are in genuine tension across that boundary: today those findings must **not** exist, and after #20 they **must**. Consequences:

- **#20 merging on its own turns the `dashboard` CI job red on `main`**, because it runs `validate:fixtures`, which now includes this sweep. That is the drift detector doing its job, not a defect — but it shouldn't land unannounced.
- I'd suggest merging **#21 → this → #20**, and I'll have the three-row follow-up ready to go straight after #20 so the window is minutes, not hours. Happy to sequence it however you two prefer — just flagging that there *is* now a sequence.

## Checklist

- [x] Stayed inside my own area — `apps/dashboard/**` only
- [x] No `contracts/` file edited
- [x] Ran my area's typecheck / build / validators, output above
- [x] No invented data — every added finding uses values the fixture's own host row already asserted, and the engine's own message strings
- [x] No new dependency

## Scope

- [x] Adds no capability from a later module — this is fixture tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
