### PR TITLE
feat(contracts): publish the metrics proxy contract, schema and real capture

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,84 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-08-12 — Metrics proxy contract published (Dev B, on Dev A's behalf)
+
+Initial publication of `proxy-api.md`, `proxy.schema.json`, `samples/metrics-dump.txt`.
+
+Closes the last Day-1 gate item from `CONTRIBUTING.md` §6 (issue #16 item 4). Answers all five
+`PROXY-Q` markers in `services/detection-engine/src/types/proxy.ts` inline in §5, plus three that
+surfaced while writing it.
+
+**Dev A has moved to other work, so this is derived from their merged code rather than authored
+alongside it.** Every claim comes from reading `services/metrics-proxy/` on `main` and running it,
+not from intent. Attribution is Dev B's; the contract's owner in `README.md` stays Dev A, because
+the code is still theirs and `CODEOWNERS` still routes `services/metrics-proxy/` to them.
+
+`samples/metrics-dump.txt` is the real 1236-line `/api/monitor/metrics` body from a live LABDEMO
+production, byte-identical to the capture behind issue #10 — copied, not regenerated. 957 metric
+lines, 15 interop hosts, 4 application. **It is 1236 lines, not the 1249 quoted in issue #10 and in
+`src/parser.js`'s comment**; the same file, counted differently, and the smaller number is what
+`wc -l` reports. Not worth chasing, worth not silently contradicting.
+
+### Three things the contract says that were not previously known
+
+- **`iris_interop_messages_errored` carries no `host` label either.** It is per-production, exactly
+  like `iris_interop_queued`: `iris_interop_messages_errored{id="LABDEMO",production="LABDEMO.Production"} 0`.
+  The parser's `METRIC_MAP` treats it as per-host, so the line is skipped for want of a `host` label
+  and `errored` is `null` on every host. **`elevated_error_rate` cannot fire per host today** — the
+  same structural gap as `queue_buildup` (#12) and, unlike that one, not filed. §6.3. Worse than
+  `queued` in one respect: no per-production total is published anywhere, because
+  `messages_errored` is not in `SCALAR_FAMILIES`, so the value is parsed and dropped.
+- **Every one of the 15 real hosts is rejected by Dev B's `isProxyHost()`.** Measured, not
+  predicted. Three field-level mismatches, each independently sufficient: `name` vs `host`,
+  `messagesErrored` vs `errored`, and `queued: null` against a finite-number guard. The guard
+  log-and-skips per host, which is right — but a mismatch in a field every host shares turns "skip
+  the bad entry" into "report zero hosts", with no error surfaced. §5.2.
+- **The engine's live client cannot work today, for two more reasons the mock cannot show.** It
+  requests `/api/metrics` (the real route is `/proxy/metrics` → `404`), and it reads `alerts` from
+  the metrics payload, where they are never present — alerts are a separate endpoint, so
+  `system_alert` can never fire in live mode. Both pass typecheck and every unit test. This is
+  ADR 0004's named cost landing a second time: `mockClient.ts` reads fixtures written to the
+  engine's own assumed shape, so mocking against them proves self-consistency and nothing else.
+
+None of these change a published field. **All of the reconciliation is on Dev B's side** — the
+proxy's shape is verified against live IRIS, and `contracts/` is not edited to make a consumer
+compile.
+
+### Two open items, deliberately not resolved here
+
+- **§6.1 — `queued: null` vs `queued: 0`.** The schema permits `null` because that is what the
+  proxy emits; a schema that rejected the running code would be a fiction. **The contract position
+  is that `0` is the conformant placeholder**, and the recommended fix is one line on the engine
+  side: accept `null` and have `queue_buildup` skip an unmeasurable host, the way comparative rules
+  already skip a warming baseline. That preserves the absent-is-not-zero invariant the rest of the
+  payload depends on instead of carving out an exception for the inconvenient field.
+- **§6.2 — `errored` vs `messagesErrored`.** Raised on #16. Recommendation is `errored`, and the
+  tie-break is blast radius: `errored` costs one line in the engine, `messagesErrored` costs a
+  change to a ratified contract with a live consumer — its schema, its `.d.ts`, two samples and Dev
+  C's components — for a naming preference. Published as `errored` because that is what the code
+  emits. **A request for a decision, not a decision.**
+
+### `validate.mjs`
+
+Extended, structure unchanged: `PROXY_MUST_ACCEPT` (5), `PROXY_MUST_REJECT` (8), and
+`CAPTURE_CLAIMS` (7) alongside the existing arrays. 31 checks total, up from 11.
+
+`samples/metrics-dump.txt` is Prometheus text, not JSON, so it cannot be validated against a
+schema the way the healthscan samples are. `CAPTURE_CLAIMS` covers it with regexes over the label
+shapes the contract quotes — including two asserting a label is **absent** (`queued` and
+`messages_errored` have no `host` label). An assertion that something is missing is the only way a
+future capture silently gaining it gets noticed.
+
+Two of the must-reject cases are the engine's *current* shape (`name`, `messagesErrored`). If §6.2
+is settled the other way, those checks fail and say so — which is the point of putting them there
+rather than in a comment.
+
+Verified: `npm run validate` → 31/31. Confirmed the new checks can fail, rather than assuming it:
+adding `Active` to the status enum fails 1, narrowing `NullableCount` to `integer` fails 3, and
+stripping the `messages_errored` line from the capture fails 1. A validator never seen to fail is
+not known to be testing anything.
+
 ## 2026-08-10 — `FHIR Transform` removed from the samples (Dev A)
 
 **No schema change and no field change.** `host` is `{"type": "string", "minLength": 1}` with no

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,8 +7,15 @@ path all three developers read, which is why it is PR-gated.
 |---|---|---|
 | `proxy-api.md`, `proxy.schema.json` | Dev A | Dev B |
 | `healthscan-api.md`, `healthscan.schema.json`, `healthscan.d.ts` | Dev B | Dev C |
-| `samples/metrics-dump.txt`, `samples/alerts.json`, `samples/proxy-response.json` | Dev A | Dev B |
+| `samples/metrics-dump.txt` | Dev A | Dev B |
 | `samples/hosts-response.json`, `samples/findings-response.json` | Dev B | Dev C |
+
+`samples/alerts.json` and `samples/proxy-response.json` were planned in `CONTRIBUTING.md` §1 and do
+not exist. Both are derivable without inventing anything — a real alerts capture is at
+`services/metrics-proxy/fixtures/alerts-live-capture.json`, and a proxy response is
+`src/parser.js` applied to `samples/metrics-dump.txt` — but neither is committed here yet, so a
+consumer mocking Dev A must run the parser or point at `npm run mock`. Noted rather than quietly
+left off the table.
 
 ## Why the samples matter
 
@@ -19,6 +26,11 @@ what makes "works against the mock" predict "works against the real thing."
 Samples are captured from live IRIS wherever possible, not invented. The Health Scan samples in
 this directory use real measured values from the LABDEMO production — `avgProcessingTime: 0.08`
 for Lab Router is what IRIS actually reported, not a plausible-looking number.
+
+`samples/metrics-dump.txt` is the strongest form of this: a raw 1236-line `/api/monitor/metrics`
+body, not a reshaped one. It is what proved the proxy's original parser wrong in six places
+(issue #10) and what turned up two further mismatches while `proxy-api.md` was written — both
+found by running real code over real bytes, neither visible from a hand-written fixture.
 
 ## Never edit a contract in place
 
@@ -63,12 +75,19 @@ the shared fixtures disagree, CI says so — rather than the Day-5 rehearsal.
 cd contracts && npm install && npm run validate
 ```
 
-It checks three things, and the last two are what make the first mean anything:
+It checks four things, and the middle two are what make the first mean anything:
 
-- each sample against **one named definition** (`HostsResponse` / `FindingsResponse`)
-- structural cases that must **pass** — `[]`, and sub-second timestamps from any language
+- each JSON sample against **one named definition** (`HostsResponse` / `FindingsResponse`)
+- structural cases that must **pass** — `[]`, sub-second timestamps from any language, and the real
+  proxy payloads including their `null`s
 - cases that must **fail** — a retired `Warning` status, an unknown finding type, a hosts array
-  served in the findings position
+  served in the findings position, an alerts response in the metrics position, and the engine's
+  current `name`/`messagesErrored` host shape
+- **claims about `samples/metrics-dump.txt`**, which is Prometheus text and cannot be schema-checked
+  at all. Regexes over the label shapes `proxy-api.md` quotes, two of them asserting a label is
+  **absent** — `iris_interop_queued` and `iris_interop_messages_errored` carry no `host` label, and
+  an assertion that something is missing is the only way a future capture silently gaining it gets
+  noticed
 
 **Do not replace this with an `ajv-cli` one-liner.** Three reasons, all learned the hard way on
 PR #3:

--- a/contracts/proxy-api.md
+++ b/contracts/proxy-api.md
@@ -1,0 +1,365 @@
+# Metrics proxy API contract
+
+**Owner:** Dev A · **Consumer:** Dev B · **Port:** `3001` · **Status:** published
+
+Three read-only endpoints. The proxy polls the IRIS built-in `/api/monitor/` API, parses the
+Prometheus text format, and republishes it as per-host JSON. **It forwards and reshapes; it does
+not detect, threshold, or judge.** Baseline comparison and findings are the detection engine's job
+(`healthscan-api.md`).
+
+Machine-readable: `proxy.schema.json`.
+Shared fixture: `samples/metrics-dump.txt` — the raw IRIS `/api/monitor/metrics` body every
+snapshot in this document was derived from. Feed it to `src/parser.js` and you get the values
+quoted here.
+
+**Published by Dev B on Dev A's behalf.** Dev A has moved to other work; this contract is derived
+from their merged code (`services/metrics-proxy/`) rather than authored alongside it, so it
+documents what the proxy *does* today, not an intent. Where the code and Dev B's engine disagree,
+§6 names it rather than resolving it silently.
+
+---
+
+## 1. `GET /proxy/metrics`
+
+The latest metric snapshot. One entry per interoperability host IRIS reported, plus per-production
+scalars and diagnostics.
+
+```json
+{
+  "hosts": [
+    {
+      "host": "Lab Router",
+      "type": "process",
+      "status": "OK",
+      "isFramework": false,
+      "queued": null,
+      "messages": 126,
+      "messagesPerSec": 1.2,
+      "errored": null,
+      "avgProcessingTime": 0.08,
+      "avgQueueingTime": 0,
+      "lastActivity": "2026-08-11T23:59:55.162Z",
+      "lastActivityElapsedSeconds": 4.838
+    }
+  ],
+  "systemAlertsNew": 1,
+  "systemAlertsLog": 1,
+  "_meta": {
+    "polledAt": "2026-08-12T00:00:00Z",
+    "production": "LABDEMO.Production",
+    "productionQueued": 0,
+    "absentFamilies": [],
+    "hostCount": 15,
+    "applicationHostCount": 4
+  }
+}
+```
+
+Those are measured values from `samples/metrics-dump.txt`, not illustrative ones.
+
+### 1.1 Host fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Config item name, exactly as the IRIS `host` label carries it. **The join key** — see Q1. |
+| `type` | string | `service` \| `process` \| `operation` \| `unknown`. Normalized — see Q6. |
+| `status` | string | The IRIS `status` label, passed through. `Unknown` when IRIS sent no `iris_interop_hosts` line. Enum in Q7. |
+| `isFramework` | boolean | `true` for IRIS's own plumbing. Flag, not a filter — see Q5. |
+| `queued` | number \| **null** | Per-host queue depth. **`null` on every host today** — see Q2 and §6.1. |
+| `messages` | number \| null | Cumulative messages since production start. |
+| `messagesPerSec` | number \| null | Throughput over the IRIS sampling window. |
+| `errored` | number \| **null** | Cumulative errored count. **`null` on every host today** — see Q8. |
+| `avgProcessingTime` | number \| null | **Seconds.** Aggregated across message types — see Q3. |
+| `avgQueueingTime` | number \| null | **Seconds.** Aggregated across message types — see Q3. |
+| `lastActivity` | string \| null | ISO 8601 UTC, `Z`-suffixed. Derived — see Q4. |
+| `lastActivityElapsedSeconds` | number \| null | Seconds since last activity, as IRIS gives it — see Q4. |
+
+Hosts are in stable alphabetical order by `host` (`localeCompare`), matching the findings API so
+the dashboard never reorders rows between polls.
+
+**`null` means IRIS reported no series. `0` means IRIS measured zero.** This distinction is the
+single most important thing in this contract and it is not cosmetic: on the instance behind
+`fixtures/metrics-live-capture.txt`, IRIS emitted **no `iris_interop_messages_errored` and no
+`iris_interop_last_activity` lines at all** — the families were absent, not zero-valued. Publishing
+`0` there would make `elevated_error_rate` structurally unable to fire while looking like a
+measurement, and nothing would say why. `_meta.absentFamilies` names what IRIS did not send.
+
+Consumers must therefore treat every numeric host field as nullable and **skip a rule rather than
+substitute a value.** A rule fed a fabricated zero reports on data that does not exist.
+
+### 1.2 Top-level and `_meta` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `hosts` | array | Possibly empty. Never absent. |
+| `systemAlertsNew` | number \| null | `iris_system_alerts_new`. **Consume-on-read** — reads `0` almost always, see §2. |
+| `systemAlertsLog` | number \| null | `iris_system_alerts_log`. Durable count from `alerts.log`; does not reset on read. |
+| `warming` | boolean | **Present and `true` only before the first poll completes.** Absent otherwise — see §4. |
+| `_meta.polledAt` | string \| null | ISO 8601 UTC. When the proxy sampled IRIS. `null` while warming. |
+| `_meta.production` | string \| null | Production name, e.g. `LABDEMO.Production`. `null` if IRIS sent no `production` label. |
+| `_meta.productionQueued` | number \| null | `iris_interop_queued` — the **per-production** total. The only real queue number available today, see Q2. |
+| `_meta.absentFamilies` | string[] | Tracked metric families IRIS did not emit. Diagnostics, not data. |
+| `_meta.hostCount` | number | `hosts.length`, framework included. |
+| `_meta.applicationHostCount` | number | Hosts with `isFramework: false`. |
+
+**`_meta` is diagnostics, not payload.** `absentFamilies` exists so a consumer can distinguish
+"unmeasurable on this instance" from "measured zero"; it is not something to build a finding on.
+
+## 2. `GET /proxy/alerts`
+
+`/api/monitor/alerts`, forwarded.
+
+```json
+{
+  "alerts": [
+    {
+      "time": "2026-08-10T06:40:33.420Z",
+      "severity": "2",
+      "message": "Failed to allocate 18402MB shared memory using large pages.  Switching to small pages.",
+      "observedAt": "2026-08-12T08:45:30.264Z"
+    }
+  ],
+  "_meta": {
+    "polledAt": "2026-08-12T08:45:30.264Z",
+    "shape": "array",
+    "count": 2,
+    "newInLastPoll": 2,
+    "accumulatedSince": "2026-08-12T08:45:30.264Z",
+    "droppedCount": 0,
+    "consumeOnRead": true,
+    "systemAlertsNew": 1,
+    "systemAlertsLog": 1,
+    "suspectShapeMismatch": false
+  }
+}
+```
+
+**Alert objects are forwarded upstream-shaped and unmodified, plus one added field.** IRIS's keys
+are `time`, `severity`, `message`; `severity` is a **numeric string** (`"2"`), matching the level
+column in `alerts.log`, not a word. `observedAt` is the proxy's addition — the poll that saw the
+alert. IRIS alert bodies carry no unique id, so `observedAt` is what tells two identical repeated
+messages apart.
+
+The proxy does not map these onto `timestamp`/`text`/`source`. Inventing a `source` IRIS does not
+supply, or deciding what `"2"` means as a word, are consumer decisions — see §6.2.
+
+| `_meta` field | Notes |
+|---|---|
+| `shape` | How the upstream payload was read: `array`, `empty`, `wrapped:<key>`, `single-object`, `unparseable`, `unrecognized-object`, `unrecognized-<type>`. |
+| `count` | Alerts in the buffer (total accumulated). |
+| `newInLastPoll` | Alerts the last poll returned. `0` is the normal steady state. |
+| `accumulatedSince` | First alerts poll of this proxy process. |
+| `droppedCount` | Alerts evicted from the 500-entry buffer. Non-zero means the list is no longer complete. |
+| `consumeOnRead` | Always `true`. A reminder, not a setting. |
+| `suspectShapeMismatch` | `true` when metrics saw unread alerts the last alerts poll did not return. A hint toward a mapping gap, not a verdict. |
+| `raw`, `keys`, `error` | Present only on an unrecognized or unparseable payload, carrying the evidence needed to fix the mapping. |
+
+**`/api/monitor/alerts` is consume-on-read, and this shapes the endpoint.** Verified against IRIS
+2024.1 on 2026-08-11: the first `GET` returned two alerts, every `GET` after it returned `[]`,
+while `iris_system_alerts_log` stayed at `2` and `iris_system_alerts_new` dropped `1 → 0`. The
+proxy's own poll is what clears an alert from IRIS, so nothing can re-fetch it.
+
+Three consequences a consumer must plan around:
+
+- **`alerts` is cumulative since proxy start, not per-poll.** A per-poll snapshot would expose an
+  alert for one interval and then lose it permanently. Use `newInLastPoll` for "what is new".
+- **Do not `curl` `/api/monitor/alerts` yourself.** A second reader — another proxy instance, the
+  SMP, a manual curl — steals alerts from the proxy irrecoverably.
+- **`systemAlertsNew` is not a useful cross-check for the buffer total.** It is the same
+  consume-on-read counter, driven to `0` by our own poll. It is meaningful only against
+  `newInLastPoll`, and even then the two families are polled 30 s and 10 s apart, so a transient
+  disagreement is normal. Reported for diagnosis, not to assert on.
+
+**`shape` is the field to watch.** The metrics text format is pinned by three captures; the alerts
+payload is pinned by one, obtained by accident on a first-ever read. A consumer seeing
+`shape: "unrecognized-object"` should read a `0` as a mapping gap, **not** as a healthy production.
+
+## 3. `GET /proxy/health`
+
+```json
+{
+  "status": "ok",
+  "uptime": 3.7539876,
+  "lastPoll": "2026-08-12T08:45:30.237Z",
+  "production": "LABDEMO.Production",
+  "hostCount": 15,
+  "applicationHostCount": 4
+}
+```
+
+| `status` | Meaning |
+|---|---|
+| `starting` | No poll has completed yet. `lastPoll` is `null` and the other fields are absent. |
+| `ok` | A poll completed **and** it described a production. |
+| `reachable, but no interop metrics` | A poll completed and contained no `iris_interop_*` family at all. A `hint` field names the likely cause. |
+
+**This is the endpoint a smoke test should assert on, and the third status is why.** Measured
+2026-08-11: pointing the proxy at port 80 with no `IRIS_BASE_PATH` reaches the `/api/monitor/` web
+app of the **`%SYS`** namespace rather than the instance's own. That answers HTTP 200 with 906
+lines of perfectly real metrics and not one `iris_interop_*` family. The poll succeeds, so a
+health check that only meant "a poll succeeded" said `ok` while `/proxy/metrics` reported zero
+hosts — indistinguishable from a stopped production unless you already suspected the URL.
+
+---
+
+## 4. Errors and empty states
+
+| Situation | Response |
+|---|---|
+| Proxy starting, no poll yet | `200` + empty list + **`warming: true`** on `/proxy/metrics` and `/proxy/alerts`; `status: "starting"` on `/proxy/health` |
+| IRIS unreachable, no poll has ever succeeded | Same as above — `warming: true` persists |
+| IRIS unreachable after a successful poll | `200` + the **last good snapshot**, unchanged. `_meta.polledAt` stops advancing |
+| Production stopped / namespace not interop-enabled | `200` + `hosts: []`, and `/proxy/health` reports `reachable, but no interop metrics` |
+| No alerts | `200` + `alerts: []` |
+| Unknown route | `404` (Express default HTML) |
+
+**`warming` is `200`, not `503`.** A 503 during the ~10 s startup window read to the detection
+engine as "the proxy is down" and produced a spurious system-level finding on every restart
+(issue #10). An empty snapshot is the honest answer: there are no hosts to report *yet*, which is
+different from a failure.
+
+**A stale snapshot is served silently.** There is no `X-Proxy-State` header and no staleness flag —
+`_meta.polledAt` is the only signal, and a consumer that cares must compare it to its own clock.
+This is a deliberate asymmetry with the findings API, which does label staleness
+(`X-Healthscan-State: stale`): the proxy is one hop from IRIS and the engine already polls on a
+known interval, so the engine is the layer that can tell "stale" from "quiet".
+
+**No CORS headers are sent.** The proxy's only consumer is the detection engine, server-side. If a
+browser ever needs to reach `:3001` directly this becomes a contract change.
+
+---
+
+## 5. The five PROXY-Q questions, answered
+
+Dev B's engine holds assumptions about this output, tagged `// PROXY-Q<n>` in
+`services/detection-engine/src/types/proxy.ts`. All five, plus three that surfaced while deriving
+this contract from the merged code.
+
+| # | Question | Answer |
+|---|---|---|
+| **Q1** | Array or object keyed by host? `status` passed through or normalized? | **Array**, under a `hosts` key, alphabetical by host. Your assumption holds. `status` is **passed through** unchanged — also as assumed. **But the field is `host`, not `name`** (Q9), and the array is nested in an object alongside `_meta`, not returned bare. |
+| **Q2** | Is `queued` present per host? | **The field is present; the value is not.** `iris_interop_queued` carries no `host` label — labels are exactly `id` and `production`, verified in all three captures. The proxy publishes **`queued: null`** on every host and the real per-production total as `_meta.productionQueued` (`0` in the sample). Per-host depth needs `Ens.Util.Statistics:EnumerateHostStatus`, which the poller does not read. **`queue_buildup` cannot fire per host today** — issue #12, ADR 0001. See §6.1: `null` vs `0` is an open discrepancy. |
+| **Q3** | Are `avg*` already aggregated, or raw per-`messagetype` series? | **Already aggregated by the proxy, weighted by `iris_interop_sample_count`.** Your assumption holds and aggregation does *not* move to the engine. IRIS emits one series per `(host, messagetype)`; `sample_count` is its own family keyed the same way, not a label, so the proxy indexes it in a pre-pass. A host with no sample-count line falls back to an unweighted mean rather than dropping out. **`sampleCount` is not published per host** (Q10) — you no longer need it, since you are not doing the weighting. |
+| **Q4** | Elapsed seconds, or a pre-computed timestamp? | **Both.** `lastActivityElapsedSeconds` is IRIS's own value (elapsed seconds, e.g. `4.838` — *not* an epoch timestamp), and `lastActivity` is `polledAt − elapsed` as ISO 8601 UTC. Prefer `lastActivityElapsedSeconds` for `stalled_host`: it is the measurement, and the timestamp inherits poll-timing error (±10 s). Both are `null` when IRIS emitted no line, rather than reading as "active just now". |
+| **Q5** | Are framework hosts filtered by the proxy? | **They reach you, flagged.** Your assumption holds and your own filter stays necessary. Every host carries `isFramework` (`Ens.`/`EnsLib.` prefix, plus the bare `ActivityReporter` spelling). **Filtering is not optional:** in `samples/metrics-dump.txt`, 11 of 15 hosts are framework, and `Ens.MonitorService` is one of the few with `avg_*` series — an unfiltered snapshot reports framework timings as application latency. Filter on `isFramework` rather than re-deriving the prefix rule; the metric label carries the *item* name, which has been both `ActivityReporter` and `Ens.Activity.Operation.Local`, so a prefix rule alone was never enough. |
+
+### 5.1 Three more, found while writing this
+
+| # | Question | Answer |
+|---|---|---|
+| **Q6** | `type` vocabulary | IRIS says **`actor`** where the MVP doc says `process`; the proxy normalizes `actor → process`, so the IRIS word never reaches you. `hosttype` rides on the `avg_*` families only — `iris_interop_hosts` carries no type label at all. A host with no `avg_*` series therefore reports **`type: "unknown"`**: 8 of 15 hosts in the sample, all framework. Treat `unknown` as a real value, not a bug. |
+| **Q7** | Exact `status` enum | `OK`, `Error`, `Inactive`, `Retry`, `Stopped`, `Unconfigured`, `Disabled`, plus **`Unknown`** when IRIS sent no `iris_interop_hosts` line for a host. **There is no `Active` and no `Warning`.** Same enum as `healthscan-api.md` Q1 with `Unknown` added, so your `dead_host` mapping needs no change. |
+| **Q8** | Is `errored` per host? | **No — and this was not previously known.** `iris_interop_messages_errored` carries **no `host` label** in `samples/metrics-dump.txt`: `iris_interop_messages_errored{id="LABDEMO",production="LABDEMO.Production"} 0`. It is per-production, exactly like `queued`. The proxy's `METRIC_MAP` treats it as per-host, so with no `host` label the line is skipped and **`errored` is `null` on every host** — and unlike `queued`, the per-production total is *not* published anywhere. `elevated_error_rate` cannot fire today, for the same structural reason as `queue_buildup`. See §6.3. |
+
+### 5.2 What changes for Dev B
+
+**Every one of the 15 hosts in `samples/metrics-dump.txt` is currently rejected by
+`isProxyHost()`.** Measured, not predicted — the probe output is in the PR body. Three field-level
+mismatches, each independently sufficient to reject a host:
+
+| # | Engine expects | Proxy publishes | Effect |
+|---|---|---|---|
+| **Q9** | `name: string` | `host: string` | `name` is `undefined` → every host rejected |
+| **Q8** | `messagesErrored: number` | `errored: number \| null` | `messagesErrored` is `undefined` → every host rejected |
+| **Q2** | `queued: number` (finite) | `queued: null` | fails `isFiniteNumber` → every host rejected |
+
+The guard log-and-skips per host, which is the right design — but when the mismatch is in a field
+*every* host shares, "skip the bad entry" becomes "report zero hosts", and the dashboard shows an
+empty grid with no error anywhere. **A per-entry guard cannot degrade gracefully against a
+whole-payload mismatch.** Worth noting for the class of bug, not just this instance.
+
+Two more that degrade quietly rather than rejecting:
+
+| # | Engine expects | Proxy publishes | Effect |
+|---|---|---|---|
+| **Q10** | `avgProcessingTime`/`avgQueueingTime` finite | `null` for a host with no `avg_*` series | that host alone is rejected — correct, but silent. `sampleCount` is absent; unneeded per Q3 |
+| **Q11** | `ProxyResponse.sampledAt`, `.production`, `.alerts` | `_meta.polledAt`, `_meta.production`; alerts on a **separate endpoint** | `HttpProxyClient` falls back to `new Date()` and `'unknown'`, and reads `body.alerts` from the metrics payload — always empty, so **`system_alert` can never fire in live mode.** Passes typecheck and every unit test; only live integration would show it |
+| **Q12** | `GET {base}/api/metrics` | `GET /proxy/metrics` | `404` — no snapshot at all in live mode |
+
+Q12 is the cheapest and the most total: one string in `src/proxy/client.ts`. Q11 needs the client
+to read `_meta` and to fetch `/proxy/alerts` as a second request. **None of this is visible from
+the mock**, because `mockClient.ts` reads fixtures written to the engine's own assumed shape — the
+exact cost ADR 0004 names, coming due a second time. Reconciling against
+`samples/metrics-dump.txt` rather than a hand-written fixture is what closes it.
+
+**All of it is Dev B's side to change.** The proxy is the producer, its shape is verified against
+live IRIS, and `contracts/` is not edited to make a consumer compile.
+
+---
+
+## 6. Open items — decisions, not defects
+
+Three things this contract deliberately does not settle. Each needs a one-line change on one side
+or the other, and picking a side unilaterally is how a silent contract change happens.
+
+### 6.1 `queued: null` vs `queued: 0`
+
+**The contract position is `0`.** `proxy.schema.json` permits `null` because that is what the
+proxy emits today, and a schema that rejected the running code would be a fiction.
+
+The two sides both have a real argument, which is why this is not obvious:
+
+- **The proxy's `null`** is honest. `services/metrics-proxy/src/parser.test.js` pins it explicitly:
+  *"`queued: 0` per host would assert every host is drained while 14 sit somewhere."* Publishing
+  `0` while `_meta.productionQueued` is `486` is a false statement about each host.
+- **The engine's finite-number guard** is also right: a rule cannot compare `null` to a baseline,
+  and `0` at least keeps the host visible so its other seven metrics can be evaluated.
+
+Rejecting the whole host is the worst of both — it loses `status`, `messagesPerSec` and everything
+else over one unmeasurable field. **Recommended fix, one line, engine side:** relax the guard to
+accept `null` for `queued` and have `queue_buildup` skip a host whose depth is unmeasurable, the
+same way comparative rules already skip a warming baseline. That keeps the "absent is not zero"
+invariant that the rest of the payload depends on, rather than carving out an exception for the one
+field where it is inconvenient.
+
+Closing it properly is issue #12 — a small `%CSP.REST` wrapper over
+`Ens.Util.Statistics:EnumerateHostStatus`, which returns per-host depth keyed by config item name,
+so the `host` join key survives. Until then, note Dev C's number from #16: `queue_buildup` has
+`absoluteFloor: 50`, and the captured depth of `48` **will not trip the rule**. "Wired up and
+returning real numbers" and "the finding fires" are two separate milestones.
+
+### 6.2 `errored` vs `messagesErrored`
+
+Raised on #16. The two names are not otherwise distinguishable, so this is a coin toss with a tie-break:
+
+- **`errored`** matches `healthscan-api.md` §1, which is **already ratified and already rendered by
+  Dev C's dashboard**. Renaming it would be a change to a published contract with a live consumer.
+- **`messagesErrored`** matches the IRIS family name `iris_interop_messages_errored` and is
+  arguably clearer about what is counted.
+
+**Recommendation: `errored`, and the tie-break is blast radius, not aesthetics.** `errored` costs
+one line in `services/detection-engine/src/types/proxy.ts` and its guard. `messagesErrored` costs
+that plus a change to a ratified contract, its schema, its `.d.ts`, two samples and Dev C's
+components — for a naming preference. See `README.md`'s "estimating what a change costs": the
+question is not how many lines reference a value but whether anything *means* something in terms
+of it, and `errored` already means something downstream.
+
+This contract publishes `errored` because that is what the code emits. **It is a request for a
+decision, not a decision.**
+
+### 6.3 `errored` is per-production upstream, so no rename fixes it
+
+Q8's discovery outlives the naming question. `iris_interop_messages_errored` has no `host` label,
+so **`elevated_error_rate` cannot fire per host regardless of what the field is called** — the same
+structural gap as `queue_buildup`, and it has not been filed.
+
+Worth deciding alongside #12, because the fix is the same shape: `EnumerateHostStatus` returns
+per-host error counts as well as queue depth, so one REST wrapper closes both rules. Two of eight
+finding types depend on it. Filed against `iris/**`, which is now unowned — flagging it here so
+it is at least written down.
+
+Note the proxy publishes **no** per-production error total: unlike `queued`, `messages_errored` is
+not in `SCALAR_FAMILIES`, so the value is parsed and then dropped. Adding it to `_meta` as
+`productionErrored` would be a one-line proxy change and would at least make the number visible.
+Not done here — this is a contract PR, not an implementation one.
+
+---
+
+## 7. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by all
+three developers. See `README.md` in this directory.
+
+**With Dev A gone, this contract has no author to arbitrate it.** That makes the changelog entry
+matter more, not less: it is the only record of why a field is shaped the way it is once nobody
+present remembers writing the code.

--- a/contracts/proxy.schema.json
+++ b/contracts/proxy.schema.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://production-guardian/contracts/proxy.schema.json",
+  "title": "Production Guardian — metrics proxy API",
+  "description": "Schemas for GET /proxy/metrics, /proxy/alerts and /proxy/health. Owner: Dev A. See proxy-api.md.",
+
+  "definitions": {
+    "Timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$",
+      "description": "ISO 8601 UTC, Z-suffixed. Sub-second digits optional: JS toISOString() emits milliseconds, Python isoformat() microseconds. Same pattern as healthscan.schema.json."
+    },
+
+    "NullableNumber": {
+      "type": ["number", "null"],
+      "description": "null means IRIS reported no series for this metric; 0 means IRIS measured zero. Never conflate them — see proxy-api.md §1.1."
+    },
+
+    "NullableCount": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Cumulative count. null means the metric family was absent, not zero."
+    },
+
+    "ProxyHost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "type",
+        "status",
+        "isFramework",
+        "queued",
+        "messages",
+        "messagesPerSec",
+        "errored",
+        "avgProcessingTime",
+        "avgQueueingTime",
+        "lastActivity",
+        "lastActivityElapsedSeconds"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Config item name from the IRIS `host` label. Display name, so it contains spaces ('Lab Router'). The join key through to Finding.host — NOT `name`, see proxy-api.md Q9."
+        },
+        "type": {
+          "type": "string",
+          "description": "Normalized host type. IRIS reports processes as 'actor'; the proxy maps actor -> process. 'unknown' when IRIS emitted no avg_* series for the host, which is the only place the hosttype label rides — a real value, not a defect.",
+          "enum": ["service", "process", "operation", "unknown"]
+        },
+        "status": {
+          "type": "string",
+          "description": "The IRIS `status` label, passed through. 'Unknown' when no iris_interop_hosts line was emitted for this host. There is no 'Active' and no 'Warning'. Enumerated for validation; consumers must still render unrecognized values neutrally rather than failing.",
+          "enum": [
+            "OK",
+            "Error",
+            "Inactive",
+            "Retry",
+            "Stopped",
+            "Unconfigured",
+            "Disabled",
+            "Unknown"
+          ]
+        },
+        "isFramework": {
+          "type": "boolean",
+          "description": "True for IRIS's own plumbing (Ens.*, EnsLib.*, and the bare 'ActivityReporter' spelling). A flag rather than a filter: dropping these at the proxy would hide them from the consumer with no way to ask why. 11 of 15 hosts in samples/metrics-dump.txt are framework."
+        },
+        "queued": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "Per-host queue depth. null on every host today: iris_interop_queued carries no host label, so the value is not in /api/monitor/metrics at all. The per-production total is _meta.productionQueued. 0 is the contract-conformant placeholder — see proxy-api.md §6.1, issue #12."
+        },
+        "messages": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "Cumulative messages processed since production start."
+        },
+        "messagesPerSec": {
+          "$ref": "#/definitions/NullableNumber",
+          "description": "Throughput over the IRIS sampling window."
+        },
+        "errored": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "Cumulative errored messages. null on every host today: iris_interop_messages_errored carries no host label either, and unlike queued no per-production total is published. See proxy-api.md Q8 and §6.3. Named `errored` to match the ratified healthscan contract, not `messagesErrored` — §6.2 is a request for a decision."
+        },
+        "avgProcessingTime": {
+          "$ref": "#/definitions/NullableNumber",
+          "description": "SECONDS. Aggregated across message types, weighted by iris_interop_sample_count — IRIS emits one series per (host, messagetype). null when the host has processed nothing since stats were enabled."
+        },
+        "avgQueueingTime": {
+          "$ref": "#/definitions/NullableNumber",
+          "description": "SECONDS. Same aggregation as avgProcessingTime."
+        },
+        "lastActivity": {
+          "oneOf": [{ "$ref": "#/definitions/Timestamp" }, { "type": "null" }],
+          "description": "Derived as polledAt minus lastActivityElapsedSeconds, so accuracy is bounded by poll timing — treat as +/-10s. null when IRIS emitted no last_activity line, rather than reading as 'active just now'."
+        },
+        "lastActivityElapsedSeconds": {
+          "$ref": "#/definitions/NullableNumber",
+          "description": "Seconds since last activity as iris_interop_last_activity holds it — ELAPSED SECONDS, not an epoch timestamp. This is the measurement; prefer it over lastActivity for stalled_host."
+        }
+      }
+    },
+
+    "ProxyAlert": {
+      "type": "object",
+      "description": "One /api/monitor/alerts entry, forwarded upstream-shaped. additionalProperties stays open deliberately: the alerts payload is pinned by a single capture obtained on a first-ever read, so an unfamiliar key must not fail validation.",
+      "required": ["time", "severity", "message"],
+      "properties": {
+        "time": {
+          "type": "string",
+          "minLength": 1,
+          "description": "As IRIS emits it. Not pattern-constrained: this is upstream's format, not ours."
+        },
+        "severity": {
+          "type": "string",
+          "description": "A NUMERIC STRING ('2'), matching the level column in alerts.log — not a word. Mapping it to info/warning/critical is the consumer's decision, see proxy-api.md §6.2."
+        },
+        "message": { "type": "string" },
+        "observedAt": {
+          "$ref": "#/definitions/Timestamp",
+          "description": "The proxy's addition: the poll that observed this alert. IRIS alert bodies carry no unique id, so this is what distinguishes two identical repeated messages."
+        }
+      }
+    },
+
+    "MetricsMeta": {
+      "type": "object",
+      "description": "Diagnostics, not payload. Nothing here should feed a finding.",
+      "required": ["polledAt"],
+      "properties": {
+        "polledAt": {
+          "oneOf": [{ "$ref": "#/definitions/Timestamp" }, { "type": "null" }],
+          "description": "When the proxy sampled IRIS. null while warming. The only staleness signal — there is no X-Proxy-State header."
+        },
+        "production": { "type": ["string", "null"] },
+        "productionQueued": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "iris_interop_queued: the per-PRODUCTION total. The only real queue number available from /api/monitor/metrics."
+        },
+        "absentFamilies": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tracked metric families IRIS did not emit. A family listed here is 'unmeasurable on this instance', NOT zero."
+        },
+        "hostCount": { "type": "integer", "minimum": 0 },
+        "applicationHostCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "AlertsMeta": {
+      "type": "object",
+      "required": ["polledAt", "shape", "count"],
+      "properties": {
+        "polledAt": {
+          "oneOf": [{ "$ref": "#/definitions/Timestamp" }, { "type": "null" }]
+        },
+        "shape": {
+          "type": ["string", "null"],
+          "description": "How the upstream payload was interpreted. Anything other than array/empty/wrapped:* means a zero count is a mapping gap, not a healthy production. Open string: `wrapped:<key>` and `unrecognized-<type>` are parameterized."
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Alerts in the accumulating buffer — NOT the last poll's count."
+        },
+        "newInLastPoll": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The last poll's own count. 0 is the normal steady state under consume-on-read."
+        },
+        "accumulatedSince": {
+          "oneOf": [{ "$ref": "#/definitions/Timestamp" }, { "type": "null" }]
+        },
+        "droppedCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Alerts evicted from the 500-entry buffer. Non-zero means the list is no longer complete, and the data is unrecoverable."
+        },
+        "consumeOnRead": { "type": "boolean" },
+        "systemAlertsNew": { "$ref": "#/definitions/NullableCount" },
+        "systemAlertsLog": { "$ref": "#/definitions/NullableCount" },
+        "suspectShapeMismatch": {
+          "type": "boolean",
+          "description": "True when metrics saw unread alerts the last alerts poll did not return. A hint toward a mapping problem, not a verdict."
+        },
+        "keys": { "type": "array", "items": { "type": "string" } },
+        "error": { "type": "string" },
+        "raw": {
+          "description": "The unrecognized payload, kept rather than discarded. Any type."
+        }
+      }
+    },
+
+    "MetricsResponse": {
+      "type": "object",
+      "description": "GET /proxy/metrics. Always 200, including during the startup window — see the warming note below and proxy-api.md §4.",
+      "additionalProperties": false,
+      "required": ["hosts", "_meta"],
+      "properties": {
+        "hosts": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ProxyHost" },
+          "description": "Stable alphabetical order by host. Empty while warming, or when the production is stopped."
+        },
+        "systemAlertsNew": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "iris_system_alerts_new. Consume-on-read, so it reads 0 almost always on a proxy that polls alerts."
+        },
+        "systemAlertsLog": {
+          "$ref": "#/definitions/NullableCount",
+          "description": "iris_system_alerts_log. Durable count from alerts.log; does not reset on read."
+        },
+        "warming": {
+          "type": "boolean",
+          "description": "Present and true ONLY before the first poll completes; absent afterwards. 200 rather than 503 deliberately: a 503 read to the engine as 'proxy is down' and produced a spurious finding on every restart (issue #10)."
+        },
+        "_meta": { "$ref": "#/definitions/MetricsMeta" }
+      }
+    },
+
+    "AlertsResponse": {
+      "type": "object",
+      "description": "GET /proxy/alerts. `alerts` is cumulative since proxy start, not per-poll — /api/monitor/alerts is consume-on-read and the proxy's own poll is what clears it from IRIS.",
+      "additionalProperties": false,
+      "required": ["alerts", "_meta"],
+      "properties": {
+        "alerts": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ProxyAlert" }
+        },
+        "warming": { "type": "boolean" },
+        "_meta": { "$ref": "#/definitions/AlertsMeta" }
+      }
+    },
+
+    "HealthResponse": {
+      "type": "object",
+      "description": "GET /proxy/health. The endpoint a smoke test should assert on: 'ok' means a poll completed AND described a production, which 'a poll succeeded' alone did not.",
+      "additionalProperties": false,
+      "required": ["status", "uptime", "lastPoll"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["starting", "ok", "reachable, but no interop metrics"],
+          "description": "'reachable, but no interop metrics' is the %SYS-namespace case: HTTP 200, hundreds of real metric lines, not one iris_interop_* family. Indistinguishable from a stopped production without this."
+        },
+        "uptime": {
+          "type": "number",
+          "minimum": 0,
+          "description": "process.uptime() in seconds."
+        },
+        "lastPoll": {
+          "oneOf": [{ "$ref": "#/definitions/Timestamp" }, { "type": "null" }],
+          "description": "null while status is 'starting'."
+        },
+        "production": { "type": ["string", "null"] },
+        "hostCount": { "type": "integer", "minimum": 0 },
+        "applicationHostCount": { "type": "integer", "minimum": 0 },
+        "hint": {
+          "type": "string",
+          "description": "Present only on 'reachable, but no interop metrics'. Names the likely cause, usually a wrong IRIS_BASE_PATH."
+        }
+      }
+    }
+  }
+}

--- a/contracts/samples/metrics-dump.txt
+++ b/contracts/samples/metrics-dump.txt
@@ -1,0 +1,1236 @@
+# HELP iris_cpu_pct CPU usage (percentage) by process type
+# TYPE iris_cpu_pct gauge
+iris_cpu_pct{id="AUXWD"} 0
+iris_cpu_pct{id="CSPSRV"} 0
+iris_cpu_pct{id="GARCOL"} 0
+iris_cpu_pct{id="JRNDMN"} 0
+iris_cpu_pct{id="LICENSESRV"} 0
+iris_cpu_pct{id="WRTDMN"} 0
+# HELP iris_cpu_usage CPU usage (percentage) system-wide
+# TYPE iris_cpu_usage gauge
+iris_cpu_usage 1
+# HELP iris_csp_activity Web requests served by the Web Gateway Server since it was started
+# TYPE iris_csp_activity gauge
+iris_csp_activity{id="172.24.0.1:80"} 21
+# HELP iris_csp_actual_connections Current connections to this server by the Web Gateway Server
+# TYPE iris_csp_actual_connections gauge
+iris_csp_actual_connections{id="172.24.0.1:80"} 20
+# HELP iris_csp_gateway_latency Time (milliseconds) required to obtain a response from the Web Gateway Server when fetching metrics represented by Web sensors
+# TYPE iris_csp_gateway_latency gauge
+# UNIT iris_csp_gateway_latency milliseconds
+iris_csp_gateway_latency{id="172.24.0.1:80"} 4.043
+# HELP iris_csp_in_use_connections Current connections to this server by the Web Gateway Server that are processing a Web request
+# TYPE iris_csp_in_use_connections gauge
+iris_csp_in_use_connections{id="172.24.0.1:80"} 1
+# HELP iris_csp_private_connections Current connections to this server by the Web Gateway Server that are reserved for state-aware applications (Preserve mode 1)
+# TYPE iris_csp_private_connections gauge
+iris_csp_private_connections{id="172.24.0.1:80"} 0
+# HELP iris_csp_sessions Currently active Web session IDs on this server
+# TYPE iris_csp_sessions gauge
+iris_csp_sessions 5
+# HELP iris_cache_efficiency Cache efficiency: global references / physical reads + writes (percentage)
+# TYPE iris_cache_efficiency gauge
+iris_cache_efficiency 277.136
+# HELP iris_cached_query_by_ns Total number of cached queries in each namespace
+# TYPE iris_cached_query_by_ns gauge
+iris_cached_query_by_ns{id="%SYS"} 211
+iris_cached_query_by_ns{id="USER"} 74
+iris_cached_query_by_ns{id="HSLIB"} 63
+iris_cached_query_by_ns{id="HSSYS"} 9
+iris_cached_query_by_ns{id="INTEROP"} 70
+iris_cached_query_by_ns{id="LABDEMO"} 51
+iris_cached_query_by_ns{id="HSCUSTOM"} 0
+iris_cached_query_by_ns{id="HSSYSLOCALTEMP"} 0
+iris_cached_query_by_ns{id="AGENTICDEVELOPMENT"} 15
+# HELP iris_db_expansion_size_mb Default size (in megabytes) to expand a database when it fills
+# TYPE iris_db_expansion_size_mb gauge
+# UNIT iris_db_expansion_size_mb megabytes
+iris_db_expansion_size_mb{id="AGENTICDEVELOPMENT"} 0
+iris_db_expansion_size_mb{id="ENSLIB"} 0
+iris_db_expansion_size_mb{id="HSCUSTOM"} 0
+iris_db_expansion_size_mb{id="HSLIB"} 0
+iris_db_expansion_size_mb{id="HSSYS"} 0
+iris_db_expansion_size_mb{id="HSSYSLOCALTEMP"} 0
+iris_db_expansion_size_mb{id="INTEROP"} 0
+iris_db_expansion_size_mb{id="IRISAUDIT"} 0
+iris_db_expansion_size_mb{id="IRISLOCALDATA"} 0
+iris_db_expansion_size_mb{id="IRISMETRICS"} 0
+iris_db_expansion_size_mb{id="IRISSECURITY"} 0
+iris_db_expansion_size_mb{id="IRISSYS"} 0
+iris_db_expansion_size_mb{id="IRISTEMP"} 0
+iris_db_expansion_size_mb{id="LABDEMO"} 0
+iris_db_expansion_size_mb{id="NEWINTEROP"} 0
+iris_db_expansion_size_mb{id="USER"} 0
+# HELP iris_db_free_space Available space (in megabytes) in a database
+# TYPE iris_db_free_space gauge
+# UNIT iris_db_free_space megabytes
+iris_db_free_space{id="AGENTICDEVELOPMENT"} 4.4
+iris_db_free_space{id="ENSLIB"} 16
+iris_db_free_space{id="HSCUSTOM"} 7.3
+iris_db_free_space{id="HSLIB"} 179
+iris_db_free_space{id="HSSYS"} 7.5
+iris_db_free_space{id="HSSYSLOCALTEMP"} .34
+iris_db_free_space{id="INTEROP"} 12
+iris_db_free_space{id="IRISAUDIT"} 5.8
+iris_db_free_space{id="IRISLOCALDATA"} 3.3
+iris_db_free_space{id="IRISMETRICS"} .24
+iris_db_free_space{id="IRISSECURITY"} 8.2
+iris_db_free_space{id="IRISSYS"} 2.7
+iris_db_free_space{id="IRISTEMP"} 19
+iris_db_free_space{id="LABDEMO"} .33
+iris_db_free_space{id="NEWINTEROP"} 4.5
+iris_db_free_space{id="USER"} 7.8
+# HELP iris_db_latency Time to complete a random read from the database (milliseconds)
+# TYPE iris_db_latency gauge
+# UNIT iris_db_latency milliseconds
+iris_db_latency{id="/iris-shared/durable/mgr/skilltest/"} 3.276
+iris_db_latency{id="AGENTICDEVELOPMENT"} 4.008
+iris_db_latency{id="ENSLIB"} 0.708
+iris_db_latency{id="HSCUSTOM"} 4.182
+iris_db_latency{id="HSLIB"} 2.456
+iris_db_latency{id="HSSYS"} 3.263
+iris_db_latency{id="HSSYSLOCALTEMP"} 3.564
+iris_db_latency{id="INTEROP"} 3.567
+iris_db_latency{id="IRISAUDIT"} 2.971
+iris_db_latency{id="IRISMETRICS"} 4.232
+iris_db_latency{id="IRISSECURITY"} 3.481
+iris_db_latency{id="IRISSYS"} 4.769
+iris_db_latency{id="IRISTEMP"} 2.823
+iris_db_latency{id="LABDEMO"} 4.917
+iris_db_latency{id="NEWINTEROP"} 5.859
+iris_db_latency{id="USER"} 3.967
+# HELP iris_db_max_size_mb Maximum size (in megabytes) allowed for a database, 0=unlimited
+# TYPE iris_db_max_size_mb gauge
+# UNIT iris_db_max_size_mb megabytes
+iris_db_max_size_mb{id="AGENTICDEVELOPMENT"} 0
+iris_db_max_size_mb{id="ENSLIB"} 0
+iris_db_max_size_mb{id="HSCUSTOM"} 0
+iris_db_max_size_mb{id="HSLIB"} 0
+iris_db_max_size_mb{id="HSSYS"} 0
+iris_db_max_size_mb{id="HSSYSLOCALTEMP"} 0
+iris_db_max_size_mb{id="INTEROP"} 0
+iris_db_max_size_mb{id="IRISAUDIT"} 0
+iris_db_max_size_mb{id="IRISLOCALDATA"} 0
+iris_db_max_size_mb{id="IRISMETRICS"} 0
+iris_db_max_size_mb{id="IRISSECURITY"} 0
+iris_db_max_size_mb{id="IRISSYS"} 0
+iris_db_max_size_mb{id="IRISTEMP"} 0
+iris_db_max_size_mb{id="LABDEMO"} 0
+iris_db_max_size_mb{id="NEWINTEROP"} 0
+iris_db_max_size_mb{id="USER"} 0
+# HELP iris_db_size_mb Current size (in megabytes) of a database
+# TYPE iris_db_size_mb gauge
+# UNIT iris_db_size_mb megabytes
+iris_db_size_mb{id="USER",dir="/iris-shared/durable/mgr/user/"} 11
+iris_db_size_mb{id="HSLIB",dir="/usr/irissys/mgr/hslib/"} 1623
+iris_db_size_mb{id="HSSYS",dir="/iris-shared/durable/mgr/hssys/"} 21
+iris_db_size_mb{id="ENSLIB",dir="/usr/irissys/mgr/enslib/"} 213
+iris_db_size_mb{id="INTEROP",dir="/iris-shared/durable/mgr/interop/"} 41
+iris_db_size_mb{id="IRISSYS",dir="/iris-shared/durable/mgr/"} 70
+iris_db_size_mb{id="LABDEMO",dir="/iris-shared/durable/mgr/labdemo/"} 144
+iris_db_size_mb{id="HSCUSTOM",dir="/iris-shared/durable/mgr/HSCUSTOM/"} 21
+iris_db_size_mb{id="IRISTEMP",dir="/iris-shared/durable/mgr/iristemp/"} 20
+iris_db_size_mb{id="IRISAUDIT",dir="/iris-shared/durable/mgr/irisaudit/"} 11
+iris_db_size_mb{id="NEWINTEROP",dir="/iris-shared/durable/mgr/newinterop/"} 114
+iris_db_size_mb{id="IRISMETRICS",dir="/iris-shared/durable/mgr/irismetrics/"} 1
+iris_db_size_mb{id="IRISSECURITY",dir="/iris-shared/durable/mgr/irissecurity/"} 21
+iris_db_size_mb{id="IRISLOCALDATA",dir="/iris-shared/durable/mgr/irislocaldata/"} 11
+iris_db_size_mb{id="HSSYSLOCALTEMP",dir="/iris-shared/durable/mgr/hssyslocaltemp/"} 1
+iris_db_size_mb{id="AGENTICDEVELOPMENT",dir="/iris-shared/durable/mgr/agenticdevelopment/"} 114
+# HELP iris_directory_space Free space (in megabytes) available on the database directory's storage volume
+# TYPE iris_directory_space gauge
+# UNIT iris_directory_space megabytes
+iris_directory_space{id="USER",dir="/iris-shared/durable/mgr/user/"} 1390308
+iris_directory_space{id="HSLIB",dir="/usr/irissys/mgr/hslib/"} 841961
+iris_directory_space{id="HSSYS",dir="/iris-shared/durable/mgr/hssys/"} 1390308
+iris_directory_space{id="ENSLIB",dir="/usr/irissys/mgr/enslib/"} 841961
+iris_directory_space{id="INTEROP",dir="/iris-shared/durable/mgr/interop/"} 1390308
+iris_directory_space{id="IRISSYS",dir="/iris-shared/durable/mgr/"} 1390308
+iris_directory_space{id="LABDEMO",dir="/iris-shared/durable/mgr/labdemo/"} 1390308
+iris_directory_space{id="HSCUSTOM",dir="/iris-shared/durable/mgr/HSCUSTOM/"} 1390308
+iris_directory_space{id="IRISTEMP",dir="/iris-shared/durable/mgr/iristemp/"} 1390308
+iris_directory_space{id="IRISAUDIT",dir="/iris-shared/durable/mgr/irisaudit/"} 1390308
+iris_directory_space{id="NEWINTEROP",dir="/iris-shared/durable/mgr/newinterop/"} 1390308
+iris_directory_space{id="IRISMETRICS",dir="/iris-shared/durable/mgr/irismetrics/"} 1390308
+iris_directory_space{id="IRISSECURITY",dir="/iris-shared/durable/mgr/irissecurity/"} 1390308
+iris_directory_space{id="HSSYSLOCALTEMP",dir="/iris-shared/durable/mgr/hssyslocaltemp/"} 1390308
+iris_directory_space{id="AGENTICDEVELOPMENT",dir="/iris-shared/durable/mgr/agenticdevelopment/"} 1390308
+iris_directory_space{id="/iris-shared/durable/mgr/skilltest/",dir="/iris-shared/durable/mgr/skilltest/"} 1390308
+# HELP iris_disk_percent_full Space in use (percentage) on the database directory's storage volume
+# TYPE iris_disk_percent_full gauge
+iris_disk_percent_full{id="USER",dir="/iris-shared/durable/mgr/user/"} 28.71
+iris_disk_percent_full{id="HSLIB",dir="/usr/irissys/mgr/hslib/"} 18.34
+iris_disk_percent_full{id="HSSYS",dir="/iris-shared/durable/mgr/hssys/"} 28.71
+iris_disk_percent_full{id="ENSLIB",dir="/usr/irissys/mgr/enslib/"} 18.34
+iris_disk_percent_full{id="INTEROP",dir="/iris-shared/durable/mgr/interop/"} 28.71
+iris_disk_percent_full{id="IRISSYS",dir="/iris-shared/durable/mgr/"} 28.71
+iris_disk_percent_full{id="LABDEMO",dir="/iris-shared/durable/mgr/labdemo/"} 28.71
+iris_disk_percent_full{id="HSCUSTOM",dir="/iris-shared/durable/mgr/HSCUSTOM/"} 28.71
+iris_disk_percent_full{id="IRISTEMP",dir="/iris-shared/durable/mgr/iristemp/"} 28.71
+iris_disk_percent_full{id="IRISAUDIT",dir="/iris-shared/durable/mgr/irisaudit/"} 28.71
+iris_disk_percent_full{id="NEWINTEROP",dir="/iris-shared/durable/mgr/newinterop/"} 28.71
+iris_disk_percent_full{id="IRISMETRICS",dir="/iris-shared/durable/mgr/irismetrics/"} 28.71
+iris_disk_percent_full{id="IRISSECURITY",dir="/iris-shared/durable/mgr/irissecurity/"} 28.71
+iris_disk_percent_full{id="HSSYSLOCALTEMP",dir="/iris-shared/durable/mgr/hssyslocaltemp/"} 28.71
+iris_disk_percent_full{id="AGENTICDEVELOPMENT",dir="/iris-shared/durable/mgr/agenticdevelopment/"} 28.71
+iris_disk_percent_full{id="/iris-shared/durable/mgr/skilltest/",dir="/iris-shared/durable/mgr/skilltest/"} 28.71
+# HELP iris_ecp_conn Total active ECP connections on this system as an ECP application server
+# TYPE iris_ecp_conn gauge
+iris_ecp_conn 0
+# HELP iris_ecp_conn_max Maximum active ECP connections from this system as an ECP application server
+# TYPE iris_ecp_conn_max gauge
+iris_ecp_conn_max 2
+# HELP iris_ecps_conn Total active client connections to this system as an ECP data server
+# TYPE iris_ecps_conn gauge
+iris_ecps_conn 0
+# HELP iris_ecps_conn_max Maximum active client connections to this system as an ECP data server
+# TYPE iris_ecps_conn_max gauge
+iris_ecps_conn_max 1
+# HELP iris_glo_a_seize_per_sec Global resource Aseizes (per second)
+# TYPE iris_glo_a_seize_per_sec gauge
+iris_glo_a_seize_per_sec 0
+# HELP iris_glo_n_seize_per_sec Global resource Nseizes (per second)
+# TYPE iris_glo_n_seize_per_sec gauge
+iris_glo_n_seize_per_sec 0
+# HELP iris_glo_ref_per_sec Global references, local databases (per second)
+# TYPE iris_glo_ref_per_sec gauge
+iris_glo_ref_per_sec 6073
+# HELP iris_glo_ref_rem_per_sec Global references, remote databases (per second)
+# TYPE iris_glo_ref_rem_per_sec gauge
+iris_glo_ref_rem_per_sec 0
+# HELP iris_glo_seize_per_sec Global resource seizes (per second)
+# TYPE iris_glo_seize_per_sec gauge
+iris_glo_seize_per_sec 0
+# HELP iris_glo_update_per_sec Global updates, local SET and KILL (per second)
+# TYPE iris_glo_update_per_sec gauge
+iris_glo_update_per_sec 403
+# HELP iris_glo_update_rem_per_sec Global updates, remote local SET and KILL (per second)
+# TYPE iris_glo_update_rem_per_sec gauge
+iris_glo_update_rem_per_sec 0
+# HELP iris_iju_count Current count of updaters
+# TYPE iris_iju_count gauge
+iris_iju_count 0
+# HELP iris_iju_lock Flag to momentarily block updaters at beginning of write daemon pass
+# TYPE iris_iju_lock gauge
+iris_iju_lock 0
+# HELP iris_interop_alert_delay Count of Host Items that have triggered Alert for Message processing Delay
+# TYPE iris_interop_alert_delay gauge
+iris_interop_alert_delay{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_avg_processing_time Average time message was being processed by host items
+# TYPE iris_interop_avg_processing_time gauge
+# UNIT iris_interop_avg_processing_time seconds
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="actor",host="Lab Router",messagetype="ORM_O01",production="LABDEMO.Production"} .08
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="actor",host="FHIR Transform",messagetype="ORM_O01",production="LABDEMO.Production"} .08
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="actor",host="Ens.ScheduleHandler",messagetype="-",production="LABDEMO.Production"} .01
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="service",host="EMR Source",messagetype="ORM_O01",production="LABDEMO.Production"} .01
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="service",host="Ens.MonitorService",messagetype="-",production="LABDEMO.Production"} 0
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="service",host="Ens.ScheduleService",messagetype="-",production="LABDEMO.Production"} 0
+iris_interop_avg_processing_time{id="LABDEMO",hosttype="operation",host="Cloud API",messagetype="Ens.StringRequest",production="LABDEMO.Production"} .05
+# HELP iris_interop_avg_queueing_time Average time message was queued before being processed by a host item
+# TYPE iris_interop_avg_queueing_time gauge
+# UNIT iris_interop_avg_queueing_time seconds
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="actor",host="Lab Router",messagetype="ORM_O01",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="actor",host="FHIR Transform",messagetype="ORM_O01",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="actor",host="Ens.ScheduleHandler",messagetype="-",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="service",host="EMR Source",messagetype="ORM_O01",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="service",host="Ens.MonitorService",messagetype="-",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="service",host="Ens.ScheduleService",messagetype="-",production="LABDEMO.Production"} 0
+iris_interop_avg_queueing_time{id="LABDEMO",hosttype="operation",host="Cloud API",messagetype="Ens.StringRequest",production="LABDEMO.Production"} .03
+# HELP iris_interop_hosts Count of host items by Status
+# TYPE iris_interop_hosts gauge
+iris_interop_hosts{id="LABDEMO",status="OK",host="Cloud API",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.Actor",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.Alarm",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EMR Source",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Lab Router",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="FHIR Transform",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.MonitorService",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.ScheduleHandler",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.ScheduleService",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EnsLib.Testing.Process",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EnsLib.Testing.Service",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EnsLib.Background.Service",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="Ens.Activity.Operation.Local",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EnsLib.Background.Workflow.Operation",production="LABDEMO.Production"} 1
+iris_interop_hosts{id="LABDEMO",status="OK",host="EnsLib.Background.Process.ExportMessageSearch",production="LABDEMO.Production"} 1
+# HELP iris_interop_last_activity Last Activity Time
+# TYPE iris_interop_last_activity gauge
+# UNIT iris_interop_last_activity Seconds
+iris_interop_last_activity{id="LABDEMO",host="Cloud API",production="LABDEMO.Production"} 4.841
+iris_interop_last_activity{id="LABDEMO",host="Ens.Actor",production="LABDEMO.Production"} 105.09
+iris_interop_last_activity{id="LABDEMO",host="Ens.Alarm",production="LABDEMO.Production"} 105.084
+iris_interop_last_activity{id="LABDEMO",host="EMR Source",production="LABDEMO.Production"} 4.947
+iris_interop_last_activity{id="LABDEMO",host="Lab Router",production="LABDEMO.Production"} 4.838
+iris_interop_last_activity{id="LABDEMO",host="FHIR Transform",production="LABDEMO.Production"} 4.839
+iris_interop_last_activity{id="LABDEMO",host="Ens.ScheduleHandler",production="LABDEMO.Production"} 105.047
+iris_interop_last_activity{id="LABDEMO",host="Ens.ScheduleService",production="LABDEMO.Production"} 105.062
+iris_interop_last_activity{id="LABDEMO",host="EnsLib.Testing.Process",production="LABDEMO.Production"} 105.06
+iris_interop_last_activity{id="LABDEMO",host="EnsLib.Testing.Service",production="LABDEMO.Production"} 105.159
+iris_interop_last_activity{id="LABDEMO",host="EnsLib.Background.Service",production="LABDEMO.Production"} 105.164
+iris_interop_last_activity{id="LABDEMO",host="Ens.Activity.Operation.Local",production="LABDEMO.Production"} 45.067
+iris_interop_last_activity{id="LABDEMO",host="EnsLib.Background.Workflow.Operation",production="LABDEMO.Production"} 105.162
+iris_interop_last_activity{id="LABDEMO",host="EnsLib.Background.Process.ExportMessageSearch",production="LABDEMO.Production"} 105.167
+# HELP iris_interop_messages Count of Messages processed since production started
+# TYPE iris_interop_messages counter
+iris_interop_messages{id="LABDEMO",host="Cloud API",production="LABDEMO.Production"} 42
+iris_interop_messages{id="LABDEMO",host="Ens.Actor",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="Ens.Alarm",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="EMR Source",production="LABDEMO.Production"} 21
+iris_interop_messages{id="LABDEMO",host="Lab Router",production="LABDEMO.Production"} 126
+iris_interop_messages{id="LABDEMO",host="FHIR Transform",production="LABDEMO.Production"} 126
+iris_interop_messages{id="LABDEMO",host="Ens.ScheduleHandler",production="LABDEMO.Production"} 2
+iris_interop_messages{id="LABDEMO",host="Ens.ScheduleService",production="LABDEMO.Production"} 1
+iris_interop_messages{id="LABDEMO",host="EnsLib.Testing.Process",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="EnsLib.Testing.Service",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="EnsLib.Background.Service",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="Ens.Activity.Operation.Local",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="EnsLib.Background.Workflow.Operation",production="LABDEMO.Production"} 0
+iris_interop_messages{id="LABDEMO",host="EnsLib.Background.Process.ExportMessageSearch",production="LABDEMO.Production"} 0
+# HELP iris_interop_messages_aborted Count of Aborted messages since production started
+# TYPE iris_interop_messages_aborted gauge
+iris_interop_messages_aborted{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_messages_discarded Count of Discarded messages since production started
+# TYPE iris_interop_messages_discarded gauge
+iris_interop_messages_discarded{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_messages_errored Count of Errored message since production started
+# TYPE iris_interop_messages_errored gauge
+iris_interop_messages_errored{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_messages_per_sec Count of Messages processed since production started per second
+# TYPE iris_interop_messages_per_sec counter
+iris_interop_messages_per_sec{id="LABDEMO",host="Cloud API",production="LABDEMO.Production"} .4
+iris_interop_messages_per_sec{id="LABDEMO",host="Ens.Actor",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="Ens.Alarm",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EMR Source",production="LABDEMO.Production"} .2
+iris_interop_messages_per_sec{id="LABDEMO",host="Lab Router",production="LABDEMO.Production"} 1.2
+iris_interop_messages_per_sec{id="LABDEMO",host="FHIR Transform",production="LABDEMO.Production"} 1.2
+iris_interop_messages_per_sec{id="LABDEMO",host="Ens.ScheduleHandler",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="Ens.ScheduleService",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EnsLib.Testing.Process",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EnsLib.Testing.Service",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EnsLib.Background.Service",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="Ens.Activity.Operation.Local",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EnsLib.Background.Workflow.Operation",production="LABDEMO.Production"} 0
+iris_interop_messages_per_sec{id="LABDEMO",host="EnsLib.Background.Process.ExportMessageSearch",production="LABDEMO.Production"} 0
+# HELP iris_interop_messages_suspended Count of Suspended messages since production started
+# TYPE iris_interop_messages_suspended gauge
+iris_interop_messages_suspended{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_queued Count of queued messages for hosts with Queue Count Alert value
+# TYPE iris_interop_queued gauge
+iris_interop_queued{id="LABDEMO",production="LABDEMO.Production"} 0
+# HELP iris_interop_sample_count Activity Count of Host Items within the sampling window
+# TYPE iris_interop_sample_count gauge
+iris_interop_sample_count{id="LABDEMO",hosttype="actor",host="Lab Router",messagetype="ORM_O01",production="LABDEMO.Production"} 24
+iris_interop_sample_count{id="LABDEMO",hosttype="actor",host="FHIR Transform",messagetype="ORM_O01",production="LABDEMO.Production"} 24
+iris_interop_sample_count{id="LABDEMO",hosttype="actor",host="Ens.ScheduleHandler",messagetype="-",production="LABDEMO.Production"} 1
+iris_interop_sample_count{id="LABDEMO",hosttype="service",host="EMR Source",messagetype="ORM_O01",production="LABDEMO.Production"} 12
+iris_interop_sample_count{id="LABDEMO",hosttype="service",host="Ens.MonitorService",messagetype="-",production="LABDEMO.Production"} 12
+iris_interop_sample_count{id="LABDEMO",hosttype="service",host="Ens.ScheduleService",messagetype="-",production="LABDEMO.Production"} 1
+iris_interop_sample_count{id="LABDEMO",hosttype="operation",host="Cloud API",messagetype="Ens.StringRequest",production="LABDEMO.Production"} 24
+# HELP iris_interop_sample_count_per_sec Activity Count of Host Items within the sampling window per second
+# TYPE iris_interop_sample_count_per_sec gauge
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="actor",host="Lab Router",messagetype="ORM_O01",production="LABDEMO.Production"} .48
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="actor",host="FHIR Transform",messagetype="ORM_O01",production="LABDEMO.Production"} .48
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="actor",host="Ens.ScheduleHandler",messagetype="-",production="LABDEMO.Production"} .02
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="service",host="EMR Source",messagetype="ORM_O01",production="LABDEMO.Production"} .24
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="service",host="Ens.MonitorService",messagetype="-",production="LABDEMO.Production"} .24
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="service",host="Ens.ScheduleService",messagetype="-",production="LABDEMO.Production"} .02
+iris_interop_sample_count_per_sec{id="LABDEMO",hosttype="operation",host="Cloud API",messagetype="Ens.StringRequest",production="LABDEMO.Production"} .48
+# HELP iris_jrn_block_per_sec Journal blocks written to disk (per second)
+# TYPE iris_jrn_block_per_sec gauge
+iris_jrn_block_per_sec 0
+# HELP iris_jrn_entry_per_sec Journal records created (per second)
+# TYPE iris_jrn_entry_per_sec gauge
+iris_jrn_entry_per_sec 107
+# HELP iris_jrn_free_space Available space (in megabytes) for a journal directory
+# TYPE iris_jrn_free_space gauge
+# UNIT iris_jrn_free_space megabytes
+iris_jrn_free_space{id="WIJ",dir="default"} 1390307.99
+iris_jrn_free_space{id="primary",dir="/iris-shared/durable/mgr/journal/"} 1390308.05
+iris_jrn_free_space{id="secondary",dir="/iris-shared/durable/mgr/journal/"} 1390308.05
+# HELP iris_jrn_size Current size of all journal files (in megabytes)
+# TYPE iris_jrn_size gauge
+# UNIT iris_jrn_size megabytes
+iris_jrn_size{id="WIJ"} 161
+iris_jrn_size{id="primary"} 34
+iris_jrn_size{id="secondary"} 0
+# HELP iris_log_reads_per_sec Logical reads (per second)
+# TYPE iris_log_reads_per_sec gauge
+iris_log_reads_per_sec 2007
+# HELP iris_mirror_member_type Mirror member type of this instance (1:Indeterminate, 2:Not Member, 3:Failover, 4:Async, 5:Disaster Recovery, 6:Read-Only Reporting, 7:Read-Write Reporting)
+# TYPE iris_mirror_member_type gauge
+iris_mirror_member_type 2
+# HELP iris_obj_a_seize_per_sec Object resource Aseizes (per second)
+# TYPE iris_obj_a_seize_per_sec gauge
+iris_obj_a_seize_per_sec 0
+# HELP iris_obj_del_per_sec Objecta deleted (per second)
+# TYPE iris_obj_del_per_sec gauge
+iris_obj_del_per_sec 0
+# HELP iris_obj_hit_per_sec Object references, in process memory (per second)
+# TYPE iris_obj_hit_per_sec gauge
+iris_obj_hit_per_sec 0
+# HELP iris_obj_load_per_sec Object loaded from disk, not in shared memory (per second)
+# TYPE iris_obj_load_per_sec gauge
+iris_obj_load_per_sec 0
+# HELP iris_obj_miss_per_sec Object references, not found in process memory (per second)
+# TYPE iris_obj_miss_per_sec gauge
+iris_obj_miss_per_sec 0
+# HELP iris_obj_new_per_sec Objects initialized (per second)
+# TYPE iris_obj_new_per_sec gauge
+iris_obj_new_per_sec 0
+# HELP iris_obj_seize_per_sec Object resource seizes (per second)
+# TYPE iris_obj_seize_per_sec gauge
+iris_obj_seize_per_sec 0
+# HELP iris_page_space_percent_used Page file space used (percentage of maximum allocated)
+# TYPE iris_page_space_percent_used gauge
+iris_page_space_percent_used 0
+# HELP iris_phys_mem_percent_used Physical memory (RAM) used (percentage)
+# TYPE iris_phys_mem_percent_used gauge
+iris_phys_mem_percent_used 2
+# HELP iris_phys_reads_per_sec Physical database block reads from disk (per second)
+# TYPE iris_phys_reads_per_sec gauge
+iris_phys_reads_per_sec 26
+# HELP iris_phys_writes_per_sec Physical database block writes to disk (per second)
+# TYPE iris_phys_writes_per_sec gauge
+iris_phys_writes_per_sec 1
+# HELP iris_process State of a process
+# TYPE iris_process gauge
+iris_process{id="2066",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="LABDEMO",routine="%SYS.cspServer2"} 1
+iris_process{id="2069",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer2"} 1
+iris_process{id="2072",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer2"} 1
+iris_process{id="2073",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer2"} 1
+iris_process{id="2074",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer2"} 1
+iris_process{id="2075",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer2"} 1
+iris_process{id="2076",state="RUN",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="SYS.Monitor.DashboardSensors.1"} 1
+iris_process{id="2086",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="LABDEMO",routine="%SYS.cspServer2"} 1
+iris_process{id="2089",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2090",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2091",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2092",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2093",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2094",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2095",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2096",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2097",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2098",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="2099",state="EVTW",waitstate="",jobtype="2",clientname="",namespace="LABDEMO",routine="Ens.Queue.1"} 1
+iris_process{id="891",state="RUN",waitstate="",jobtype="4",clientname="",namespace="",routine="CONTROL"} 1
+iris_process{id="932",state="RUNW",waitstate="",jobtype="5",clientname="",namespace="",routine="WRTDMN"} 1
+iris_process{id="933",state="RUNW",waitstate="",jobtype="6",clientname="",namespace="",routine="GARCOL"} 1
+iris_process{id="934",state="RUNW",waitstate="",jobtype="7",clientname="",namespace="",routine="JRNDMN"} 1
+iris_process{id="935",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="936",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="937",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="938",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="939",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="940",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="941",state="RUNW",waitstate="",jobtype="10",clientname="",namespace="",routine="AUXWD"} 1
+iris_process{id="942",state="RUNW",waitstate="",jobtype="30",clientname="",namespace="",routine="EXPDMN"} 1
+iris_process{id="944",state="EVTW",waitstate="",jobtype="41",clientname="",namespace="%SYS",routine="MONITOR"} 1
+iris_process{id="945",state="RUNW",waitstate="",jobtype="38",clientname="",namespace="%SYS",routine="CLNDMN"} 1
+iris_process{id="971",state="EVTW",waitstate="",jobtype="13",clientname="",namespace="%SYS",routine="LMFMON"} 1
+iris_process{id="973",state="HANG",waitstate="",jobtype="21",clientname="",namespace="%SYS",routine="RECEIVE"} 1
+iris_process{id="976",state="READ",waitstate="",jobtype="24",clientname="",namespace="%SYS",routine="%SYS.SERVER"} 1
+iris_process{id="979",state="SEMW",waitstate="",jobtype="59",clientname="",namespace="%SYS",routine="%SYS.WorkQueueMgr"} 1
+iris_process{id="982",state="EVTW",waitstate="",jobtype="36",clientname="",namespace="%SYS",routine="%SYS.TaskSuper.1"} 1
+iris_process{id="983",state="EVTW",waitstate="",jobtype="42",clientname="",namespace="%SYS",routine="%SYS.Monitor.Control.1"} 1
+iris_process{id="984",state="SEMW",waitstate="",jobtype="59",clientname="",namespace="%SYS",routine="%SYS.WorkQueueMgr"} 1
+iris_process{id="2012",state="EVTW",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2013",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2016",state="EVTW",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2017",state="EVTW",waitstate="",jobtype="27",clientname="localhost",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2022",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2023",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="1002",state="EVTW",waitstate="",jobtype="59",clientname="",namespace="%SYS",routine="%SYS.WorkQueueMgr"} 1
+iris_process{id="2026",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2027",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2028",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2029",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="LABDEMO",routine="%SYS.cspServer2"} 1
+iris_process{id="2030",state="EVTW",waitstate="",jobtype="27",clientname="",namespace="%SYS",routine="%SYS.cspServer3"} 1
+iris_process{id="2031",state="EVTW",waitstate="",jobtype="59",clientname="",namespace="%SYS",routine="%SYS.WorkQueueMgr"} 1
+iris_process{id="2032",state="READ",waitstate="",jobtype="27",clientname="localhost",namespace="LABDEMO",routine="%SYS.cspServer2"} 1
+# HELP iris_process_block_allocs Count of database blocks newly allocated by process
+# TYPE iris_process_block_allocs counter
+iris_process_block_allocs{id="2066"} 15
+iris_process_block_allocs{id="2069"} 62
+iris_process_block_allocs{id="2072"} 0
+iris_process_block_allocs{id="2073"} 33
+iris_process_block_allocs{id="2074"} 0
+iris_process_block_allocs{id="2075"} 0
+iris_process_block_allocs{id="2076"} 0
+iris_process_block_allocs{id="2086"} 85
+iris_process_block_allocs{id="2089"} 3
+iris_process_block_allocs{id="2090"} 11
+iris_process_block_allocs{id="2091"} 1
+iris_process_block_allocs{id="2092"} 0
+iris_process_block_allocs{id="2093"} 0
+iris_process_block_allocs{id="2094"} 1
+iris_process_block_allocs{id="2095"} 12
+iris_process_block_allocs{id="2096"} 2
+iris_process_block_allocs{id="2097"} 0
+iris_process_block_allocs{id="2098"} 7
+iris_process_block_allocs{id="2099"} 4
+iris_process_block_allocs{id="891"} 0
+iris_process_block_allocs{id="932"} 0
+iris_process_block_allocs{id="933"} 0
+iris_process_block_allocs{id="934"} 0
+iris_process_block_allocs{id="935"} 0
+iris_process_block_allocs{id="936"} 0
+iris_process_block_allocs{id="937"} 0
+iris_process_block_allocs{id="938"} 0
+iris_process_block_allocs{id="939"} 0
+iris_process_block_allocs{id="940"} 0
+iris_process_block_allocs{id="941"} 0
+iris_process_block_allocs{id="942"} 0
+iris_process_block_allocs{id="944"} 0
+iris_process_block_allocs{id="945"} 0
+iris_process_block_allocs{id="971"} 0
+iris_process_block_allocs{id="973"} 0
+iris_process_block_allocs{id="976"} 0
+iris_process_block_allocs{id="979"} 258
+iris_process_block_allocs{id="982"} 1
+iris_process_block_allocs{id="983"} 9
+iris_process_block_allocs{id="984"} 0
+iris_process_block_allocs{id="2012"} 10
+iris_process_block_allocs{id="2013"} 2
+iris_process_block_allocs{id="2016"} 5
+iris_process_block_allocs{id="2017"} 5
+iris_process_block_allocs{id="2022"} 0
+iris_process_block_allocs{id="2023"} 0
+iris_process_block_allocs{id="1002"} 0
+iris_process_block_allocs{id="2026"} 0
+iris_process_block_allocs{id="2027"} 0
+iris_process_block_allocs{id="2028"} 0
+iris_process_block_allocs{id="2029"} 43
+iris_process_block_allocs{id="2030"} 0
+iris_process_block_allocs{id="2031"} 6
+iris_process_block_allocs{id="2032"} 66
+# HELP iris_process_block_writes Count of database blocks queued for writing by process
+# TYPE iris_process_block_writes counter
+iris_process_block_writes{id="2066"} 29
+iris_process_block_writes{id="2069"} 71
+iris_process_block_writes{id="2072"} 0
+iris_process_block_writes{id="2073"} 53
+iris_process_block_writes{id="2074"} 0
+iris_process_block_writes{id="2075"} 0
+iris_process_block_writes{id="2076"} 0
+iris_process_block_writes{id="2086"} 85
+iris_process_block_writes{id="2089"} 8
+iris_process_block_writes{id="2090"} 48
+iris_process_block_writes{id="2091"} 25
+iris_process_block_writes{id="2092"} 1
+iris_process_block_writes{id="2093"} 0
+iris_process_block_writes{id="2094"} 1
+iris_process_block_writes{id="2095"} 18
+iris_process_block_writes{id="2096"} 6
+iris_process_block_writes{id="2097"} 0
+iris_process_block_writes{id="2098"} 20
+iris_process_block_writes{id="2099"} 12
+iris_process_block_writes{id="891"} 0
+iris_process_block_writes{id="932"} 0
+iris_process_block_writes{id="933"} 0
+iris_process_block_writes{id="934"} 0
+iris_process_block_writes{id="935"} 0
+iris_process_block_writes{id="936"} 0
+iris_process_block_writes{id="937"} 0
+iris_process_block_writes{id="938"} 0
+iris_process_block_writes{id="939"} 0
+iris_process_block_writes{id="940"} 0
+iris_process_block_writes{id="941"} 0
+iris_process_block_writes{id="942"} 0
+iris_process_block_writes{id="944"} 0
+iris_process_block_writes{id="945"} 0
+iris_process_block_writes{id="971"} 3
+iris_process_block_writes{id="973"} 0
+iris_process_block_writes{id="976"} 0
+iris_process_block_writes{id="979"} 385
+iris_process_block_writes{id="982"} 22
+iris_process_block_writes{id="983"} 35
+iris_process_block_writes{id="984"} 0
+iris_process_block_writes{id="2012"} 15
+iris_process_block_writes{id="2013"} 1
+iris_process_block_writes{id="2016"} 5
+iris_process_block_writes{id="2017"} 5
+iris_process_block_writes{id="2022"} 1
+iris_process_block_writes{id="2023"} 0
+iris_process_block_writes{id="1002"} 168
+iris_process_block_writes{id="2026"} 0
+iris_process_block_writes{id="2027"} 0
+iris_process_block_writes{id="2028"} 0
+iris_process_block_writes{id="2029"} 72
+iris_process_block_writes{id="2030"} 0
+iris_process_block_writes{id="2031"} 51
+iris_process_block_writes{id="2032"} 88
+# HELP iris_process_commands Count of ObjectScript commands executed by process
+# TYPE iris_process_commands counter
+iris_process_commands{id="2066"} 130892
+iris_process_commands{id="2069"} 878054
+iris_process_commands{id="2072"} 10984
+iris_process_commands{id="2073"} 340537
+iris_process_commands{id="2074"} 11053
+iris_process_commands{id="2075"} 9356
+iris_process_commands{id="2076"} 1160917
+iris_process_commands{id="2086"} 386279
+iris_process_commands{id="2089"} 103895
+iris_process_commands{id="2090"} 132516
+iris_process_commands{id="2091"} 41235
+iris_process_commands{id="2092"} 2103
+iris_process_commands{id="2093"} 1268
+iris_process_commands{id="2094"} 1285
+iris_process_commands{id="2095"} 93777
+iris_process_commands{id="2096"} 24253
+iris_process_commands{id="2097"} 1254
+iris_process_commands{id="2098"} 554853
+iris_process_commands{id="2099"} 453579
+iris_process_commands{id="891"} 0
+iris_process_commands{id="932"} 89
+iris_process_commands{id="933"} 0
+iris_process_commands{id="934"} 562
+iris_process_commands{id="935"} 3
+iris_process_commands{id="936"} 3
+iris_process_commands{id="937"} 3
+iris_process_commands{id="938"} 1
+iris_process_commands{id="939"} 1
+iris_process_commands{id="940"} 1
+iris_process_commands{id="941"} 1
+iris_process_commands{id="942"} 0
+iris_process_commands{id="944"} 9301
+iris_process_commands{id="945"} 0
+iris_process_commands{id="971"} 5655
+iris_process_commands{id="973"} 3208
+iris_process_commands{id="976"} 209
+iris_process_commands{id="979"} 614497
+iris_process_commands{id="982"} 17935
+iris_process_commands{id="983"} 255668
+iris_process_commands{id="984"} 18100
+iris_process_commands{id="2012"} 1194481
+iris_process_commands{id="2013"} 1704
+iris_process_commands{id="2016"} 1186469
+iris_process_commands{id="2017"} 1186918
+iris_process_commands{id="2022"} 1603
+iris_process_commands{id="2023"} 1598
+iris_process_commands{id="1002"} 313497
+iris_process_commands{id="2026"} 1598
+iris_process_commands{id="2027"} 1598
+iris_process_commands{id="2028"} 1598
+iris_process_commands{id="2029"} 466910
+iris_process_commands{id="2030"} 1598
+iris_process_commands{id="2031"} 32907
+iris_process_commands{id="2032"} 517651
+# HELP iris_process_count Total number of active processes
+# TYPE iris_process_count gauge
+iris_process_count 54
+# HELP iris_process_glo_refs Count of global references by process
+# TYPE iris_process_glo_refs counter
+iris_process_glo_refs{id="2066"} 6801
+iris_process_glo_refs{id="2069"} 129413
+iris_process_glo_refs{id="2072"} 436
+iris_process_glo_refs{id="2073"} 45636
+iris_process_glo_refs{id="2074"} 436
+iris_process_glo_refs{id="2075"} 355
+iris_process_glo_refs{id="2076"} 457735
+iris_process_glo_refs{id="2086"} 37107
+iris_process_glo_refs{id="2089"} 4843
+iris_process_glo_refs{id="2090"} 11765
+iris_process_glo_refs{id="2091"} 1684
+iris_process_glo_refs{id="2092"} 154
+iris_process_glo_refs{id="2093"} 120
+iris_process_glo_refs{id="2094"} 128
+iris_process_glo_refs{id="2095"} 11096
+iris_process_glo_refs{id="2096"} 2359
+iris_process_glo_refs{id="2097"} 124
+iris_process_glo_refs{id="2098"} 34761
+iris_process_glo_refs{id="2099"} 24903
+iris_process_glo_refs{id="891"} 0
+iris_process_glo_refs{id="932"} 733
+iris_process_glo_refs{id="933"} 0
+iris_process_glo_refs{id="934"} 194
+iris_process_glo_refs{id="935"} 32
+iris_process_glo_refs{id="936"} 32
+iris_process_glo_refs{id="937"} 32
+iris_process_glo_refs{id="938"} 32
+iris_process_glo_refs{id="939"} 32
+iris_process_glo_refs{id="940"} 32
+iris_process_glo_refs{id="941"} 32
+iris_process_glo_refs{id="942"} 0
+iris_process_glo_refs{id="944"} 84
+iris_process_glo_refs{id="945"} 21
+iris_process_glo_refs{id="971"} 252
+iris_process_glo_refs{id="973"} 311
+iris_process_glo_refs{id="976"} 17
+iris_process_glo_refs{id="979"} 73327
+iris_process_glo_refs{id="982"} 754
+iris_process_glo_refs{id="983"} 4589
+iris_process_glo_refs{id="984"} 549
+iris_process_glo_refs{id="2012"} 458666
+iris_process_glo_refs{id="2013"} 129
+iris_process_glo_refs{id="2016"} 458294
+iris_process_glo_refs{id="2017"} 458331
+iris_process_glo_refs{id="2022"} 90
+iris_process_glo_refs{id="2023"} 89
+iris_process_glo_refs{id="1002"} 32485
+iris_process_glo_refs{id="2026"} 89
+iris_process_glo_refs{id="2027"} 89
+iris_process_glo_refs{id="2028"} 89
+iris_process_glo_refs{id="2029"} 55242
+iris_process_glo_refs{id="2030"} 89
+iris_process_glo_refs{id="2031"} 5548
+iris_process_glo_refs{id="2032"} 86207
+# HELP iris_process_jrn_entries Count of journal entries by process
+# TYPE iris_process_jrn_entries counter
+iris_process_jrn_entries{id="2066"} 335
+iris_process_jrn_entries{id="2069"} 84
+iris_process_jrn_entries{id="2072"} 1
+iris_process_jrn_entries{id="2073"} 85
+iris_process_jrn_entries{id="2074"} 1
+iris_process_jrn_entries{id="2075"} 1
+iris_process_jrn_entries{id="2076"} 2
+iris_process_jrn_entries{id="2086"} 2
+iris_process_jrn_entries{id="2089"} 1947
+iris_process_jrn_entries{id="2090"} 1704
+iris_process_jrn_entries{id="2091"} 656
+iris_process_jrn_entries{id="2092"} 13
+iris_process_jrn_entries{id="2093"} 10
+iris_process_jrn_entries{id="2094"} 13
+iris_process_jrn_entries{id="2095"} 87
+iris_process_jrn_entries{id="2096"} 76
+iris_process_jrn_entries{id="2097"} 13
+iris_process_jrn_entries{id="2098"} 5781
+iris_process_jrn_entries{id="2099"} 4831
+iris_process_jrn_entries{id="891"} 0
+iris_process_jrn_entries{id="932"} 0
+iris_process_jrn_entries{id="933"} 0
+iris_process_jrn_entries{id="934"} 0
+iris_process_jrn_entries{id="935"} 0
+iris_process_jrn_entries{id="936"} 0
+iris_process_jrn_entries{id="937"} 0
+iris_process_jrn_entries{id="938"} 0
+iris_process_jrn_entries{id="939"} 0
+iris_process_jrn_entries{id="940"} 0
+iris_process_jrn_entries{id="941"} 0
+iris_process_jrn_entries{id="942"} 0
+iris_process_jrn_entries{id="944"} 0
+iris_process_jrn_entries{id="945"} 0
+iris_process_jrn_entries{id="971"} 6
+iris_process_jrn_entries{id="973"} 0
+iris_process_jrn_entries{id="976"} 0
+iris_process_jrn_entries{id="979"} 0
+iris_process_jrn_entries{id="982"} 36
+iris_process_jrn_entries{id="983"} 5
+iris_process_jrn_entries{id="984"} 0
+iris_process_jrn_entries{id="2012"} 5
+iris_process_jrn_entries{id="2013"} 0
+iris_process_jrn_entries{id="2016"} 3
+iris_process_jrn_entries{id="2017"} 3
+iris_process_jrn_entries{id="2022"} 1
+iris_process_jrn_entries{id="2023"} 0
+iris_process_jrn_entries{id="1002"} 0
+iris_process_jrn_entries{id="2026"} 0
+iris_process_jrn_entries{id="2027"} 0
+iris_process_jrn_entries{id="2028"} 0
+iris_process_jrn_entries{id="2029"} 83
+iris_process_jrn_entries{id="2030"} 0
+iris_process_jrn_entries{id="2031"} 583
+iris_process_jrn_entries{id="2032"} 169
+# HELP iris_process_ppg_size_mb Process private global blocks in MB
+# TYPE iris_process_ppg_size_mb gauge
+# UNIT iris_process_ppg_size_mb mb
+iris_process_ppg_size_mb{id="2066"} 0.008
+iris_process_ppg_size_mb{id="2069"} 0.008
+iris_process_ppg_size_mb{id="2072"} 0.000
+iris_process_ppg_size_mb{id="2073"} 0.008
+iris_process_ppg_size_mb{id="2074"} 0.000
+iris_process_ppg_size_mb{id="2075"} 0.000
+iris_process_ppg_size_mb{id="2076"} 0.000
+iris_process_ppg_size_mb{id="2086"} 0.008
+iris_process_ppg_size_mb{id="2089"} 0.000
+iris_process_ppg_size_mb{id="2090"} 0.023
+iris_process_ppg_size_mb{id="2091"} 0.000
+iris_process_ppg_size_mb{id="2092"} 0.000
+iris_process_ppg_size_mb{id="2093"} 0.000
+iris_process_ppg_size_mb{id="2094"} 0.008
+iris_process_ppg_size_mb{id="2095"} 0.000
+iris_process_ppg_size_mb{id="2096"} 0.000
+iris_process_ppg_size_mb{id="2097"} 0.000
+iris_process_ppg_size_mb{id="2098"} 0.023
+iris_process_ppg_size_mb{id="2099"} 0.023
+iris_process_ppg_size_mb{id="891"} 0.000
+iris_process_ppg_size_mb{id="932"} 0.000
+iris_process_ppg_size_mb{id="933"} 0.000
+iris_process_ppg_size_mb{id="934"} 0.000
+iris_process_ppg_size_mb{id="935"} 0.000
+iris_process_ppg_size_mb{id="936"} 0.000
+iris_process_ppg_size_mb{id="937"} 0.000
+iris_process_ppg_size_mb{id="938"} 0.000
+iris_process_ppg_size_mb{id="939"} 0.000
+iris_process_ppg_size_mb{id="940"} 0.000
+iris_process_ppg_size_mb{id="941"} 0.000
+iris_process_ppg_size_mb{id="942"} 0.000
+iris_process_ppg_size_mb{id="944"} 0.000
+iris_process_ppg_size_mb{id="945"} 0.000
+iris_process_ppg_size_mb{id="971"} 0.000
+iris_process_ppg_size_mb{id="973"} 0.008
+iris_process_ppg_size_mb{id="976"} 0.000
+iris_process_ppg_size_mb{id="979"} 0.000
+iris_process_ppg_size_mb{id="982"} 0.000
+iris_process_ppg_size_mb{id="983"} 0.039
+iris_process_ppg_size_mb{id="984"} 0.000
+iris_process_ppg_size_mb{id="2012"} 0.008
+iris_process_ppg_size_mb{id="2013"} 0.008
+iris_process_ppg_size_mb{id="2016"} 0.008
+iris_process_ppg_size_mb{id="2017"} 0.008
+iris_process_ppg_size_mb{id="2022"} 0.008
+iris_process_ppg_size_mb{id="2023"} 0.000
+iris_process_ppg_size_mb{id="1002"} 0.000
+iris_process_ppg_size_mb{id="2026"} 0.000
+iris_process_ppg_size_mb{id="2027"} 0.000
+iris_process_ppg_size_mb{id="2028"} 0.000
+iris_process_ppg_size_mb{id="2029"} 0.008
+iris_process_ppg_size_mb{id="2030"} 0.000
+iris_process_ppg_size_mb{id="2031"} 0.008
+iris_process_ppg_size_mb{id="2032"} 0.008
+# HELP iris_process_phys_reads Count of physical database block reads by process
+# TYPE iris_process_phys_reads counter
+iris_process_phys_reads{id="2066"} 99
+iris_process_phys_reads{id="2069"} 1755
+iris_process_phys_reads{id="2072"} 0
+iris_process_phys_reads{id="2073"} 27
+iris_process_phys_reads{id="2074"} 0
+iris_process_phys_reads{id="2075"} 0
+iris_process_phys_reads{id="2076"} 0
+iris_process_phys_reads{id="2086"} 1029
+iris_process_phys_reads{id="2089"} 37
+iris_process_phys_reads{id="2090"} 57
+iris_process_phys_reads{id="2091"} 34
+iris_process_phys_reads{id="2092"} 3
+iris_process_phys_reads{id="2093"} 0
+iris_process_phys_reads{id="2094"} 0
+iris_process_phys_reads{id="2095"} 12
+iris_process_phys_reads{id="2096"} 18
+iris_process_phys_reads{id="2097"} 0
+iris_process_phys_reads{id="2098"} 17
+iris_process_phys_reads{id="2099"} 7
+iris_process_phys_reads{id="891"} 0
+iris_process_phys_reads{id="932"} 0
+iris_process_phys_reads{id="933"} 0
+iris_process_phys_reads{id="934"} 0
+iris_process_phys_reads{id="935"} 0
+iris_process_phys_reads{id="936"} 0
+iris_process_phys_reads{id="937"} 0
+iris_process_phys_reads{id="938"} 0
+iris_process_phys_reads{id="939"} 0
+iris_process_phys_reads{id="940"} 0
+iris_process_phys_reads{id="941"} 0
+iris_process_phys_reads{id="942"} 0
+iris_process_phys_reads{id="944"} 31
+iris_process_phys_reads{id="945"} 1
+iris_process_phys_reads{id="971"} 0
+iris_process_phys_reads{id="973"} 3
+iris_process_phys_reads{id="976"} 1
+iris_process_phys_reads{id="979"} 1
+iris_process_phys_reads{id="982"} 20
+iris_process_phys_reads{id="983"} 56
+iris_process_phys_reads{id="984"} 0
+iris_process_phys_reads{id="2012"} 345
+iris_process_phys_reads{id="2013"} 0
+iris_process_phys_reads{id="2016"} 0
+iris_process_phys_reads{id="2017"} 0
+iris_process_phys_reads{id="2022"} 0
+iris_process_phys_reads{id="2023"} 0
+iris_process_phys_reads{id="1002"} 42
+iris_process_phys_reads{id="2026"} 0
+iris_process_phys_reads{id="2027"} 0
+iris_process_phys_reads{id="2028"} 0
+iris_process_phys_reads{id="2029"} 887
+iris_process_phys_reads{id="2030"} 0
+iris_process_phys_reads{id="2031"} 104
+iris_process_phys_reads{id="2032"} 68
+# HELP iris_res_a_seize Resource Seize satisfied after a busy wait
+# TYPE iris_res_a_seize counter
+iris_res_a_seize{id="EVT"} 0
+iris_res_a_seize{id="IPQ"} 0
+iris_res_a_seize{id="LRU"} 1
+iris_res_a_seize{id="Pid"} 0
+iris_res_a_seize{id="RCT"} 0
+iris_res_a_seize{id="SEM"} 0
+iris_res_a_seize{id="Lock"} 0
+iris_res_a_seize{id="Misc"} 1
+iris_res_a_seize{id="OCSP"} 0
+iris_res_a_seize{id="Stat"} 0
+iris_res_a_seize{id="UUID"} 0
+iris_res_a_seize{id="ECP_C"} 0
+iris_res_a_seize{id="ECP_S"} 0
+iris_res_a_seize{id="Queue"} 0
+iris_res_a_seize{id="iKnow"} 0
+iris_res_a_seize{id="Dirset"} 0
+iris_res_a_seize{id="Expand"} 0
+iris_res_a_seize{id="Global"} 0
+iris_res_a_seize{id="IjcDev"} 0
+iris_res_a_seize{id="Mirror"} 0
+iris_res_a_seize{id="SatMap"} 0
+iris_res_a_seize{id="StrTab"} 0
+iris_res_a_seize{id="Journal"} 0
+iris_res_a_seize{id="LockDev"} 0
+iris_res_a_seize{id="LockLHB"} 4
+iris_res_a_seize{id="Per-BDB"} 0
+iris_res_a_seize{id="Routine"} 9
+iris_res_a_seize{id="TransCB"} 0
+iris_res_a_seize{id="TtyHash"} 0
+iris_res_a_seize{id="GfileTab"} 0
+iris_res_a_seize{id="GmemHeap"} 0
+iris_res_a_seize{id="LockHTAB"} 0
+iris_res_a_seize{id="ObjClass"} 27
+iris_res_a_seize{id="RUNLEVEL"} 0
+iris_res_a_seize{id="Volqueue"} 0
+iris_res_a_seize{id="ECP_ALL_C"} 0
+iris_res_a_seize{id="ECP_S_SES"} 0
+iris_res_a_seize{id="ECP_S_SFN"} 0
+iris_res_a_seize{id="JrnSFNTab"} 0
+iris_res_a_seize{id="SEM_WaitQ"} 0
+iris_res_a_seize{id="ECP_C_Mess"} 0
+iris_res_a_seize{id="ECP_C_PBLK"} 0
+iris_res_a_seize{id="ECP_C_PPNT"} 0
+iris_res_a_seize{id="ECP_S_Lock"} 0
+iris_res_a_seize{id="ECP_S_Read"} 0
+iris_res_a_seize{id="ECP_S_WORK"} 0
+iris_res_a_seize{id="StrTabHead"} 0
+iris_res_a_seize{id="BlkSrch_DEQ"} 0
+iris_res_a_seize{id="BlkSrch_ENQ"} 1
+iris_res_a_seize{id="ECP_S_ASYNC"} 0
+iris_res_a_seize{id="ECP_S_TRANS"} 0
+iris_res_a_seize{id="ECP_C_ANSBUF"} 0
+iris_res_a_seize{id="QUEUE_WAIT_Q"} 0
+iris_res_a_seize{id="ECP_S_BACKOBJ"} 0
+iris_res_a_seize{id="PIDTAB_Expand"} 0
+iris_res_a_seize{id="ECP_S_Purge_BigKill"} 0
+# HELP iris_res_n_seize Resource Seize not satisfied and had to hibernate
+# TYPE iris_res_n_seize counter
+iris_res_n_seize{id="EVT"} 0
+iris_res_n_seize{id="IPQ"} 0
+iris_res_n_seize{id="LRU"} 0
+iris_res_n_seize{id="Pid"} 0
+iris_res_n_seize{id="RCT"} 0
+iris_res_n_seize{id="SEM"} 0
+iris_res_n_seize{id="Lock"} 0
+iris_res_n_seize{id="Misc"} 0
+iris_res_n_seize{id="OCSP"} 0
+iris_res_n_seize{id="Stat"} 0
+iris_res_n_seize{id="UUID"} 0
+iris_res_n_seize{id="ECP_C"} 0
+iris_res_n_seize{id="ECP_S"} 0
+iris_res_n_seize{id="Queue"} 0
+iris_res_n_seize{id="iKnow"} 0
+iris_res_n_seize{id="Dirset"} 0
+iris_res_n_seize{id="Expand"} 0
+iris_res_n_seize{id="Global"} 0
+iris_res_n_seize{id="IjcDev"} 0
+iris_res_n_seize{id="Mirror"} 0
+iris_res_n_seize{id="SatMap"} 0
+iris_res_n_seize{id="StrTab"} 0
+iris_res_n_seize{id="Journal"} 0
+iris_res_n_seize{id="LockDev"} 0
+iris_res_n_seize{id="LockLHB"} 0
+iris_res_n_seize{id="Per-BDB"} 0
+iris_res_n_seize{id="Routine"} 0
+iris_res_n_seize{id="TransCB"} 0
+iris_res_n_seize{id="TtyHash"} 0
+iris_res_n_seize{id="GfileTab"} 0
+iris_res_n_seize{id="GmemHeap"} 0
+iris_res_n_seize{id="LockHTAB"} 0
+iris_res_n_seize{id="ObjClass"} 0
+iris_res_n_seize{id="RUNLEVEL"} 0
+iris_res_n_seize{id="Volqueue"} 0
+iris_res_n_seize{id="ECP_ALL_C"} 0
+iris_res_n_seize{id="ECP_S_SES"} 0
+iris_res_n_seize{id="ECP_S_SFN"} 0
+iris_res_n_seize{id="JrnSFNTab"} 0
+iris_res_n_seize{id="SEM_WaitQ"} 0
+iris_res_n_seize{id="ECP_C_Mess"} 0
+iris_res_n_seize{id="ECP_C_PBLK"} 0
+iris_res_n_seize{id="ECP_C_PPNT"} 0
+iris_res_n_seize{id="ECP_S_Lock"} 0
+iris_res_n_seize{id="ECP_S_Read"} 0
+iris_res_n_seize{id="ECP_S_WORK"} 0
+iris_res_n_seize{id="StrTabHead"} 0
+iris_res_n_seize{id="BlkSrch_DEQ"} 0
+iris_res_n_seize{id="BlkSrch_ENQ"} 0
+iris_res_n_seize{id="ECP_S_ASYNC"} 0
+iris_res_n_seize{id="ECP_S_TRANS"} 0
+iris_res_n_seize{id="ECP_C_ANSBUF"} 0
+iris_res_n_seize{id="QUEUE_WAIT_Q"} 0
+iris_res_n_seize{id="ECP_S_BACKOBJ"} 0
+iris_res_n_seize{id="PIDTAB_Expand"} 0
+iris_res_n_seize{id="ECP_S_Purge_BigKill"} 0
+# HELP iris_res_seize Resource Seize
+# TYPE iris_res_seize counter
+iris_res_seize{id="EVT"} 15445
+iris_res_seize{id="IPQ"} 0
+iris_res_seize{id="LRU"} 7407
+iris_res_seize{id="Pid"} 0
+iris_res_seize{id="RCT"} 0
+iris_res_seize{id="SEM"} 53
+iris_res_seize{id="Lock"} 4187
+iris_res_seize{id="Misc"} 267
+iris_res_seize{id="OCSP"} 0
+iris_res_seize{id="Stat"} 0
+iris_res_seize{id="UUID"} 129
+iris_res_seize{id="ECP_C"} 0
+iris_res_seize{id="ECP_S"} 0
+iris_res_seize{id="Queue"} 0
+iris_res_seize{id="iKnow"} 29
+iris_res_seize{id="Dirset"} 2
+iris_res_seize{id="Expand"} 12
+iris_res_seize{id="Global"} 126
+iris_res_seize{id="IjcDev"} 0
+iris_res_seize{id="Mirror"} 0
+iris_res_seize{id="SatMap"} 0
+iris_res_seize{id="StrTab"} 0
+iris_res_seize{id="Journal"} 0
+iris_res_seize{id="LockDev"} 0
+iris_res_seize{id="LockLHB"} 31458
+iris_res_seize{id="Per-BDB"} 450
+iris_res_seize{id="Routine"} 4877
+iris_res_seize{id="TransCB"} 23495
+iris_res_seize{id="TtyHash"} 0
+iris_res_seize{id="GfileTab"} 1145
+iris_res_seize{id="GmemHeap"} 4108
+iris_res_seize{id="LockHTAB"} 17656
+iris_res_seize{id="ObjClass"} 28513
+iris_res_seize{id="RUNLEVEL"} 0
+iris_res_seize{id="Volqueue"} 0
+iris_res_seize{id="ECP_ALL_C"} 0
+iris_res_seize{id="ECP_S_SES"} 0
+iris_res_seize{id="ECP_S_SFN"} 0
+iris_res_seize{id="JrnSFNTab"} 3
+iris_res_seize{id="SEM_WaitQ"} 17111
+iris_res_seize{id="ECP_C_Mess"} 0
+iris_res_seize{id="ECP_C_PBLK"} 0
+iris_res_seize{id="ECP_C_PPNT"} 0
+iris_res_seize{id="ECP_S_Lock"} 0
+iris_res_seize{id="ECP_S_Read"} 0
+iris_res_seize{id="ECP_S_WORK"} 0
+iris_res_seize{id="StrTabHead"} 133
+iris_res_seize{id="BlkSrch_DEQ"} 7706
+iris_res_seize{id="BlkSrch_ENQ"} 7513
+iris_res_seize{id="ECP_S_ASYNC"} 0
+iris_res_seize{id="ECP_S_TRANS"} 22
+iris_res_seize{id="ECP_C_ANSBUF"} 0
+iris_res_seize{id="QUEUE_WAIT_Q"} 0
+iris_res_seize{id="ECP_S_BACKOBJ"} 0
+iris_res_seize{id="PIDTAB_Expand"} 0
+iris_res_seize{id="ECP_S_Purge_BigKill"} 0
+# HELP iris_rtn_a_seize_per_sec Routine resource Aseizes (per second)
+# TYPE iris_rtn_a_seize_per_sec gauge
+iris_rtn_a_seize_per_sec 0
+# HELP iris_rtn_call_local_per_sec Routine calls, local (per second)
+# TYPE iris_rtn_call_local_per_sec gauge
+iris_rtn_call_local_per_sec 760
+# HELP iris_rtn_call_miss_per_sec Routines calls not found in memory (per second)
+# TYPE iris_rtn_call_miss_per_sec gauge
+iris_rtn_call_miss_per_sec 4
+# HELP iris_rtn_call_remote_per_sec Routine calls, remote (per second)
+# TYPE iris_rtn_call_remote_per_sec gauge
+iris_rtn_call_remote_per_sec 0
+# HELP iris_rtn_count_by_ns Total number of routines in each namespace
+# TYPE iris_rtn_count_by_ns gauge
+iris_rtn_count_by_ns{id="%SYS"} 12893
+iris_rtn_count_by_ns{id="USER"} 11195
+iris_rtn_count_by_ns{id="HSLIB"} 32047
+iris_rtn_count_by_ns{id="HSSYS"} 31849
+iris_rtn_count_by_ns{id="INTEROP"} 31688
+iris_rtn_count_by_ns{id="LABDEMO"} 31654
+iris_rtn_count_by_ns{id="HSCUSTOM"} 31448
+iris_rtn_count_by_ns{id="HSSYSLOCALTEMP"} 11017
+iris_rtn_count_by_ns{id="AGENTICDEVELOPMENT"} 31568
+# HELP iris_rtn_load_per_sec Routines locally loaded from or saved to disk (per second)
+# TYPE iris_rtn_load_per_sec gauge
+iris_rtn_load_per_sec 7
+# HELP iris_rtn_load_rem_per_sec Routines remotely loaded from or saved to disk (per second)
+# TYPE iris_rtn_load_rem_per_sec gauge
+iris_rtn_load_rem_per_sec 0
+# HELP iris_rtn_seize_per_sec Routine resource seizes (per second)
+# TYPE iris_rtn_seize_per_sec gauge
+iris_rtn_seize_per_sec 19
+# HELP iris_sam_get_db_sensors_seconds Time to fetch Database related metrics
+# TYPE iris_sam_get_db_sensors_seconds gauge
+# UNIT iris_sam_get_db_sensors_seconds seconds
+iris_sam_get_db_sensors_seconds .011081
+# HELP iris_sam_get_interop_sensors_seconds Time to fetch Interoperability related metrics
+# TYPE iris_sam_get_interop_sensors_seconds gauge
+# UNIT iris_sam_get_interop_sensors_seconds seconds
+iris_sam_get_interop_sensors_seconds .000452
+# HELP iris_sam_get_jrn_sensors_seconds Time to fetch Journal related metrics
+# TYPE iris_sam_get_jrn_sensors_seconds gauge
+# UNIT iris_sam_get_jrn_sensors_seconds seconds
+iris_sam_get_jrn_sensors_seconds .141656
+# HELP iris_sam_get_sql_sensors_seconds Time to fetch SQL related metrics
+# TYPE iris_sam_get_sql_sensors_seconds gauge
+# UNIT iris_sam_get_sql_sensors_seconds seconds
+iris_sam_get_sql_sensors_seconds .002825
+# HELP iris_sam_get_wqm_sensors_seconds Time to fetch Work Queue Manger related metrics
+# TYPE iris_sam_get_wqm_sensors_seconds gauge
+# UNIT iris_sam_get_wqm_sensors_seconds seconds
+iris_sam_get_wqm_sensors_seconds .00011
+# HELP iris_smh_available Shared memory available (bytes) by purpose
+# TYPE iris_smh_available gauge
+# UNIT iris_smh_available bytes
+iris_smh_available{id="Classes_Instantiated"} 37888
+iris_smh_available{id="DB_Name_&_Directory"} 63726
+iris_smh_available{id="Global_Mapping"} 59936
+iris_smh_available{id="Lock_Table"} 182960
+iris_smh_available{id="Routine_Buffer_In_Use_Table"} 44544
+iris_smh_available{id="Security_System"} 0
+iris_smh_available{id="Semaphores_objects"} 52736
+iris_smh_available{id="TTY_Hash_Table"} 32760
+# HELP iris_smh_percent_full Shared memory in use (percentage of allocated) by purpose
+# TYPE iris_smh_percent_full gauge
+iris_smh_percent_full{id="Classes_Instantiated"} 99
+iris_smh_percent_full{id="DB_Name_&_Directory"} 3
+iris_smh_percent_full{id="Global_Mapping"} 70
+iris_smh_percent_full{id="Lock_Table"} 7
+iris_smh_percent_full{id="Routine_Buffer_In_Use_Table"} 32
+iris_smh_percent_full{id="Semaphores_objects"} 20
+iris_smh_percent_full{id="TTY_Hash_Table"} 50
+# HELP iris_smh_total Shared memory allocated (bytes) for current instance
+# TYPE iris_smh_total gauge
+# UNIT iris_smh_total bytes
+iris_smh_total 7208960
+# HELP iris_smh_total_percent_full Shared memory in use (percentage of allocated) for current instance
+# TYPE iris_smh_total_percent_full gauge
+iris_smh_total_percent_full 2
+# HELP iris_smh_used Shared memory in use (bytes) by purpose
+# TYPE iris_smh_used gauge
+# UNIT iris_smh_used bytes
+iris_smh_used{id="Classes_Instantiated"} 5073920
+iris_smh_used{id="DB_Name_&_Directory"} 1810
+iris_smh_used{id="Global_Mapping"} 136672
+iris_smh_used{id="Lock_Table"} 13648
+iris_smh_used{id="Routine_Buffer_In_Use_Table"} 20992
+iris_smh_used{id="Security_System"} 65536
+iris_smh_used{id="Semaphores_objects"} 12800
+iris_smh_used{id="TTY_Hash_Table"} 32776
+# HELP iris_sql_commands_per_second Average number of ObjectScript commands executed by SQL queries (per second)
+# TYPE iris_sql_commands_per_second gauge
+iris_sql_commands_per_second{id="%SYS"} 11.2
+iris_sql_commands_per_second{id="LABDEMO"} 2089.083333333333333
+iris_sql_commands_per_second{id="all"} 2100.283333333333333
+# HELP iris_sql_queries_avg_runtime Average SQL statement runtime in seconds
+# TYPE iris_sql_queries_avg_runtime gauge
+# UNIT iris_sql_queries_avg_runtime seconds
+iris_sql_queries_avg_runtime{id="%SYS"} .0001222857142857142857
+iris_sql_queries_avg_runtime{id="LABDEMO"} .00002957275390625
+iris_sql_queries_avg_runtime{id="all"} .00003051377477042049299
+# HELP iris_sql_queries_avg_runtime_std_dev Standard deviation for SQL statement runtime
+# TYPE iris_sql_queries_avg_runtime_std_dev gauge
+iris_sql_queries_avg_runtime_std_dev{id="%SYS"} .0003288322774100296054
+iris_sql_queries_avg_runtime_std_dev{id="LABDEMO"} .0005099935924651100455
+iris_sql_queries_avg_runtime_std_dev{id="all"} .000508479171319277254
+# HELP iris_sql_queries_per_second Average number of SQL statements per second
+# TYPE iris_sql_queries_per_second gauge
+iris_sql_queries_per_second{id="%SYS"} .35
+iris_sql_queries_per_second{id="LABDEMO"} 34.13333333333333333
+iris_sql_queries_per_second{id="all"} 34.48333333333333333
+# HELP iris_sql_row_count_per_second Average number of SQL rows returned per second
+# TYPE iris_sql_row_count_per_second gauge
+iris_sql_row_count_per_second{id="%SYS"} .1
+iris_sql_row_count_per_second{id="LABDEMO"} 36.45
+iris_sql_row_count_per_second{id="all"} 36.55
+# HELP iris_system_alerts Number of system alerts posted since startup
+# TYPE iris_system_alerts gauge
+iris_system_alerts 1
+# HELP iris_system_alerts_log Number of alerts recorded in the alerts.log file
+# TYPE iris_system_alerts_log gauge
+iris_system_alerts_log 1
+# HELP iris_system_alerts_new A boolean value indicating that alerts have been posted since the last time the Alerts API was called
+# TYPE iris_system_alerts_new gauge
+iris_system_alerts_new 1
+# HELP iris_system_info Key system information, including version, platform, product name, and other relevant details
+# TYPE iris_system_info untyped
+iris_system_info{id="IRIS",product="IRIS for UNIX",platform="Ubuntu Server LTS for x86-64 Containers",version="2026.1",build_number="219",build_date="67619"} 1
+# HELP iris_system_state An integer representing the overal state of the system (-1: Hung, 0: OK, 1: Warning, 2: Alert)
+# TYPE iris_system_state gauge
+iris_system_state 1
+# HELP iris_trans_open_count Open transactions on the current instance
+# TYPE iris_trans_open_count gauge
+iris_trans_open_count 0
+# HELP iris_trans_open_secs Duration (seconds) of all open  transactions on the current instance
+# TYPE iris_trans_open_secs gauge
+# UNIT iris_trans_open_secs seconds
+iris_trans_open_secs 0
+# HELP iris_trans_open_secs_max Duration (seconds) of longest currently open  transaction on the current instance
+# TYPE iris_trans_open_secs_max gauge
+# UNIT iris_trans_open_secs_max seconds
+iris_trans_open_secs_max 0
+# HELP iris_wd_buffer_redirty Number of database buffers written during most recent write daemon cycle that were also written in prior cycle
+# TYPE iris_wd_buffer_redirty gauge
+iris_wd_buffer_redirty 19
+# HELP iris_wd_buffer_write Number of database buffers written during most recent write daemon cycle
+# TYPE iris_wd_buffer_write gauge
+iris_wd_buffer_write 86
+# HELP iris_wd_condition A flag indicating that some set/kill operations may be blocked
+# TYPE iris_wd_condition gauge
+iris_wd_condition 0
+# HELP iris_wd_cycle_time Time (milliseconds) for most recent write daemon cycle to complete
+# TYPE iris_wd_cycle_time gauge
+# UNIT iris_wd_cycle_time milliseconds
+iris_wd_cycle_time 159
+# HELP iris_wd_pass Current pass of the write daemon since startup
+# TYPE iris_wd_pass gauge
+iris_wd_pass 89
+# HELP iris_wd_phase Current phase of the write daemon
+# TYPE iris_wd_phase gauge
+iris_wd_phase 0
+# HELP iris_wd_proc_in_global Number of processes actively holding global buffers at start of most recent write daemon cycle
+# TYPE iris_wd_proc_in_global gauge
+iris_wd_proc_in_global 0
+# HELP iris_wd_size_write Size (kilobytes) of database buffers written during most recent write daemon cycle
+# TYPE iris_wd_size_write gauge
+# UNIT iris_wd_size_write kilobytes
+iris_wd_size_write 688
+# HELP iris_wd_sleep Time (milliseconds) that write daemon was inactive before most recent write daemon cycle began
+# TYPE iris_wd_sleep gauge
+# UNIT iris_wd_sleep milliseconds
+iris_wd_sleep 79983
+# HELP iris_wd_suspended Indicates WD is suspended.
+# TYPE iris_wd_suspended gauge
+iris_wd_suspended 0
+# HELP iris_wd_temp_queue In-memory buffers used at start of most recent write daemon cycle
+# TYPE iris_wd_temp_queue gauge
+iris_wd_temp_queue 214
+# HELP iris_wd_temp_write In-memory buffers written during most recent write daemon cycle (typically none)
+# TYPE iris_wd_temp_write gauge
+iris_wd_temp_write 0
+# HELP iris_wdwij_time Time (milliseconds) write daemon spent writing to WIJ file during most recent cycle
+# TYPE iris_wdwij_time gauge
+# UNIT iris_wdwij_time milliseconds
+iris_wdwij_time 25
+# HELP iris_wd_write_time Time (milliseconds) write daemon spent writing buffers to  databases during most recent cycle
+# TYPE iris_wd_write_time gauge
+# UNIT iris_wd_write_time milliseconds
+iris_wd_write_time 131
+# HELP iris_wij_writes_per_sec WIJ physical block writes (per second)
+# TYPE iris_wij_writes_per_sec gauge
+iris_wij_writes_per_sec 0
+# HELP iris_wqm_active_worker_jobs Average number of worker jobs running logic that are not blocked
+# TYPE iris_wqm_active_worker_jobs gauge
+iris_wqm_active_worker_jobs{id="Default"} 0
+iris_wqm_active_worker_jobs{id="SYS"} 0
+# HELP iris_wqm_commands_per_sec Average number of commands executed per second
+# TYPE iris_wqm_commands_per_sec gauge
+iris_wqm_commands_per_sec{id="Default"} 0
+iris_wqm_commands_per_sec{id="SYS"} 237
+# HELP iris_wqm_globals_per_sec Average number of global references per second
+# TYPE iris_wqm_globals_per_sec gauge
+iris_wqm_globals_per_sec{id="Default"} 0
+iris_wqm_globals_per_sec{id="SYS"} 24
+# HELP iris_wqm_max_active_worker_jobs Max number of active workers since last log entry
+# TYPE iris_wqm_max_active_worker_jobs gauge
+iris_wqm_max_active_worker_jobs{id="Default"} 0
+iris_wqm_max_active_worker_jobs{id="SYS"} 0
+# HELP iris_wqm_max_work_queue_depth Max number of work queue entries since last log entry (tasks waiting for workers to service them)
+# TYPE iris_wqm_max_work_queue_depth gauge
+iris_wqm_max_work_queue_depth{id="Default"} 0
+iris_wqm_max_work_queue_depth{id="SYS"} 0
+# HELP iris_wqm_waiting_worker_jobs Average number of worker jobs waiting for a group to connect to (currently idle but available to do work)
+# TYPE iris_wqm_waiting_worker_jobs gauge
+iris_wqm_waiting_worker_jobs{id="Default"} 0
+iris_wqm_waiting_worker_jobs{id="SYS"} 1

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -3,6 +3,8 @@
  *
  *   node contracts/validate.mjs
  *
+ * Covers both contracts: healthscan (Dev B -> Dev C) and proxy (Dev A -> Dev B).
+ *
  * Exits non-zero on the first failure, so it works unchanged as a CI step.
  *
  * Why a script rather than an ajv-cli one-liner:
@@ -27,6 +29,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const SCHEMA_ID = 'https://production-guardian/contracts/healthscan.schema.json';
+const PROXY_SCHEMA_ID = 'https://production-guardian/contracts/proxy.schema.json';
 
 /** Each sample is validated against ONE named definition, never "either". */
 const CASES = [
@@ -165,13 +168,171 @@ const MUST_ACCEPT = [
   },
 ];
 
+/**
+ * The proxy contract's own cases. Separate arrays rather than a `schema` field on the
+ * existing ones, so nothing above changes shape.
+ *
+ * `samples/metrics-dump.txt` is raw Prometheus text, not JSON, so it cannot be validated
+ * against a schema the way the healthscan samples are — the structural check below is
+ * what covers it. The snapshot here carries the real Lab Router values that
+ * `services/metrics-proxy/src/parser.js` produces from that capture, so a schema that
+ * stopped accepting the proxy's actual output fails here.
+ */
+const REAL_LAB_ROUTER = {
+  host: 'Lab Router',
+  type: 'process',
+  status: 'OK',
+  isFramework: false,
+  queued: null,
+  messages: 126,
+  messagesPerSec: 1.2,
+  errored: null,
+  avgProcessingTime: 0.08,
+  avgQueueingTime: 0,
+  lastActivity: '2026-08-11T23:59:55.162Z',
+  lastActivityElapsedSeconds: 4.838,
+};
+
+const PROXY_MUST_ACCEPT = [
+  {
+    name: 'real Lab Router host, nulls included',
+    definition: 'ProxyHost',
+    data: REAL_LAB_ROUTER,
+  },
+  {
+    name: 'warming metrics response (200, not 503)',
+    definition: 'MetricsResponse',
+    data: { hosts: [], systemAlertsNew: null, warming: true, _meta: { polledAt: null } },
+  },
+  {
+    name: 'real metrics response',
+    definition: 'MetricsResponse',
+    data: {
+      hosts: [REAL_LAB_ROUTER],
+      systemAlertsNew: 1,
+      systemAlertsLog: 1,
+      _meta: {
+        polledAt: '2026-08-12T00:00:00Z',
+        production: 'LABDEMO.Production',
+        productionQueued: 0,
+        absentFamilies: [],
+        hostCount: 15,
+        applicationHostCount: 4,
+      },
+    },
+  },
+  {
+    name: 'real alert, severity as the numeric string IRIS emits',
+    definition: 'ProxyAlert',
+    data: {
+      time: '2026-08-11T04:12:07.382Z',
+      severity: '2',
+      message: '^ISCSOAP in Namespace MAIN has been active for 452 day(s).',
+      observedAt: '2026-08-12T08:45:30.264Z',
+    },
+  },
+  {
+    name: 'health reporting a reachable instance with no interop metrics',
+    definition: 'HealthResponse',
+    data: {
+      status: 'reachable, but no interop metrics',
+      uptime: 2.58,
+      lastPoll: '2026-08-12T08:50:16.079Z',
+      production: null,
+      hostCount: 0,
+      applicationHostCount: 0,
+      hint: 'IRIS answered but sent no iris_interop_* families.',
+    },
+  },
+];
+
+/**
+ * The proxy cases that must FAIL. The last two are the engine's current shape
+ * (`name`, `messagesErrored`) — see `proxy-api.md` §5.2. They are here so that if the
+ * naming question in §6.2 is settled the other way, this check says so.
+ */
+const PROXY_MUST_REJECT = [
+  {
+    name: 'status "Active" — not in the IRIS enum',
+    definition: 'ProxyHost',
+    data: { ...REAL_LAB_ROUTER, status: 'Active' },
+  },
+  {
+    name: 'type "actor" — must be normalized to process',
+    definition: 'ProxyHost',
+    data: { ...REAL_LAB_ROUTER, type: 'actor' },
+  },
+  {
+    name: 'lastActivity with an offset instead of Z',
+    definition: 'ProxyHost',
+    data: { ...REAL_LAB_ROUTER, lastActivity: '2026-08-11T23:59:55+00:00' },
+  },
+  {
+    name: 'null host name',
+    definition: 'ProxyHost',
+    data: { ...REAL_LAB_ROUTER, host: null },
+  },
+  {
+    name: 'metrics response with no _meta',
+    definition: 'MetricsResponse',
+    data: { hosts: [] },
+  },
+  {
+    name: 'alerts response served in the metrics position',
+    definition: 'MetricsResponse',
+    data: { alerts: [], _meta: { polledAt: null, shape: 'empty', count: 0 } },
+  },
+  {
+    name: 'engine-shaped host: `name` instead of `host`',
+    definition: 'ProxyHost',
+    data: (() => {
+      const { host, ...rest } = REAL_LAB_ROUTER;
+      return { ...rest, name: host };
+    })(),
+  },
+  {
+    name: 'engine-shaped host: `messagesErrored` instead of `errored`',
+    definition: 'ProxyHost',
+    data: (() => {
+      const { errored, ...rest } = REAL_LAB_ROUTER;
+      return { ...rest, messagesErrored: 0 };
+    })(),
+  },
+];
+
+/**
+ * Structural claims about the raw capture. Not a schema check — it is a text body — but
+ * the contract quotes label shapes out of it, so a capture that lost them would make
+ * `proxy-api.md` describe something no longer in the repo.
+ *
+ * Both `_absent` lines are the point: they are what §6.1 and §6.3 are about, and an
+ * assertion that a label is *missing* is the only way a future capture silently gaining
+ * it gets noticed.
+ */
+const CAPTURE_CLAIMS = [
+  { name: 'host label is `host`, with spaces', re: /^iris_interop_hosts\{[^}]*host="Lab Router"/m },
+  { name: 'status is a label, and reads OK', re: /^iris_interop_hosts\{[^}]*status="OK"/m },
+  { name: 'last_activity is elapsed seconds', re: /^iris_interop_last_activity\{[^}]*host="Lab Router"[^}]*\} 4\.838$/m },
+  { name: 'hosttype rides on avg_processing_time as `actor`', re: /^iris_interop_avg_processing_time\{[^}]*hosttype="actor"/m },
+  { name: 'sample_count is its own family, per (host, messagetype)', re: /^iris_interop_sample_count\{[^}]*host="Lab Router"[^}]*messagetype="ORM_O01"/m },
+  { name: 'queued carries NO host label (§6.1)', re: /^iris_interop_queued\{id="LABDEMO",production="LABDEMO\.Production"\} 0$/m },
+  { name: 'messages_errored carries NO host label (§6.3)', re: /^iris_interop_messages_errored\{id="LABDEMO",production="LABDEMO\.Production"\} 0$/m },
+];
+
 const ajv = new Ajv({ strict: false, allErrors: true });
 addFormats(ajv);
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'healthscan.schema.json'), 'utf8')));
+ajv.addSchema(JSON.parse(readFileSync(join(here, 'proxy.schema.json'), 'utf8')));
 
 const validatorFor = (definition) => {
   const validate = ajv.getSchema(`${SCHEMA_ID}#/definitions/${definition}`);
   if (validate === undefined) throw new Error(`no such definition: ${definition}`);
+  return validate;
+};
+
+const proxyValidatorFor = (definition) => {
+  const validate = ajv.getSchema(`${PROXY_SCHEMA_ID}#/definitions/${definition}`);
+  if (validate === undefined) throw new Error(`no such proxy definition: ${definition}`);
   return validate;
 };
 
@@ -201,9 +362,27 @@ for (const { name, definition, data } of MUST_REJECT) {
   report(!validate(data), `rejects: ${name}`);
 }
 
+for (const { name, definition, data } of PROXY_MUST_ACCEPT) {
+  const validate = proxyValidatorFor(definition);
+  const ok = validate(data);
+  report(ok, `proxy accepts: ${name}`);
+  if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+}
+
+for (const { name, definition, data } of PROXY_MUST_REJECT) {
+  const validate = proxyValidatorFor(definition);
+  report(!validate(data), `proxy rejects: ${name}`);
+}
+
+const capture = readFileSync(join(here, 'samples/metrics-dump.txt'), 'utf8');
+for (const { name, re } of CAPTURE_CLAIMS) {
+  report(re.test(capture), `metrics-dump.txt: ${name}`);
+}
+
 console.log(
   failures === 0
-    ? `\nall checks passed (${CASES.length} samples, ${MUST_ACCEPT.length} accept, ${MUST_REJECT.length} reject)`
+    ? `\nall checks passed (${CASES.length} samples, ${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length} accept, `
+      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length} reject, ${CAPTURE_CLAIMS.length} capture claims)`
     : `\n${failures} check(s) failed`,
 );
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes the last Day-1 gate item from `CONTRIBUTING.md` §6 — item 4 of #16.

**Dev A (@kskubach) has moved to other work, so Dev B is taking over their outstanding tasks.** This is authorized by the repo owner. The work is attributed to me; I am not acting as Dev A. The owner named in `contracts/README.md` stays Dev A, because `services/metrics-proxy/` is still their code and CODEOWNERS still routes it to them.

Three files were missing from the gate. All three are here:

```
PRESENT  contracts/healthscan-api.md          Dev B
PRESENT  contracts/samples/findings-response.json
ADDED    contracts/proxy-api.md
ADDED    contracts/proxy.schema.json
ADDED    contracts/samples/metrics-dump.txt   (the real capture, copied)
```

## The contract is derived from the code, not from intent

Dev A is not here to describe their own component, so nothing in `proxy-api.md` is a guess. The parser was run over the real capture, and **the real proxy (`index.js`) was run against a stub IRIS serving that same capture**, so all three endpoints were observed rather than inferred. That is what turned up two mismatches nobody had found.

`samples/metrics-dump.txt` is copied, not regenerated — verified byte-identical:

```
$ git hash-object C:/temp/real-metrics-capture.txt
537b6d5183501bc4ad2ceba05cabe5c9a8dd28b7
$ git rev-parse :contracts/samples/metrics-dump.txt
537b6d5183501bc4ad2ceba05cabe5c9a8dd28b7
```

One small correction: it is **1236 lines**, not the 1249 quoted in #10 and in `src/parser.js`'s comment. Same file, counted differently; `wc -l` says 1236. Not worth chasing, worth not silently contradicting.

## The five PROXY-Q answers

| # | Question | Answer | Contradicts the assumption? |
|---|---|---|---|
| **Q1** | Array, or object keyed by host? `status` passed through or normalized? | **Array** under a `hosts` key, alphabetical. `status` **passed through** unchanged. But the array is nested in an object alongside `_meta`, and **the field is `host`, not `name`**. | Partly — see Q9 |
| **Q2** | Is `queued` present per host? | **Field yes, value no.** `iris_interop_queued` carries no `host` label (labels are exactly `id`, `production` — verified in all three captures). Proxy publishes **`queued: null`** per host and the real per-production total as `_meta.productionQueued` (`0` in the sample). `queue_buildup` cannot fire per host today. #12, ADR 0001. | **Yes** — `null`, not `0`. See §6.1 |
| **Q3** | `avg*` aggregated, or raw per-`messagetype`? | **Already aggregated by the proxy, weighted by `iris_interop_sample_count`.** Aggregation does *not* move to the engine. A host with no sample-count line falls back to an unweighted mean rather than dropping out. | No — assumption holds |
| **Q4** | Elapsed seconds, or a pre-computed timestamp? | **Both.** `lastActivityElapsedSeconds` is IRIS's own value (elapsed seconds, e.g. `4.838` — not epoch); `lastActivity` is `polledAt − elapsed` as ISO 8601. Prefer the elapsed figure for `stalled_host`: it is the measurement, the timestamp inherits ±10 s poll error. | No — assumption holds |
| **Q5** | Framework hosts filtered by the proxy? | **They reach you, flagged `isFramework`.** Your own filter stays necessary — **11 of 15 hosts in the capture are framework**, and `Ens.MonitorService` is one of the few *with* `avg_*` series, so an unfiltered snapshot reports framework timings as application latency. Filter on the flag, not the prefix: the label carries the *item* name, which has been both `ActivityReporter` and `Ens.Activity.Operation.Local`. | No — assumption holds |

Three more surfaced while writing it (§5.1): **Q6** `type` is `service`/`process`/`operation`/**`unknown`** (`hosttype` rides on `avg_*` only, so 8 of 15 hosts report `unknown` — a real value, not a bug); **Q7** the status enum adds **`Unknown`** to the seven, with no `Active` and no `Warning`; **Q8** below.

## Two things that were not previously known

### `iris_interop_messages_errored` carries no `host` label either

```
iris_interop_messages_errored{id="LABDEMO",production="LABDEMO.Production"} 0
```

Per-production, exactly like `queued`. `METRIC_MAP` treats it as per-host, so the line is skipped for want of a `host` label and **`errored` is `null` on every host**. `elevated_error_rate` cannot fire per host today — the same structural gap as `queue_buildup`, and **not filed anywhere**. §6.3.

Worse than `queued` in one respect: no per-production total is published, because `messages_errored` is not in `SCALAR_FAMILIES`, so the value is parsed and dropped. `EnumerateHostStatus` returns per-host error counts *and* queue depth, so the #12 REST wrapper closes both rules. Two of eight finding types depend on it.

### All 15 real hosts are rejected by the engine's `isProxyHost()`

Measured against the real capture, not predicted:

```
     Cloud API           REJECT: name=undefined queued=null messagesErrored=undefined
     EMR Source          REJECT: name=undefined queued=null messagesErrored=undefined
     FHIR Transform      REJECT: name=undefined queued=null messagesErrored=undefined
     Lab Router          REJECT: name=undefined queued=null messagesErrored=undefined
[fw] Ens.MonitorService  REJECT: name=undefined queued=null messages=null ... 

isProxyHost(): accepted 0 / rejected 15 of 15 hosts
after name/queued/messagesErrored normalisation: accepted 6 / 15
application hosts after framework filter: Cloud API, EMR Source, FHIR Transform, Lab Router
```

Three independent mismatches: `name` vs `host` (Q9), `messagesErrored` vs `errored` (Q8), `queued: null` against a finite-number guard (Q2).

**The guard log-and-skips per host, which is the right design — but when the mismatch is in a field every host shares, "skip the bad entry" becomes "report zero hosts"**, and the dashboard shows an empty grid with no error anywhere. A per-entry guard cannot degrade gracefully against a whole-payload mismatch. Worth noting for the class of bug, not just this instance.

Two further live-mode breaks the mock cannot show (§5.2): the client requests **`/api/metrics`** (real route is `/proxy/metrics` → `404`), and reads `alerts` from the metrics payload where they never appear — alerts are a **separate endpoint**, so `system_alert` can never fire live. Both pass typecheck and all unit tests. This is ADR 0004's named cost landing a second time: `mockClient.ts` reads fixtures written to the engine's own assumed shape, so mocking against them proves self-consistency and nothing else.

**All the reconciliation is my side to do, in a follow-up PR.** The proxy's shape is verified against live IRIS, and `contracts/` is not edited to make a consumer compile.

## Two decisions needed — flagging, not deciding

### `queued: null` vs `queued: 0` (§6.1)

The proxy emits `null`; the engine's guard requires a finite number and **rejects the whole host** on seeing it. Both sides are defensible, which is why I have not picked one silently:

- **`null` is honest.** `src/parser.test.js` pins it: *"`queued: 0` per host would assert every host is drained while 14 sit somewhere."*
- **The finite-number guard is also right.** A rule cannot compare `null` to a baseline, and `0` at least keeps the host visible so its other seven metrics can be evaluated.

**Contract position: `0` is the conformant placeholder.** The schema permits `null` because that is what the running code emits — a schema that rejected it would be a fiction.

**Recommended fix, one line, engine side:** accept `null` for `queued` and have `queue_buildup` skip a host whose depth is unmeasurable, the way comparative rules already skip a warming baseline. That preserves the absent-is-not-zero invariant the rest of the payload depends on, instead of carving out an exception for the one field where it is inconvenient. Rejecting the whole host is the worst of the three options — it loses `status`, `messagesPerSec` and everything else over one unmeasurable field.

@tanifgit — your number from #16 still stands and is worth restating: `absoluteFloor: 50`, captured depth `48`, so **the rule will not trip even once this is wired up.** "Returning real numbers" and "the finding fires" are separate milestones.

### `errored` vs `messagesErrored` (§6.2)

Raised on #16. **Recommendation: `errored`.** The tie-break is blast radius, not aesthetics:

- `errored` costs **one line** in `services/detection-engine/src/types/proxy.ts` and its guard.
- `messagesErrored` costs that **plus a change to a ratified contract with a live consumer** — `healthscan-api.md`, its schema, its `.d.ts`, two samples, and Dev C's components — for a naming preference.

Per `contracts/README.md`: the question is not how many lines reference a value but whether anything *means* something in terms of it. `errored` already means something downstream. Published as `errored` because that is what the code emits — **a request for a decision, not a decision.**

## Verification

`npm run validate` — 31 checks, up from 11. Nothing existing changed:

```
$ cd contracts && npm run validate
ok    samples/hosts-response.json against HostsResponse
ok    samples/findings-response.json against FindingsResponse
ok    accepts: empty hosts array
ok    accepts: empty findings array
ok    accepts: JS toISOString() milliseconds
ok    accepts: Python isoformat() microseconds
ok    rejects: retired "Warning" host status
ok    rejects: hosts array served in the findings position
ok    rejects: timestamp with no timezone
ok    rejects: unknown finding type
ok    rejects: baselineValue as a string
ok    proxy accepts: real Lab Router host, nulls included
ok    proxy accepts: warming metrics response (200, not 503)
ok    proxy accepts: real metrics response
ok    proxy accepts: real alert, severity as the numeric string IRIS emits
ok    proxy accepts: health reporting a reachable instance with no interop metrics
ok    proxy rejects: status "Active" — not in the IRIS enum
ok    proxy rejects: type "actor" — must be normalized to process
ok    proxy rejects: lastActivity with an offset instead of Z
ok    proxy rejects: null host name
ok    proxy rejects: metrics response with no _meta
ok    proxy rejects: alerts response served in the metrics position
ok    proxy rejects: engine-shaped host: `name` instead of `host`
ok    proxy rejects: engine-shaped host: `messagesErrored` instead of `errored`
ok    metrics-dump.txt: host label is `host`, with spaces
ok    metrics-dump.txt: status is a label, and reads OK
ok    metrics-dump.txt: last_activity is elapsed seconds
ok    metrics-dump.txt: hosttype rides on avg_processing_time as `actor`
ok    metrics-dump.txt: sample_count is its own family, per (host, messagetype)
ok    metrics-dump.txt: queued carries NO host label (§6.1)
ok    metrics-dump.txt: messages_errored carries NO host label (§6.3)

all checks passed (2 samples, 9 accept, 13 reject, 7 capture claims)
```

The last seven are `CAPTURE_CLAIMS`: `metrics-dump.txt` is Prometheus text and cannot be schema-checked, so these are regexes over the label shapes the contract quotes. **Two of them assert a label is *absent*** — an assertion that something is missing is the only way a future capture silently gaining it gets noticed.

Two must-reject cases are the engine's *current* shape. If §6.2 is settled the other way those checks fail and say so, which is why they are there rather than in a comment.

### Proving the validator can fail

A validator that never fails is worthless, so I broke it three ways on purpose:

```
=== A: add 'Active' to the status enum (a wrong schema) ===
FAIL  proxy rejects: status "Active" — not in the IRIS enum
1 check(s) failed

=== B: narrow NullableCount to `integer` (schema disagrees with real output) ===
FAIL  proxy accepts: real Lab Router host, nulls included
FAIL  proxy accepts: warming metrics response (200, not 503)
FAIL  proxy accepts: real metrics response
3 check(s) failed

=== C: strip the messages_errored line from the capture ===
FAIL  metrics-dump.txt: messages_errored carries NO host label (§6.3)
1 check(s) failed
```

All three restored; suite green again.

### Throwaway ajv script (not committed)

Validated the schema against the snapshot the **real parser** produces from the **real capture**, plus the three live HTTP payloads captured by `curl` from the real proxy. 32/32, with 27 reject cases:

```
ok    REAL snapshot from samples/metrics-dump.txt (15 hosts) against MetricsResponse
ok    all 15 real hosts individually against ProxyHost
ok    live /proxy/metrics warming payload
ok    live /proxy/alerts warming payload
ok    live /proxy/alerts payload (2 real alerts, severity "2")
ok    live /proxy/health status=starting
ok    live /proxy/health status=ok
ok    live /proxy/health status=reachable-but-no-interop
ok    rejects: bad status enum ("Active" — does not exist in IRIS)
ok    rejects: bad status enum ("Warning" — retired in PR #3)
ok    rejects: bad type enum ("actor" — must be normalized to process)
ok    rejects: null where a string is required (host)
ok    rejects: string where a number is required (messagesPerSec)
ok    rejects: missing required field (host)
ok    rejects: missing required field (isFramework)
ok    rejects: missing required field (lastActivityElapsedSeconds)
ok    rejects: wrong timestamp format (space instead of T, no Z)
ok    rejects: timestamp with an offset instead of Z
ok    rejects: negative cumulative count (messages)
ok    rejects: non-integer cumulative count (messages)
ok    rejects: engine-shaped host: `name` instead of `host`
ok    rejects: engine-shaped host: `messagesErrored` instead of `errored`
ok    rejects: unknown extra field (additionalProperties: false)
ok    rejects: metrics response with hosts as an object, not an array
ok    rejects: alerts response served in the metrics position
ok    rejects: metrics response served in the alerts position
ok    rejects: alert severity as a number, not a numeric string
ok    rejects: null where a number is required (health uptime)
ok    rejects: null where a boolean is required (isFramework)
...
all passed (27 reject cases)
```

### The live endpoint capture

The real proxy against a stub IRIS serving `metrics-dump.txt`. This is where the endpoint behaviour in §1–§4 comes from:

```
$ curl -s http://localhost:3011/proxy/metrics   # application hosts only
{ "host": "Lab Router", "type": "process", "status": "OK", "isFramework": false,
  "queued": null, "messages": 126, "messagesPerSec": 1.2, "errored": null,
  "avgProcessingTime": 0.08, "avgQueueingTime": 0,
  "lastActivity": "2026-08-12T08:45:25.399Z", "lastActivityElapsedSeconds": 4.838 }
_meta: { production: "LABDEMO.Production", productionQueued: 0,
         absentFamilies: [], hostCount: 15, applicationHostCount: 4 }

$ curl -s http://localhost:3011/proxy/health
{"status":"ok","uptime":3.75,"lastPoll":"2026-08-12T08:45:30.237Z",
 "production":"LABDEMO.Production","hostCount":15,"applicationHostCount":4}

# warming — 200 with warming:true, NOT 503. Confirmed by pointing at a dead port.
$ curl -s -w ' <- HTTP %{http_code}' http://localhost:3012/proxy/metrics
{"hosts":[],"systemAlertsNew":null,"warming":true,"_meta":{"polledAt":null}} <- HTTP 200
$ curl -s -w ' <- HTTP %{http_code}' http://localhost:3012/proxy/health
{"status":"starting","uptime":2.31,"lastPoll":null} <- HTTP 200

# the %SYS case, reproduced by serving a body with the iris_interop_* lines stripped
$ curl -s http://localhost:3013/proxy/health
{"status":"reachable, but no interop metrics", ..., "hint":"IRIS answered but sent no
 iris_interop_* families. Usual cause is a wrong IRIS_BASE_PATH ..."}

# no CORS headers on /proxy/metrics — documented in §4
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
```

### Proxy tests untouched

```
$ cd services/metrics-proxy && npm test
ℹ tests 71 / suites 14 / pass 71 / fail 0
```

No proxy code was modified — this is a `contracts/`-only PR.

## What I could not verify

Stated plainly rather than asserted:

- **No live IRIS was available to me.** Everything is against `metrics-dump.txt` and `fixtures/`, served by a local stub. The captures are real; the *instance* was not live during this work. The `%SYS`/`IRIS_BASE_PATH` behaviour in §3 is reproduced from a stripped body and quoted from Dev A's 2026-08-11 measurement, not re-measured.
- **The alerts payload shape rests on a single capture** (`fixtures/alerts-live-capture.json`), obtained by accident on a first-ever read of a consume-on-read endpoint. `ProxyAlert` therefore leaves `additionalProperties` **open** and does not pattern-constrain `time`. `_meta.shape` is the field that makes a wrong guess loud rather than silent.
- **`Ens.Util.Statistics:EnumerateHostStatus` was not run.** The `Cloud API = 48` figure and the claim that it returns per-host error counts as well as queue depth are quoted from #12 and #10, not reproduced here.
- **The `Retry`, `Stopped`, `Unconfigured`, `Disabled` statuses do not appear in any capture** — all 15 hosts read `OK`. The enum is from IRIS source via #10, and `Unknown` is the only value I observed the proxy generate itself. Consumers should keep rendering unrecognized statuses neutrally.
- **`samples/alerts.json` and `samples/proxy-response.json`** are named in `CONTRIBUTING.md` §1 and still do not exist. Both are derivable without inventing anything, but generating them is a judgement call about what "the" canonical alerts sample is, so I noted the gap in `README.md` rather than filling it unilaterally.

## Review notes

CODEOWNERS requires all three on `contracts/`. @tanifgit requested — Q1/Q7 touch the status enum you paid 83 insertions for, and the `queued` decision affects your grid. Dev A's slot has no active reviewer.

Nothing outside `contracts/` is touched, so the `detection-engine` and `dashboard` CI jobs are unaffected. The follow-up reconciliation (`/api/metrics` → `/proxy/metrics`, `name` → `host`, `messagesErrored` → `errored`, the `queued` guard, and the alerts fetch) is a separate PR in my own area — it should not ride along with a contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
