### PR TITLE
fix(iris): PatientDispatcher never returned valid JSON on any route

### DIFF
--- a/iris/labdemo/REST/PatientDispatcher.cls
+++ b/iris/labdemo/REST/PatientDispatcher.cls
@@ -171,18 +171,32 @@ ClassMethod RecordToDynamic(rec As ProductionGuardian.LabDemo.Data.PatientRecord
 }
 
 /// Write a %DynamicObject as the response body.
+/// 
+/// `%ToJSON()` takes NO argument on purpose: with none it writes to the current device,
+/// which inside a %CSP.REST request is the CSP output stream. The obvious-looking
+/// `%ToJSON(%response.Output)` fails at runtime — %CSP.Response has no `Output` property
+/// on IRIS 2026.1 — so every route through here returned HTTP 500. Verified:
+/// `##class(%Dictionary.CompiledProperty).%ExistsId("%CSP.Response||Output")` is 0.
+/// It compiles cleanly either way, which is why nothing caught it until an endpoint was
+/// actually called (#37).
 ClassMethod WriteJSON(dyn As %DynamicObject) [ Private ]
 {
     set %response.ContentType = "application/json"
-    do dyn.%ToJSON(%response.Output)
+    do dyn.%ToJSON()
 }
 
 /// Write a JSON error response.
+/// 
+/// `write {...}` on a JSON literal emits an OREF, not JSON — measured output was
+/// `24616@%Library.DynamicObject`. A dynamic object has to be serialized explicitly;
+/// `write` on it stringifies the reference. So error bodies were unparseable even on the
+/// paths that did not 500.
 ClassMethod WriteErrorResponse(httpStatus As %Integer, message As %String) [ Private ]
 {
     set %response.Status = httpStatus _ " Error"
     set %response.ContentType = "application/json"
-    write {"error": (message)}
+    set err = {"error": (message)}
+    do err.%ToJSON()
 }
 
 }


### PR DESCRIPTION
Closes #37, which I filed while building the host-status endpoint (#36). **Two defects, not the one I filed** — I found the second while verifying the first.

## 1. `WriteJSON` returned HTTP 500 on all four routes

```objectscript
do dyn.%ToJSON(%response.Output)
```

`%CSP.Response` has no `Output` property on IRIS 2026.1. Verified rather than inferred:

```
##class(%Dictionary.CompiledProperty).%ExistsId("%CSP.Response||Output")  ->  0
```

`WriteJSON` is the sole response writer for **four routes** — GET by MRN (:89), POST (:109), `GET /count` (:120), `GET /patients` (:146) — so every JSON-returning route on this dispatcher 500'd. The class compiles cleanly either way, which is why nothing surfaced it until #36 copied the pattern and got a real 500 back from a live endpoint.

## 2. `WriteErrorResponse` emitted an OREF, not JSON

Not in the issue. Found while checking whether the error path shared the bug:

```objectscript
write {"error": (message)}
```

`write` on a dynamic object stringifies the *reference*. Measured on the live instance:

```
current:  24616@%Library.DynamicObject
correct:  {"error":"not found"}
```

So error bodies were unparseable **independently** of defect 1 — a client would receive an OREF string alongside an error status.

## Verified by calling, not compiling

A compile is not evidence that a REST route works — that's the whole lesson of this issue. So I compiled the corrected writers into a scratch namespace and called them:

```
SerializeObject -> {"patients":[],"offset":0,"limit":50}
SerializeError  -> {"error":"no such patient"}
```

Probe class deleted afterwards. **LABDEMO untouched** — no production changes, no settings changed, production still `Running`.

## Comments record the measurement, not just the fix

Both sites now say what failed and what was measured, so the obvious-looking `%ToJSON(%response.Output)` doesn't come back. It reads correct; that's the problem with it.

## The wider gap this keeps exposing

**Nothing in CI compiles or exercises `iris/**`.** This is the third defect in that directory found only by running something by hand — the DTL that never compiled (#29), and now both of these. I flagged it on #29 and it's still open.

That's the same shape as the other four we've fixed: a check that reports success while verifying nothing. Here the check simply doesn't exist, which is worse. I'd suggest a CI job that compiles `iris/**` against a container as a follow-up — happy to take it.

Refs #37, #36, #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
