### PR TITLE
fix(iris): #17 — Verify() false negative, two Storage blocks, and triggers pointing at a deleted host

### DIFF
--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -36,16 +36,21 @@ Verification: `iris_interop_queued` and `iris_interop_avg_processing_time` must 
 
 ## 3. LABDEMO production
 
-Four components (match exactly — these names appear in the proxy JSON contract):
+Three application components. **The `<Item Name="...">` set in `iris/labdemo/Production.cls`
+is authoritative** — do not maintain a second copy of the host list here, because a
+duplicated list is exactly what went stale when `FHIR Transform` was removed.
 
-| Component name | Type | Role |
-|---|---|---|
-| `EMRSource` | Business Service (HL7 file/TCP) | Inbound HL7 v2 messages |
-| `LabRouter` | Business Process (routing rule) | Routes by message type |
-| `FHIRTransform` | Business Process (DTL) | Transforms HL7 → FHIR R4 |
-| `CloudAPI` | Business Operation (HTTP) | Forwards to downstream endpoint |
+Note the names carry a space (`EMR Source`, not `EMRSource`). The spaced form is what
+appears in `/api/monitor/metrics`, in the proxy JSON, and in the dashboard, so use it
+verbatim. Class names differ from config item names: the `Cloud API` item is
+`ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation`.
 
-The synthetic HL7 generator (`iris/labdemo/HL7Generator.cls`) emits ADT^A01 and ORU^R01 messages on a configurable interval.
+`Ens.Activity.Operation.Local` is a fourth item, but it is framework plumbing for metrics
+and the findings API filters it out — it is not an application host.
+
+The synthetic HL7 generator (`iris/labdemo/HL7Generator.cls`) emits ADT^A01 messages on a
+configurable interval. That is the only type it emits and the only type the routing rule
+routes.
 
 ---
 

--- a/iris/labdemo/Data/PatientRecord.cls
+++ b/iris/labdemo/Data/PatientRecord.cls
@@ -155,6 +155,6 @@ Storage Default
 <IndexLocation>^PG.LabDemo.PatientRecordX</IndexLocation>
 <StreamLocation>^PG.LabDemo.PatientRecordS</StreamLocation>
 <Type>%Storage.Persistent</Type>
-</Storage>
+}
 
 }

--- a/iris/labdemo/HL7Generator.cls
+++ b/iris/labdemo/HL7Generator.cls
@@ -1,7 +1,8 @@
 /// Synthetic HL7 v2 message generator for the LABDEMO production.
 ///
-/// Writes ADT^A01 and ORU^R01 messages to /tmp/labdemo/hl7-in/ on a
-/// configurable interval so the production has continuous message flow.
+/// Writes ADT^A01 messages to /tmp/labdemo/hl7-in/ on a configurable interval
+/// so the production has continuous message flow. ADT^A01 is the only type
+/// emitted, and the only type the routing rule routes.
 ///
 /// Usage:
 ///   // Generate 20 messages with 2-second gaps (default):
@@ -17,7 +18,7 @@
 Class ProductionGuardian.LabDemo.HL7Generator
 {
 
-/// Default output directory — must match EMRSource FilePath setting.
+/// Default output directory — must match the EMR Source FilePath setting.
 Parameter DropDir = "/tmp/labdemo/hl7-in/";
 
 /// Generate `count` messages with `delaySecs` between each.
@@ -28,7 +29,6 @@ ClassMethod Run(count As %Integer = 20, delaySecs As %Double = 2) As %Status
 
     write "Generating ", count, " HL7 messages to ", ..#DropDir, " ...", !
     for i = 1:1:count {
-        // Alternate between ADT^A01 (admit) and ORU^R01 (lab result).
         set msg = ..BuildADTA01(i)
         set msgType = "ADT_A01"
         set filename = ..#DropDir _ msgType _ "_" _ $translate($horolog, ",", "_") _ "_" _ i _ ".hl7"
@@ -59,7 +59,7 @@ ClassMethod RunContinuous(delaySecs As %Double = 2)
         set msg = ..BuildADTA01(i)
         set msgType = "ADT_A01"
         set filename = ..#DropDir _ msgType _ "_" _ $translate($horolog, ",", "_") _ "_" _ i _ ".hl7"
-        do ..WriteFile(filename, filename)  // errors are silent in continuous mode
+        do ..WriteFile(filename, msg)  // errors are silent in continuous mode
         write $zdatetime($ztimestamp, 3, 1), "  ", msgType, !
         hang delaySecs
         set i = i + 1

--- a/iris/labdemo/Message/PatientDemographics.cls
+++ b/iris/labdemo/Message/PatientDemographics.cls
@@ -43,58 +43,9 @@ Property SourceMessageID As %String(MAXLEN = 64);
 /// ISO 8601 timestamp when this message was created (set by the DTL).
 Property ExtractedAt As %String(MAXLEN = 32);
 
-Storage Default
-{
-<Data name="PatientDemographicsDefaultData">
-<Value name="1">
-<Value>%%CLASSNAME</Value>
-</Value>
-<Value name="2">
-<Value>PatientID</Value>
-</Value>
-<Value name="3">
-<Value>LastName</Value>
-</Value>
-<Value name="4">
-<Value>FirstName</Value>
-</Value>
-<Value name="5">
-<Value>MiddleName</Value>
-</Value>
-<Value name="6">
-<Value>DateOfBirth</Value>
-</Value>
-<Value name="7">
-<Value>Sex</Value>
-</Value>
-<Value name="8">
-<Value>AddressStreet</Value>
-</Value>
-<Value name="9">
-<Value>AddressCity</Value>
-</Value>
-<Value name="10">
-<Value>AddressState</Value>
-</Value>
-<Value name="11">
-<Value>AddressZip</Value>
-</Value>
-<Value name="12">
-<Value>HomePhone</Value>
-</Value>
-<Value name="13">
-<Value>SourceMessageID</Value>
-</Value>
-<Value name="14">
-<Value>ExtractedAt</Value>
-</Value>
-</Data>
-<DataLocation>^ProductionGuardian.LabDemo.Msg.PatD</DataLocation>
-<DefaultData>PatientDemographicsDefaultData</DefaultData>
-<IdLocation>^ProductionGuardian.LabDemo.Msg.PatI</IdLocation>
-<IndexLocation>^ProductionGuardian.LabDemo.Msg.PatX</IndexLocation>
-<StreamLocation>^ProductionGuardian.LabDemo.Msg.PatS</StreamLocation>
-<Type>%Storage.Persistent</Type>
-</Storage>
+// No Storage block. Ens.Request inherits its storage from Ens.MessageBody, which pins
+// DataLocation to ^Ens.MessageBodyD; a Default map naming its own globals here fails to
+// compile with "keyword 'DataLocation' must be '^Ens.MessageBodyD'". Message bodies are
+// stored and purged by the interoperability framework, not by this class.
 
 }

--- a/iris/labdemo/Production.cls
+++ b/iris/labdemo/Production.cls
@@ -1,8 +1,10 @@
 /// LABDEMO production for Production Guardian Health Scan.
 ///
-/// Pipeline:
-///   EMRSource  →  LabRouter  →  PIDExtractProcess  →  PatientDemographicsOperation
-///   (HL7 file)    (routing)      (DTL: HL7→PID msg)    (REST POST → PatientDispatcher)
+/// Pipeline (config item names, as they appear in metrics and the proxy JSON):
+///   EMR Source  →  Lab Router  →  Cloud API
+///   (HL7 file)     (routing +      (REST POST → PatientDispatcher)
+///                   HL7ToPID DTL
+///                   applied inline)
 ///
 /// PatientDispatcher upserts patient demographics into:
 ///   ProductionGuardian.LabDemo.Data.PatientRecord (persistent table)
@@ -26,7 +28,7 @@ XData ProductionDefinition
   </Description>
 
   <!-- ============================================================
-       Business Service — EMRSource
+       Business Service — EMR Source
        Reads HL7 v2 files dropped by the HL7Generator.
        ============================================================ -->
   <Item Name="EMR Source"
@@ -47,7 +49,7 @@ XData ProductionDefinition
   </Item>
 
   <!-- ============================================================
-       Business Process — LabRouter
+       Business Process — Lab Router
        Routes ADT^A01 to Cloud API.
        Rule: ProductionGuardian.LabDemo.RoutingRule
        ============================================================ -->

--- a/iris/labdemo/README.md
+++ b/iris/labdemo/README.md
@@ -3,11 +3,17 @@
 The LABDEMO production models a realistic HL7 lab message pipeline that Health Scan monitors.
 
 ```
-EMRSource  →  LabRouter  →  PIDExtractProcess  →  PatientDemographicsOperation
-(HL7 file)    (routing)      (DTL: PID extract)    (HTTP POST → PatientDispatcher)
-                                                             ↓
-                                                  PatientRecord table (upsert by PatientID)
+EMR Source  →  Lab Router  →  Cloud API
+(HL7 file)     (routing +      (HTTP POST → PatientDispatcher)
+                HL7ToPID DTL             ↓
+                applied inline)  PatientRecord table (upsert by PatientID)
 ```
+
+There are three application hosts. `EMR Source`, `Lab Router` and `Cloud API` are the
+config item names — those are the strings that appear in `/api/monitor/metrics`, in the
+proxy JSON, and in the dashboard, so use them verbatim when reasoning about findings.
+Class names (`PatientDemographicsOperation`) differ from config item names (`Cloud API`);
+the `<Item Name="...">` set in `Production.cls` is authoritative.
 
 ---
 
@@ -15,9 +21,8 @@ EMRSource  →  LabRouter  →  PIDExtractProcess  →  PatientDemographicsOpera
 
 | File | Purpose |
 |---|---|
-| `Production.cls` | Production definition — 4 items + ActivityReporter |
-| `RoutingRule.cls` | Routes ADT^A01 and ORU^R01 to PIDExtractProcess |
-| `Process/PIDExtractProcess.cls` | BP: applies DTL, forwards PatientDemographics |
+| `Production.cls` | Production definition — 3 application items + ActivityReporter |
+| `RoutingRule.cls` | Routes ADT^A01 to Cloud API, applying HL7ToPID inline |
 | `Transform/HL7ToPID.cls` | DTL: HL7 PID segment → PatientDemographics message |
 | `Message/PatientDemographics.cls` | Ens.Request carrying extracted PID fields |
 | `Operation/PatientDemographicsOperation.cls` | BO: HTTP POST to REST dispatcher |
@@ -82,11 +87,11 @@ do ##class(ProductionGuardian.LabDemo.HL7Generator).RunContinuous(2)
 
 Each message flows:
 1. Written to `/tmp/labdemo/hl7-in/` as a `.hl7` file
-2. EMRSource picks it up and sends to LabRouter
-3. LabRouter routes it to PIDExtractProcess
-4. PIDExtractProcess runs the HL7ToPID DTL — extracts PatientID, name, DOB, sex, address, phone
-5. PatientDemographicsOperation HTTP-POSTs the JSON to `/labdemo/patients`
-6. PatientDispatcher upserts the record in `PatientRecord` (insert first time, update thereafter)
+2. `EMR Source` picks it up and sends to `Lab Router`
+3. `Lab Router` matches ADT^A01 and sends to `Cloud API`, applying the HL7ToPID DTL on the
+   way — the transform extracts PatientID, name, DOB, sex, address and phone
+4. `Cloud API` HTTP-POSTs the JSON to `/labdemo/patients`
+5. PatientDispatcher upserts the record in `PatientRecord` (insert first time, update thereafter)
 
 ---
 
@@ -131,14 +136,47 @@ write rec.LastName, " ", rec.FirstName, " (", rec.UpdateCount, " updates)"
 
 ## Inducing findings (for Health Scan testing)
 
-| Finding type | How to induce |
-|---|---|
-| Dead / inactive host | Disable EMRSource from Management Portal |
-| Elevated error rate | Misconfigure PatientDemographicsOperation HTTPPort to a closed port |
-| Queue buildup | Suspend PIDExtractProcess; run generator at fast rate |
-| Stalled host | Pause LabRouter from Management Portal |
-| Slow processing | Add a `hang 5` to PIDExtractProcess.OnRequest temporarily |
-| Throughput drop | Stop the HL7Generator |
+Only `EMR Source`, `Lab Router` and `Cloud API` exist, so every trigger targets one of
+those three. Use the config item names exactly.
+
+**Two things to know before you start, or nothing will fire and it will look broken.**
+
+*Warm-up.* Six of the eight rules are comparative — they need a baseline first.
+`minBaselineSamples` is 12 at a 10 s poll, so let the generator run for **~2 minutes of
+healthy traffic** before inducing anything. `dead_host` and `system_alert` are absolute and
+fire immediately.
+
+*The numbers have floors.* A breach must clear both the baseline multiplier **and** an
+absolute floor, so a small nudge produces nothing. The current floors are in
+`services/detection-engine/thresholds.json` — that file is authoritative, and the
+arithmetic below is quoted from it rather than restated as fact. Check it if a trigger
+stops working.
+
+| Finding type | How to induce | Why it clears the threshold |
+|---|---|---|
+| `dead_host` | Disable `EMR Source` in the Management Portal | Absolute rule: fires on status `Disabled`. No baseline needed |
+| `throughput_drop` | Stop the HL7Generator and let traffic drain | Rate falls to 0, under the 0.4 baseline fraction. Needs baseline ≥ 0.1 msg/s — generating every 2 s gives 0.5 msg/s |
+| `slow_processing` | Add `hang 1` to the top of `PatientDemographicsOperation.OnMessage` (that class is `Cloud API`), recompile | Gate is the greater of the 0.3 s `Cloud API` floor and 3× its ~0.05 s baseline, so 0.3 s. A 1 s hang clears it. `hang 5` also works but backs the queue up behind it |
+| `growing_queue_wait` | Same `hang 1` — watch `Cloud API` while the generator keeps running | Messages wait behind the hung one. Floor is 0.15 s and 3× the ~0.03 s baseline, so a 1 s hang clears it once traffic overlaps |
+| `elevated_error_rate` | Set `Cloud API`'s `HTTPPort` to a closed port (e.g. 59999) | Every message errors. Floor is 1.0 errors/min and 3× baseline; at one message per 2 s that is ~30/min |
+| `stalled_host` | Disable `Cloud API` so its queue holds messages, then wait | Needs no activity for `inactiveSeconds` (300) **while messages are queued** — so it takes **5 minutes**, and `requiresQueued` means an idle-but-empty host will not do |
+| `queue_buildup` | Disable `Cloud API`, then `do ##class(ProductionGuardian.LabDemo.HL7Generator).Run(80, 0.2)` | Depth must exceed the absolute floor of **50** as well as 5× baseline, so it needs well over 50 queued — 80 messages at 0.2 s does it. Fewer than 50 produces no finding at all. **See the caveat below** |
+| `system_alert` | Enable `Alert on Error` on `Cloud API`, then induce the error-rate trigger above | An errored message with alerting on writes an alert that `/api/monitor/alerts` serves. This is the only rule that can produce an `info` finding |
+
+Disabling a host induces `dead_host` too, so the `stalled_host` and `queue_buildup`
+triggers each surface two findings. That is correct behaviour, not a duplicate.
+
+> **`queue_buildup` caveat — the trigger is right, the plumbing may not be.** Per-host
+> queue depth is **not** in the Prometheus text. `/api/monitor/metrics` carries only
+> `iris_interop_queued{id="LABDEMO",production="LABDEMO.Production"}` — one
+> production-wide number, no `host` label (verified on the live instance). Until the proxy
+> reads per-host depth from `Ens.Util.Statistics:EnumerateHostStatus` (issue #12,
+> `PROXY-Q2`), this trigger will build a real queue that the engine cannot see. Build the
+> queue anyway when testing that work; the instruction above is what it should be measured
+> against.
+
+After the `slow_processing` / `growing_queue_wait` test, **remove the `hang`** and
+recompile — a hang left in place poisons every later baseline.
 
 ---
 
@@ -149,3 +187,19 @@ do ##class(ProductionGuardian.Setup.EnableMetrics).Verify()
 ```
 
 All 7 metric families should show FOUND after the production is running with messages flowing.
+
+`Verify()` prints the URL it requests. If it reports a 404, or a 200 with no
+`iris_interop_*` families, the URL is wrong rather than the metrics being off — point it at
+whatever works in your browser:
+
+```
+set ^ProductionGuardian.Setup("WebAppPrefix") = "/iris4health_2024_1"   // default ""
+set ^ProductionGuardian.Setup("WebPort")      = 80                      // default 52773
+set ^ProductionGuardian.Setup("WebHost")      = "127.0.0.1"
+```
+
+These mirror the metrics proxy's `IRIS_BASE_PATH` / `IRIS_PORT` / `IRIS_HOST`.
+
+Run `Verify()` **before** starting the metrics proxy, not alongside it:
+`/api/monitor/alerts` is consume-on-read, so this call takes any pending alerts that the
+proxy would otherwise publish.

--- a/iris/labdemo/RoutingRule.cls
+++ b/iris/labdemo/RoutingRule.cls
@@ -1,8 +1,9 @@
-/// Routing rule for the LabRouter Business Process.
-/// Routes HL7 messages by message type to PIDExtractProcess:
-///   ADT^A01 → PIDExtractProcess  (admit — always has a full PID segment)
-///   ORU^R01 → PIDExtractProcess  (lab result — also carries PID)
-///   All others → discarded (logged as unrouted by LabRouter)
+/// Routing rule for the Lab Router Business Process.
+/// Routes HL7 messages by message type, applying the HL7ToPID DTL inline:
+///   ADT^A01 → Cloud API, transformed by HL7ToPID  (admit — has a full PID segment)
+///   All others → discarded (logged as unrouted by Lab Router)
+///
+/// ADT^A01 is the only type routed, and the only type HL7Generator emits.
 Class ProductionGuardian.LabDemo.RoutingRule Extends Ens.Rule.Definition
 {
 

--- a/iris/labdemo/Transform/HL7ToPID.cls
+++ b/iris/labdemo/Transform/HL7ToPID.cls
@@ -3,7 +3,8 @@
 /// Extracts the PID segment from any inbound HL7 v2.x message and populates
 /// a ProductionGuardian.LabDemo.Message.PatientDemographics instance.
 ///
-/// Handles both ADT^A01 and ORU^R01 — both carry a PID segment.
+/// sourceDocType is 2.5:ADT_A01, which is the only type the routing rule sends here
+/// and the only type HL7Generator emits.
 /// If the PID segment is absent the transform still succeeds with empty fields
 /// (the operation will reject an empty PatientID).
 Class ProductionGuardian.LabDemo.Transform.HL7ToPID Extends Ens.DataTransformDTL [ DependsOn = (EnsLib.HL7.Message, ProductionGuardian.LabDemo.Message.PatientDemographics) ]
@@ -30,7 +31,7 @@ XData DTL [ XMLNamespace = "http://www.intersystems.com/dtl" ]
   <assign value='source.{PID:5(1).3}' property='target.MiddleName' action='set'/>
 
   <!-- Date of birth: PID-7 (TS, take first 8 chars for YYYYMMDD) -->
-  <assign value='$extract(source.{PID:7"),1,8)' property='target.DateOfBirth' action='set'/>
+  <assign value='$extract(source.{PID:7},1,8)' property='target.DateOfBirth' action='set'/>
 
   <!-- Sex: PID-8 -->
   <assign value='source.{PID:8}' property='target.Sex' action='set'/>

--- a/iris/setup/EnableMetrics.cls
+++ b/iris/setup/EnableMetrics.cls
@@ -14,6 +14,19 @@
 ///
 /// After running, verify with:
 ///   do ##class(ProductionGuardian.Setup.EnableMetrics).Verify()
+///
+/// Verify() builds its own URL for the local monitor API. Where that API lives is
+/// instance-specific, so three optional globals override the defaults:
+///
+///   ^ProductionGuardian.Setup("WebAppPrefix")  path in front of /api/monitor/  (default "")
+///   ^ProductionGuardian.Setup("WebHost")       host to request                 (default 127.0.0.1)
+///   ^ProductionGuardian.Setup("WebPort")       port to request                 (default: see WebPort())
+///
+/// Set them to match the URL that already works in a browser. This mirrors the
+/// metrics proxy's IRIS_BASE_PATH / IRIS_HOST / IRIS_PORT — same problem, same fix:
+///
+///   http://localhost:52773/api/monitor/metrics        -> all three defaults are fine
+///   http://localhost/iris4health_2024_1/api/monitor/  -> WebAppPrefix="/iris4health_2024_1", WebPort=80
 Class ProductionGuardian.Setup.EnableMetrics
 {
 
@@ -96,42 +109,91 @@ ClassMethod CheckActivityOperation()
     }
 }
 
+/// Path prefix in front of /api/monitor/, or "" when the API is at the web server root.
+/// On an instance fronted by an external web server the instance name is a path segment,
+/// e.g. http://localhost/iris4health_2024_1/api/monitor/metrics — requesting the bare
+/// path there returns the web server's 404, which reads as "metrics are not enabled" on
+/// an instance where they are working correctly.
+ClassMethod WebAppPrefix() As %String
+{
+    set prefix = $get(^ProductionGuardian.Setup("WebAppPrefix"), "")
+    quit:prefix="" ""
+    // Normalise to leading-slash, no-trailing-slash so path joining stays predictable.
+    set prefix = $zstrip(prefix, ">", "/")
+    quit $case($extract(prefix), "/": prefix, : "/" _ prefix)
+}
+
+/// Host to request the monitor API on. 127.0.0.1 is right for an instance whose web
+/// server shares its network namespace; a containerised instance reaching a gateway
+/// web server needs the override.
+ClassMethod WebHost() As %String
+{
+    quit $get(^ProductionGuardian.Setup("WebHost"), "127.0.0.1")
+}
+
+/// Port to request the monitor API on.
+///
+/// ^%SYS("WebServer","Port") is NOT a safe source for this. On an instance served by an
+/// external web server that node exists and holds 0 — so `$get(...,52773)` returns 0, not
+/// the default, and the request fails with "Unable to open TCP/IP socket to ...:0". A
+/// $get default only applies when the node is undefined, and this node is defined-but-zero.
+ClassMethod WebPort() As %Integer
+{
+    set port = $get(^ProductionGuardian.Setup("WebPort"), "")
+    quit:+port>0 +port
+    set sysPort = $get(^%SYS("WebServer","Port"), 0)
+    quit $select(+sysPort>0: +sysPort, 1: 52773)
+}
+
 /// Verify that the expected interop metrics are present in /api/monitor/metrics.
 /// Call after Run() and after the production is running with Ens.Activity.Operation.Local.
 ///
 /// Requires the %Net.HttpRequest class (available in all IRIS instances).
 ClassMethod Verify() As %Status
 {
-    write "=== Verifying interop metrics in /api/monitor/metrics ===",!
+    set prefix = ..WebAppPrefix()
+    set host = ..WebHost()
+    set port = ..WebPort()
 
-    // Build an HTTP request to the local /api/monitor/metrics endpoint.
+    write "=== Verifying interop metrics in /api/monitor/metrics ===",!
+    // Print the URL actually requested. A wrong prefix or port is otherwise invisible at
+    // the one moment you would want to see it.
+    write "Requesting: http://", host, ":", port, prefix, "/api/monitor/metrics",!
+
     set req = ##class(%Net.HttpRequest).%New()
-    set req.Server = "127.0.0.1"
-    set req.Port = $get(^%SYS("WebServer","Port"), 52773)  // default IRIS web port
+    set req.Server = host
+    set req.Port = port
     set req.Https = 0
     // Use the _SYSTEM account only for local verification — never in production code.
     set req.Username = $get(^ProductionGuardian.Setup("IRISUser"), "_SYSTEM")
     set req.Password = $get(^ProductionGuardian.Setup("IRISPass"), "SYS")
 
-    set sc = req.Get("/api/monitor/metrics")
+    set sc = req.Get(prefix _ "/api/monitor/metrics")
     if $$$ISERR(sc) {
         write "HTTP request failed: "
         do $system.Status.DisplayError(sc)
+        do ..WriteURLHint()
         quit sc
+    }
+
+    // A reachable web server that does not serve this path answers 404 with an OK status —
+    // Get() only errors when the socket itself fails. Without this check the 404 body is
+    // scanned for metric names, every one is reported MISSING, and the operator is sent to
+    // re-run EnableSAMForNamespace() when the real fault is the URL.
+    set status = req.HttpResponse.StatusCode
+    if (status < 200) || (status > 299) {
+        write "  FAILED: HTTP ", status, " — the monitor API is not at this URL.",!
+        do ..WriteURLHint()
+        quit $$$ERROR($$$GeneralError, "GET " _ prefix _ "/api/monitor/metrics returned HTTP " _ status)
     }
 
     set body = req.HttpResponse.Data.Read(1000000)
 
-    // Check for the two critical metric families.
-    set checks = $listbuild(
-        "iris_interop_queued",
-        "iris_interop_avg_processing_time",
-        "iris_interop_messages_per_sec",
-        "iris_interop_messages_errored",
-        "iris_interop_avg_queueing_time",
-        "iris_last_activity",
-        "iris_interop_hosts"
-    )
+    // The seven families the metrics proxy consumes. Names must match the metric text
+    // exactly: the last-activity family is iris_interop_last_activity, and the bare
+    // iris_last_activity this list used to carry appears nowhere in the output, so it
+    // reported MISSING on a healthy instance.
+    set checks = $listbuild("iris_interop_queued", "iris_interop_avg_processing_time", "iris_interop_messages_per_sec", "iris_interop_messages_errored", "iris_interop_avg_queueing_time", "iris_interop_last_activity", "iris_interop_hosts")
     set allFound = 1
     set ptr = 0
     while $listnext(checks, ptr, metric) {
@@ -143,17 +205,34 @@ ClassMethod Verify() As %Status
         }
     }
 
+    // A 200 carrying no iris_interop_* at all is the quiet failure: on port 80 without a
+    // prefix you reach the %SYS namespace's monitor web app, which answers with several
+    // hundred lines of real system metrics and not one interop family. Nothing looks
+    // broken; you simply get no hosts.
+    if '(body [ "iris_interop_") {
+        write !,"  NOTE: this response has no iris_interop_* families at all.",!
+        write "  That is what a monitor API in the wrong namespace looks like — the request",!
+        write "  succeeded, but against a namespace with no interoperability metrics.",!
+        do ..WriteURLHint()
+    }
+
     // Check alerts endpoint separately.
-    write !,"Checking /api/monitor/alerts ...",!
+    //
+    // Reading /api/monitor/alerts CLEARS the alerts it returns; only mgr/alerts.log keeps
+    // them. This call therefore steals any pending alerts from the metrics proxy, which
+    // cannot get them back. Run Verify() before starting the proxy, not alongside it.
+    write !,"Checking /api/monitor/alerts (consume-on-read — see comment) ...",!
     set req2 = ##class(%Net.HttpRequest).%New()
     set req2.Server = req.Server
     set req2.Port = req.Port
     set req2.Https = 0
     set req2.Username = req.Username
     set req2.Password = req.Password
-    set sc2 = req2.Get("/api/monitor/alerts")
+    set sc2 = req2.Get(prefix _ "/api/monitor/alerts")
     if $$$ISERR(sc2) {
         write "  FAILED to reach /api/monitor/alerts",!
+    } elseif (req2.HttpResponse.StatusCode < 200) || (req2.HttpResponse.StatusCode > 299) {
+        write "  FAILED: /api/monitor/alerts returned HTTP ", req2.HttpResponse.StatusCode, !
     } else {
         set alertBody = req2.HttpResponse.Data.Read(10000)
         if alertBody [ "[" {
@@ -169,11 +248,22 @@ ClassMethod Verify() As %Status
         write "All expected metrics found. Metrics proxy can now be started.",!
     } else {
         write "Some metrics are missing. Check:",!
+        write "  - Is the URL above the one that works in your browser?",!
         write "  - Is the production running?",!
         write "  - Was EnableSAMForNamespace() called in this namespace?",!
         write "  - Is Ens.Activity.Operation.Local in the production?",!
     }
     quit $$$OK
+}
+
+/// Print how to point Verify() at the URL that actually serves the monitor API.
+ClassMethod WriteURLHint()
+{
+    write "  Open /api/monitor/metrics in a browser, then set the globals to match it:",!
+    write "    set ^ProductionGuardian.Setup(""WebAppPrefix"") = ""/iris4health_2024_1""",!
+    write "    set ^ProductionGuardian.Setup(""WebPort"")      = 80",!
+    write "    set ^ProductionGuardian.Setup(""WebHost"")      = ""127.0.0.1""",!
+    write "  These mirror the metrics proxy's IRIS_BASE_PATH / IRIS_PORT / IRIS_HOST.",!
 }
 
 }


### PR DESCRIPTION
Closes #17.

**Dev A (`kskubach`) has moved to other work, so Dev B is taking over their outstanding tasks.** Authorized by the repo owner. All four items of #17 are addressed below. Two of the four needed confirming by compiling before touching them, and both turned out to be real — details and output inline.

Everything here is under `iris/**`. No file in `services/`, `apps/`, `contracts/` or `docs/` is touched.

---

## Item 1 — `EnableMetrics.Verify()` false negative — **fixed, and it was worse than filed**

#17 identified the missing web-app prefix. That is real, but it is one of **four** independent reasons `Verify()` misreported a healthy instance. All four verified on the live 2026.1 instance.

**a) The port was resolved to `0`.** `^%SYS("WebServer","Port")` is *defined and holds `0`* on an instance served by an external web server, and a `$get` default only applies to an **undefined** node:

```
resolved port via $get(...,52773) = [0]
is it defined? 1
ERROR #6059: Unable to open TCP/IP socket to server 127.0.0.1:0
```

So on this instance `Verify()` never reached the network at all — the prefix was moot. `WebPort()` now treats a non-positive value as absent and falls back to `52773`.

**b) No web-app prefix**, as filed. Added `WebAppPrefix()` from `^ProductionGuardian.Setup("WebAppPrefix")`, default `""`, normalised to leading-slash form. Added `WebHost()` for the same class of problem. These three deliberately mirror the metrics proxy's `IRIS_BASE_PATH` / `IRIS_HOST` / `IRIS_PORT` (694e902, #13) — same defect, same shape of fix, and `iris/labdemo/README.md` now shows the two settings side by side.

**c) A 404 was read as success.** `%Net.HttpRequest.Get()` returns `$$$OK` for any *answered* request; it only errors when the socket fails:

```
--- requesting a path we KNOW 404s ---
IsError(sc) = 0
HTTP StatusCode = 404
```

The old code therefore scanned the 404 HTML for metric names, reported all seven `MISSING`, and sent the operator to re-run `EnableSAMForNamespace()` when the real fault was the URL. `Verify()` now checks `StatusCode` and returns an error naming it. The same check was added to the alerts request, which had the same hole.

**d) One metric name was simply wrong.** The checks list carried `iris_last_activity`; the real family is `iris_interop_last_activity`. The bare name occurs **zero** times in the live output, and all 25 occurrences across the existing captures use the `iris_interop_` form — so that line reported `MISSING` on a perfectly healthy instance regardless of the URL.

### The working monitor URL on this instance

Contrary to the URL recorded in #17, **there is no prefix on our instance.** Measured:

```
=== port 80, no prefix ===                      HTTP 200  size=65650
=== port 80, /iris4health_2024_1 prefix ===     HTTP 404  size=180
=== port 52773, no prefix ===                   HTTP 000  (nothing listening)
```

`http://localhost:80/api/monitor/metrics` is the working URL, and it does carry interop data — 83 `iris_interop_*` lines across 14 families. The `/iris4health_2024_1` prefix from the issue **404s here**, which is exactly why this is a configurable global defaulting to `""` rather than a hard-coded prefix.

`Verify()` now prints the URL it requests, and warns on a 200 carrying no `iris_interop_*` at all — the port-80-without-prefix case the proxy's CLAUDE.md documents, where you reach `%SYS` and get real metrics with no interop families, indistinguishable from a stopped production.

**Verified end to end.** All seven families found, on the instance that previously reported failure:

```
=== Verifying interop metrics in /api/monitor/metrics ===
Requesting: http://host.docker.internal:80/api/monitor/metrics
  FOUND:   iris_interop_queued
  FOUND:   iris_interop_avg_processing_time
  FOUND:   iris_interop_messages_per_sec
  FOUND:   iris_interop_messages_errored
  FOUND:   iris_interop_avg_queueing_time
  FOUND:   iris_interop_last_activity
  FOUND:   iris_interop_hosts

Checking /api/monitor/alerts (consume-on-read - see comment) ...
  OK: /api/monitor/alerts returned JSON array

All expected metrics found. Metrics proxy can now be started.
```

And the negative case — a wrong prefix now fails loudly instead of misdiagnosing:

```
Requesting: http://host.docker.internal:80/iris4health_2024_1/api/monitor/metrics
  FAILED: HTTP 404 - the monitor API is not at this URL.
  Open /api/monitor/metrics in a browser, then set the globals to match it:
    set ^ProductionGuardian.Setup("WebAppPrefix") = "/iris4health_2024_1"
    ...
returned status IsError = 1
errtext: ERROR #5001: GET /iris4health_2024_1/api/monitor/metrics returned HTTP 404
```

Helper defaults and prefix normalisation were also exercised directly: `WebPort()` returns `52773` (not `0`), and `iris4health_2024_1/` / `/iris4health_2024_1` both normalise to `/iris4health_2024_1`, absent normalises to `""`.

One behavioural note worth a reviewer's eye: `Verify()` reads `/api/monitor/alerts`, which is **consume-on-read**, so it steals alerts the proxy would publish. I documented that in the code and README rather than changing it — removing the check felt out of scope for #17.

---

## Item 2 — `PatientRecord.cls` `</Storage>` — **confirmed defect, fixed**

#17 asked for this to be confirmed by compiling before fixing. It does **not** compile. The class as it stood on `main` could not load at all:

```
ERROR #5559: The class definition for class 'ProductionGuardian.LabDemo.Data.PatientRecord'
could not be parsed correctly, possibly due to non-matching {} or () characters or a
missing ; character or non-matched /* */ blocks.
  > ERROR #5030: An error occurred while compiling class '...PatientRecord'
```

Dev A's reading was right. UDL closes a Storage block with `}`; the XML end tag belongs only to the export format. Cross-checked against IRIS's own UDL for `Ens.MessageHeader`, which ends `<Type>%Storage.Persistent</Type>` / `}`. After the one-character fix:

```
Compiling class ProductionGuardian.LabDemo.Data.PatientRecord
Compiling table ProductionGuardian_LabDemo_Data.PatientRecord
Compilation finished successfully in 0.075s.
```

---

## Item 3 — `PatientDemographics.cls` has a Storage block — **confirmed defect, fixed**

Also a real defect, and a *different* one from item 2 — this class had **both** problems. Correcting only the `</Storage>` closer to isolate the second bug still fails:

```
ERROR #5477: Keyword signature error in PGTest.PD:Storage:Default, keyword
'DataLocation' must be '^Ens.MessageBodyD'
  > ERROR #5030: An error occurred while compiling class 'PGTest.PD'
```

`Ens.Request` inherits storage from `Ens.MessageBody`, which pins `DataLocation` to `^Ens.MessageBodyD`, so a Default map naming its own globals cannot compile. Removed the block entirely and left a comment saying why, so nobody re-adds it. Verified the same file with the block removed compiles:

```
Compiling class ProductionGuardian.LabDemo.Message.PatientDemographics
Compilation finished successfully in 0.106s.
```

---

## Item 4 — stale `PIDExtractProcess` references — **fixed**

Updated `Production.cls`'s pipeline comment, `RoutingRule.cls`'s header (it claimed it routed ADT^A01 **and** ORU^R01 to `PIDExtractProcess`; it routes ADT^A01 to `Cloud API`), and `README.md`'s diagram, inventory and flow narrative. `grep -rn "PIDExtractProcess\|ORU\^R01" iris/` is now empty.

### The two trigger instructions

Both named a host that does not exist, and **neither would have fired even with the name corrected** — that was the more important half:

- **Queue buildup** said "run generator at fast rate" with no target depth. `queue_buildup` has `absoluteFloor: 50`, so anything under 50 queued produces no finding at all. Now `Run(80, 0.2)` against a disabled `Cloud API`, with the floor stated so the next person understands why a small nudge does nothing.
- **Slow processing** said `hang 5`. The gate for `Cloud API` is its `0.3s` `hostOverride` floor, so `hang 1` clears it without backing the queue up behind it. The instruction now says to remove the hang afterwards — one left in place poisons every later baseline.

I filled in the other six triggers on the same basis, each with the arithmetic that clears its threshold, and added the two preconditions that otherwise make a working trigger look broken: comparative rules need ~2 minutes of healthy traffic for `minBaselineSamples: 12`, and `stalled_host` takes a full 5 minutes because `inactiveSeconds: 300` **and** `requiresQueued`. `thresholds.json` is cited as authoritative rather than restated — it is Dev B's file and the numbers will move.

**`queue_buildup` still cannot fire, and the README says so** rather than implying otherwise. Verified on the live instance that per-host depth is genuinely absent — the only line is:

```
iris_interop_queued{id="LABDEMO",production="LABDEMO.Production"} 0
```

One production-wide number, no `host` label. Until the proxy reads `EnumerateHostStatus` (#12, `PROXY-Q2`) this trigger builds a real queue the engine cannot see.

### Two extra defects found while verifying the triggers

Both block the pipeline the instructions exercise, so I fixed them here rather than filing and leaving the triggers untestable. Flagging them explicitly since neither is in #17:

**1. `Transform/HL7ToPID.cls:33` did not compile.** A stray `"` where the closing brace belongs: `source.{PID:7"),1,8)`. **The DTL could not compile, so no message could reach `Cloud API` at all** — the whole pipeline was broken on `main`, which makes this the most consequential find in the PR:

```
ERROR: HL7ToPID.cls(Transform+33) #1011: Invalid name :
  'target.DateOfBirth=$extract(source.{PID:7"),1,8)' : Offset:48
ERROR: HL7ToPID.cls(Transform+34) #1026: Invalid command : 'Catch'
ERROR: HL7ToPID.cls(Transform+71) #1043: QUIT argument not allowed : '}'
Detected 3 errors during compilation in 0.240s.
```

After `{PID:7}`:

```
Compiling class ProductionGuardian.LabDemo.Transform.HL7ToPID
Compilation finished successfully in 0.111s.
```

**2. `HL7Generator.cls:62` wrote the filename as the file's contents.** `do ..WriteFile(filename, filename)` instead of `msg`, so `RunContinuous()` produced files containing their own path — unparseable as HL7. `Run()` was correct, which is how it survived; `RunContinuous()` is what the throughput and queue triggers rely on.

Also aligned `iris/CLAUDE.md` §3, which still listed four unspaced components including `FHIRTransform`. It now points at `Production.cls` as the authoritative host list instead of keeping a second copy — a duplicated list is what went stale here in the first place — and records that the config names carry a space (`EMR Source`, not `EMRSource`), since the spaced form is what appears in the metrics and the proxy JSON.

---

## Verification and instance hygiene

All **eight** classes under `iris/labdemo/` plus `iris/setup/EnableMetrics.cls` compile clean.

Every compile ran in a **scratch namespace** (`AGENTICDEVELOPMENT`, and `USER` once to get a clean storage registration) — **never in `LABDEMO`**. Every probe class was deleted afterwards and the namespace verified empty of `ProductionGuardian*`; the test globals under `^ProductionGuardian.Setup` were killed. `LABDEMO.Production` was `Running` before and after, and no production setting was changed.

Note for reviewers: the live instance runs an older 4-host definition (including `FHIR Transform`) than `Production.cls` on `main`. That divergence is known and expected, and I did not try to reconcile it — so these classes are verified to **compile**, not verified running in LABDEMO.

Two things I could **not** verify, stated plainly rather than assumed:
- The triggers are verified against `thresholds.json` arithmetic and the live metric shape, but I did not induce all eight findings end to end — that needs the detection engine running against this production.
- `system_alert` relies on `AlertOnError`, which I confirmed exists as a real `Ens.Host` property, but I did not enable it on a host (that would be a production setting change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
