### PR TITLE
fix(ci): npm test ran zero tests on Windows and exited 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,11 @@ jobs:
           # success -- verified: `fail 1` with a step exit code of 0. Same precedent as the
           # Compile step below.
           set -o pipefail
-          FILES=$(ls test/*.test.ts | wc -l)
+          # `|| true` AND 2>/dev/null: under -e + pipefail a no-match glob would abort the
+          # step at this line, so the explanatory branch below never runs and the operator
+          # sees a bare `ls: cannot access`. 2>/dev/null alone is NOT enough — ls still exits
+          # 2 and pipefail propagates it (checked). A guard should say why it failed.
+          FILES=$( { ls test/*.test.ts 2>/dev/null || true; } | wc -l )
           if [ "$FILES" -eq 0 ]; then echo "no test files found — refusing to report success"; exit 1; fi
           npm test 2>&1 | tee /tmp/engine-test.log
           # `ℹ tests N` is the spec reporter's summary line, which is the default on
@@ -281,7 +285,7 @@ jobs:
           if ! node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
             echo "metrics-proxy defines no test script — refusing to report success"; exit 1
           fi
-          FILES=$(ls src/*.test.js | wc -l)
+          FILES=$( { ls src/*.test.js 2>/dev/null || true; } | wc -l )   # see the detection-engine job
           if [ "$FILES" -eq 0 ]; then echo "no test files found"; exit 1; fi
           npm test 2>&1 | tee /tmp/proxy-test.log
           RAN=$(sed -n 's/^.*[[:space:]]tests \([0-9]\+\)$/\1/p' /tmp/proxy-test.log | head -1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,25 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: services/detection-engine
         run: npm run typecheck
+      # `node --test <glob>` exits 0 when the glob matches NOTHING, so a moved or renamed
+      # test directory would turn this job green while running zero tests -- the same
+      # failure mode as `npm test --if-present`, which this repo has now hit five times.
+      # Assert the count is non-zero and matches the files on disk before trusting the pass.
       - name: Test
         if: steps.guard.outputs.present == 'true'
         working-directory: services/detection-engine
-        run: npm test
+        run: |
+          FILES=$(ls test/*.test.ts | wc -l)
+          if [ "$FILES" -eq 0 ]; then echo "no test files found — refusing to report success"; exit 1; fi
+          npm test 2>&1 | tee /tmp/engine-test.log
+          # `ℹ tests N` is the spec reporter's summary line, which is the default on
+          # Node 22+. Anchoring on it rather than TAP's `# tests N`, which is not emitted.
+          RAN=$(sed -n 's/^.*[[:space:]]tests \([0-9]\+\)$/\1/p' /tmp/engine-test.log | head -1)
+          RAN=${RAN:-0}
+          echo "test files on disk: $FILES | tests executed: $RAN"
+          if [ "$RAN" -eq 0 ]; then
+            echo "npm test reported zero tests — the glob matched nothing"; exit 1
+          fi
       # ADR 0004 is a promise the engine must keep: it has to start and serve with
       # Dev A's proxy absent. If this step fails, mock-first is broken.
       #
@@ -248,9 +263,21 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
         run: npm run typecheck --if-present
+      # Same zero-test guard as the detection-engine job: `node --test <glob>` exits 0 on
+      # no match, so a renamed test file would leave this green having run nothing.
       - name: Test
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
         run: |
-          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then npm test
-          else echo "::warning::metrics-proxy defines no test script — nothing was verified"; fi
+          if ! node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            echo "metrics-proxy defines no test script — refusing to report success"; exit 1
+          fi
+          FILES=$(ls src/*.test.js | wc -l)
+          if [ "$FILES" -eq 0 ]; then echo "no test files found"; exit 1; fi
+          npm test 2>&1 | tee /tmp/proxy-test.log
+          RAN=$(sed -n 's/^.*[[:space:]]tests \([0-9]\+\)$/\1/p' /tmp/proxy-test.log | head -1)
+          RAN=${RAN:-0}
+          echo "test files on disk: $FILES | tests executed: $RAN"
+          if [ "$RAN" -eq 0 ]; then
+            echo "npm test reported zero tests — the glob matched nothing"; exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,19 @@ jobs:
       # `node --test <glob>` exits 0 when the glob matches NOTHING, so a moved or renamed
       # test directory would turn this job green while running zero tests -- the same
       # failure mode as `npm test --if-present`, which this repo has now hit five times.
-      # Assert the count is non-zero and matches the files on disk before trusting the pass.
+      # Assert a non-zero executed count before trusting the pass. FILES is printed for
+      # diagnosis, NOT compared to the count: a per-file test total is not a stable thing
+      # to assert, and a comment describing a check the code does not do is this same
+      # pattern one level up.
       - name: Test
         if: steps.guard.outputs.present == 'true'
         working-directory: services/detection-engine
         run: |
+          # REQUIRED before the `| tee`. Actions' default shell is `bash -e {0}` WITHOUT
+          # pipefail, so a pipeline takes tee's exit status and a failing suite reports
+          # success -- verified: `fail 1` with a step exit code of 0. Same precedent as the
+          # Compile step below.
+          set -o pipefail
           FILES=$(ls test/*.test.ts | wc -l)
           if [ "$FILES" -eq 0 ]; then echo "no test files found — refusing to report success"; exit 1; fi
           npm test 2>&1 | tee /tmp/engine-test.log
@@ -269,6 +277,7 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         working-directory: services/metrics-proxy
         run: |
+          set -o pipefail   # see the detection-engine Test step; tee would mask a failure
           if ! node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
             echo "metrics-proxy defines no test script — refusing to report success"; exit 1
           fi

--- a/services/detection-engine/package.json
+++ b/services/detection-engine/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "dev": "node --watch src/index.ts",
     "start": "node src/index.ts",
-    "test": "node --test test/*.test.ts"
+    "test": "node --test \"test/**/*.test.ts\""
   },
   "devDependencies": {
     "@types/node": "^20.14.0",

--- a/services/metrics-proxy/package.json
+++ b/services/metrics-proxy/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "mock": "node mock-server.js",
-    "test": "node --test src/parser.test.js src/alerts.test.js src/cache.test.js src/hoststatus.test.js src/poller.test.js",
+    "test": "node --test \"src/**/*.test.js\"",
     "smoke": "node smoke-test.js"
   },
   "dependencies": {


### PR DESCRIPTION
`npm test` in `services/detection-engine` **reports success while running nothing** on Windows. Found while running the suite locally during #46.

```
> node --test test/*.test.ts
Could not find '...\services\detection-engine\test\*.test.ts'
EXIT=0
```

The glob is expanded by the **shell**. Bash on the CI runner does it, so the job is green and this was invisible. cmd.exe doesn't, so the literal string reaches Node — which finds no files and exits 0.

Fifth instance of this pattern in the repo, after `npm test --if-present`, `-c ajv-formats`, the `@devA` CODEOWNERS placeholder, and `merged === hostCount`.

## The fix, and the bigger problem behind it

Quoting the glob hands expansion to Node's own matcher (Node 22+, which `engines` already requires), so it behaves the same on both platforms.

But that only fixes today's symptom. **A glob matching nothing is not an error to `node --test`:**

```
node --test "test/**/*.nope.ts"   ->  exit 0, zero tests
```

So renaming or moving `test/` would leave CI green having verified nothing. Both test jobs now assert a non-zero executed count before trusting the pass, anchored on the spec reporter's `tests N` summary.

## Two near-misses while writing the guard

Recording these because in each case the guard would have become the thing it exists to catch:

1. **I first anchored on TAP markers** (`# tests N`, `# Subtest:`). Node 22+ defaults to the **spec** reporter, which emits neither — the guard read zero on a perfectly healthy run and would have failed CI immediately. Caught by checking real output instead of assuming the format.

2. **`metrics-proxy` enumerated its five test files by name** rather than globbing. Correct today, and a new test file would have been skipped silently forever. Now globbed — same 99 tests, and future files are picked up.

## One deliberate behaviour change

The proxy's missing-test-script branch went from `::warning::` to a hard failure:

```diff
-  else echo "::warning::metrics-proxy defines no test script — nothing was verified"; fi
+  echo "metrics-proxy defines no test script — refusing to report success"; exit 1
```

A warning that nothing was verified isn't meaningfully different from not checking. Flagging it explicitly since it's someone else's original intent I'm overriding — say so if you'd rather keep it soft.

## Verification

```
detection-engine  149/149 pass, tsc --noEmit clean
metrics-proxy      99/99 pass
contracts          15 accept / 19 reject
```

Guard confirmed **both** ways: passes on a real run, fails on a no-match glob.

(149 here vs 156 on #46 — the difference is exactly the 7 tests #46 adds. This branch is off `main` deliberately, since it touches the shared workflow file and shouldn't wait on that review.)

## Local-run note

Node 20 supports neither type stripping nor `--test` globs. `engines` requires `>=22.18`; if `node` resolves to 20 the suite now fails outright rather than passing vacuously — the intended trade, but worth knowing if your PATH has both.

Refs #46
