### PR TITLE
docs(dashboard): drop a sample-provenance premise that is not mine to assert

### DIFF
--- a/apps/dashboard/fixtures/README.md
+++ b/apps/dashboard/fixtures/README.md
@@ -10,10 +10,12 @@ the screencast source (`apps/dashboard/CLAUDE.md` §5).
   (service), `Lab Router` (process), `Cloud API` (operation), per the `<Item>` set
   in `iris/labdemo/Production.cls`. **The rule is "no invented hosts", not "there
   are three"**: `FHIR Transform` was a fourth until `contracts/` PR #15 — a real
-  pass-through routing item that left the production when the pipeline became
-  HL7→PID, which made the samples older than the production rather than wrong. A
-  fixture is a frozen snapshot of one production and is expected to need editing
-  when that production changes; nothing in `src/` is (issue #25).
+  pass-through routing item, an `<Item>` in this production from the first commit
+  until `1801a50`, removed when the pipeline became HL7→PID. Why the shared
+  `contracts/` samples still show four hosts is a separate question, and not this
+  file's to answer — see #34 and #55, which is settling it. A fixture is a frozen
+  snapshot of one production and is expected to need editing when that production
+  changes; nothing in `src/` is (issue #25).
 - **Numbers are anchored to measured LABDEMO values, never invented** (issue #6).
   The healthy steady state is the capture Dev B re-measured over three samples:
   `EMR Source 0.2` msg/sec, `Lab Router 1.2`, `Cloud API 0.4`;


### PR DESCRIPTION
Found while reviewing #55. One clause in my own area asserted the premise that PR wrong-foots, so it goes now rather than after.

## The clause

`apps/dashboard/fixtures/README.md` explained the `contracts/` samples' fourth host like this:

> `FHIR Transform` was a fourth until `contracts/` PR #15 — a real pass-through routing item that left the production when the pipeline became HL7→PID, **which made the samples older than the production rather than wrong.**

That says the sample is an *earlier state of our production*. It is not. Verifiable from the repo with no instance access:

```
$ grep -o 'production="[^"]*"' contracts/samples/metrics-dump.txt | sort -u
production="LABDEMO.Production"
```

`iris/labdemo/Production.cls` has been `Class ProductionGuardian.LabDemo.Production` in **every commit of its history**, including the first (`71c38d0`). And the host-name spellings rule out any age of it: when `FHIR Transform` existed the items were unspaced (`EMRSource`, `LabRouter`, `FHIRTransform`, `CloudAPI`); the spaced names arrived at `4a34a5b` (2026-08-10 16:14), *after* `1801a50` (11:03) removed FHIR Transform. The sample carries **spaced names and `FHIR Transform` together** — a combination no commit of that class ever produced.

## What the note says now

Keeps the checkable half — it really was an `<Item>` here from the first commit until `1801a50` — and stops explaining a capture in `contracts/` that this file does not own:

> Why the shared `contracts/` samples still show four hosts is a separate question, and not this file's to answer — see #34 and #55, which is settling it.

I deliberately did **not** substitute #55's explanation. #55 is open and I've requested changes on exactly that wording, so copying its conclusion here would plant the same premise in a third file before it is settled — which is the failure mode, not the fix. A fixtures README explaining someone else's capture is how a wrong reason spreads.

## Verified

```
npm run validate:fixtures:strict   All fixtures match the published contract.
                                   All fixture findings are self-consistent and engine-emittable.
npm run typecheck                  clean
```

Docs only — no fixture data, no `src/`, no host list added. The three other `FHIR Transform` mentions in my area (`fixtures/README.md` on the duplicated-host-list lesson and the `growing_queue_wait` baseline's origin, `validate-fixture-claims.mjs:251`) are historical and still true, so they stay.

Third stale premise in this neighbourhood this week, after #48 and #50, and the same shape both times: the arithmetic was right and the scope of the sentence was not.

Refs #55, #34
