### PR TITLE
chore(ci): the dashboard fixture step could report green on nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,24 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: apps/dashboard
         run: npm run build
-      # Dev C's own fixture validator, if present — keeps demo fixtures honest
-      # against the published schema.
-      - name: Validate fixtures
+      # Dev C's own fixture validator — keeps demo fixtures honest against the
+      # published schema AND against Dev B's shipped thresholds.
+      #
+      # STRICT, and deliberately without `--if-present`. Both are the same reason: the
+      # plain form skips cleanly when `contracts/` or `services/detection-engine/` is
+      # absent, which is right for a local dashboard-only checkout and wrong here,
+      # because a step that validates nothing while reporting success is indistinguishable
+      # from one that validated everything. `--if-present` adds a second copy of that
+      # hole -- rename the script and the step goes quietly green.
+      #
+      # Same failure the `npm test --if-present` fix in #11 addressed, and the one
+      # `apps/dashboard/fixtures/README.md` already prescribes the strict form for. Both
+      # directories are on `main`, so this passes today; it is closing a latent hole
+      # rather than fixing a live break.
+      - name: Validate fixtures (strict)
         if: steps.guard.outputs.present == 'true'
         working-directory: apps/dashboard
-        run: npm run validate:fixtures --if-present
+        run: npm run validate:fixtures:strict
 
   metrics-proxy:
     name: metrics-proxy — typecheck + tests


### PR DESCRIPTION
## What and why

The dashboard job ran `npm run validate:fixtures --if-present`. **Two holes, same shape** — a check that reports success while verifying nothing.

**1. The plain script skips cleanly when its inputs are absent.** `validate-fixtures.mjs` needs `contracts/`, `validate-fixture-claims.mjs` needs `services/detection-engine/thresholds.json`, and both skip rather than fail when those are missing. That leniency is correct for a local dashboard-only checkout and wrong in CI. Proven rather than argued, with `thresholds.json` moved aside:

```
npm run validate:fixtures          exit 0    "note  no services/detection-engine/ checkout —
                                              the engine-emittable checks did NOT run"
npm run validate:fixtures:strict   exit 1    "FAIL  --strict, but no thresholds at ..."
```

**2. `--if-present` is a second copy of the same hole.** Rename the script and the step goes quietly green. Dropped — that script is not optional. Deliberately *unlike* the `--if-present` on typecheck, which @Ari-Glikman kept in #11 for the right reason: `metrics-proxy` is plain JS and legitimately has no typecheck script, so a missing one there is correct rather than suspicious.

This is the same failure as the `npm test --if-present` fix in #11. And `apps/dashboard/fixtures/README.md` has prescribed the strict form for CI since it was written —

> That leniency is wrong for CI, where a step reporting success while validating nothing is the failure mode being guarded against — so use the strict form there

— CI just never used it. My own doc and my own pipeline disagreed, and the doc was right.

It matters more now than when I wrote that: `validate-fixture-claims.mjs` also sweeps for findings the engine *would* emit but a fixture omits (#22), so there is more behind the flag to lose.

**Both directories are on `main`, so this passes today.** Closing a latent hole, not fixing a live break — worth being clear about, since "CI change" and "CI was broken" are different claims.

## Verification

```
$ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); ..."
parsed OK; jobs: ['contracts', 'detection-engine', 'dashboard', 'metrics-proxy']
dashboard validate step: [{'name': 'Validate fixtures (strict)',
                           'if': "steps.guard.outputs.present == 'true'",
                           'working-directory': 'apps/dashboard',
                           'run': 'npm run validate:fixtures:strict'}]

$ # exit codes, thresholds.json moved aside then restored
LENIENT exit code: 0
STRICT  exit code: 1
STRICT with thresholds present: 0
```

No tabs introduced, four jobs still present, `if:` guard unchanged.

## Note on ordering

Independent of #21 and #22 — touches only `.github/`, and `main` passes strict as it stands. Merge in any order.

## Checklist

- [x] Shared `.github/` change, so all three of you are on the review per CODEOWNERS — flagging the crossing explicitly since this is outside `apps/dashboard/`
- [x] No `contracts/` file edited
- [x] Verified with actual output above, including the negative case
- [x] No invented data
- [x] No new dependency

## Scope

- [x] Adds no capability from a later module — CI configuration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
