### PR TITLE
fix(dashboard): size the loading skeletons to the production, not to a constant

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -305,7 +305,7 @@ Going through the dev proxy means **CORS is never your problem** and Dev B can b
 
 Demo mode is a **first-class deliverable**, not a stub — it is the Day-5 fallback and the screencast source.
 
-- Fixtures use the LABDEMO production's three real components, so demo and live look continuous: **EMR Source** (service), **Lab Router** (process), **Cloud API** (operation). There was a fourth, `FHIR Transform`, until `contracts/` PR #15 dropped it — a real pass-through routing item that left the production when the pipeline became HL7→PID.
+- **Fixtures name only components that really exist in the monitored production**, so demo and live look continuous. For LABDEMO today that is **EMR Source** (service), **Lab Router** (process), **Cloud API** (operation) — read from the `<Item>` set in `iris/labdemo/Production.cls`, which is the authority. Do not treat that list as a constant: there was a fourth, `FHIR Transform`, until `contracts/` PR #15, and the rule being enforced here is *never invent a host*, not *there are three hosts*. **Nothing in `src/` may hardcode a host name or a host count** — issue #25 has the reasoning and the evidence that the runtime is production-agnostic.
 - Fixture files are plain JSON matching the contract exactly — the same guards run over them. If a fixture fails validation, the contract transcription is wrong.
 - Each fixture is a scenario file containing `{ hosts: Host[], findings: Finding[] }`. `scenario-healthy.json` has zero findings — that exercises the empty state, which is easy to forget and looks bad if broken on stage.
 - `mockClient` supports a **scripted progression**: healthy → degrading → findings appear, advancing on each poll so the dashboard visibly comes alive during the demo without anyone touching IRIS. Make it loop, and make it restartable from the UI.
@@ -415,7 +415,7 @@ From §4.5 of the MVP plan, in order:
 
 | # | Task | Est. | Done when |
 |---|---|---|---|
-| 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders all three LABDEMO hosts and all fixture findings; every state designed; `tsc` clean |
+| 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders every host the API returns, whatever the count, and all fixture findings; every state designed; `tsc` clean |
 | 2 | Live polling + demo/live toggle (`?mode=live`) | 0.75 d | Visible change reflected within 10 s; API failure degrades to last-good + banner, never blanks |
 | 3 | Finding detail view | 0.5 d | Click a finding → current vs. baseline, metric, timestamp; keyboard accessible; drawer survives polls |
 | 4 | Screencast + static fallback | 0.5 d | `dist/index.html` opens from `file://` in demo mode; screencast recorded |
@@ -431,7 +431,8 @@ Sequencing note: tasks 1–3 need only the contract, so they proceed regardless 
 
 - **Ask before widening scope.** If a request implies any module from §1.1, say so instead of building it.
 - **The contract is upstream of you.** Never edit `contracts/`. Never add a field to a type to make a component work — surface it as a contract question.
-- **Never invent data.** No placeholder hosts, no made-up metrics, no fabricated findings outside `fixtures/`. Fixtures use the three LABDEMO components and the eight real finding types.
+- **Never invent data.** No placeholder hosts, no made-up metrics, no fabricated findings outside `fixtures/`. Fixtures name only components the monitored production really has, and only the eight real finding types.
+- **Never hardcode a host name or a host count in `src/`.** The UI renders whatever the API returns. A count compiled in is a UI component tracking someone else's config, and it goes stale the moment the production changes — see issue #25.
 - **No new dependencies** without stating why and what it replaces.
 - **No `fetch` outside `src/api/`.** No component talks to the network.
 - **No hard-coded colors, spacing, or radii.** Use the tokens in §7.1. If a token is missing, add it to `tokens.css` rather than inlining a value.

--- a/apps/dashboard/fixtures/README.md
+++ b/apps/dashboard/fixtures/README.md
@@ -5,11 +5,15 @@ the screencast source (`apps/dashboard/CLAUDE.md` §5).
 
 ## Rules these files follow
 
-- **The three LABDEMO components only** — `EMR Source` (service), `Lab Router`
-  (process), `Cloud API` (operation). Demo and live must look continuous, so no
-  invented hosts. `FHIR Transform` was a fourth until `contracts/` PR #15: it was
-  a real pass-through routing item, removed from the production when the pipeline
-  became HL7→PID, so the samples were older than the production rather than wrong.
+- **Only components the production really has** — never an invented host, because
+  demo and live must look continuous. For LABDEMO today that is `EMR Source`
+  (service), `Lab Router` (process), `Cloud API` (operation), per the `<Item>` set
+  in `iris/labdemo/Production.cls`. **The rule is "no invented hosts", not "there
+  are three"**: `FHIR Transform` was a fourth until `contracts/` PR #15 — a real
+  pass-through routing item that left the production when the pipeline became
+  HL7→PID, which made the samples older than the production rather than wrong. A
+  fixture is a frozen snapshot of one production and is expected to need editing
+  when that production changes; nothing in `src/` is (issue #25).
 - **Numbers are anchored to measured LABDEMO values, never invented** (issue #6).
   The healthy steady state is the capture Dev B re-measured over three samples:
   `EMR Source 0.2` msg/sec, `Lab Router 1.2`, `Cloud API 0.4`;

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -42,8 +42,17 @@ export function App(): JSX.Element {
   const liveClient = useMemo(() => createLiveClient(), []);
   const api = mode === 'live' ? liveClient : mockClient;
 
-  const { hosts, findings, loading, error, lastSuccessAt, newFindingIds, refresh, resetSeen } =
-    useHealthScan(api, { cacheLastGood: mode === 'live' });
+  const {
+    hosts,
+    findings,
+    loading,
+    error,
+    lastSuccessAt,
+    newFindingIds,
+    refresh,
+    resetSeen,
+    hostCountHint,
+  } = useHealthScan(api, { cacheLastGood: mode === 'live' });
 
   const onTick = useCallback(
     (signal: AbortSignal) => refresh(signal),
@@ -209,7 +218,13 @@ export function App(): JSX.Element {
           <h2 id="pg-hosts-heading" className="pg-section__title">
             Hosts
           </h2>
-          <HostGrid hosts={hosts} findings={findings} now={now} loading={loading} />
+          <HostGrid
+            hosts={hosts}
+            findings={findings}
+            now={now}
+            loading={loading}
+            skeletonCount={hostCountHint}
+          />
         </section>
 
         <section className="pg-section" aria-labelledby="pg-findings-heading">

--- a/apps/dashboard/src/api/lastGood.ts
+++ b/apps/dashboard/src/api/lastGood.ts
@@ -14,6 +14,19 @@ import type { FindingView, HostView } from '../types/healthscan';
 
 const KEY = 'pg.healthscan.lastGood.v1';
 
+/*
+ * How many hosts the monitored production last reported.
+ *
+ * Its own key, not part of `LastGood`, because the two have different rules: the
+ * payload is live-mode-only (caching demo fixtures would let a stale scenario
+ * resurface as real data), whereas this is a layout hint worth keeping in both
+ * modes. An integer cannot resurface as anything.
+ *
+ * Exists so the loading skeletons match whatever production this is pointed at
+ * rather than a number compiled in. See issue #25.
+ */
+const HOST_COUNT_KEY = 'pg.healthscan.hostCount.v1';
+
 export interface LastGood {
   hosts: HostView[];
   findings: FindingView[];
@@ -46,6 +59,31 @@ export function writeLastGood(value: LastGood): void {
   } catch (cause) {
     // Quota or a disabled store — not worth surfacing to the operator.
     console.warn('[healthscan] could not write the last-good cache', cause);
+  }
+}
+
+/** Last observed host count, or null if this browser has never seen a payload. */
+export function readHostCountHint(): number | null {
+  try {
+    const raw = window.localStorage.getItem(HOST_COUNT_KEY);
+    if (raw === null) return null;
+    const count = Number(raw);
+    // A non-integer or a zero tells us nothing useful, so treat it as unknown
+    // rather than rendering no skeletons at all.
+    return Number.isInteger(count) && count > 0 ? count : null;
+  } catch (cause) {
+    console.warn('[healthscan] could not read the host-count hint', cause);
+    return null;
+  }
+}
+
+export function writeHostCountHint(count: number): void {
+  if (!Number.isInteger(count) || count <= 0) return;
+  try {
+    window.localStorage.setItem(HOST_COUNT_KEY, String(count));
+  } catch {
+    // A missing layout hint costs one frame of a mismatched skeleton row. Not
+    // worth a console line on every poll.
   }
 }
 

--- a/apps/dashboard/src/components/HostGrid.tsx
+++ b/apps/dashboard/src/components/HostGrid.tsx
@@ -16,7 +16,27 @@ export interface HostGridProps {
   findings: readonly FindingView[];
   now: number;
   loading: boolean;
+  /**
+   * How many loading skeletons to draw — the host count this browser last saw.
+   * `null` on a first-ever visit, when nothing legitimately knows the answer.
+   */
+  skeletonCount?: number | null;
 }
+
+/*
+ * Used only until the first response of a browser's first-ever session, after which
+ * the observed count takes over.
+ *
+ * Deliberately not "the LABDEMO host count": this file used to hardcode 4, then 3
+ * when a component was removed from the production, which is a UI component
+ * tracking someone else's config (issue #25). Any value here is a guess, so it is
+ * named as one and it self-corrects after one poll.
+ */
+const FIRST_VISIT_SKELETONS = 3;
+
+/* A production with 200 hosts should not paint 200 placeholder cards. Two rows'
+   worth is enough to show the shape of what is coming. */
+const MAX_SKELETONS = 12;
 
 /** `finding.host` is always exactly a `host.host` value — same string, same case (§4 Q8). */
 function severityByHost(
@@ -48,13 +68,20 @@ function HostSkeleton(): JSX.Element {
   );
 }
 
-export function HostGrid({ hosts, findings, now, loading }: HostGridProps): JSX.Element {
-  // Skeletons, not spinners (§7.3) — three, matching the LABDEMO host count, so
-  // the layout does not jump when real data lands.
+export function HostGrid({
+  hosts,
+  findings,
+  now,
+  loading,
+  skeletonCount = null,
+}: HostGridProps): JSX.Element {
+  // Skeletons, not spinners (§7.3), as many as this production last reported, so the
+  // layout does not jump when real data lands — whatever production that is.
   if (loading && hosts.length === 0) {
+    const count = Math.min(skeletonCount ?? FIRST_VISIT_SKELETONS, MAX_SKELETONS);
     return (
       <div className="pg-grid">
-        {[0, 1, 2].map((index) => (
+        {Array.from({ length: count }, (_, index) => (
           <HostSkeleton key={index} />
         ))}
       </div>

--- a/apps/dashboard/src/hooks/useHealthScan.ts
+++ b/apps/dashboard/src/hooks/useHealthScan.ts
@@ -11,7 +11,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import type { HealthScanApi } from '../api/HealthScanApi';
-import { readLastGood, writeLastGood } from '../api/lastGood';
+import { readHostCountHint, readLastGood, writeHostCountHint, writeLastGood } from '../api/lastGood';
 import type { FindingView, HostView } from '../types/healthscan';
 import { compareSeverity, toSeverity } from '../lib/severity';
 import { parseTimestamp } from '../lib/format';
@@ -57,6 +57,13 @@ export interface UseHealthScanResult extends HealthScanState {
   refresh: (signal?: AbortSignal) => Promise<void>;
   /** Drops cached ids so the next refresh treats everything as pre-existing. */
   resetSeen: () => void;
+  /**
+   * How many hosts this browser last saw, or null if it never has. Sizes the
+   * loading skeletons to the production actually being monitored rather than to a
+   * count compiled in (issue #25). Read once: after the first response `hosts` is
+   * populated and the skeletons are gone, so a live value would never be used.
+   */
+  hostCountHint: number | null;
 }
 
 export interface UseHealthScanOptions {
@@ -134,6 +141,10 @@ export function useHealthScan(
         if (cacheLastGood) {
           writeLastGood({ hosts, findings: sorted, at });
         }
+        // Unconditional, unlike the payload cache: the host count is a layout hint
+        // rather than data, so it is as useful in demo mode and cannot resurface as
+        // a stale finding.
+        writeHostCountHint(hosts.length);
       } catch (cause) {
         // An abort is the caller's own doing (unmount, next tick) — not an error.
         if (cause instanceof DOMException && cause.name === 'AbortError') return;
@@ -153,5 +164,7 @@ export function useHealthScan(
     seenIds.current = new Set();
   }, []);
 
-  return { ...state, refresh, resetSeen };
+  const [hostCountHint] = useState<number | null>(() => readHostCountHint());
+
+  return { ...state, refresh, resetSeen, hostCountHint };
 }


### PR DESCRIPTION
## What and why

The two dashboard items from #25. Refs #25.

`HostGrid` rendered a **hardcoded** number of loading skeletons. It said `4`, then said `3` when a component was removed from LABDEMO — a UI component tracking someone else's production config, which is exactly the smell #25 is about. It now uses however many hosts this browser last actually saw.

## How the count is sourced

Its own `localStorage` key rather than a field inside `LastGood`, because the two have different rules:

| | scope | why |
|---|---|---|
| `LastGood` payload | live mode only | caching demo fixtures would let a stale scenario resurface as real data |
| host count hint | both modes | it is a layout hint, and an integer cannot resurface as anything |

So `writeHostCountHint` is unconditional while `writeLastGood` stays gated on `cacheLastGood`.

On a browser's **first ever visit** nothing legitimately knows the answer. The fallback is named `FIRST_VISIT_SKELETONS` rather than something implying it is a fact about a production, and it self-corrects after one poll. Clamped at `MAX_SKELETONS = 12` so a 200-host production doesn't paint 200 placeholder cards.

`HostGrid` stays presentational — the count arrives as a prop, and the storage read sits in `useHealthScan` alongside the other cache access, read once since after the first response `hosts` is populated and the skeleton branch is unreachable.

## Verified end to end, because this is exactly the kind of thing that fails silently

A hint that never persists looks identical to one that works — both render *some* skeletons. So I made the two paths distinguishable: mock latency temporarily raised to 4 s, healthy fixture temporarily given 5 hosts.

```
load 1  fresh profile, budget long enough for the fetch to land
        -> observes 5 hosts, writes the hint

load 2  same profile, budget short enough to catch the loading state
        -> 5 skeletons: four in the first row, one wrapping to the second
```

**Confirmed over `http` and over `file://`**, so the §6 static fallback gets the same behaviour. Worth checking rather than assuming — `lastGood.ts` already carries a warning that `localStorage` can be unavailable under `file://`, and if that were true here the hint would have been dead in the shipped fallback build.

Worth recording that my first attempt appeared to show the hint *not* working. The cause was mine, not the code's: a virtual-time budget shorter than the simulated latency, so load 1 never completed a fetch and had nothing to persist. Both temporary test edits are reverted — healthy fixture back to 3 hosts, latency back to 120 ms.

```
npx tsc --noEmit                  clean
npm run build                     dist/index.html  201.87 kB | gzip: 61.88 kB
npm run validate:fixtures:strict  8/8 both directions
```

## The docs half

The "three LABDEMO components" rules in `CLAUDE.md` §5, §8, §9 and `fixtures/README.md` read as an architectural assumption about how many hosts exist. The rule they actually exist to enforce is **"never invent a host"** — a very different statement, and the FHIR Transform removal showed the difference costing real work.

Reworded so the component list points at `iris/labdemo/Production.cls` as the authority rather than restating it as a constant, plus a new explicit rule in §9:

> **Never hardcode a host name or a host count in `src/`.** The UI renders whatever the API returns. A count compiled in is a UI component tracking someone else's config, and it goes stale the moment the production changes.

`fixtures/README.md` also now draws the line that matters: a fixture is a frozen snapshot of one production and is *expected* to need editing when that production changes; nothing in `src/` is.

## Deliberately not changed

`FindingsList` keeps its fixed count of three placeholder rows. That one is **not** tracking production config — there is no "expected findings count", and a healthy production has zero. Changing it for symmetry would be noise.

## Checklist

- [x] Stayed inside my own area — `apps/dashboard/**` only
- [x] No `contracts/` file edited
- [x] Ran typecheck, build and validators, output above
- [x] No invented data
- [x] No new dependency

## Scope

- [x] Adds no capability from a later module — loading-state sizing and documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
