### PR TITLE
feat(metrics-proxy): collect alerts when iris_system_alerts_new says to (#67)

### DIFF
--- a/services/metrics-proxy/src/cache.test.js
+++ b/services/metrics-proxy/src/cache.test.js
@@ -101,6 +101,52 @@ describe('alerts buffer — accumulation', () => {
   });
 });
 
+describe('alerts buffer — two concurrent readers (#69)', () => {
+  beforeEach(() => _resetForTests());
+
+  // #69 added a second caller of pollAlerts() -- the iris_system_alerts_new flag path --
+  // alongside the 30s interval. So two reads of a CONSUME-ON-READ endpoint can now overlap,
+  // and exactly one of them gets the alert while the other gets []. A change motivated by
+  // reducing races on that endpoint must not introduce one.
+  //
+  // WHAT ACTUALLY MAKES IT SAFE, having tested it: the buffer is APPEND-ONLY. `_alerts` is
+  // never reassigned by a read -- only pushed to, trimmed when over the cap, and cleared by
+  // _resetForTests(). So an empty read has nothing to clobber with.
+  //
+  // @tanifgit and I both identified `if (!snapshot.alerts.length) return;` as the
+  // load-bearing line. It is not: removing it leaves all 103 tests passing, because
+  // iterating an empty array is a no-op. It is an early-out, not a guard. Recording that
+  // because a comment naming the wrong protective mechanism is worse than none -- someone
+  // hardening this would preserve the return and feel safe, when the property to preserve is
+  // append-only.
+  it('keeps the alert whichever concurrent read lands second', () => {
+    setAlertsSnapshot(poll([{ message: 'Cloud API failed' }], '2026-08-13T10:00:00.000Z'));
+    setAlertsSnapshot(poll([], '2026-08-13T10:00:01.000Z'));
+    assert.equal(getAlertsSnapshot().alerts.length, 1, 'the empty read must not clobber it');
+
+    _resetForTests();
+
+    // And the other order, because "whichever lands second" is the whole claim.
+    setAlertsSnapshot(poll([], '2026-08-13T10:00:00.000Z'));
+    setAlertsSnapshot(poll([{ message: 'Cloud API failed' }], '2026-08-13T10:00:01.000Z'));
+    assert.equal(getAlertsSnapshot().alerts.length, 1, 'order must not matter');
+  });
+
+  it('newInLastPoll can briefly understate, while count does not', () => {
+    // The one cosmetic consequence: `_alertsSnapshot = snapshot` runs before the early
+    // return, so a racing empty read leaves newInLastPoll at 0 for one cycle even though
+    // the alert WAS collected. Pinned rather than fixed -- count comes from the buffer per
+    // the contract, so nothing user-visible is wrong, and #67's argument was partly about
+    // diagnostics being trustworthy, so the one field that can understate should be known.
+    setAlertsSnapshot(poll([{ message: 'Cloud API failed' }], '2026-08-13T10:00:00.000Z'));
+    setAlertsSnapshot(poll([], '2026-08-13T10:00:01.000Z'));
+
+    const out = getAlertsSnapshot();
+    assert.equal(out._meta.newInLastPoll, 0, 'understates for one cycle, by design');
+    assert.equal(out.alerts.length, 1, 'but the alert is there');
+  });
+});
+
 describe('alerts buffer — bounded growth', () => {
   beforeEach(() => _resetForTests());
 

--- a/services/metrics-proxy/src/poller.js
+++ b/services/metrics-proxy/src/poller.js
@@ -171,6 +171,30 @@ async function pollMetrics() {
 
     setMetricsSnapshot(snapshot);
 
+    // iris_system_alerts_new is a gauge on THIS endpoint saying whether alerts are waiting
+    // to be collected -- spec §1.3 names it as a source for system_alert alongside
+    // /api/monitor/alerts, and it was parsed but never acted on (#67).
+    //
+    // Collect NOW rather than waiting for the blind 30s tick. Two reasons:
+    //   1. latency -- system_alert was up to 30s behind the other seven finding types,
+    //      which #44's four-stage model did not account for at all
+    //   2. /api/monitor/alerts is CONSUME-ON-READ, so a blind poll touches a one-shot
+    //      resource twice a minute whether or not anything is there. Reading when the flag
+    //      says there is something narrows the window in which an SMP session or a stray
+    //      curl can steal an alert from us
+    //
+    // ADDITIVE, deliberately: the blind interval below is untouched. A missed flag
+    // transition then costs latency, not the alert -- whereas replacing the blind poll
+    // would make a missed transition mean the alert is never collected at all. Strictly
+    // more collection, never less (agreed with Dev C on #67).
+    if (snapshot.systemAlertsNew > 0) {
+      console.log(
+        `[poller] iris_system_alerts_new=${snapshot.systemAlertsNew} — collecting alerts now ` +
+        `instead of waiting up to ${ALERTS_INTERVAL}ms`
+      );
+      await pollAlerts();
+    }
+
     const hs = snapshot._meta.hostStatus;
     let suffix = '';
     if (!IRIS_HOSTSTATUS_PATH) {

--- a/services/metrics-proxy/src/poller.test.js
+++ b/services/metrics-proxy/src/poller.test.js
@@ -51,6 +51,45 @@ function requestedPath(basePath) {
  * something under IRIS_BASE_PATH, so which prefix applies to which URL is the thing
  * most likely to be got wrong and the least visible when it is.
  */
+/**
+ * One metrics cycle where the metrics body reports `iris_system_alerts_new = flagValue`.
+ * Returns every path requested, so a test can assert whether /api/monitor/alerts was
+ * collected within that cycle rather than left to the blind interval (#67).
+ */
+function pathsForAlertsFlag(flagValue) {
+  const script = `
+    const http = require('http');
+    const seen = [];
+    const server = http.createServer((req, res) => {
+      seen.push(req.url);
+      if (req.url.includes('hoststatus')) {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end(JSON.stringify({hosts: [], _meta: {productionState: 'Running'}}));
+      } else if (req.url.includes('alerts')) {
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end('[]');
+      } else {
+        res.writeHead(200, {'Content-Type': 'text/plain'});
+        res.end('iris_system_alerts_new ${flagValue}\\n');
+      }
+    });
+    server.listen(0, '127.0.0.1', async () => {
+      process.env.IRIS_HOST = '127.0.0.1';
+      process.env.IRIS_PORT = String(server.address().port);
+      const { pollMetrics } = require(${JSON.stringify(path.join(__dirname, "poller.js"))});
+      await pollMetrics();
+      process.stdout.write('<<<' + JSON.stringify(seen) + '>>>');
+      server.close();
+    });
+  `;
+  const out = execFileSync(process.execPath, ['-e', script], {
+    env: { ...process.env, IRIS_HOSTSTATUS_PATH: '' },
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  return JSON.parse(out.slice(out.indexOf('<<<') + 3, out.lastIndexOf('>>>')));
+}
+
 function requestedPathsForCycle(env) {
   // The result is fenced in a sentinel because the poller logs to stdout itself, and
   // reported exactly once after pollMetrics resolves — awaiting it is what guarantees
@@ -139,5 +178,30 @@ describe('IRIS_BASE_PATH', () => {
 
   it('ignores surrounding whitespace from a hand-edited .env', () => {
     assert.equal(requestedPath('  /iris4health_2024_1  '), '/iris4health_2024_1/api/monitor/metrics');
+  });
+});
+
+describe('iris_system_alerts_new triggers immediate alert collection (#67)', () => {
+  it('collects alerts within the metrics cycle when the flag is set', () => {
+    // Spec §1.3 names this gauge as a source for system_alert alongside the alerts
+    // endpoint. It was parsed and carried in the snapshot but never acted on, so
+    // system_alert lagged the other seven finding types by up to ALERTS_POLL_INTERVAL_MS
+    // (30s) — a term #44's four-stage latency model did not account for at all.
+    const paths = pathsForAlertsFlag(1);
+    assert.ok(
+      paths.some((p) => p.includes('/api/monitor/alerts')),
+      `expected the alerts endpoint to be collected in this cycle, saw ${JSON.stringify(paths)}`,
+    );
+  });
+
+  it('does NOT collect when the flag is zero', () => {
+    // The consumption half: /api/monitor/alerts is consume-on-read, so a poll when nothing
+    // is waiting is a needless touch of a one-shot resource — and a window in which an SMP
+    // session or a stray curl can steal an alert from the proxy.
+    const paths = pathsForAlertsFlag(0);
+    assert.ok(
+      !paths.some((p) => p.includes('/api/monitor/alerts')),
+      `expected no alerts request when nothing is waiting, saw ${JSON.stringify(paths)}`,
+    );
   });
 });


### PR DESCRIPTION
Closes #67, in the shape we agreed: **flag-gated poll added, blind 30s poll untouched.** Strictly more collection, never less.

The gauge was already parsed, tested and carried in the snapshot — it was simply never acted on. So this is wiring, not new parsing, which is smaller than I estimated when filing.

## Your framing was right about which half matters

> The consumption argument is the stronger half… the current design touches a one-shot resource **twice a minute, forever**, whether or not there is anything to collect.

Agreed, and it's the half with a test of its own — `does NOT collect when the flag is zero`. That's the assertion protecting the race window, and it would be easy to lose in a later refactor that made collection unconditional "for reliability".

## Verified live, and the honest evidence is the log

```
[poller] metrics: 12 hosts polled at 09:51:49.623Z
[poller] iris_system_alerts_new=1 — collecting alerts now instead of waiting up to 30000ms
```

Collection happened on the **very next metrics poll** after the alert appeared, not on the 30s tick.

**My wall-clock figure of 16.2s is not the improvement and I'm not quoting it.** It includes an MCP round trip of ~15s between stamping `t0` and the alert actually being written — the same trap that invalidated #44's first measurement. Fifth instance of that pattern today, and this time I caught it by decomposing before writing the number down rather than after.

## Your correction to #44's model is the part worth carrying

> Nothing in #44's four-stage model accounted for the alerts path at all — it treated every finding as coming from the metrics scrape. That is a real gap in the analysis and it was mine as much as anyone's.

It was more mine than yours — I built the four-stage table and I'd measured `system_alert` live twice without noticing it came down a different path. **Two paths with different stage counts** is the right way to say it, and with this landed they converge, so #44's model becomes true for all eight types rather than seven.

## And it resolves the demo tension you spotted

`Triggers.SystemAlert()` says *arm it last* because `Reset()` can't clear it — but a 30s wait for the only `info` finding made that impractical, so the workable order was arm it *first*. With this, arming it last costs a metrics poll rather than half a minute. I've left the "arm it last" note as it stands since it's still true, and the reason it's now cheap is in this PR.

## Verification

```
101/101 proxy tests, both new ones verified non-vacuous by removing the hook
engine and contracts untouched
```

Also characterised the gauge before relying on it: flips to `1` ~2s after an alert, stays `1` while unread, resets on read. My **first** probe concluded it didn't work — 3s wait, saw `0`, and the alert had reached the proxy anyway. Wrong conclusion from a real observation, corrected by re-running, which is the remedy you named on #67.

Refs #67, #44, #66, #57, spec §1.3
