### PR TITLE
docs(adr-0005): confirm the latency measurements against the compose stack (n=12), and a harness to re-measure

### DIFF
--- a/docs/decisions/0005-latency-bar.md
+++ b/docs/decisions/0005-latency-bar.md
@@ -66,6 +66,44 @@ argument. It also means **8.86 s is the first sample from the upper half of `[5,
 arithmetic bound below is not a hypothetical worst case being defended against measurements —
 the measurements have started walking into it.
 
+### Confirmed against the containerised stack, n=12 — the prediction above held
+
+The measurements above were taken on the demo instance: IRIS behind an external web gateway,
+with the proxy and engine as host processes. The compose stack (#72, #78) is the reference
+environment now — four containers, no gateway hop, `Cloud API` posting to `127.0.0.1:52773`
+in-container. Re-measured there with `tools/measure-latency.mjs`, which arms the trigger and
+reads the findings API **inside one process**, so no agent round trip enters the sample (the
+mistake that invalidated the first figure on #44):
+
+| | to findings API | on screen, +1.0 s expected | over the 10 s bar |
+|---|---|---|---|
+| n=12, proxy 2500 ms, engine 5000 ms | min 6.09, median 9.75, mean 9.04, max 10.73 | min 7.09, median 10.75, mean 10.04, max 11.73 | **9 of 12** |
+
+**This is worse than the 2 of 7 above, and it is the section above being proved right rather
+than a regression.** That earlier figure came from very nearly phase-locked timers; this section
+predicted that drift would sweep the debounce across `[5, 10)` and make the unfavourable case
+"not merely possible but eventually certain". With the phase-lock removed — each run injects at a
+different offset in the proxy's cycle — the samples do exactly that, and the majority land above
+the bar. Fewer than half of runs meeting a bar is the honest picture of a system whose *typical*
+case sits just under it and whose *bound* is far above.
+
+Two notes on the method, because both were mistakes I made first:
+
+- **A linear phase ramp is not a stagger.** Sweeping the offset 0 → interval in equal increments
+  produced a monotonic sequence (10.67 → 9.25 s) that reads as a trend in the product and is
+  really the ramp walking toward the next poll boundary in step with the run counter. The offsets
+  are bit-reversed now, and the correlation disappears.
+- **Worst case and expected case are not comparable.** Adding a full dashboard interval to every
+  sample and comparing against figures that used a measured mean would manufacture a regression
+  out of a change of convention. The harness reports both; the table above uses the expected
+  case, matching how the n=7 row was built.
+
+The containerised topology did **not** make this faster, which is worth stating because the
+opposite was the reasonable expectation from removing a network hop. The gateway hop was never a
+significant term — it was inside the proxy staleness window either way — and the budget is
+dominated by the debounce, which is unchanged. Removing a service simplified the deployment; it
+did not buy latency.
+
 So the honest bound is the arithmetic one, stated for the **shipped** intervals — proxy 2500 ms
 (#75), engine 5000 ms, dashboard 2000 ms (#68):
 
@@ -139,14 +177,29 @@ for it here.**
 - `sustainedSeconds` must not be lowered to chase this number without revisiting this ADR; #46's
   own comment and #64's floor are the reasons
 - any figure in this ADR that is a mean is situational until the services are launched in a
-  randomised phase relationship. The bound is not
+  randomised phase relationship. The bound is not. The n=12 run is the closest thing here to a
+  non-situational sample, because it staggers injection across the proxy's poll cycle rather
+  than launching the services and hoping — and it is the worse number of the two
+- **re-measuring is now one command**: `node tools/measure-latency.mjs [runs]` against a running
+  stack. Anyone disputing a figure here can produce their own rather than arguing from the
+  arithmetic, and the harness owns both ends of the clock so an agent round trip cannot leak in
 - the criterion in the source document is unchanged and still says 10 s. This ADR is the
   deviation record, and the numbers quoted in `apps/dashboard/CLAUDE.md` §8 and
   `apps/dashboard/README.md` point here rather than restating a duration
 
 ## Status
 
-`proposed`. Drafted by Dev C from the #44 thread; the measurements are Dev B's and are theirs to
-confirm or correct. It should be `accepted` before anyone describes MVP 1 as complete, because
-this is the single place where MVP 1 does not meet the spec as written and it needs to be
-findable by someone who has only read the spec.
+`proposed`, pending Dev C's review of the n=12 section.
+
+Drafted by Dev C from the #44 thread. The measurements were Dev B's to confirm or correct, and
+they are now **confirmed** — re-measured against the containerised reference stack with the
+phase-lock removed, which is what the "any figure that is a mean is situational" caveat was
+waiting for. The direction of the correction is worth naming: the new numbers are **worse** than
+the ones drafted here, and they move the deviation from "misses the bar occasionally" to "misses
+it more often than not". That does not change the decision — 20 s still covers the 14.5 s bound
+with margin — but it does change what an honest sentence about it says, so it should not flip to
+`accepted` on the author of the measurement's word alone.
+
+It should be `accepted` before anyone describes MVP 1 as complete, because this is the single
+place where MVP 1 does not meet the spec as written and it needs to be findable by someone who
+has only read the spec.

--- a/docs/decisions/0005-latency-bar.md
+++ b/docs/decisions/0005-latency-bar.md
@@ -1,6 +1,6 @@
 # ADR 0005 — The "updates within 10 s" acceptance criterion is not met, and what we state instead
 
-- **Status:** proposed
+- **Status:** accepted
 - **Date:** 2026-08-13
 - **Deciders:** Dev B, Dev C
 - **Drafted by:** Dev C
@@ -214,17 +214,27 @@ for it here.**
 
 ## Status
 
-`proposed`, pending Dev C's review of the n=12 section.
+**`accepted`** — 2026-08-13, drafted by Dev C, measurements by Dev B, reviewed and approved by
+Dev C at `c584a8f` (#83).
 
-Drafted by Dev C from the #44 thread. The measurements were Dev B's to confirm or correct, and
-they are now **confirmed** — re-measured against the containerised reference stack with the
-phase-lock removed, which is what the "any figure that is a mean is situational" caveat was
-waiting for. The direction of the correction is worth naming: the new numbers are **worse** than
-the ones drafted here, and they move the deviation from "misses the bar occasionally" to "misses
-it more often than not". That does not change the decision — 20 s still covers the 14.5 s bound
-with margin — but it does change what an honest sentence about it says, so it should not flip to
-`accepted` on the author of the measurement's word alone.
+How it got here, because the field is recording the process as much as the conclusion:
 
-It should be `accepted` before anyone describes MVP 1 as complete, because this is the single
-place where MVP 1 does not meet the spec as written and it needs to be findable by someone who
-has only read the spec.
+- Dev C drafted this from the #44 thread and deliberately left Status at `proposed`, because the
+  measurements were Dev B's and *"flipping the field myself would defeat the point of having it"*
+- the measurements were **confirmed by re-measuring, not by re-reading** — n=12 against the
+  containerised reference stack with the phase-lock removed, which is exactly what the "any figure
+  that is a mean is situational" caveat was waiting for
+- the correction went in the direction that makes the product look **worse**: from "misses the bar
+  occasionally" (2 of 7) to "misses it more often than not" (9 of 12). The decision did not move —
+  20 s still covers the 14.5 s bound with margin — but the sentence describing it did
+- Dev B declined to flip this on the strength of their own measurement, and Dev C's approval
+  reviewed the n=12 section rather than rubber-stamping it, catching that the appended section had
+  left the Decision contradicting its own evidence
+
+The prerequisite is also satisfied: #82 merged, so the Consequences bullet claiming
+`apps/dashboard/CLAUDE.md` §8 and `apps/dashboard/README.md` point here rather than restating a
+duration is now true on `main`. It was not when this ADR was drafted, and an ADR cannot be
+`accepted` while its Consequences describe a state of the world that is not real.
+
+This is the single place where MVP 1 knowingly does not meet the spec as written, and it is
+findable by someone who has only read the spec.

--- a/docs/decisions/0005-latency-bar.md
+++ b/docs/decisions/0005-latency-bar.md
@@ -62,9 +62,11 @@ So the sweep was demonstrated in one restart rather than over hours, and the two
 that change came out at **10.18 s and 11.32 s** — worse than the mean above, because the proxy
 improvement (−0.66 s) was smaller than the debounce re-phasing (+1.5 to +3.2 s). The 5.64–5.71 s
 cluster was an artifact, as this section already argued; #75 is the evidence rather than the
-argument. It also means **8.86 s is the first sample from the upper half of `[5, 10)`**, so the
+argument. It also means **8.86 s was the first sample from the upper half of `[5, 10)`**, so the
 arithmetic bound below is not a hypothetical worst case being defended against measurements —
-the measurements have started walking into it.
+the measurements have started walking into it. ("The highest recorded on this project", as the
+table above said when written; the n=12 run below has since exceeded it, which is the point that
+section makes.)
 
 ### Confirmed against the containerised stack, n=12 — the prediction above held
 
@@ -82,10 +84,16 @@ mistake that invalidated the first figure on #44):
 **This is worse than the 2 of 7 above, and it is the section above being proved right rather
 than a regression.** That earlier figure came from very nearly phase-locked timers; this section
 predicted that drift would sweep the debounce across `[5, 10)` and make the unfavourable case
-"not merely possible but eventually certain". With the phase-lock removed — each run injects at a
-different offset in the proxy's cycle — the samples do exactly that, and the majority land above
-the bar. Fewer than half of runs meeting a bar is the honest picture of a system whose *typical*
-case sits just under it and whose *bound* is far above.
+"not merely possible but eventually certain". With the phase-lock removed — consecutive runs
+inject at decorrelated offsets in the proxy's cycle — the samples do exactly that, and the
+majority land above the bar.
+
+**So the measured typical is now above 10 s, not below it.** The median is 10.75 s. The 9.8 s
+"typical" quoted elsewhere in this ADR is the *arithmetic* figure derived from the intervals, and
+it is no longer what the samples show — which is why the Decision below no longer states a
+typical at all. Naming that explicitly because the first version of this section said the typical
+case "sits just under" the bar, directly beneath a table showing the opposite; the arithmetic and
+the measurement had diverged and only one of them was in front of me.
 
 Two notes on the method, because both were mistakes I made first:
 
@@ -117,9 +125,15 @@ arithmetic gave `5.0 + 10.0 + 2.0 ≈ 17 s` worst and `~11 s` typical. **The dec
 move**: 20 s covered 17 s and covers 14.5 s with more margin. What changes is that a reader
 comparing the bound against the shipped configuration now gets the same answer the ADR gives.
 
-Note the typical figure has dropped below 10 s while the **bound has not**, and the bound is what
-a criterion is. That gap — a system that usually meets a bar it cannot guarantee — is the whole
-reason this ADR exists rather than a one-line change to a number.
+Note the **arithmetic** typical has dropped below 10 s while the **bound has not**, and the bound
+is what a criterion is. That gap is the whole reason this ADR exists rather than a one-line change
+to a number.
+
+This paragraph used to add "a system that usually meets a bar it cannot guarantee". The n=12
+measurement below retires that phrasing: the *arithmetic* typical is 9.8 s, but the *measured*
+median is 10.75 s with 9 of 12 runs over, so "usually meets" describes the arithmetic and not the
+system. The gap is real either way — it is now between the bound and the measurement rather than
+between the bound and a comfortable typical.
 
 ## Why 10 s is not reachable
 
@@ -146,23 +160,34 @@ The two other terms were examined and are not where the budget is:
 
 ## Decision
 
-**State the criterion as: findings appear on screen within 20 s of a change, typically ~10 s,
-measured 8.8–11.6 s — for the seven metric-derived finding types.**
+**State the criterion as: findings appear on screen within 20 s of a change, measured
+7.1–11.7 s with a median of 10.8 s — for the seven metric-derived finding types.**
 
-Three numbers, each true, rather than one that needs a footnote:
+Two numbers, each true, rather than one that needs a footnote:
 
 - **20 s** is the bound we can defend without qualification, because it covers the swept worst
   case (14.5 s on the shipped intervals) rather than the phase alignment we happened to measure
-- **~10 s** is the typical figure on the shipped intervals with the phase-lock artifact removed
-  (9.8 s arithmetic). It was ~11 s before the proxy poll was halved
-- **8.8–11.6 s** is what was actually observed, with `n` and whose machine, per #70 — n=7 at the
-  5000 ms proxy poll, plus n=2 at 2500 ms which came out at 10.2 s and 11.3 s
+- **7.1–11.7 s, median 10.8 s** is what was actually observed, with `n` and whose machine per
+  #70 — n=12 on the containerised reference stack with injection staggered across the proxy's
+  poll cycle. **9 of those 12 were over 10 s.** Earlier samples, superseded because their timers
+  were near phase-locked: n=7 at a 5000 ms proxy poll gave 8.8–11.6 s with 2 over, and n=2 after
+  #75 gave 10.2 s and 11.3 s
 
-**Do not collapse these into one number.** The typical figure sits below 10 s and the bound does
-not, which is exactly the situation the criterion has to describe: a system that usually meets a
-bar it cannot guarantee. Quoting only the typical would re-create the claim this ADR exists to
-retract, and quoting only the bound would understate a product that is normally twice as good as
-its guarantee.
+**A "typically ~10 s" figure used to be the third number here and it has been removed.** It read
+as a claim about observed behaviour, and the n=12 measurement contradicts it: the measured median
+is 10.75 s, i.e. *above* the bar, and three quarters of runs miss it. The 9.8 s arithmetic
+*typical* is still computable from the intervals and still appears above in the bound derivation,
+but it is not what a reader gets when they see "typically" next to a measured range, so quoting
+it in the criterion overstated the product. Caught by Dev C on the review of the n=12 change,
+which is the review catching exactly what it is for: the confirming measurement falsified the
+sentence it was appended beneath, and appending without re-reading the Decision left the ADR
+contradicting itself.
+
+**Do not collapse the two remaining numbers into one.** The bound is what a criterion *is*, and
+the measured range is what someone will see; a system that misses a self-imposed bar in most runs
+while never approaching its stated bound is precisely the situation this ADR exists to describe.
+Quoting only the measurement would suggest a guarantee we do not have, and quoting only the bound
+would understate a product that is normally well inside it.
 
 `system_alert` is stated **separately** and is not covered by the above. Until #69 it came down a
 different path — a blind 30 s poll of the consume-on-read alerts endpoint — so its worst case was

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,7 +14,14 @@ rather than in the spec itself.
 | [0002](0002-baseline-strategy.md) | Rolling 30-minute in-memory window; nothing persisted | proposed |
 | [0003](0003-threshold-configuration.md) | JSON config file, hot-reloaded, conservative defaults | proposed |
 | [0004](0004-mock-first-contracts.md) | All three build against mocked contracts from Day 1 | accepted 2026-08-12 |
-| [0005](0005-latency-bar.md) | The "updates within 10 s" criterion is not met; we state 20 s, typically ~10 s | proposed |
+| [0005](0005-latency-bar.md) | The "updates within 10 s" criterion is not met; we state 20 s, and cite the measured range | accepted 2026-08-13 |
+
+**The Decision column does not restate the latency figures**, on purpose. It said "typically
+~10 s" until 2026-08-13, which was true of the drafted n=7 measurement and false of the n=12 one
+that replaced it (median 10.75 s, 9 of 12 over the bar) — so this table was carrying a retired
+number while 0005 itself had corrected it. Same pattern as #63, #68, #82 and #84: a figure copied
+out of its one home goes stale when the home moves. Summarise the *shape* of a decision here and
+leave the numbers to the ADR.
 
 0001–0003 were drafted by Dev B, who implements them, and follow the MVP doc's recommendations.
 

--- a/tools/measure-latency.mjs
+++ b/tools/measure-latency.mjs
@@ -1,0 +1,209 @@
+// Measure end-to-end detection latency against a running stack.
+//
+//   node tools/measure-latency.mjs [runs] [--engine URL]
+//
+// WHY A SCRIPT RATHER THAN A SEQUENCE OF COMMANDS. The clock has to start when the fault is
+// injected and stop when the finding is visible, and BOTH have to happen inside one process.
+// Driving the injection from an agent tool call adds ~15s of round trip to the measured
+// interval, which is larger than the thing being measured -- that mistake invalidated the
+// first figure on #44 and a later stopwatch reading on #67. Anything that measures this has
+// to own both ends.
+//
+// WHAT IS MEASURED. Wall clock from "the fault exists in IRIS" to "the finding is readable
+// from the findings API". That is proxy staleness + engine debounce, and it deliberately
+// EXCLUDES the dashboard's own poll -- the dashboard adds [0, VITE_POLL_INTERVAL_MS) on top,
+// which is bounded arithmetic rather than something worth sampling. Report both.
+//
+// PHASE STAGGERING. Injecting at a fixed offset in the proxy's poll cycle measures one
+// favourable phase and calls it the distribution -- exactly the artifact that made an earlier
+// set of numbers look better than the system was (#75). Each run therefore sleeps a fraction of
+// the proxy interval first, so the samples spread across the cycle. Derived from the run index
+// rather than Math.random(), so a re-run is comparable.
+//
+// The offsets are BIT-REVERSED rather than a linear ramp -- see the comment at the stagger. A
+// ramp correlates run order with phase and produces a monotonic sequence that reads as a trend
+// in the system when it is an artifact of the sweep.
+
+const args = process.argv.slice(2);
+const runs = Number(args.find((a) => /^\d+$/.test(a)) ?? 7);
+const flag = (name, fallback) => {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+
+const ENGINE = flag('--engine', 'http://localhost:3002');
+// The proxy interval, used only to size the phase stagger. Read from the environment so this
+// stays correct if compose changes it.
+const PROXY_INTERVAL_MS = Number(process.env.METRICS_POLL_INTERVAL_MS ?? 2500);
+const DASHBOARD_INTERVAL_MS = Number(process.env.VITE_POLL_INTERVAL_MS ?? 2000);
+
+const HOST = 'Cloud API';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Triggers are ObjectScript, so arming one means a session inside the container. `docker exec`
+// is a LOCAL process spawn (~200ms), and crucially the clock starts AFTER it returns -- so the
+// spawn cost is outside the sample rather than something to subtract.
+import { spawn } from 'node:child_process';
+
+// spawn with an explicit stdin.end(), NOT execFile's `input` option. With `input` the session
+// opened and then hung until the timeout killed it -- stdout stopped at the bare `LABDEMO>`
+// prompt and the process died on SIGTERM. The terminal reads interactively and needs stdin
+// CLOSED before it will act on the trailing `halt`; writing then ending is unambiguous.
+function irisSession(code) {
+  return new Promise((resolve, reject) => {
+    const p = spawn('docker', ['exec', '-i', 'pg-iris', 'iris', 'session', 'IRIS', '-U', 'LABDEMO']);
+    let out = '';
+    p.stdout.on('data', (d) => (out += d));
+    p.stderr.on('data', (d) => (out += d));
+    const timer = setTimeout(() => {
+      p.kill();
+      reject(new Error('iris session timed out after 60s'));
+    }, 60_000);
+    p.on('close', () => {
+      clearTimeout(timer);
+      resolve(out);
+    });
+    p.on('error', reject);
+    p.stdin.write(code + '\nhalt\n');
+    p.stdin.end();
+  });
+}
+
+async function arm() {
+  return irisSession('do ##class(ProductionGuardian.LabDemo.Triggers).DeadHost()');
+}
+async function reset() {
+  return irisSession('do ##class(ProductionGuardian.LabDemo.Triggers).Reset()');
+}
+
+async function findings() {
+  const res = await fetch(`${ENGINE}/api/healthscan/findings`);
+  if (!res.ok) throw new Error(`findings -> HTTP ${res.status}`);
+  return res.json();
+}
+
+async function waitForClear(timeoutMs = 120_000) {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    const f = await findings();
+    if (f.length === 0) return true;
+    await sleep(500);
+  }
+  return false;
+}
+
+/** Poll the findings API hard until dead_host appears, and return the elapsed ms. */
+async function timeToDetect(t0, timeoutMs = 60_000) {
+  const until = t0 + timeoutMs;
+  while (Date.now() < until) {
+    const f = await findings();
+    if (f.some((x) => x.type === 'dead_host' && x.host === HOST)) {
+      return Date.now() - t0;
+    }
+    // 100ms so the sampling granularity is far below the thing measured. The findings API is
+    // an in-memory read, so this costs the engine nothing meaningful.
+    await sleep(100);
+  }
+  return null;
+}
+
+const stats = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const sum = s.reduce((a, b) => a + b, 0);
+  return {
+    n: s.length,
+    min: s[0],
+    max: s[s.length - 1],
+    mean: sum / s.length,
+    median: s[Math.floor(s.length / 2)],
+  };
+};
+
+console.log(`measuring ${runs} runs against ${ENGINE}`);
+console.log(`proxy interval ${PROXY_INTERVAL_MS}ms, dashboard interval ${DASHBOARD_INTERVAL_MS}ms`);
+console.log('clock: fault armed in IRIS -> dead_host readable from the findings API');
+console.log('(dashboard adds [0, dashboardInterval) on top -- reported separately)\n');
+
+const samples = [];
+for (let i = 0; i < runs; i++) {
+  // Start clean, or the finding from the previous run is still present and the next
+  // measurement reads ~0.
+  await reset();
+  if (!(await waitForClear())) {
+    console.log(`run ${i + 1}: findings did not clear, skipping`);
+    continue;
+  }
+  // Let the baseline settle so the comparative rules are not warming. dead_host is absolute
+  // and does not need it, but a warm baseline keeps the run representative of the demo.
+  await sleep(8_000);
+
+  // Phase stagger: spread injection across the proxy's poll cycle.
+  //
+  // A LINEAR RAMP IS NOT A STAGGER. Sweeping 0 -> interval in equal increments produced samples
+  // that fell monotonically (10.67 -> 9.25 across 2143ms), which reads as a trend in the system
+  // and is really just the ramp walking toward the next poll boundary in step with the runs.
+  // Interleaving the offsets breaks that correlation while still covering the cycle evenly:
+  // run order 0, 1/2, 1/4, 3/4, 1/8 ... via bit-reversal of the run index.
+  const bitrev = (n, bits) => {
+    let r = 0;
+    for (let b = 0; b < bits; b++) if (n & (1 << b)) r |= 1 << (bits - 1 - b);
+    return r;
+  };
+  const bits = Math.max(1, Math.ceil(Math.log2(runs)));
+  const phase = Math.round((bitrev(i, bits) / (1 << bits)) * PROXY_INTERVAL_MS);
+  await sleep(phase);
+
+  await arm();
+  const t0 = Date.now(); // AFTER the spawn returns -- no process-start cost in the sample
+  const ms = await timeToDetect(t0);
+
+  if (ms === null) {
+    console.log(`run ${i + 1}: no dead_host within 60s (phase +${phase}ms)`);
+    continue;
+  }
+  samples.push(ms);
+  const worst = ms + DASHBOARD_INTERVAL_MS;
+  console.log(
+    `run ${i + 1}: ${(ms / 1000).toFixed(2)}s to API` +
+      `  (+dashboard worst case = ${(worst / 1000).toFixed(2)}s)` +
+      `  phase +${phase}ms`,
+  );
+}
+
+await reset();
+await waitForClear();
+
+if (samples.length === 0) {
+  console.log('\nno samples collected');
+  process.exit(1);
+}
+
+const api = stats(samples);
+// TWO on-screen figures, because one of them is not comparable to anything.
+//
+// The dashboard's contribution is uniform on [0, interval): a change can land just before its
+// next poll or just after one. So:
+//   - WORST CASE adds the full interval. It is the honest upper bound, and it is what a
+//     "within 10s" criterion has to be judged against if the claim is to hold every time.
+//   - EXPECTED adds half. This is what the ADR's existing figures effectively report, because
+//     it measured the dashboard poll as an observed value (mean 1.03s at a 2s interval).
+// Quoting worst case against the ADR's expected case would manufacture a regression out of a
+// change of convention, which is the kind of comparison #63 was about.
+const worst = stats(samples.map((x) => x + DASHBOARD_INTERVAL_MS));
+const expected = stats(samples.map((x) => x + DASHBOARD_INTERVAL_MS / 2));
+const overWorst = samples.filter((x) => x + DASHBOARD_INTERVAL_MS > 10_000).length;
+const overExpected = samples.filter((x) => x + DASHBOARD_INTERVAL_MS / 2 > 10_000).length;
+
+const f = (x) => (x / 1000).toFixed(2);
+console.log(`\n--- to findings API (proxy staleness + engine debounce), n=${api.n} ---`);
+console.log(`  min ${f(api.min)}  median ${f(api.median)}  mean ${f(api.mean)}  max ${f(api.max)}`);
+console.log(`\n--- on screen, EXPECTED (+${DASHBOARD_INTERVAL_MS / 2}ms, half the poll) ---`);
+console.log(
+  `  min ${f(expected.min)}  median ${f(expected.median)}  mean ${f(expected.mean)}  max ${f(expected.max)}`,
+);
+console.log(`  over the 10s bar: ${overExpected} of ${api.n}`);
+console.log(`\n--- on screen, WORST CASE (+${DASHBOARD_INTERVAL_MS}ms, a full poll) ---`);
+console.log(
+  `  min ${f(worst.min)}  median ${f(worst.median)}  mean ${f(worst.mean)}  max ${f(worst.max)}`,
+);
+console.log(`  over the 10s bar: ${overWorst} of ${api.n}`);

--- a/tools/measure-latency.mjs
+++ b/tools/measure-latency.mjs
@@ -28,7 +28,15 @@ const args = process.argv.slice(2);
 const runs = Number(args.find((a) => /^\d+$/.test(a)) ?? 7);
 const flag = (name, fallback) => {
   const i = args.indexOf(name);
-  return i >= 0 ? args[i + 1] : fallback;
+  if (i < 0) return fallback;
+  // A trailing `--engine` with no value used to yield undefined and fail later inside fetch(),
+  // with an error naming neither the flag nor the omission (@tanifgit, #83).
+  const value = args[i + 1];
+  if (value === undefined || value.startsWith('--')) {
+    console.error(`${name} needs a value, e.g. ${name} http://localhost:3002`);
+    process.exit(2);
+  }
+  return value;
 };
 
 const ENGINE = flag('--engine', 'http://localhost:3002');
@@ -37,7 +45,15 @@ const ENGINE = flag('--engine', 'http://localhost:3002');
 const PROXY_INTERVAL_MS = Number(process.env.METRICS_POLL_INTERVAL_MS ?? 2500);
 const DASHBOARD_INTERVAL_MS = Number(process.env.VITE_POLL_INTERVAL_MS ?? 2000);
 
-const HOST = 'Cloud API';
+// NO HOST NAME HERE. Root CLAUDE.md §6: the `<Item>` set in Production.cls is authoritative and
+// must not be restated -- a copied host list is what went stale when FHIR Transform was removed.
+// A literal 'Cloud API' here would be a third copy in a third area, and `devA/labdemo-pipeline-simplify`
+// is an open branch that RENAMES production items. The day it lands, every run would time out with
+// "no dead_host within 60s", which reads as the product failing to detect rather than as a stale
+// constant in the measuring tool (@tanifgit, #83).
+//
+// Matching on type alone is sufficient: reset() + waitForClear() guarantee an empty findings list
+// before arming, so any dead_host inside the window is the one this run armed.
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // Triggers are ObjectScript, so arming one means a session inside the container. `docker exec`
@@ -97,7 +113,7 @@ async function timeToDetect(t0, timeoutMs = 60_000) {
   const until = t0 + timeoutMs;
   while (Date.now() < until) {
     const f = await findings();
-    if (f.some((x) => x.type === 'dead_host' && x.host === HOST)) {
+    if (f.some((x) => x.type === 'dead_host')) {
       return Date.now() - t0;
     }
     // 100ms so the sampling granularity is far below the thing measured. The findings API is
@@ -137,7 +153,14 @@ for (let i = 0; i < runs; i++) {
   // and does not need it, but a warm baseline keeps the run representative of the demo.
   await sleep(8_000);
 
-  // Phase stagger: spread injection across the proxy's poll cycle.
+  // Phase stagger: DECORRELATE consecutive runs from the proxy's poll cycle.
+  //
+  // Not "sweep the cycle evenly", which an earlier version of this comment claimed and the
+  // harness cannot deliver (@tanifgit, #83): the value below is an ADDED SLEEP, and the true
+  // offset is that sleep plus uncontrolled variable time -- waitForClear polls at 500ms
+  // granularity, then an 8s settle, then a variable-duration session spawn. So the offsets are
+  // decorrelated, not controlled, which is all this needs to be. Also note runs is rounded up to
+  // a power of two below, so for n=12 the four offsets at ==3 mod 4 are never drawn.
   //
   // A LINEAR RAMP IS NOT A STAGGER. Sweeping 0 -> interval in equal increments produced samples
   // that fell monotonically (10.67 -> 9.25 across 2143ms), which reads as a trend in the system
@@ -154,11 +177,21 @@ for (let i = 0; i < runs; i++) {
   await sleep(phase);
 
   await arm();
-  const t0 = Date.now(); // AFTER the spawn returns -- no process-start cost in the sample
+  // t0 AFTER arm() resolves, which is when `docker exec` CLOSES -- not when the trigger ran.
+  //
+  // BIAS, STATED RATHER THAN IMPLIED (@tanifgit, #83): the fault exists in IRIS from the moment
+  // DeadHost() executes, which is before `halt`, process exit and the exec round trip. All of
+  // that teardown sits outside the interval, so these samples are biased LOW and true latency is
+  // >= reported. The direction is favourable to us, which is exactly why it needs saying: "9 of
+  // 12 over the bar" is a FLOOR, not an estimate, and nobody should later argue these numbers
+  // are pessimistic. Removing the bias means stamping t0 inside the session ($ZTIMESTAMP written
+  // by the trigger) -- deliberately not done, because it would put a clock read in Triggers.cls
+  // for the benefit of a measuring tool.
+  const t0 = Date.now();
   const ms = await timeToDetect(t0);
 
   if (ms === null) {
-    console.log(`run ${i + 1}: no dead_host within 60s (phase +${phase}ms)`);
+    console.log(`run ${i + 1}: no dead_host within 60s (+${phase}ms sleep)`);
     continue;
   }
   samples.push(ms);
@@ -166,7 +199,7 @@ for (let i = 0; i < runs; i++) {
   console.log(
     `run ${i + 1}: ${(ms / 1000).toFixed(2)}s to API` +
       `  (+dashboard worst case = ${(worst / 1000).toFixed(2)}s)` +
-      `  phase +${phase}ms`,
+      `  +${phase}ms sleep`,
   );
 }
 


### PR DESCRIPTION
Answers the item ADR 0005's Status left for Dev B: *"the measurements are Dev B's and are theirs to confirm or correct."*

**Confirmed — and corrected in the unfavourable direction.** Which is the ADR being right, not a regression.

## The numbers

Containerised stack (#78), proxy 2500 ms / engine 5000 ms / dashboard 2000 ms:

| | to findings API | on screen (+1.0 s expected) | over the 10 s bar |
|---|---|---|---|
| **n=12** | min 6.09, median 9.75, mean 9.04, max 10.73 | min 7.09, median 10.75, mean 10.04, max 11.73 | **9 of 12** |
| drafted, n=7 | — | min 8.81, max 11.59, mean 9.90 | 2 of 7 |

The drafted figure came from very nearly phase-locked timers. The ADR argued drift would sweep the debounce across `[5, 10)` and make the unfavourable case *"not merely possible but eventually certain"*. Staggering injection across the proxy's poll cycle removes the phase-lock, and the samples do exactly that — the majority land above the bar.

So the deviation moves from **"misses the bar occasionally"** to **"misses it more often than not."** The decision does not move: 20 s still covers the 14.5 s arithmetic bound with margin. What changes is what an honest sentence about it says.

## The harness

`tools/measure-latency.mjs` arms the trigger and reads the findings API **inside one process**. That is the whole point — driving the injection from an agent tool call adds ~15 s of round trip, which is larger than the thing being measured, and it is what invalidated the first figure on #44 and a later stopwatch reading. Not avoidable by hand.

```bash
node tools/measure-latency.mjs 12
```

So a disputed figure here can now be answered with a measurement instead of an argument from the arithmetic.

## Two method errors of mine, both corrected and both commented in place

**A linear phase ramp is not a stagger.** My first run swept the offset 0 → interval in equal increments and produced this:

```
10.67  10.91  10.60  10.46  9.85  9.54  9.25
```

A clean monotonic decline, which reads as a trend in the product. It is the ramp walking toward the next poll boundary in step with the run counter — the sweep correlating with itself. Offsets are bit-reversed now and the correlation disappears. Same family as the phase-lock artifact this ADR already documents, which is what made me look twice.

**Worst case and expected case are not comparable.** My first summary added a *full* dashboard interval to every sample and compared the result against rows built from a *measured mean* (1.03 s at a 2 s interval). That manufactures a regression out of a change of convention — the #63 mistake in a new place. The harness now reports both, and the table above uses the expected case to match how the n=7 row was built.

## One expectation that turned out wrong

**Removing the gateway hop did not make this faster.** I expected it would, and said so on #78 — reasonable, since #78 deletes a network hop. But that hop was inside the proxy staleness window either way, and the budget is dominated by the debounce, which is unchanged. Containerising simplified the deployment; it did not buy latency. Recorded in the ADR because the opposite is the intuitive guess.

## Status stays `proposed`

Deliberately. @tanifgit — you were right not to flip it yourself, and the same logic applies to me more strongly: the numbers moved in the direction that makes our deviation look worse, and `accepted` on the measurer's own word is exactly what that field exists to prevent. Yours to review.

Also: this confirms the "what was measured" answer you asked for on #78 — **the compose stack is the reference environment now**, and the ADR says so.

## Verification

Engine 179/179, proxy 103/103. Docs plus one new tool under `tools/` (shared, PR + review per root `CLAUDE.md` §3); nothing under `apps/dashboard/**`. Branched from `main`, so it is independent of #78 and can land in either order.

Windows host / Docker Desktop / IRIS 2026.3.0AI Build 126U, measured ~20 minutes after `compose up` — naming the duration too, since a time-dependent claim without it is unfalsifiable.

Refs #44, #72, #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)