### PR TITLE
chore: reassign Dev A's areas to Dev B and drop the stale three-way gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,11 @@
 # means reviews are NOT requested for that path. Verify a handle resolves before
 # trusting it -- a typo here looks identical to working config.
 
-# ---- Dev A -- IRIS and metrics ingestion ----
-/iris/                        @kskubach
-/services/metrics-proxy/      @kskubach
+# ---- IRIS and metrics ingestion ----
+# Dev A's former area. Dev A moved off the project 2026-08-12 and Dev B took over their
+# outstanding tasks (#36, #38), so these are Dev B's now.
+/iris/                        @Ari-Glikman
+/services/metrics-proxy/      @Ari-Glikman
 
 # ---- Dev B -- detection engine and findings API ----
 /services/detection-engine/   @Ari-Glikman
@@ -16,21 +18,26 @@
 /docs/demo/                   @tanifgit
 
 # ---- Shared, PR-gated ----
-# A contract change needs all three. That sounds heavy and is the point: a silent
-# contract change is the failure mode that breaks the Day-5 integration, and the
-# review takes 30 seconds.
-/contracts/                   @kskubach @Ari-Glikman @tanifgit
+# A contract change needs EVERY remaining developer -- two since 2026-08-12, three before
+# that. The count is not the point; requiring someone other than the author is. A silent
+# contract change is the failure mode that breaks the Day-5 integration, and the review
+# takes 30 seconds.
+#
+# Note this now means a contract PR cannot be self-approved: GitHub refuses to let an
+# author approve their own PR, so with two developers the gate is exactly "the other
+# person looked at it".
+/contracts/                   @Ari-Glikman @tanifgit
 
 # ADRs record decisions nobody should change unilaterally.
-/docs/decisions/              @kskubach @Ari-Glikman @tanifgit
+/docs/decisions/              @Ari-Glikman @tanifgit
 
 # Root config, tooling, CI.
-/tools/                       @kskubach @Ari-Glikman @tanifgit
-/.github/                     @kskubach @Ari-Glikman @tanifgit
+/tools/                       @Ari-Glikman @tanifgit
+/.github/                     @Ari-Glikman @tanifgit
 
 # Source material is read-only after Day 1 -- any change here wants three pairs of eyes.
-/docs/production-guardian-healthscan-mvp1.docx  @kskubach @Ari-Glikman @tanifgit
-/docs/production-guardian-demo.html             @kskubach @Ari-Glikman @tanifgit
+/docs/production-guardian-healthscan-mvp1.docx  @Ari-Glikman @tanifgit
+/docs/production-guardian-demo.html             @Ari-Glikman @tanifgit
 
 # Catch-all for anything not matched above.
-*                             @kskubach @Ari-Glikman @tanifgit
+*                             @Ari-Glikman @tanifgit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
 # CLAUDE.md — Production Guardian (shared rules)
 
-Rules that apply to **all three developers**. Deep, area-specific instructions live in the nearest `CLAUDE.md` to the files being edited:
+Rules that apply to **every developer**. Deep, area-specific instructions live in the nearest `CLAUDE.md` to the files being edited:
 
 | Area | File |
 |---|---|
 | Dashboard / UI (Dev C) | `apps/dashboard/CLAUDE.md` |
 | Detection engine + findings API (Dev B) | `services/detection-engine/CLAUDE.md` |
-| Metrics proxy (Dev A) | `services/metrics-proxy/CLAUDE.md` |
-| IRIS, LABDEMO, triggers (Dev A) | `iris/CLAUDE.md` |
+| Metrics proxy (Dev B, was Dev A) | `services/metrics-proxy/CLAUDE.md` |
+| IRIS, LABDEMO, triggers (Dev B, was Dev A) | `iris/CLAUDE.md` |
 
-**Keep this file stable.** Every edit here is a merge conflict for the other two developers. Area-specific rules belong in an area file, not here.
+**Keep this file stable.** Every edit here is a merge conflict for everyone else. Area-specific rules belong in an area file, not here.
 
 ---
 
@@ -46,7 +46,7 @@ Also out: historical trend charts, multi-production support (single production o
 
 | Path | Owner |
 |---|---|
-| `iris/**`, `services/metrics-proxy/**` | Dev A |
+| `iris/**`, `services/metrics-proxy/**` | Dev B (was Dev A) |
 | `services/detection-engine/**` | Dev B |
 | `apps/dashboard/**`, `docs/demo/**` | Dev C |
 | `contracts/**` | see §4 — **nobody edits without a PR** |
@@ -63,13 +63,13 @@ Full explanation and rationale: `CONTRIBUTING.md`.
 
 - **Never edit a file in `contracts/`** as part of an implementation task.
 - Never add a field to a local type to make code compile — that is a **contract change request** to the owning developer.
-- A contract change is its own PR, with a `contracts/CHANGELOG.md` entry, reviewed by all three developers.
+- A contract change is its own PR, with a `contracts/CHANGELOG.md` entry, reviewed by **every other developer**. Two remain since 2026-08-12 (Dev A moved off; Dev B took their areas), so in practice that is one other person — and GitHub will not let an author approve their own PR, which is the point.
 
 ## 5. Ports and conventions
 
 | Service | Port | Owner |
 |---|---|---|
-| Metrics proxy | `3001` | Dev A |
+| Metrics proxy | `3001` | Dev B (was Dev A) |
 | Findings API (`/api/healthscan/*`) | `3002` | Dev B |
 | Dashboard dev server | `5173` | Dev C |
 
@@ -77,7 +77,7 @@ Branches: `devA/…`, `devB/…`, `devC/…`. Commit subjects scoped to the area
 
 ## 6. Working rules for Claude Code
 
-- **Never invent data.** No placeholder hosts, no fabricated metrics or findings outside a declared fixtures directory. Demo data uses the four LABDEMO components (EMR Source, Lab Router, FHIR Transform, Cloud API) and the eight real finding types.
+- **Never invent data.** No placeholder hosts, no fabricated metrics or findings outside a declared fixtures directory. Demo data uses the LABDEMO application components and the eight real finding types. The authoritative host list is the `<Item>` set in `iris/labdemo/Production.cls` — do not restate it, because a copied host list is what went stale when `FHIR Transform` was removed.
 - **Mock-first is the plan, not a fallback.** Dev B builds against a mock of Dev A's proxy; Dev C builds against a mock of Dev B's findings API. Never block on another developer's service being up.
 - **No new dependencies** without stating why and what it replaces.
 - **Match the surrounding code** — same naming, file shape, and comment density. Comment the non-obvious, not the obvious.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,21 @@ Three Claude Code sessions can run concurrently against this tree without touchi
 
 ## 2. Ownership map
 
+> **Team change, 2026-08-12.** Dev A moved off the project and Dev B took over their
+> outstanding tasks and their two areas (`iris/**`, `services/metrics-proxy/**`,
+> `contracts/proxy-*`). Two developers remain. Where this file says "all three" it now means
+> **every remaining developer** — the count was never the point; requiring someone other than
+> the author is. GitHub will not let an author approve their own PR, so with two people the
+> gate is exactly "the other person looked at it". Prose elsewhere describing the original
+> three-way split is left as written, because it records how the project was structured.
+
+
 | Path | Owner | Everyone else |
 |---|---|---|
-| `iris/**`, `services/metrics-proxy/**` | Dev A | read-only |
+| `iris/**`, `services/metrics-proxy/**` | Dev B (was Dev A) | read-only |
 | `services/detection-engine/**` | Dev B | read-only |
 | `apps/dashboard/**`, `docs/demo/**` | Dev C | read-only |
-| `contracts/proxy-*` | Dev A | read + PR |
+| `contracts/proxy-*` | Dev B (was Dev A) | read + PR |
 | `contracts/healthscan-*` | Dev B | read + PR |
 | `contracts/samples/**` | producer of each file | read-only |
 | `tools/**`, root config, `.github/**` | shared | PR + one review |


### PR DESCRIPTION
Closes #38.

## Confirming, since you asked rather than assumed

> reassigning `/iris/` and `/services/metrics-proxy/` to you should be your call to confirm, not mine to assume from a PR description

Right call, and: **confirmed.** `/iris/`, `/services/metrics-proxy/` and `contracts/proxy-*` are Dev B's. Dev A moved off on 2026-08-12 and we took over their outstanding tasks — #29, #30, #36 and the ADR 0004 tick were all that work.

Taking **both** your options, since they aren't exclusive.

## 1. CODEOWNERS — `@kskubach` off all 10 lines

Five shared lines become `@Ari-Glikman @tanifgit`; the two former Dev A areas become `@Ari-Glikman`.

Your framing of the urgency is what made this worth doing now rather than later: per #11, **an unresolvable owner invalidates the entire rule line including valid co-owners.** So the moment their push access is revoked, `/contracts/`, `/docs/decisions/`, `/tools/`, `/.github/` and the `*` catch-all would all request nobody — #11's bug in reverse, with the warning already written at the top of the file we'd be breaking.

`/contracts/` losing its gate is the one that matters, and #11 exists precisely because that gate was once requesting nobody without anyone noticing.

```
$ gh api repos/.../codeowners/errors?ref=main --jq '.errors|length'
0
```

## 2. The doc sentence — and I went slightly further

"all three developers" → **"every remaining developer"** in root `CLAUDE.md` §4 and `CONTRIBUTING.md` §2, with a dated team-change note in the ownership map.

Your point that "all three" reads stale to anyone joining later is right, and I've recorded the thing I think a newcomer would actually wonder — whether the gate still means anything with two people:

> GitHub will not let an author approve their own PR, so with two people the gate is exactly "the other person looked at it".

That's the honest version. The count was never the point; requiring someone other than the author is.

**Historical prose describing the original three-way split is left as written** — `CONTRIBUTING.md` §4's rationale, the §1 tree comments, ADR 0004's evidence. It records how the project was structured, and rewriting it would erase the reason the `contracts/` mechanism exists at all.

## One thing found while editing

Root `CLAUDE.md` §6 still named "the four LABDEMO components (EMR Source, Lab Router, FHIR Transform, Cloud API)" — `FHIR Transform` left the production in #14. It now points at `iris/labdemo/Production.cls` as authoritative instead of restating the list.

That's the **fifth** time a copied host list has gone stale (contract samples, engine fixtures, dashboard fixtures, the CI count, and now this), which rather makes your #25 point about frozen copies for the last time.

Refs #38, #11, #36, #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
