### PR TITLE
ci: record why iris-compile uses the community image, and what to do when it goes red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,31 @@ jobs:
   # cannot pull. Verified locally that this image's USER namespace already has Ens.*,
   # Ens.DataTransformDTL and the HL7 2.5 schema, so no EnableNamespace step is needed.
   #
+  # DELIBERATE, and not a divergence anyone maintains: the PRODUCT runs on the EAP IRIS
+  # image with the AI Hub feature set, which docker-compose points at via a locally loaded
+  # tag (#72). This job uses the public image for one reason only -- a GitHub-hosted runner
+  # cannot authenticate to a private registry, and certainly cannot perform an EAP
+  # download and `docker load`. So the choice here was never which image to prefer; it was
+  # compile-check the ObjectScript on every PR, or not at all.
+  #
+  # THEREFORE THIS IS A SUBSET CHECK. The community image is a narrower feature set, so
+  # "compiles in CI" is weaker evidence than "compiles on the image we ship". It has never
+  # been a false PASS -- everything under iris/ uses standard interop (Ens.*,
+  # Security.Applications, %SYS.System) -- but the day we depend on an AI-Hub-only class it
+  # becomes a false FAIL: this job goes red on correct code, because the class is absent
+  # here and present on the image we run.
+  #
+  # WHEN THAT HAPPENS, do not "fix" it by pointing this job at the EAP image (impossible on
+  # a hosted runner) or by deleting it (it is the only machine-independent check that our
+  # ObjectScript compiles at all -- ~650 lines of Triggers.cls and FirstBoot.cls that
+  # otherwise only one person can run, see #70). The options are, in order of preference:
+  #   1. exclude the AI-Hub-dependent classes from LoadDir and say which, so the rest stays
+  #      covered and the gap is named
+  #   2. a self-hosted runner with the EAP image loaded, which also fixes #70
+  #   3. drop the job, and record in #70 that ObjectScript verification is now single-machine
+  # Flagged in advance because a red build on correct code is the situation in which the
+  # cheapest action is the worst one.
+  #
   # Verified to CATCH a real defect, not merely to pass: reintroducing HL7ToPID's stray
   # quote produces `#1011: Invalid name` and the job fails.
   #


### PR DESCRIPTION
**Comment-only. 25 lines, all comments, no step or key touched** — YAML parses and `iris-compile` still has its 6 steps.

Records a decision made today and a failure we know is coming.

## The decision

Containerisation is **in MVP 1** and `docker-compose.yml` will point at the **EAP IRIS image with the AI Hub feature set**, loaded locally from a documented one-time prerequisite (#72). One image for the product, no qualification.

This job keeps the public community image, and the reason is narrower than I first described it: **a GitHub-hosted runner cannot authenticate to a private registry**, and certainly cannot perform an EAP download and `docker load`. So the choice here was never which image to prefer — it was *compile-check the ObjectScript on every PR, or not at all.*

I'd earlier called this "two images by design", which overstated it. It is one runtime image, plus a CI job that compiles against a public one because it has no other option.

## The failure that's coming, and why it's written down now

This makes `iris-compile` a **subset check**, with the failure mode inverted from the usual one:

- it has never been a false **pass** — everything under `iris/` uses standard interop (`Ens.*`, `Security.Applications`, `%SYS.System`)
- the day we depend on an AI-Hub-only class it becomes a false **fail**: red on correct code, because the class is absent here and present on the image we run

**That's the dangerous shape**, because the cheapest available action is the worst one. So the options are ranked in the comment rather than left to whoever is looking at a red build:

1. exclude the AI-Hub-dependent classes from `LoadDir` and **say which**, so the rest stays covered and the gap is named
2. a self-hosted runner with the EAP image loaded — which also fixes #70
3. drop the job, and record in #70 that ObjectScript verification became single-machine

And explicitly: **don't point it at the EAP image** (impossible on a hosted runner) and **don't delete it** — it's the only machine-independent check that your ~650 lines of `Triggers.cls` and `FirstBoot.cls` compile at all.

## Why bother

It sits directly under the existing `WHAT IT DOES NOT CATCH` block, which is the note that has already earned its keep three times (#29, #17, and #37 as the documented gap). Same reasoning: the moment someone is confused by this job is the moment they'll act on the wrong instinct, and by then the person who knew why won't necessarily be looking.

`.github/**` is shared, so this needs your review. Expected to be uncontroversial — if you disagree with the ranking of the three options, that's the part worth arguing about, since it's the one that will actually be read under pressure.

Refs #72, #70, #73
