### PR TITLE
feat(dashboard): container image — the dashboard's service for the compose chain

### DIFF
--- a/apps/dashboard/.dockerignore
+++ b/apps/dashboard/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+*.log

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,0 +1,52 @@
+# Health Scan dashboard — build the single-file bundle, serve it with nginx.
+#
+# Two stages so the runtime image carries no Node and no source: the output is one
+# HTML file plus an nginx config.
+#
+# NOT the Vite dev server. `npm run dev` is for development; a container running it
+# would ship a dev build behind a watcher. This serves the same `dist/index.html`
+# artefact the file:// fallback is verified against (CLAUDE.md §6), so the container
+# and the fallback cannot drift apart.
+
+FROM node:22-alpine AS build
+WORKDIR /app
+
+# package files first so `npm ci` is cached independently of source edits.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# `npm run build` runs `tsc --noEmit` first, so a type error fails the image build
+# rather than producing one that serves a stale bundle.
+RUN npm run build
+
+
+FROM nginx:1.27-alpine AS serve
+
+# host:port of the findings API, no scheme. `detection-engine` is the compose service
+# name; override to host.docker.internal:3002 to run this container against an engine
+# on the host, which is how it was verified.
+ENV HEALTHSCAN_UPSTREAM=detection-engine:3002
+
+# Only substitute our own placeholder. Without a filter the entrypoint's envsubst
+# considers every environment variable, and nginx's own `$host`/`$uri` are one
+# accidental collision away from being rewritten to nothing.
+# Opt in to the image deriving NGINX_LOCAL_RESOLVERS from /etc/resolv.conf. Its
+# 15-local-resolvers.envsh returns early unless this is set -- so without it the template's
+# ${NGINX_LOCAL_RESOLVERS} renders LITERALLY and nginx dies with
+# `host not found in resolver "${NGINX_LOCAL_RESOLVERS}"`. Found by reading the script
+# rather than guessing at the variable name.
+ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
+ENV NGINX_ENVSUBST_FILTER="HEALTHSCAN_UPSTREAM|NGINX_LOCAL_RESOLVERS"
+
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build /app/dist/index.html /usr/share/nginx/html/index.html
+
+EXPOSE 80
+
+# Compose can gate on this with `depends_on: condition: service_healthy`. Checks the
+# document rather than the port, because nginx accepts connections before the template
+# has been rendered and a config error would otherwise look healthy.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO /dev/null http://127.0.0.1/index.html || exit 1

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -202,6 +202,36 @@ Fixtures pass through the same guards as live data. **If a guard drops a fixture
 entry, the transcription is wrong** — that is why fixture validation is worth
 watching in the console.
 
+## Running it in a container
+
+`Dockerfile` builds the same single-file bundle the `file://` fallback uses and serves it
+with nginx, which also proxies the findings API so the browser only ever talks to one
+origin. This is the dashboard's service for the compose chain (#72).
+
+```bash
+docker build -t pg-dashboard:local apps/dashboard
+docker run -d -p 5173:80 -e HEALTHSCAN_UPSTREAM=detection-engine:3002 pg-dashboard:local
+```
+
+`HEALTHSCAN_UPSTREAM` is `host:port`, no scheme, and defaults to the compose service name.
+The app keeps its relative `/api/healthscan` base URL in every environment — nothing about
+the image is environment-specific, which is why the proxy exists rather than a build-time
+URL.
+
+Two properties worth knowing, both verified rather than intended:
+
+- **it does not need the engine to start.** nginx resolves the upstream per request, not at
+  config load, so the container comes up immediately, serves demo mode (which needs no
+  backend at all), returns 502 on the live path until the engine appears, and recovers on
+  its own. Measured: engine stopped → `/` still 200 and the container stays healthy with 0
+  restarts; engine restarted → live path back to 200 with no dashboard restart. **So it
+  needs no `depends_on`**, which matters because IRIS takes minutes to initialise
+- **on a plain `docker run` the upstream must be reachable by whatever DNS the container
+  has.** The resolver is derived from `/etc/resolv.conf`, so on a user-defined network it is
+  Docker's embedded DNS and service names resolve; on the default bridge it is public DNS
+  and `host.docker.internal` does **not** resolve. Compose always creates a user-defined
+  network, so this only bites ad-hoc runs
+
 ## Status by phase
 
 | Phase | Work | Status |

--- a/apps/dashboard/nginx.conf.template
+++ b/apps/dashboard/nginx.conf.template
@@ -1,0 +1,76 @@
+# Serves the built dashboard and proxies the findings API, so the browser only ever
+# talks to one origin.
+#
+# WHY PROXY AT ALL. The browser runs on the HOST, not inside the compose network, so it
+# cannot resolve `detection-engine`. Two ways out: point the app straight at a published
+# port and rely on CORS, or proxy here. Proxying wins for the same reason it does in
+# vite.config.ts -- "CORS is never the dashboard's problem" -- and it keeps
+# VITE_HEALTHSCAN_BASE_URL as the relative `/api/healthscan` in every environment. A
+# base URL baked at build time with a host-side hostname in it is the alternative, and
+# it would make the image environment-specific.
+#
+# HEALTHSCAN_UPSTREAM is substituted at container start by the nginx image's envsubst
+# entrypoint (host:port, no scheme). Defaults are in the Dockerfile.
+server {
+    listen 80;
+    server_name _;
+
+    # Single self-contained file: `base: './'` + viteSingleFile(), the same artefact the
+    # file:// fallback uses (CLAUDE.md §6). Nothing else to serve.
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # No caching of the entry document. Everything is inlined into it, so a cached
+    # index.html is a cached application -- and a presenter reloading after a rebuild
+    # getting the previous build is the worst possible five seconds.
+    location = /index.html {
+        add_header Cache-Control "no-store" always;
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /api/healthscan/ {
+        # RESOLVE AT REQUEST TIME, NOT AT CONFIG LOAD. A literal hostname in proxy_pass is
+        # resolved when nginx reads its config, so this container refused to start at all
+        # while the engine was absent -- `host not found in upstream`, exit before serving
+        # anything. That is the wrong failure: demo mode needs no backend, so the dashboard
+        # is useful the moment it is up, and IRIS takes minutes to initialise behind it.
+        #
+        # Assigning to a variable defers resolution to each request via the resolver below,
+        # so this starts immediately, serves demo mode, returns 502 on the live path until
+        # the engine appears, and recovers on its own without a restart. It also means the
+        # dashboard needs no `depends_on` in compose.
+        #
+        # NGINX_LOCAL_RESOLVERS is derived from the container's /etc/resolv.conf by the
+        # image's own 15-local-resolvers.envsh, which exists for exactly this case. Do NOT
+        # hardcode 127.0.0.11: Docker's embedded DNS is only present on a user-defined
+        # network, so a hardcoded one works under compose and fails on `docker run` with
+        # `Connection refused` and a 502 that looks like the engine is down. Measured.
+        #
+        # `valid=10s` so a restarted engine's new address is picked up rather than cached
+        # for nginx's lifetime.
+        resolver ${NGINX_LOCAL_RESOLVERS} valid=10s ipv6=off;
+        set $healthscan_upstream "http://${HEALTHSCAN_UPSTREAM}";
+
+        # $request_uri, so the original path AND query string are passed through
+        # unchanged -- with a variable in proxy_pass, nginx does not append the matched
+        # location automatically.
+        proxy_pass $healthscan_upstream$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # The dashboard polls every 2s and gives up on its own (usePolling aborts each
+        # tick before the next), so a hung upstream must not tie up a worker for the
+        # nginx default of 60s. Shorter than the poll interval would abort healthy
+        # requests; this is comfortably above it and well below the default.
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+
+        # Findings change every poll. A cached 200 here would freeze the dashboard while
+        # it looked live, which is the one failure mode worse than an error banner.
+        add_header Cache-Control "no-store" always;
+    }
+}


### PR DESCRIPTION
My half of #72, and the easy one as promised. Ready for the compose file to reference — `image`/`build` pointing here, `HEALTHSCAN_UPSTREAM=detection-engine:3002`, **no `depends_on` needed** (see below).

## What it is

Multi-stage: node builds the **same single-file bundle the `file://` fallback is verified against**, nginx serves it and proxies `/api/healthscan`. So the container and the fallback cannot drift apart, and the runtime image carries no Node and no source.

**Why a proxy rather than a build-time URL:** the browser runs on the *host*, so it cannot resolve `detection-engine`. The alternatives were baking a host-side hostname into the bundle at build time — which makes the image environment-specific — or relying on CORS. Proxying keeps `VITE_HEALTHSCAN_BASE_URL` as the relative `/api/healthscan` in every environment, for the same reason `vite.config.ts` gives for the dev proxy. **The container and the dev server now behave identically.**

## Three things I only found by running it

**1. nginx resolves `proxy_pass` hostnames at config load.** A literal upstream made the container **refuse to start while the engine was absent** — `host not found in upstream`, dead before serving anything. That's the wrong failure for this service: demo mode needs no backend, and IRIS takes minutes to initialise behind it. Assigning the upstream to a variable defers resolution to each request.

Verified rather than intended:

```
engine stopped     GET /  -> 200      container running/healthy, 0 restarts
                   GET /api -> 502
engine restarted   GET /api -> 200    no dashboard restart
```

**So it needs no `depends_on`** — worth knowing when you write the compose file, because gating the dashboard on IRIS would mean nobody sees anything for minutes when demo mode was available the whole time.

**2. Don't hardcode `resolver 127.0.0.11`.** Docker's embedded DNS only exists on a user-defined network, so a hardcoded one works under compose and fails on `docker run` with a 502 that looks like the engine is down. Using the resolver the image derives from `/etc/resolv.conf` is correct in both.

**3. That derivation is opt-in.** `15-local-resolvers.envsh` returns early unless `NGINX_ENTRYPOINT_LOCAL_RESOLVERS` is set, so without it the template's `${NGINX_LOCAL_RESOLVERS}` rendered **literally** and nginx died with `host not found in resolver "${NGINX_LOCAL_RESOLVERS}"`. Found by reading the script inside the image rather than guessing the variable name — which is the fourth time this week that reading the thing beat reasoning about it.

## Verified as a compose rehearsal, not just a build

User-defined network, engine in a container aliased `detection-engine`, dashboard proxying by service name:

```
GET /                        200
GET /api/healthscan/hosts    real host rows through the proxy
GET /api/healthscan/findings real findings, incl. system_alert at info severity
```

Then driven in a headless browser at `?mode=live`: **3 host cards, correct names, `Hosts OK (of 3)` reading 2 while `Cloud API` was in `Error`, no `NaN`.** Screenshot taken. That last detail is the one I'd point at — the count was *right* rather than *three*, so it's rendering the data rather than a fixture.

## Small deliberate choices

- **`no-store` on the document and on API responses.** Everything is inlined into `index.html`, so a cached document is a cached *application* — a presenter reloading after a rebuild and getting the previous build is the worst possible five seconds. And a cached findings response would freeze the dashboard while it looked live
- **`HEALTHCHECK` hits `/index.html`, not the port** — nginx accepts connections before the template is rendered, so a port check would call a broken config healthy. Usable for `condition: service_healthy` if you want it, though per (1) you don't need it
- **`proxy_read_timeout 10s`** — comfortably above the 2s poll and well below nginx's 60s default, so a hung upstream can't tie up workers

## What's left for you on #72

The `iris` and `webgateway` services, the two Node services, and the compose file itself. This one is done and independently testable — `docker build -t pg-dashboard:local apps/dashboard` and the run command in the README.

`apps/dashboard/**` only. No contract, no fixture, no `src/` change.

Refs #72, #70
