### PR TITLE
docs(contracts): say which production metrics-dump.txt came from (#34)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,26 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-13 — sample-provenance caveat on `metrics-dump.txt` (Dev B)
+
+**Documentation only. No field added, removed or retyped; no schema change; every existing
+payload stays valid.** Recorded here because `contracts/` is edited by PR regardless of how
+small the change is, and because the thing being written down was load-bearing enough to cost
+a full diagnosis cycle.
+
+`samples/metrics-dump.txt` reports four application hosts, `samples/hosts-response.json`
+reports three, and that disagreement sits in the one directory whose purpose is that everybody
+mocks the same bytes. The reason is now stated in `proxy-api.md` §1: the sample was captured
+from **`LABDEMO.Production`, an unrelated production with its own class tree that does not
+exist in this repo** — not from a stale deployment of `iris/labdemo/Production.cls`, which was
+not compiled in the namespace at all until 2026-08-12.
+
+So the sample is authoritative for label *shapes* and metric *families*, and not for the
+roster. Requested by Dev C on #34, who also asked that the note say **different production**
+rather than *stale deployment*, since writing down the wrong reason is how a wrong conclusion
+gets re-derived later.
+
+
 ## 2026-08-12 — `_meta.hostStatus.undescribedHosts` added (Dev B)
 
 Adds one diagnostic field, no change to any host or finding field. Follows the same-day entry
@@ -404,10 +424,18 @@ Units confirmed empirically rather than assumed: Cloud API configured at 0.05s l
 Samples carry real measured values from the LABDEMO production, including a genuinely induced
 degraded state (Cloud API disabled → queue depth 48), not invented numbers.
 
-### Known gap, not a contract change
+### Known gap, not a contract change — CLOSED 2026-08-12
 
 `iris_interop_queued` carries no `host` label — it emits once per production. Per-host queue depth
 is available from `Ens.Util.Statistics:EnumerateHostStatus` (verified: `Cloud API = 48` while
 disabled), so `Host.queued` stays a required number. **This needs Dev A's proxy to read host
 status, not only the Prometheus metrics text.** Raised with Dev A separately; no contract impact
 if that holds.
+
+**Resolved, and one clause of it turned out wrong.** The proxy reads host status as of #12/#36,
+so per-host depth flows end to end. But "`Host.queued` stays a required number" did not hold:
+it is `["integer","null"]` since the 2026-08-12 entry above, because a host whose depth is not
+measurable must be distinguishable from one measuring zero. Still required — a null *value* is
+legal, an absent *key* is not. #31 confirmed the same per-production shape for
+`messages_errored`, re-verified 2026-08-12 against `ProductionGuardian.LabDemo.Production`
+with traffic flowing rather than only against the capture from an unrelated production.

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -24,6 +24,21 @@ roster. Requested by Dev C on #34, who also asked that the note say **different 
 rather than *stale deployment*, since writing down the wrong reason is how a wrong conclusion
 gets re-derived later.
 
+**The evidence is in the repo, not on an instance** — deliberately, since `contracts/` is read
+by whoever comes next and they will not have this instance. `metrics-dump.txt` carries
+`production="LABDEMO.Production"`; `Production.cls` has been
+`ProductionGuardian.LabDemo.Production` in every commit; and the sample's spaced host names
+coexist with `FHIR Transform`, a combination no commit of `Production.cls` produced, because
+FHIR Transform was removed *before* the rename to spaced names. Dev C established that chain
+on #55 and it is stronger than the compile-date reason this entry originally carried.
+
+For completeness, and cited rather than asserted: `LABDEMO.Production` was still present on the
+instance on 2026-08-13 (it is deliberately not deleted, #34 condition 4), and its items are
+`LABDEMO.Service.EMRSource`, `LABDEMO.Process.LabRouter`, `LABDEMO.Process.FHIRTransform`,
+`LABDEMO.Operation.CloudAPI`. That is an observation from `Ens.Config.Production`, not something
+derivable from this repo — which is why the note in `proxy-api.md` rests on the two repo facts
+instead.
+
 
 ## 2026-08-12 — `_meta.hostStatus.undescribedHosts` added (Dev B)
 
@@ -337,6 +352,17 @@ from the start.
 **Dev B's instance still runs the older production definition,** so a fresh capture there will show
 four hosts until it is reloaded from `iris/labdemo/`. That is expected and breaks nothing: an extra
 host is over-coverage, and the parser reads whatever `host` labels arrive.
+
+> **ATTRIBUTION SUPERSEDED 2026-08-13 — see the 2026-08-13 entry at the top.** The paragraph above
+> reads the four-host capture as *this* production, one version behind. It was a different
+> production: the sample's own label says `production="LABDEMO.Production"`, and
+> `iris/labdemo/Production.cls` has been `ProductionGuardian.LabDemo.Production` in every commit.
+> The sample's host names are also a combination this repo never produced — spaced names *and*
+> `FHIR Transform`, whereas here FHIR Transform only ever coexisted with **unspaced** names.
+>
+> The rest of this entry stands, including the part that matters most: the capture is **real, not
+> invented**. Only the "one version behind our own production" attribution is wrong. Left in place
+> rather than rewritten, because an entry that quietly changes its reasoning stops being a record.
 
 **Changes:**
 

--- a/contracts/proxy-api.md
+++ b/contracts/proxy-api.md
@@ -17,6 +17,23 @@ Shared fixture: `samples/metrics-dump.txt` — the raw IRIS `/api/monitor/metric
 snapshot in this document was derived from. Feed it to `src/parser.js` and you get the values
 quoted here.
 
+> **The sample's HOST ROSTER is not the part it is authoritative for.** `metrics-dump.txt` is a
+> real capture, and every label *shape* and metric *family* in it is canonical — that is what
+> this document is derived from and what your parser must handle. But its four application
+> hosts (`EMR Source`, `Lab Router`, `FHIR Transform`, `Cloud API`) come from
+> **`LABDEMO.Production` — a different production, with its own class tree
+> (`LABDEMO.Process.FHIRTransform`, …) that does not exist in this repo** (#34).
+>
+> It was never a stale deployment of `iris/labdemo/Production.cls`: that class was not
+> compiled in the namespace at all until 2026-08-12. So `_meta.applicationHostCount: 4` below
+> is a true reading of a production we do not ship, and it disagrees with
+> `samples/hosts-response.json`'s 3 for that reason and no other. **Neither is wrong.**
+>
+> `iris/labdemo/Production.cls` is authoritative for the roster, and
+> `services/metrics-proxy/fixtures/metrics-live-capture-3host.txt` is the first capture taken
+> from it. Do not derive a host count, or a claim about what LABDEMO has ever contained, from
+> this sample.
+
 **Published by Dev B on Dev A's behalf.** Dev A has moved to other work; this contract is derived
 from their merged code (`services/metrics-proxy/`) rather than authored alongside it, so it
 documents what the proxy *does* today, not an intent. Where the code and Dev B's engine disagree,

--- a/contracts/proxy-api.md
+++ b/contracts/proxy-api.md
@@ -20,14 +20,30 @@ quoted here.
 > **The sample's HOST ROSTER is not the part it is authoritative for.** `metrics-dump.txt` is a
 > real capture, and every label *shape* and metric *family* in it is canonical — that is what
 > this document is derived from and what your parser must handle. But its four application
-> hosts (`EMR Source`, `Lab Router`, `FHIR Transform`, `Cloud API`) come from
-> **`LABDEMO.Production` — a different production, with its own class tree
-> (`LABDEMO.Process.FHIRTransform`, …) that does not exist in this repo** (#34).
+> hosts come from a **different production**, whose class tree does not exist in this repo.
 >
-> It was never a stale deployment of `iris/labdemo/Production.cls`: that class was not
-> compiled in the namespace at all until 2026-08-12. So `_meta.applicationHostCount: 4` below
-> is a true reading of a production we do not ship, and it disagrees with
-> `samples/hosts-response.json`'s 3 for that reason and no other. **Neither is wrong.**
+> Two facts settle that from the repo alone, no instance access needed (#34):
+>
+> ```
+> $ grep -o 'production="[^"]*"' contracts/samples/metrics-dump.txt | sort -u
+> production="LABDEMO.Production"
+> ```
+>
+> `iris/labdemo/Production.cls` has been `Class ProductionGuardian.LabDemo.Production` in
+> **every commit of its history**, first commit included. And the sample's host names are a
+> combination this repo never produced: when a FHIR Transform item existed here the names were
+> **unspaced** (`EMRSource`, `LabRouter`, `FHIRTransform`), and the spaced names arrived only
+> *after* that item had been removed. The sample carries spaced names **and** `FHIR Transform`
+> together.
+>
+> So `_meta.applicationHostCount: 4` is a true reading of a production we do not ship, and it
+> disagrees with `samples/hosts-response.json`'s 3 for that reason and no other. **Neither is
+> wrong.**
+>
+> **What is NOT claimed:** that a FHIR Transform host was never ours. It was — as
+> `<Item Name="FHIRTransform">` from the first commit until `1801a50`, when the pipeline became
+> HL7→PID. The narrow, provable claim is that **this capture** did not come from this repo's
+> production.
 >
 > `iris/labdemo/Production.cls` is authoritative for the roster, and
 > `services/metrics-proxy/fixtures/metrics-live-capture-3host.txt` is the first capture taken


### PR DESCRIPTION
The last of your six conditions on #34. Kept out of #53 deliberately — `contracts/` gets its own PR per root `CLAUDE.md` §4, however small the change.

**Documentation only.** No field added, removed or retyped, no schema change, no sample touched:

```
contracts/CHANGELOG.md | 30 +++++++++++++++++++++++++++++-
contracts/proxy-api.md | 17 +++++++++++++++++
```

Every existing payload stays valid; `validate.mjs` passes unchanged at 15 accept / 19 reject / 7 capture claims.

## What it says

`samples/metrics-dump.txt` reports 4 application hosts and `samples/hosts-response.json` reports 3 — in the one directory whose entire purpose is that we mock identical bytes. `proxy-api.md` §1 now states why:

> The sample's **host roster** is not the part it is authoritative for. Its four application hosts come from **`LABDEMO.Production` — a different production, with its own class tree that does not exist in this repo.** It was never a stale deployment of `iris/labdemo/Production.cls`: that class was not compiled in the namespace at all until 2026-08-12.

So the sample is canonical for label *shapes* and metric *families*, and not for the roster. Both files were always correct, about different productions.

I took your wording point exactly — **"different production"**, not "stale deployment". My original §"Which way" on #34 asked for the wrong reason, and you were right that writing down the wrong reason is how a wrong conclusion gets re-derived in three months.

## One thing I also closed, because it was wrong rather than merely dated

The tail of `CHANGELOG.md` carried:

> `iris_interop_queued` carries no `host` label … **so `Host.queued` stays a required number.**

The first half held and #12/#36 resolved the gap. But **that clause did not**: `queued` is `["integer","null"]` since the 2026-08-12 entry, because a host whose depth is unmeasurable has to be distinguishable from one measuring zero (#49). Still *required* — a null **value** is legal, an absent **key** is not.

That's the third stale-premise note found this week, and it was sitting in the changelog whose job is recording why things are the way they are.

Also recorded that #31's per-production shape is now confirmed against `ProductionGuardian.LabDemo.Production` **with traffic flowing**, rather than resting only on the capture from the unrelated production — your condition 3, and you were right that it would have been a shame to close #31 on the weaker evidence.

## Review note

You're the only other reviewer, and GitHub won't let me approve my own PR — which is the point of the rule. Worth saying plainly that **nothing here changes behaviour**, so if you'd rather this waited until after the demo, it can; #53 doesn't depend on it. The reason I'd rather it landed now is that the sample and the note being out of step is exactly the kind of thing that costs someone a diagnosis cycle, and it just cost me one.

Refs #34, #31, #49, #12, #36
