### PR TITLE
docs(contributing): §7b — what an end-to-end claim has to name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,38 @@ Reading stays allowed â€” Dev C *should* read the contract. Only writing is bloc
 - Never commit `.env`, `node_modules/`, `dist/`, `.claude/settings.local.json`, or video files (link the screencast or use Git LFS).
 - Run your area's build and typecheck before opening a PR.
 
+## 7b. Claiming something works
+
+Agreed on #70 after a week in which the errors were overwhelmingly *prose about correct
+measurements* rather than wrong measurements or broken code.
+
+**An end-to-end claim names who measured it, on what, how many times, and — if timing is
+involved — under what alignment.** Not ceremony: every one of those four was omitted at least
+once this week, and each omission changed a conclusion.
+
+| omit | what it cost |
+|---|---|
+| **who / on what** | `:3001` and `:3002` answer only on Dev B's machine, so "verified live" meant one person's session. Dev C could not run the check they had committed to (#34, #70) |
+| **how many** | "measured 9.67s and 10.42s" read as a bracket. At n=7 one run hit 11.59s, and *2 of 7* were over the bar (#44) |
+| **under what alignment** | 6 of 7 samples put one term at the floor of its range, because two 5s pollers had been started a second apart and were accidentally phase-locked. The mean was an artifact of launch order (#44, ADR 0005) |
+| **composed vs measured** | "9.67s on screen" was one machine's measurement plus another's bound. That composition is a third category and it is the one most likely to hide an error — it did (#70) |
+
+So: **a measurement composed from two environments is not a measurement**, and should say so.
+
+Two habits that follow, both cheap:
+
+- **before quoting an operating range, run the suite across it.** A test already asserting the
+  real constraint is the fastest way to find out you have modelled the wrong quantity — one
+  `npm test` at the interval in question would have caught a wrong floor twice (#64, #65)
+- **when a review claims "this is safe because X", the reviewer owes the same non-vacuity test
+  the author does.** Naming a protective mechanism without checking that removing it breaks
+  something leaves a booby trap for whoever hardens it next (#69)
+
+None of this applies to unit or contract evidence, which is machine-independent and shared by
+construction — that is ADR 0004 paying off. It applies to live, cross-service,
+timing-dependent claims, which is where our strongest evidence and our weakest attribution
+have both been.
+
 ## 8. Day-1 setup checklist
 
 Turn each of these into a GitHub issue rather than tracking it here â€” a checklist nobody ticks off in a file is worse than no checklist.


### PR DESCRIPTION
**#70's item 1, which we both agreed to and neither of us wrote.** I found it catching up on your merges: the issue closed as `COMPLETED` and `grep -i "who measured" CONTRIBUTING.md` returns nothing.

That's the week's own failure mode one level up — an agreed decision with no record, which is what #71 was about for the descope and what the `ATTRIBUTION SUPERSEDED` block was about in the changelog. Worth fixing rather than noting.

## What it says

Four things an end-to-end claim has to name, each of which was omitted at least once this week, **and each omission changed a conclusion:**

| omit | what it cost |
|---|---|
| who / on what | "verified live" meant one session; I couldn't run a check I'd committed to (#34) |
| how many | `9.67 / 10.42` read as a bracket. At n=7 one run hit 11.59 and **2 of 7** were over the bar (#44) |
| under what alignment | 6 of 7 samples pinned one term to its floor because two 5 s pollers were started a second apart (ADR 0005) |
| composed vs measured | "on screen" was your measurement plus my bound — a third category, and the likeliest to hide an error |

Attribution where it's due: **the alignment clause is yours**, asked for after the phase-lock; the `n` was mine; the composed-measurement category is the one neither of us had named *as a category* until it bit.

Plus the two habits from the same week, and the second one is mine because I earned it:

- **run the suite across an operating range before quoting it** — one `npm test` at the interval in question would have caught a wrong floor twice (#64, #65)
- **a reviewer claiming "this is safe because X" owes the same non-vacuity test the author does** — I named the wrong protective line on #69, and only your experiment found it

## Scoped deliberately

It does **not** apply to unit or contract evidence. That's machine-independent by construction, and as you put it on #70, that's ADR 0004 paying off in a way neither of us had articulated. It applies to **live, cross-service, timing-dependent** claims — where our strongest evidence and our weakest attribution have both been.

## On #70 closing

No objection: the tier table and the composed-row caveat are in the issue body, and the actual fix is #72, which is in progress rather than deferred. This was just the one item that fell between the two.

`CONTRIBUTING.md` is shared, so this needs your review. If you think §7b overstates it — a week of two people is a small sample for a process rule — say so and I'd rather cut it to the four-item list without the table.

Refs #70, #44, #64, #65, #69, #34
