### PR TITLE
fix(contributing): five raw 0x97 bytes broke the file's encoding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,8 +187,8 @@ Reading stays allowed â€” Dev C *should* read the contract. Only writing is bloc
 Agreed on #70 after a week in which the errors were overwhelmingly *prose about correct
 measurements* rather than wrong measurements or broken code.
 
-**An end-to-end claim names who measured it, on what, how many times, and — if timing is
-involved — under what alignment.** Not ceremony: every one of those four was omitted at least
+**An end-to-end claim names who measured it, on what, how many times, and â€” if timing is
+involved â€” under what alignment.** Not ceremony: every one of those four was omitted at least
 once this week, and each omission changed a conclusion.
 
 | omit | what it cost |
@@ -196,21 +196,21 @@ once this week, and each omission changed a conclusion.
 | **who / on what** | `:3001` and `:3002` answer only on Dev B's machine, so "verified live" meant one person's session. Dev C could not run the check they had committed to (#34, #70) |
 | **how many** | "measured 9.67s and 10.42s" read as a bracket. At n=7 one run hit 11.59s, and *2 of 7* were over the bar (#44) |
 | **under what alignment** | 6 of 7 samples put one term at the floor of its range, because two 5s pollers had been started a second apart and were accidentally phase-locked. The mean was an artifact of launch order (#44, ADR 0005) |
-| **composed vs measured** | "9.67s on screen" was one machine's measurement plus another's bound. That composition is a third category and it is the one most likely to hide an error — it did (#70) |
+| **composed vs measured** | "9.67s on screen" was one machine's measurement plus another's bound. That composition is a third category and it is the one most likely to hide an error â€” it did (#70) |
 
 So: **a measurement composed from two environments is not a measurement**, and should say so.
 
 Two habits that follow, both cheap:
 
 - **before quoting an operating range, run the suite across it.** A test already asserting the
-  real constraint is the fastest way to find out you have modelled the wrong quantity — one
+  real constraint is the fastest way to find out you have modelled the wrong quantity â€” one
   `npm test` at the interval in question would have caught a wrong floor twice (#64, #65)
 - **when a review claims "this is safe because X", the reviewer owes the same non-vacuity test
   the author does.** Naming a protective mechanism without checking that removing it breaks
   something leaves a booby trap for whoever hardens it next (#69)
 
 None of this applies to unit or contract evidence, which is machine-independent and shared by
-construction — that is ADR 0004 paying off. It applies to live, cross-service,
+construction â€” that is ADR 0004 paying off. It applies to live, cross-service,
 timing-dependent claims, which is where our strongest evidence and our weakest attribution
 have both been.
 


### PR DESCRIPTION
Follow-up to #80, which I approved on content and merged — it was green, clean, and the wording is right. **But it landed five raw cp1252 `0x97` bytes, so `main`'s `CONTRIBUTING.md` is currently not valid UTF-8:**

```
main now: 0x97 count 5
  valid UTF-8: NO
```

I merged it anyway rather than blocking, because the content is correct and holding an approved PR over five bytes would have been the wrong trade — this is a two-minute follow-up instead.

## The fix

Five bytes, five lines:

```
CONTRIBUTING.md | 10 +++++-----
1 file changed, 5 insertions(+), 5 deletions(-)
```

`0x97` → the UTF-8 em dash (`e2 80 94`). Verified afterwards that §7b's content is entirely intact — the section header, all four table rows, both habits, and the ADR 0004 scoping paragraph.

The visible symptom was a replacement character in the section's own headline claim:

```
before:  who measured it, on what, how many times, and � if timing is involved
after:   who measured it, on what, how many times, and — if timing is involved
```

Distinct from the `0x94` bytes elsewhere in the file — those are the box-drawing in the directory tree and were already there. `main` before #80 was valid UTF-8 with zero `0x97`, which is how I know this PR was the cause rather than a pre-existing condition.

## Third time, so it's worth a check rather than a fix

Same defect I introduced in #62, same cause both times: **a Python write without an explicit encoding on a Windows shell**, which silently emits cp1252 for characters outside ASCII.

If it happens again I'd add a CI step — `python -c "open(f,'rb').read().decode('utf-8')"` across the tracked text files is about three lines and would catch it at PR time rather than after merge. Not proposing it now; two occurrences is a coincidence and three is a pattern, and we're at two-and-a-bit since one of them was mine.

Worth noting the irony for the record: a section titled *"Claiming something works"* shipped with an unrenderable character in the sentence defining what a claim must name. Nothing about the *content* was wrong — which is itself an instance of §7b's point that our errors have been prose-and-presentation rather than substance.
