### PR TITLE
docs+fix: document and log the unattributed-alert gap (#61)

### DIFF
--- a/contracts/healthscan-api.md
+++ b/contracts/healthscan-api.md
@@ -95,7 +95,30 @@ Sorted `detectedAt` descending, severity as tiebreak (critical → warning → i
 | `slow_processing` | `iris_interop_avg_processing_time` | Avg processing time exceeds baseline by > X% |
 | `growing_queue_wait` | `iris_interop_avg_queueing_time` | Queue wait trending upward |
 | `throughput_drop` | `iris_interop_messages_per_sec` | Messages/sec falls below baseline |
-| `system_alert` | `/api/monitor/alerts` | New alert posted to alerts.log |
+| `system_alert` | `/api/monitor/alerts` | New alert posted to alerts.log **that names a configured host** — see below |
+
+> **`system_alert` surfaces the host-attributable SUBSET of the alert log, not the log (#61).**
+>
+> An alert is matched to a host by the **host name appearing in its message text**. An alert
+> that names no configured host produces **no finding at all** — it is not surfaced
+> unattributed, and nothing in either endpoint records that it was seen. Verified against five
+> realistic texts:
+>
+> | alert message | result |
+> |---|---|
+> | `Cloud API failed to send message` | **fires** |
+> | `Disk space for database IRIS/mgr/ is critically low` | silent |
+> | `License limit exceeded: 100 of 100 connections` | silent |
+> | `Journal file system is full` | silent |
+> | `WARNING: write daemon is falling behind` | silent |
+>
+> So instance-level alerts — disk, license, journal, write daemon — are **out of scope for
+> Health Scan MVP 1**, which reports per-host conditions. That is a deliberate limitation, not
+> an oversight: attributing them would require either a pseudo-host that corresponds to no
+> config item (breaking §2's "only application config items appear") or a production-level
+> findings channel, which is a new output shape and belongs to a later module. Recorded here
+> because a consumer cannot tell "no such alert" from "alert discarded" by reading the
+> endpoints, and would otherwise learn the difference only from `detect/engine.ts`.
 
 **Sustained breach.** Per MVP §6, a rule must breach on **2+ consecutive samples** before a
 finding is emitted. A single-sample spike produces nothing. This is why findings are stateful

--- a/services/detection-engine/CLAUDE.md
+++ b/services/detection-engine/CLAUDE.md
@@ -170,6 +170,38 @@ Do not "fix" this by lowering a warning band: reaching `info` would require lowe
 top risk. A quiet findings list is the point. `thresholds.json` carries the same note, and
 `test/scenario.test.ts` asserts `info` comes only from `system_alert`, so a drift fails loudly.
 
+### 5.2b `system_alert` only sees alerts that name a host
+
+An alert is matched to a host by **substring**: the host name must appear in the alert's
+message text (`detect/engine.ts`, `#evaluateAlerts`). An alert naming no configured host
+produces **no finding at all** — not an unattributed one, and nothing records that it was
+seen. Measured (#61):
+
+```
+Cloud API failed to send message                      -> FIRES
+Disk space for database IRIS/mgr/ is critically low   -> SILENT
+License limit exceeded: 100 of 100 connections        -> SILENT
+Journal file system is full                           -> SILENT
+WARNING: write daemon is falling behind               -> SILENT
+```
+
+**This is deliberate for MVP 1 and it is a real coverage limitation.** Instance-level alerts
+are the class an operator most wants surfaced, and Health Scan does not surface them. The two
+ways to change that both cost more than they are worth here: a synthetic `System` host would
+be an entry in the host array corresponding to no config item, which breaks the "only
+application config items appear" guarantee in `contracts/healthscan-api.md` §2 — the same
+invariant #34 was diagnosed against — and a production-level findings channel is a new output
+shape, i.e. Health Summary's job (root `CLAUDE.md` §2).
+
+**Do not "fix" this by loosening the match.** Matching more broadly means attributing an
+instance-wide condition to whichever host name happens to appear in the text, which is worse
+than silence: a confident wrong attribution rather than a known gap. If it is addressed later,
+the shape to reach for is a count of unattributed alerts in an existing `_meta` object, not a
+change to what a `Finding` is.
+
+The engine logs each unattributed alert once, so the gap is visible in operation rather than
+only in this file.
+
 ### 5.3 An alert is an event, not a sustained condition
 
 `system_alert` is exempt from the sustained-breach *suppression* that the other rules use, though

--- a/services/detection-engine/src/detect/engine.ts
+++ b/services/detection-engine/src/detect/engine.ts
@@ -54,6 +54,8 @@ export class DetectionEngine {
   #stale = false;
   /** Inert-override warnings already emitted, so the log is not repeated per poll. */
   #warnedOverrides = new Set<string>();
+  /** Unattributed alerts already logged, so a persistent one is reported once (#61). */
+  #loggedUnattributedAlerts = new Set<string>();
   readonly #log: (msg: string) => void;
 
   #config: ThresholdConfig;
@@ -178,9 +180,42 @@ export class DetectionEngine {
     }
 
     this.#warnInertOverrides(seenHosts);
+    this.#logUnattributedAlerts(response.alerts, seenHosts);
 
     this.#lastPollAt = now;
     this.#stale = false;
+  }
+
+  /**
+   * Log each alert that matches no configured host, once (#61).
+   *
+   * `system_alert` matches an alert to a host by the host name appearing in the message
+   * text, so an instance-level alert -- disk space, license limit, journal full -- produces
+   * NO finding at all. That is deliberate for MVP 1 (see CLAUDE.md §5.2b: the alternatives
+   * are a pseudo-host that breaks the "only config items appear" guarantee, or a
+   * production-level channel that belongs to Health Summary).
+   *
+   * But silently discarding it is worse than declining it: a consumer cannot tell "no such
+   * alert" from "alert dropped" by reading either endpoint. This makes the gap visible in
+   * operation for the cost of a log line, with no contract change.
+   *
+   * Keyed by alert time + message so a persistent alert logs once rather than every poll --
+   * the same reasoning as `#warnedOverrides`.
+   */
+  #logUnattributedAlerts(
+    alerts: readonly ProxyAlert[],
+    seenHosts: ReadonlySet<string>,
+  ): void {
+    for (const alert of alerts) {
+      if ([...seenHosts].some((host) => alert.message.includes(host))) continue;
+      const key = `${alert.time}|${alert.message}`;
+      if (this.#loggedUnattributedAlerts.has(key)) continue;
+      this.#loggedUnattributedAlerts.add(key);
+      this.#log(
+        `alert matches no configured host, so no finding is emitted for it ` +
+          `(severity ${alert.severity}): ${alert.message}`,
+      );
+    }
   }
 
   snapshot(): EngineSnapshot {

--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -1057,3 +1057,65 @@ describe('the published wire preserves null where the schema allows it (#52)', (
     assert.equal(byHost.get('Unknown')?.queued, null, 'an absent count is not');
   });
 });
+
+/**
+ * An alert matching no host is logged, not silently dropped (#61).
+ *
+ * `system_alert` matches by host name appearing in the message text, so instance-level
+ * alerts — disk space, license limit, journal full, write daemon — produce no finding at all.
+ * That limitation is deliberate for MVP 1 (CLAUDE.md §5.2b), but it must be visible: a
+ * consumer cannot tell "no such alert" from "alert discarded" by reading either endpoint.
+ *
+ * Raised by @tanifgit on #61, who noted they would have guessed such alerts appeared
+ * unattributed rather than not at all — which is the reason the gap has to be stated rather
+ * than merely accepted.
+ */
+describe('unattributed alerts are logged (#61)', () => {
+  function withAlert(message: string): ProxyResponse {
+    return {
+      ...response([proxyHost({ host: 'Cloud API' })]),
+      alerts: [{ time: '2026-08-06T15:59:00Z', severity: '1', message }],
+    };
+  }
+
+  it('logs an instance-level alert and emits no finding for it', () => {
+    const lines: string[] = [];
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), (m) => lines.push(m));
+    engine.applyPoll(withAlert('Journal file system is full'), T0);
+
+    assert.deepEqual(
+      engine.snapshot().findings.map((f) => f.type),
+      [],
+      'an alert naming no host must not produce a finding',
+    );
+    assert.equal(lines.length, 1, `expected one log line, got ${JSON.stringify(lines)}`);
+    assert.match(lines[0] ?? '', /matches no configured host/);
+    assert.match(lines[0] ?? '', /Journal file system is full/, 'the text must be quoted');
+  });
+
+  it('logs it ONCE, not every poll', () => {
+    // Same reasoning as #warnedOverrides: a persistent alert would otherwise fill the log.
+    const lines: string[] = [];
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), (m) => lines.push(m));
+    let at = T0;
+    for (let i = 0; i < 20; i += 1) {
+      engine.applyPoll(withAlert('License limit exceeded'), at);
+      at += POLL_MS;
+    }
+    assert.equal(lines.length, 1, `logged ${lines.length} times across 20 polls`);
+  });
+
+  it('does NOT log an alert that does name a host', () => {
+    // Otherwise the log would fire on exactly the alerts that work correctly.
+    const lines: string[] = [];
+    const engine = new DetectionEngine(structuredClone(DEFAULT_CONFIG), (m) => lines.push(m));
+    engine.applyPoll(withAlert('Cloud API failed to send message'), T0);
+    engine.applyPoll(withAlert('Cloud API failed to send message'), T0 + POLL_MS);
+
+    assert.deepEqual(lines, [], 'a host-attributable alert is handled, not reported as a gap');
+    assert.ok(
+      engine.snapshot().findings.some((f) => f.type === 'system_alert'),
+      'and it must still fire',
+    );
+  });
+});


### PR DESCRIPTION
Your option 4, in the two places you identified. And you argued against (1) and (3) better than I did — I'd framed (1) as "changes the roster and needs your rendering", which understates it.

## The argument I'd missed on (1)

> A pseudo-host is an entry in the host array that corresponds to no config item, which is exactly the thing three issues this week established the roster must not contain.

Right — and I verified both citations before accepting it:

```
healthscan-api.md:53   "...filtered out. For LABDEMO that means exactly three"
healthscan-api.md:138  Q8 | finding.host is always exactly a host.host value
```

Q8 would survive; §2's guarantee would not. That sentence is why `isFramework` filtering exists and what `_meta.applicationHostCount` counts — the invariant #34 was diagnosed against. Not a cost, an inconsistency.

## Documented in both places

**`contracts/healthscan-api.md`** — the row said *"New alert posted to alerts.log"*, which describes a rule that surfaces the log. It surfaces the host-attributable **subset**, and a consumer could only learn the difference from `engine.ts`. Now says so, with the five-text table. You're right that this is the one that would have prevented your wrong guess.

**`services/detection-engine/CLAUDE.md` §5.2b** — next to the info-severity note, where the semantics live for whoever edits the rule next. Includes an explicit *do not loosen the match*: matching more broadly attributes an instance-wide condition to whichever host name happens to appear in the text, which is a **confident wrong attribution rather than a known gap** — strictly worse.

## I had to implement the log line, because I'd already documented it

I wrote "the engine logs each unattributed alert once" into `CLAUDE.md` **before it did**. That's documentation asserting behaviour that doesn't exist — the exact defect this week keeps producing, and I caught it only because I went to check the sentence was true.

Implemented: `#evaluateAlerts` runs per-host so it can't tell that an alert matched *no* host; the check belongs in `applyPoll` after the host loop. Keyed by `time|message` so a persistent alert logs once, same reasoning as `#warnedOverrides`.

```
alert matches no configured host, so no finding is emitted for it (severity 1): Journal file system is full
```

Three tests: logs and emits no finding; logs **once** across 20 polls; and does **not** log an alert that does name a host — that last one matters, or the log would fire on exactly the alerts that work.

## Deliberately not touching FindingsResponse

You said don't, and I agree: it's a bare array, so adding `_meta` is a breaking change to both endpoints for a diagnostic, four days out. Your suggested shape for later — `unattributedCount` in the existing `AlertsMeta` — is one field in an object already built for this purpose, and is what I'd reach for if it's ever addressed.

```
173/173, tsc clean, contracts validate 15 accept / 19 reject unchanged
```

## On your closing point

> the run that fails first is the evidence, and it gets discarded once the second run succeeds

That's the sharpest statement of it yet, and it applies to this PR too — the log line exists because I went back to a sentence I'd written and asked whether it was true, rather than moving on once the docs read well. I'm taking it as: **when the first attempt produces nothing, ask what it proved before fixing the setup.**

Refs #61, #57, #56, #34
