### PR TITLE
docs: descope the screencast and cue sheet from MVP 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ production-guardian/
 │  ├─ production-guardian-healthscan-mvp1.docx
 │  ├─ decisions/                 # ADRs: the 4 open decisions from §7.4 of the MVP doc
 │  └─ demo/                      # ── DEV C ──  screencast, cue-sheet.md
+│                                #   DESCOPED from MVP 1 (2026-08-13); dir not created yet
 │
 └─ .github/
    ├─ CODEOWNERS                 # ★ mechanically enforces ownership, see §4

--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -328,7 +328,7 @@ plugins: [react(), viteSingleFile()]
 - `npm run build` → `dist/index.html`, a single self-contained file, demo mode by default.
 - Verify it by opening `dist/index.html` **directly from the filesystem** (not via a server). If it needs a server, the fallback has failed.
 - `docs/production-guardian-demo.html` stays as the belt-and-braces concept fallback. Do not modify it.
-- Deliver alongside: the **screencast** and the **presenter cue sheet** (`docs/demo/`), both explicitly on Dev C's task list.
+- The **screencast** and the **presenter cue sheet** (`docs/demo/`) are **descoped from MVP 1** — see §8. Demo mode itself is the deliverable; the artefacts describing it come later.
 
 ---
 
@@ -419,8 +419,13 @@ From §4.5 of the MVP plan, in order:
 | 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders every host the API returns, whatever the count, and all fixture findings; every state designed; `tsc` clean |
 | 2 | Live polling + demo/live toggle (`?mode=live`) | 0.75 d | Visible change reflected within 10 s; API failure degrades to last-good + banner, never blanks |
 | 3 | Finding detail view | 0.5 d | Click a finding → current vs. baseline, metric, timestamp; keyboard accessible; drawer survives polls |
-| 4 | Screencast + static fallback | 0.5 d | `dist/index.html` opens from `file://` in demo mode; screencast recorded |
-| 5 | Presenter cue sheet | 0.25 d | `docs/demo/cue-sheet.md` — click path, what to say, what to do if live mode dies |
+| 4 | Static fallback build | 0.5 d | `dist/index.html` opens from `file://` in demo mode |
+| ~~4b~~ | ~~Screencast~~ | — | **DESCOPED from MVP 1** — after MVP 1, see below |
+| ~~5~~ | ~~Presenter cue sheet~~ | — | **DESCOPED from MVP 1** — after MVP 1, see below |
+
+**Tasks 4b and 5 are descoped from MVP 1** (decided 2026-08-13). The screencast and `docs/demo/cue-sheet.md` are presentation artefacts, not product: neither is code, neither is verifiable by a test, and the screencast needs a human to record. Nothing in the *overall* acceptance below depends on either — the static fallback is what makes the demo survivable, and that is done.
+
+`docs/demo/` therefore does not exist and should not be created before MVP 1 closes. If a request asks for the cue sheet or the screencast, say it is descoped rather than building it — the same rule §1.1 applies to the later modules.
 
 **Overall acceptance (from the MVP doc):** *dashboard renders all hosts + findings live; updates within 10 s of a change; fallback to demo mode is seamless.*
 

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -3,10 +3,10 @@
 Operator-facing frontend for Production Guardian MVP 1. React 18 + Vite +
 TypeScript, no runtime dependencies beyond React itself.
 
-**Current state:** host grid, findings list, severity summary, finding detail
-drawer, live polling and a demo/live toggle — tasks 1–3 of `CLAUDE.md` §8, plus
-the static fallback build. Outstanding: the screencast and the presenter cue
-sheet, both of which need a human rather than code — see
+**Current state: MVP 1 complete.** Host grid, findings list, severity summary,
+finding detail drawer, live polling and a demo/live toggle — tasks 1–4 of
+`CLAUDE.md` §8, including the static fallback build. The screencast and the
+presenter cue sheet are **descoped from MVP 1** and will follow after it — see
 [Status by phase](#status-by-phase).
 
 ---
@@ -209,8 +209,13 @@ watching in the console.
 | 2 | Live polling, demo/live toggle, `ConnectionBanner`, last-good cache | **done** |
 | 3 | Finding detail drawer — current vs. baseline, metric, timestamp | **done** |
 | 4 | Static fallback build | **done** — `dist/index.html` opens from `file://` |
-| 4 | Screencast (needs a human to record) | not started |
-| 5 | `docs/demo/cue-sheet.md` | not started |
+| — | Screencast | **descoped from MVP 1** (2026-08-13) |
+| — | `docs/demo/cue-sheet.md` | **descoped from MVP 1** (2026-08-13) |
+
+Both are presentation artefacts rather than product, neither is verifiable by a
+test, and the screencast needs a human to record. Nothing in MVP 1's overall
+acceptance depends on either — the static fallback is what makes the demo
+survivable, and it is done. `docs/demo/` does not exist yet by design.
 
 Click any finding row to open the detail drawer: current vs. baseline side by
 side, the comparison between them, the underlying IRIS metric, and detected-at as


### PR DESCRIPTION
Decision from today: **the screencast and the presenter cue sheet are descoped from MVP 1.** This makes that clear in the repo, because it currently isn't — and the way I found out is the reason it needs writing down.

## Why it needed a PR rather than just doing it

Asked to settle the cue sheet, I found the repo and my own working notes disagreeing:

- `apps/dashboard/CLAUDE.md` §8 lists both as tasks 4 and 5 from MVP §4.5, and §6 says *"both explicitly on Dev C's task list"*
- `CONTRIBUTING.md` assigns me `docs/demo/`
- `README.md` had them as *"not started"*
- I had a note saying they were descoped — **and no record of that decision anywhere in the repo**

So the descope may well have been decided before and never written down, which is the same failure we have spent the week fixing in the other direction. Now it is recorded with a date, in the three places that carry scope.

## The reasoning, stated where it will be read

Both are **presentation artefacts, not product**: neither is code, neither is verifiable by a test, and the screencast needs a human to record. Nothing in MVP 1's overall acceptance depends on either — *"renders all hosts + findings live; updates within N s of a change; fallback to demo mode is seamless."* The thing that makes the demo survivable is the **static fallback**, and that is done and verified opening from `file://`.

`CLAUDE.md` §8 also now instructs future work to **refuse rather than build** if asked for them, the same way §1.1 handles the later modules. That is the part that stops this drifting back in.

## Deliberately not done

- **`docs/demo/` is not created.** An empty directory promising a deliverable is worse than its absence
- **ADR 0002's mention of the cue sheet is untouched.** It records what was believed when it was written, and rewriting an ADR to match a later decision is how a record stops being one — same reasoning as the `ATTRIBUTION SUPERSEDED` block in `contracts/CHANGELOG.md`
- **Forward references calling demo mode "the screencast source" are left as-is** — still true whenever the screencast happens, and they do not imply MVP 1 scope

## Your side

`CONTRIBUTING.md` is the shared file, so this needs your review by §3 regardless of size — one comment line on the `docs/demo/` tree entry. Everything else is `apps/dashboard/**`.

Verified: `tsc --noEmit` clean, `validate:fixtures:strict` passes. Docs only, no code touched.

**With this, `apps/dashboard/` is MVP 1 complete** — tasks 1 through 4, with the two descoped items recorded rather than outstanding. The one acceptance criterion still open across the project is the latency bar on #44, which is a decision rather than work.
