### PR TITLE
feat(detection-engine): warn when a hostOverrides key matches no observed host

### DIFF
--- a/services/detection-engine/src/config/thresholds.ts
+++ b/services/detection-engine/src/config/thresholds.ts
@@ -268,6 +268,33 @@ export function configFor<K extends keyof RuleConfigs>(
   return { ...config.rules[rule], ...(override as object) } as RuleConfigs[K];
 }
 
+/** Override keys, excluding the `_comment` documentation entries. */
+export function declaredOverrideHosts(config: ThresholdConfig): string[] {
+  return Object.keys(config.hostOverrides).filter((key) => !key.startsWith('_'));
+}
+
+/**
+ * Override keys that match no host the engine has actually seen.
+ *
+ * `hostOverrides` is keyed by a literal host name, so pointing the engine at a different
+ * production makes every override inert — silently. The tuning simply stops applying and
+ * nothing says so. Raised by Dev C in #25, and it is the same shape as three failures
+ * this project has already fixed: `npm test --if-present` reporting green on nothing,
+ * `-c ajv-formats` quietly ignoring `format`, and the `@devA` CODEOWNERS placeholder
+ * requesting review from nobody. A config that weakens without complaining.
+ *
+ * Returns the inert keys so the caller can log them. Deliberately not an error: an
+ * override for a host that is temporarily absent from a running production is
+ * legitimate, and refusing to start would be worse than saying so.
+ */
+export function inertOverrideHosts(
+  config: ThresholdConfig,
+  observedHosts: Iterable<string>,
+): string[] {
+  const seen = new Set(observedHosts);
+  return declaredOverrideHosts(config).filter((host) => !seen.has(host));
+}
+
 /**
  * Live config holder. Reads once at construction, then re-reads on file change.
  * A bad file is logged and ignored — `current` keeps the last good value.

--- a/services/detection-engine/src/detect/engine.ts
+++ b/services/detection-engine/src/detect/engine.ts
@@ -10,7 +10,7 @@
 
 import { BaselineStore } from '../baseline/window.ts';
 import type { ThresholdConfig } from '../config/thresholds.ts';
-import { configFor } from '../config/thresholds.ts';
+import { configFor, inertOverrideHosts } from '../config/thresholds.ts';
 import type {
   Finding,
   HealthScanState,
@@ -51,10 +51,14 @@ export class DetectionEngine {
   #seenAlerts = new Set<string>();
   #lastPollAt: number | null = null;
   #stale = false;
+  /** Inert-override warnings already emitted, so the log is not repeated per poll. */
+  #warnedOverrides = new Set<string>();
+  readonly #log: (msg: string) => void;
 
   #config: ThresholdConfig;
 
-  constructor(config: ThresholdConfig) {
+  constructor(config: ThresholdConfig, log: (msg: string) => void = console.error) {
+    this.#log = log;
     this.#config = config;
     this.#baselines = new BaselineStore(config.baselineWindowSeconds, config.minBaselineSamples);
     this.#registry = new FindingRegistry(config.sustainedSamples);
@@ -72,6 +76,7 @@ export class DetectionEngine {
       next.sustainedSamples !== this.#config.sustainedSamples;
 
     this.#config = next;
+    this.#warnedOverrides.clear();
     if (structural) {
       this.#baselines = new BaselineStore(next.baselineWindowSeconds, next.minBaselineSamples);
       this.#registry = new FindingRegistry(next.sustainedSamples);
@@ -132,6 +137,8 @@ export class DetectionEngine {
       this.#priorErrored.delete(known);
     }
 
+    this.#warnInertOverrides(seenHosts);
+
     this.#lastPollAt = now;
     this.#stale = false;
   }
@@ -144,6 +151,26 @@ export class DetectionEngine {
       state: this.#state(hosts),
       lastPollAt: this.#lastPollAt,
     };
+  }
+
+  /**
+   * Warn once per (config, host-set) when a hostOverrides key matches nothing we have
+   * seen. The override is simply inert -- the tuning stops applying and nothing says so
+   * -- which is exactly the silent-weakening failure #25 raised.
+   *
+   * Not an error: a host can be legitimately absent from a running production, and
+   * refusing to start would be worse than reporting it.
+   */
+  #warnInertOverrides(seenHosts: ReadonlySet<string>): void {
+    for (const host of inertOverrideHosts(this.#config, seenHosts)) {
+      const key = `${host}|${[...seenHosts].sort().join(',')}`;
+      if (this.#warnedOverrides.has(key)) continue;
+      this.#warnedOverrides.add(key);
+      this.#log(
+        `thresholds: hostOverrides["${host}"] matches no observed host, so its tuning is ` +
+          `inert. Observed: ${[...seenHosts].sort().join(', ') || '(none)'}`,
+      );
+    }
   }
 
   #state(hosts: readonly Host[]): HealthScanState {

--- a/services/detection-engine/test/config.test.ts
+++ b/services/detection-engine/test/config.test.ts
@@ -12,6 +12,8 @@ import {
   ConfigValidationError,
   DEFAULT_CONFIG,
   configFor,
+  declaredOverrideHosts,
+  inertOverrideHosts,
   validateConfig,
 } from '../src/config/thresholds.ts';
 
@@ -148,5 +150,41 @@ describe('per-host overrides', () => {
       configFor(config, 'queue_buildup', 'Lab Router'),
       DEFAULT_CONFIG.rules.queue_buildup,
     );
+  });
+});
+
+describe('inert host overrides (#25)', () => {
+  // hostOverrides is keyed by a literal host name, so pointing the engine at another
+  // production makes every override inert -- silently. The tuning stops applying and
+  // nothing says so, which is the same silent-weakening shape as `npm test --if-present`
+  // reporting green on nothing.
+  const config = validateConfig({
+    hostOverrides: { 'Cloud API': { slow_processing: { absoluteFloorSeconds: 0.3 } } },
+  });
+
+  it('ignores _comment keys when listing declared overrides', () => {
+    const documented = validateConfig({
+      hostOverrides: {
+        _comment: 'rare and always commented',
+        'Cloud API': { slow_processing: { absoluteFloorSeconds: 0.3 } },
+      },
+    });
+    assert.deepEqual(declaredOverrideHosts(documented), ['Cloud API']);
+  });
+
+  it('reports an override that matches no observed host', () => {
+    assert.deepEqual(inertOverrideHosts(config, ['Tick Feed', 'Risk Filter']), ['Cloud API']);
+  });
+
+  it('reports nothing when the override does apply', () => {
+    assert.deepEqual(inertOverrideHosts(config, ['Cloud API', 'Lab Router']), []);
+  });
+
+  it('reports every declared override when no hosts have been seen at all', () => {
+    assert.deepEqual(inertOverrideHosts(config, []), ['Cloud API']);
+  });
+
+  it('does not report anything when no overrides are declared', () => {
+    assert.deepEqual(inertOverrideHosts(validateConfig({}), ['Tick Feed']), []);
   });
 });

--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -438,3 +438,39 @@ describe('findings ordering (contract §2)', () => {
     assert.equal(findings[0]?.severity, 'critical', 'critical sorts first within a timestamp');
   });
 });
+
+describe('inert override warning reaches the log (#25)', () => {
+  const withOverride: ThresholdConfig = {
+    ...DEFAULT_CONFIG,
+    hostOverrides: { 'Cloud API': { slow_processing: { absoluteFloorSeconds: 0.3 } } },
+  };
+
+  it('warns once, not once per poll', () => {
+    const logs: string[] = [];
+    const engine = new DetectionEngine(withOverride, (msg) => logs.push(msg));
+    let at = T0;
+    for (let i = 0; i < 5; i += 1) {
+      engine.applyPoll(response([proxyHost({ name: 'Tick Feed' })]), at);
+      at += POLL_MS;
+    }
+    assert.equal(logs.length, 1, `expected one warning, got ${logs.length}`);
+    assert.match(logs[0] ?? '', /hostOverrides\["Cloud API"\] matches no observed host/);
+    assert.match(logs[0] ?? '', /Observed: Tick Feed/);
+  });
+
+  it('stays silent when the override applies', () => {
+    const logs: string[] = [];
+    const engine = new DetectionEngine(withOverride, (msg) => logs.push(msg));
+    engine.applyPoll(response([proxyHost({ name: 'Cloud API' })]), T0);
+    assert.deepEqual(logs, []);
+  });
+
+  it('warns again after reconfigure, so a corrected file is re-checked', () => {
+    const logs: string[] = [];
+    const engine = new DetectionEngine(withOverride, (msg) => logs.push(msg));
+    engine.applyPoll(response([proxyHost({ name: 'Tick Feed' })]), T0);
+    engine.reconfigure(withOverride);
+    engine.applyPoll(response([proxyHost({ name: 'Tick Feed' })]), T0 + POLL_MS);
+    assert.equal(logs.length, 2);
+  });
+});


### PR DESCRIPTION
The cheap half of #25 — the part @tanifgit scoped as *"a latent bug at any production count"*.

## Reproduced first

`hostOverrides` is keyed by a literal host name, so on a different production every override goes inert **silently**:

```
override keys declared: Cloud API
configFor(slow_processing,"Cloud API")   floor = 0.3   (applied)
configFor(slow_processing,"Risk Filter") floor = 0.2   (base config, override inert)
warning emitted: NONE
```

You're right that this is the same shape as three failures we've already fixed — `npm test --if-present` reporting green on nothing, `-c ajv-formats` quietly ignoring `format`, and the `@devA` CODEOWNERS placeholder requesting review from nobody. A config that weakens without complaining.

## Now

```
thresholds: hostOverrides["Cloud API"] matches no observed host, so its tuning is
inert. Observed: Risk Filter, Tick Feed
```

A **warning, not an error** — a host can be legitimately absent from a running production, and refusing to start would be worse than saying so. Emitted once per (config, host-set) rather than per poll, and reset on `reconfigure` so a corrected file gets re-checked. `DetectionEngine` now takes an optional log sink, which also makes it testable rather than eyeball-only.

**133/133 tests**, and I verified they fail without the fix rather than only that they pass with it — commenting out the warn call fails 2 of the 3 new engine tests.

## I reproduced your larger finding too, and it's real

Independently, on my own synthetic quiet production:

```
steady state findings: 0
findings after a 10x regression on EVERY metric: 0
```

Confirmed. And your framing is the useful part: **the multipliers travel, the floors don't.** `3.0x` means the same thing on any production; `0.2s` encodes LABDEMO's magnitude. My #20 retune fixed LABDEMO and moved the bug to everything quieter — which is the same defect recurring one level up, exactly as you say.

**Not addressed here, deliberately.** It's an ADR-level design question, the options interact with *why* the floors exist (stopping `1 → 5` firing as "5× baseline" on trivia), and multi-production support is out of MVP 1 per root `CLAUDE.md` §2. I'd rather leave your issue open with the analysis intact than half-fix it under time pressure.

If it's wanted before Day 5, the option I'd argue for is `floor = max(k × baseline, tiny_absolute)` — it keeps the floor's actual purpose while making it scale-relative, and `tiny_absolute` becomes a sanity bound rather than the binding constraint. But that deserves the ADR you suggested, not a number change in a PR.

## On your 26-file classification

That's the most useful artifact in #25 — one runtime file, and it was a loading-skeleton count. Worth pairing with the observation I reached from the CI side in #19: four copies of a fact and the copies drift. Yours quantifies it, which is better.

Entirely within `services/detection-engine/`. Refs #25
