### PR TITLE
perf(metrics-proxy): 2500ms metrics poll — option 2 from #44

### DIFF
--- a/services/metrics-proxy/.env.example
+++ b/services/metrics-proxy/.env.example
@@ -49,7 +49,7 @@ IRIS_HOSTSTATUS_PATH=/labdemo/monitor/hoststatus
 # Halved from 10000 for #44: the engine cannot observe a change sooner than we do, so
 # this stage plus the engine's own poll plus its sustained-breach gap put the chain over
 # the MVP's "updates within 10s" bar. Raise it if the IRIS instance is under scrape load.
-METRICS_POLL_INTERVAL_MS=5000
+METRICS_POLL_INTERVAL_MS=2500
 
 # How often to poll /api/monitor/alerts (milliseconds). Default: 30000.
 ALERTS_POLL_INTERVAL_MS=30000

--- a/services/metrics-proxy/src/poller.js
+++ b/services/metrics-proxy/src/poller.js
@@ -48,11 +48,25 @@ function normalizeBasePath(raw) {
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
-// 5s, halved from 10s for #44's latency budget: the engine cannot see a change sooner
-// than we do, so this was one of the two 10s stages that put the chain over the 10s
-// acceptance bar. /api/monitor/metrics is a cheap read, so 2x the scrape rate is fine.
-// Alerts stay at 30s -- they are events with their own timestamps, not a sampled value.
-const METRICS_INTERVAL = parseInt(process.env.METRICS_POLL_INTERVAL_MS || '5000', 10);
+// 2500ms. Halved twice now for #44's latency budget -- 10s -> 5s -> 2.5s -- because this is
+// the only term in the four-stage chain gated by nothing but the IRIS scrape rate. The
+// engine's interval has a hard floor (#64: 4500 already breaks an invariant); this does not.
+//
+// Measured across 7 end-to-end runs at 5000ms, staleness ranged 0.33-3.93s, and the 3.93s
+// sample produced the only run over the bar. Halving the interval halves that range.
+//
+// It does NOT reach the 10s bar and is not claimed to: the debounce dominates and is the
+// term we deliberately will not shorten (MVP §6 false positives).
+//
+// WHY 2500 AND NOT 3000: 5000 is a multiple of 2500, so the proxy and engine timers stay
+// HARMONICALLY related and their phase relationship stays stable. A non-divisor would
+// decorrelate them, making the debounce sweep its whole [5,10) range over hours
+// (@tanifgit, #44). Stability is preferable for a demo: behaving the same at hour 3 as at
+// minute 3 is worth more than an averaged-out worst case.
+//
+// Alerts stay at 30s -- events with their own timestamps, not a sampled value, and #69's
+// flag-triggered collection is what actually made them timely.
+const METRICS_INTERVAL = parseInt(process.env.METRICS_POLL_INTERVAL_MS || '2500', 10);
 const ALERTS_INTERVAL  = parseInt(process.env.ALERTS_POLL_INTERVAL_MS  || '30000', 10);
 
 /**


### PR DESCRIPTION
Option 2, as agreed. **And the measurement immediately demonstrated your sweep argument, which is worth more than the change itself.**

## The intended effect happened

```
proxy staleness   5000ms: 0.33-3.93  mean 1.77   (n=7)
                  2500ms: 0.46-1.76  mean 1.11   (n=2)
```

Range halved, as predicted. That's the term that produced the only run over the bar at 5000ms.

**2500 rather than 3000 on your advice**, and I verified the reasoning rather than taking it — `gcd(2500, 5000) = 2500`, so the timers stay harmonically related, while 3000 or 2000 give `gcd 1000` and decorrelate. Your framing that 2500 is *neutral, not helpful* is right, and I'd argue neutral is what we want: a demo behaving the same at hour 3 as at minute 3 beats an averaged-out worst case.

## But the end-to-end numbers got worse, and that's your point arriving early

Restarting the proxy at a new interval **re-phased it against the engine**, and the debounce moved straight off the floor it had been pinned to:

```
debounce   5000ms: 5.64-7.35   (6 of 7 within 0.07s of each other)
           2500ms: 6.43-8.86   <- 8.86 is the highest debounce measured on this project
```

So the two runs after the change came out at **10.18s and 11.32s** — worse than the 5000ms mean, because the proxy improvement (−0.66s) was dwarfed by the debounce re-phasing (+1.5 to +3.2s).

That is **not a regression from this change.** It's the same system sampled at a different phase, and it's direct evidence for the thing you argued from first principles:

> Two independent `setInterval` timers don't stay locked — they drift … your six runs at 5.64–5.71s are one point in a sweep

You expected that to appear over hours. It appeared in one restart. So the 5.64–5.71s cluster really was an artifact of how I'd started the services, and **8.86s is the first sample from the upper half of the range.**

## What that means for the bar

Your 20s recommendation looks better supported than when you made it. With the debounce sampling `[5, 10)` for real rather than sitting at 5.65:

- worst realistic = unlucky proxy phase + upper debounce + 2s poll ≈ **14s+**
- and my "9.67s / 10.42s" figures were **two favourable samples of one favourable alignment**, which is a weaker claim than I made even after correcting it once

I'd support 20s on this evidence. Not 10s, and not the ~12s that the pre-restart numbers would have suggested.

## Reporting both halves

The honest summary of this PR is: **the change is right, and its benefit is smaller than the noise it sits in.** I could have posted the halved proxy range and stopped — it's the flattering half and it's true. The debounce number is the one that changes the conclusion.

```
103/103, live chain clean, alerts unchanged at 30s (#69's flag is what made them timely)
```

Refs #44, #64, #69
