### PR TITLE
test(detection-engine): pin that the wire keeps null where the schema allows it

### DIFF
--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -983,3 +983,77 @@ describe('no message ever stringifies a null (#51)', () => {
     assert.equal(finding.message, 'Cloud API is Disabled with 6 message(s) queued');
   });
 });
+
+/**
+ * The wire must carry `null` through for the two fields the schema declares nullable.
+ *
+ * This closes a hole @tanifgit found on #52: with the coercion RESTORED on `main`, all
+ * 167 tests still passed. Nothing defended the un-coerced wire, so `orZero()` could come
+ * back for `queued`/`errored` and no check would object — which is exactly how it survived
+ * past its justification in the first place (a test asserting "no nullable numerics"
+ * actively kept it alive until #51).
+ *
+ * A permitted-but-unexercised path decays. Their side now REQUIRES a fixture to render the
+ * em dash; this is the same requirement one layer up, on the producer.
+ *
+ * Scope is deliberate: only `queued` and `errored`. The schema still declares
+ * messagesPerSec, avgProcessingTime and avgQueueingTime as plain numbers, so coercing
+ * those is REQUIRED and asserted below — widening them is a contract PR, not a fix.
+ */
+describe('the published wire preserves null where the schema allows it (#52)', () => {
+  /** Every nullable proxy count absent — what an undescribed host looks like (#36). */
+  function unmeasured(overrides: Partial<ProxyHost> = {}): ProxyHost {
+    return proxyHost({
+      queued: null,
+      errored: null,
+      messagesPerSec: null,
+      avgProcessingTime: null,
+      avgQueueingTime: null,
+      ...overrides,
+    });
+  }
+
+  it('serves queued and errored as null, not 0', () => {
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), () => {});
+    engine.applyPoll(response([unmeasured()]), T0);
+
+    const [host] = engine.snapshot().hosts;
+    assert.ok(host !== undefined);
+    assert.equal(host.queued, null, 'a coerced 0 here is a confident lie about a real host');
+    assert.equal(host.errored, null, 'same for errored — absent is not "no errors"');
+  });
+
+  it('still coerces the three fields the schema declares as plain numbers', () => {
+    // The other half of the contract. If this fails, we are emitting null against a
+    // non-nullable field and Dev C's guard is entitled to reject the whole host (#32).
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), () => {});
+    engine.applyPoll(response([unmeasured()]), T0);
+
+    const [host] = engine.snapshot().hosts;
+    assert.ok(host !== undefined);
+    for (const field of ['messagesPerSec', 'avgProcessingTime', 'avgQueueingTime'] as const) {
+      assert.equal(
+        typeof host[field],
+        'number',
+        `Host.${field} is not nullable in the schema — widening it is a contracts/ PR`,
+      );
+    }
+  });
+
+  it('keeps a measured zero distinguishable from an absent count', () => {
+    // The distinction the whole of #49 turns on. If both render as 0 the dashboard cannot
+    // tell "nothing queued" from "depth unknown", which is what the em dash exists for.
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), () => {});
+    engine.applyPoll(
+      response([
+        proxyHost({ host: 'Measured', queued: 0, errored: 0 }),
+        unmeasured({ host: 'Unknown' }),
+      ]),
+      T0,
+    );
+
+    const byHost = new Map(engine.snapshot().hosts.map((h) => [h.host, h]));
+    assert.equal(byHost.get('Measured')?.queued, 0, 'a measured zero is a reading');
+    assert.equal(byHost.get('Unknown')?.queued, null, 'an absent count is not');
+  });
+});


### PR DESCRIPTION
The producer-side counterpart to #52, and it closes a hole @tanifgit found there.

## The hole

They noticed that removing `orZero` isn't the same as pinning its absence. Verified on `main` before writing anything:

```
=== with orZero RESTORED on main -- does anything fail? ===
tests 167 | pass 167 | fail 0
```

**Nothing defended the un-coerced wire.** The coercion could come back for `queued`/`errored` and no check would object — which is exactly how it survived past its justification the first time. A test asserting *"no nullable numerics"* actively kept it alive until #51 corrected it.

Their framing:

> A permitted-but-unexercised path decays the same way.

#52 makes the em dash **required** in a fixture. This is the same requirement one layer up, on the producer.

## Three tests

- `queued` and `errored` come out `null`, not `0`
- the **other three** fields are still coerced — the schema declares `messagesPerSec`, `avgProcessingTime` and `avgQueueingTime` as plain numbers, so emitting `null` there is what would entitle your guard to reject a whole host (#32). Widening them is a `contracts/` PR, not a fix, and this test says so
- a **measured `0`** stays distinguishable from an **absent count** — the distinction the whole of #49 turns on, and the reason the em dash exists at all

## Verified non-vacuous

Restored `orZero` and 2 of the 3 fail:

```
✖ serves queued and errored as null, not 0
  AssertionError: a coerced 0 here is a confident lie about a real host
✖ keeps a measured zero distinguishable from an absent count
  AssertionError: an absent count is not
```

`170/170`, `tsc --noEmit` clean.

Between this and #52, both directions of the nullable-wire contract are pinned. Neither was before, and the gap was invisible from either side alone — which is the argument for the reviewer being someone whose code consumes the output.

Refs #52, #49, #51, #35, #36
