### PR TITLE
docs(dashboard): make ADR 0005's Consequences true, and fix three stale copied values

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -417,7 +417,7 @@ From §4.5 of the MVP plan, in order:
 | # | Task | Est. | Done when |
 |---|---|---|---|
 | 1 | Dashboard against mocked schema — host grid, findings list, severity summary | 1.5 d | Renders every host the API returns, whatever the count, and all fixture findings; every state designed; `tsc` clean |
-| 2 | Live polling + demo/live toggle (`?mode=live`) | 0.75 d | Visible change reflected within 10 s; API failure degrades to last-good + banner, never blanks |
+| 2 | Live polling + demo/live toggle (`?mode=live`) | 0.75 d | Visible change reflected within the latency stated in **ADR 0005** (not restated here); API failure degrades to last-good + banner, never blanks |
 | 3 | Finding detail view | 0.5 d | Click a finding → current vs. baseline, metric, timestamp; keyboard accessible; drawer survives polls |
 | 4 | Static fallback build | 0.5 d | `dist/index.html` opens from `file://` in demo mode |
 | ~~4b~~ | ~~Screencast~~ | — | **DESCOPED from MVP 1** — after MVP 1, see below |
@@ -428,6 +428,12 @@ From §4.5 of the MVP plan, in order:
 `docs/demo/` therefore does not exist and should not be created before MVP 1 closes. If a request asks for the cue sheet or the screencast, say it is descoped rather than building it — the same rule §1.1 applies to the later modules.
 
 **Overall acceptance (from the MVP doc):** *dashboard renders all hosts + findings live; updates within 10 s of a change; fallback to demo mode is seamless.*
+
+**The middle clause is not met, deliberately and on the record — see [ADR 0005](../../docs/decisions/0005-latency-bar.md), which is the only place the restated criterion is written down.** Reaching 10 s would mean lowering `sustainedSeconds`, i.e. lowering the false-positive protection MVP §6 names as the top risk; that was declined twice on the record (#44, #64). The dashboard poll was the one term gated by no invariant, and it was spent (5 s → 2 s, #68).
+
+The quote above is left verbatim because the MVP doc is read-only (root `CLAUDE.md` §3) — this note is the deviation record, not an edit to the criterion.
+
+**Do not restate the latency figures anywhere in this directory**, including here: link the ADR. Three copied values in this repo have already gone stale — the backoff ladder and the engine poll floor in `README.md`, and the bare "within 10 s" that used to sit in the task 2 row above.
 
 Sequencing note: tasks 1–3 need only the contract, so they proceed regardless of backend readiness. Task 2's live path is verifiable against a two-endpoint stub returning fixture JSON — build that stub inside `apps/dashboard/` if Dev B's API is not up yet, and delete it once it is.
 

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -56,8 +56,14 @@ can always tell what you are looking at.
 
 ## Live mode
 
-The dashboard polls both endpoints every 5 s (`VITE_POLL_INTERVAL_MS`), pauses
+The dashboard polls both endpoints every 2 s (`VITE_POLL_INTERVAL_MS`), pauses
 while the tab is hidden, and refetches the moment it returns.
+
+2 s, not 5 s: this poll is the last stage before the screen and the only one gated
+by no invariant, so it is the one latency term we could spend (#68). What that does
+and does not buy for the end-to-end figure is
+[ADR 0005](../../docs/decisions/0005-latency-bar.md) — which is the only place that
+figure is written down, deliberately, so there is nothing here to go stale.
 
 Dev B's detection engine serves both endpoints on `:3002`. It runs with **nothing
 on `:3001`** — it replays captured LABDEMO fixtures through healthy → degrading →
@@ -67,12 +73,20 @@ dead → recovery, so findings appear *and clear* without IRIS being involved:
 cd ../../services/detection-engine && npm install && npm start
 ```
 
-The default 10 s poll means the baseline needs ~14 polls to warm before the first
-finding is confirmed. To watch a whole cycle without waiting, compress it:
+The engine's default 5 s poll means the baseline needs ~14 polls to warm before the
+first finding is confirmed. To watch a whole cycle without waiting, compress it —
+**but not below 2000 ms**:
 
 ```bash
-POLL_INTERVAL_MS=700 npm start     # full appear-and-clear cycle in ~30 s
+POLL_INTERVAL_MS=2000 npm start    # full appear-and-clear cycle, still emits
 ```
+
+`POLL_INTERVAL_MS` has floors, and they do not fail loudly. The engine's
+`sustainedSeconds` gate needs `(sustainedSamples - 1) x interval > sustainedSeconds`,
+so **4500 ms already breaks an invariant** and finding types stop emitting entirely
+below ~1750 ms (#64, #65). This file used to suggest `700`, at which **nothing fires
+at all** — you get a warm baseline, a healthy grid, and no findings, which reads as a
+broken dashboard rather than a poll rate below its floor.
 
 Then open <http://localhost:5173/?mode=live>, or click **Live** in the header.
 The mode is reflected in the URL, so it's shareable.
@@ -82,10 +96,13 @@ The mode is reflected in the URL, so it's shareable.
 This is the demo-reliability path, and the one worth testing by hand:
 
 1. Start the engine, open `?mode=live`, confirm the teal **LIVE** pill and data flowing.
-2. **Kill the engine.** Within ~5 s: a red banner appears, the last-good data stays
+2. **Kill the engine.** Within ~2 s: a red banner appears, the last-good data stays
    on screen but dimmed, labelled `Showing data as of HH:MM:SS UTC`. **It must
    never blank.**
-3. Wait. Polling backs off 5 s → 10 s → 20 s → 30 s rather than hammering. At
+3. Wait. Polling backs off by **doubling from the poll interval**, capped at 30 s,
+   rather than hammering — at the default 2 s that is 4 s → 8 s → 16 s → 30 s. The
+   ladder is derived from the interval rather than fixed, so it moves with
+   `VITE_POLL_INTERVAL_MS`; don't re-copy it here when that changes. At
    **3 consecutive failures** a *Switch to demo mode* button appears — the
    on-stage escape hatch.
 4. **Restart the engine.** The banner clears on the next successful poll, with no


### PR DESCRIPTION
Makes ADR 0005's Consequences true, and fixes three stale copied values found while checking it.

## Why this is a prerequisite for #44

ADR 0005's Consequences says:

> the numbers quoted in `apps/dashboard/CLAUDE.md` §8 and `apps/dashboard/README.md` point here rather than restating a duration

Neither did. §8 restated a bare "within 10 s" as task 2's acceptance, and the dashboard README did not mention the ADR at all — so the one clause of MVP 1 we knowingly do not meet was not findable from the area that fails it.

That is the exact failure the ADR exists to prevent. Its own Context says a restated figure "would look — to anyone reading later — as though it had always been the target," and that is what §8 was doing. An ADR cannot go from `proposed` to `accepted` while its Consequences describe a state of the world that is not real, so this clears the way.

Both files now link the ADR, and §8 says not to restate the latency figures anywhere in this directory — **including in that note itself**. One place holds the numbers.

## Three stale copied values

Each is a value duplicated out of the code and then left behind when the code moved.

| site | was | now |
|---|---|---|
| `README.md` | dashboard polls every **5 s** | 2 s — it has been since #68 |
| `README.md` | backoff `5 s → 10 s → 20 s → 30 s` | the rule, plus 4 → 8 → 16 → 30 at the shipped interval |
| `README.md` | `POLL_INTERVAL_MS=700` | `2000`, with the floors and why they are quiet |
| `README.md` | banner within ~5 s | ~2 s — that is one poll |
| `CLAUDE.md` §8 | "within 10 s" | links ADR 0005 |

**The `700` one has a real cost.** `thresholds.json` documents that 4500 ms already breaks the `sustainedSeconds` invariant and that finding types stop emitting entirely below ~1750 ms (#64, #65). At 700 ms nothing fires at all — you get a warm baseline, a healthy grid and no findings, which reads as a broken dashboard rather than a poll rate under its floor. It is the instruction someone follows while rehearsing the demo, which is the worst moment to be handed a configuration where the product looks dead.

**The backoff ladder is the tidiest illustration of the pattern.** `usePolling.ts` derives the sequence from the interval specifically so it cannot go stale, and says so twice — *"the sequence is derived from the interval, not fixed, so it moves with `VITE_POLL_INTERVAL_MS` rather than being restated here"* and *"a copied one goes stale the moment that changes."* The README copied it out anyway, and #68 duly staled it. The code predicted the failure mode and the prose committed it.

Verified rather than assumed: `OFFER_DEMO_AFTER = 3`, so "3 consecutive failures" was already correct and is unchanged.

## Not in this PR

**ADR 0005's Status stays `proposed`.** The measurements are Dev B's to confirm or correct — that request is on #78, item 5 — and flipping the field myself would defeat the point of having it.

I also have not touched the ADR body. If the answer to the topology question on #78 is that the compose stack is now the reference environment, that is a Dev B edit to "What was measured", not a Dev C one.

## Verification

```
tsc --noEmit                    clean
npm run build                   clean, 201.89 kB single-file bundle
validate:fixtures:strict        8/8, contract + self-consistency + emittability sweeps
encoding                        both files valid UTF-8, zero U+FFFD, no line-ending churn
```

Docs-only; no `src/` change, so no behaviour change. Dev C area only (`apps/dashboard/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
