### PR TITLE
contracts: the four MVP 2 contracts — Early Warning, AI Detective, Smart Resolve, MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ Thumbs.db
 # even though the default value is a well-known one -- root CLAUDE.md §5. The template is
 # committed; the rendered file never is.
 docker/webgateway/CSP.ini
+
+# Local MCP connection config for iris-agentic-dev. Carries a password, and the host/port are
+# machine-specific -- the compose stack's published port differs per developer. Same reasoning
+# as docker/webgateway/CSP.ini: the rendered file with a credential is never committed.
+.iris-agentic-dev.toml

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,106 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-18 — four new MVP 2 contracts (Dev B)
+
+**Additive only. The two MVP 1 contracts are untouched** — `healthscan-api.md` and
+`proxy-api.md` are byte-identical, no field added, removed or retyped, no sample changed.
+`validate.mjs` unchanged at 15 accept / 19 reject / 7 capture claims, and still passing: the new
+shapes have **no schema and no samples yet**, so CI does not know these endpoints exist. That gap
+is named in each file rather than left to be discovered.
+
+| New | Owner | Consumers |
+|---|---|---|
+| `earlywarning-api.md` | Dev B | Dev C |
+| `investigation-api.md` | Dev B | Dev C |
+| `resolve-api.md` | Dev B (spec says Dev A + Dev B; Dev A left 2026-08-12 and Dev B inherited `iris/**`) | Dev C |
+| `mcp-tools.md` | Dev B (spec says Dev A; same reason) | Dev B, the AI Hub agent |
+
+Status on all four is **`proposed`**, not published. Each names what is missing before that
+changes: a `.schema.json`, a `.d.ts`, and a sample **captured from a live run**. The worked
+examples in all four are hand-constructed and arithmetically consistent, which is not the same
+bar as `contracts/samples/`, and every file says so at the top.
+
+### The three design rules worth reading before the schemas
+
+**A projection is not a measurement** (`earlywarning-api.md` §1.4). Every computed number is
+nested inside `projection` with `kind: "projection"`; every observed number sits outside it, so a
+consumer cannot hold a forecast without also holding the label. There is deliberately no
+`secondsToThreshold: 0` for an already-crossed queue, because zero reads as a measurement of now.
+This is #58's defect class — a derived value published in a slot promising an observed one — and
+"queue crosses threshold in 4 minutes" is a far more attractive version of it, because an operator
+will act on the sentence.
+
+**The data boundary is structural, not a footnote** (`investigation-api.md` §2.3, `mcp-tools.md`
+§6). The browser sends `{"findingId": "..."}` and nothing else, `additionalProperties: false` — so
+every value the external model sees was engine-measured or tool-read, and a browser cannot inject
+text into an LLM prompt. Tool *return values* are the only place instance data crosses the
+boundary by design, so the permitted and forbidden lists are per-tool. `get_recent_errors` is the
+live risk rather than a formality: it returns an IRIS error code mapped through an allowlist to a
+catalogue string, `unclassified` with no text for anything unrecognised. Two edges named because
+they are the ones that get missed — refusal *reason strings* cross the boundary too, and a count of
+one can itself be content, which is why the windows are bounded.
+
+**A recommended action is a structured object, never prose** (`investigation-api.md` §3.3). It is
+the input to a live production write that a human approves, and free text cannot be bounds-checked
+or matched against a whitelist. `recommendedAction.action` is `{type, host, size}` and is a
+field-for-field match with what `resolve-api.md` accepts — verified across both files, so there is
+no translation layer for Dev C to write.
+
+### Three cross-contract conflicts found and resolved while drafting
+
+Recorded because they were caught by writing the contracts *together* rather than in sequence, and
+each would have been a live integration bug:
+
+1. **`recommendedAction` shape.** `resolve-api.md` refuses unknown keys *inside* `action`, so a
+   flat action object carrying advisory fields would have been rejected as `malformed_request`.
+   Advisory fields (`currentValue`, `bounds`, `reversible`, `requiresApproval`, `summary`) are now
+   siblings of `action`, not members of it.
+2. **Bounds disagreed** — `1`–`4` versus `2`–`8`. Settled at `2`–`8`: the lower bound excludes `1`
+   because `1` is the *shipped* value, so recommending it is a no-op dressed as a fix.
+3. **Reusing Early Warning's `projection` inside an investigation would have been `null` every
+   time.** Early Warning publishes `projection: null` with reason `already_crossed` exactly when a
+   queue has crossed its threshold — which is the state that made `queue_buildup` fire, i.e. the
+   only condition an investigation is ever requested for. Renamed to `trend`, keeping the field
+   names and units but dropping the forecast framing, with `thresholdCrossed: true` and
+   `secondsToThreshold: null` as the normal case. Without it the "queue slope positive" evidence
+   bullet was unobtainable.
+
+### `resource` vs `role` is a distinction, not a disagreement
+
+`mcp-tools.md` gates on IRIS **resources** (`PG_Read`, `PG_Resolve`); `resolve-api.md` publishes
+the **role** that holds one (`%Guardian_Read`, `%Guardian_Resolve`) in `audit.role`. Reconciled
+after both landed, with a table in `resolve-api.md` §9.3, because grepping for one string and
+finding the other looks exactly like the #84 stale-copy pattern and invites a "fix" that would
+break it.
+
+### What is asserted about the runtime, and how it was established
+
+Authorization and audit are stated as a **guarantee** rather than a convention: they are performed
+by the runtime around every tool execution, in that order, so a tool author cannot forget them or
+bypass them via a careless `%Invoke` — and because the check precedes execution, a denied call
+cannot have partially mutated the production. Read from the shipped body of
+`%AI.ToolMgr.ExecuteTool` in the running `pg-iris` container, not inferred from the class list,
+because "the classes exist" and "the classes are enforced" are different claims and only the second
+is worth anything on a live production. Working notes in `docs/mvp2-aihub-verified-api.md`.
+
+Two things are **explicitly unverified** and flagged in the files rather than assumed: what an
+audit record contains once written (Dev C has to display one), and whether the default policy
+actually denies — `%AI.Policy.ConsoleAuth`/`ConsoleAudit` are wired out of the box, and "enforced
+by the runtime" is only a safety property if the configured policy refuses. `resolve-api.md` makes
+registering our own policy and testing a denial acceptance criteria rather than assumptions.
+
+### One change outside `contracts/` that these depend on
+
+`POST /api/resolve` cannot work as the engine stands: it sends `Access-Control-Allow-Methods: GET,
+OPTIONS` and no `Access-Control-Allow-Headers`, so a browser preflight for a JSON POST fails while
+every existing GET keeps working. Verified against the live engine. Not fixed here — it is engine
+code, not a contract — but named so it is not discovered from a dashboard that silently cannot
+submit an approval.
+
+---
+
+
 ## 2026-08-13 — `system_alert` scope stated in `healthscan-api.md` (Dev B)
 
 **Documentation only.** No field added, removed or retyped; no schema change; no sample

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -1,0 +1,574 @@
+# Early Warning API contract
+
+**Owner:** Dev B · **Consumer:** Dev C · **Port:** `3002` · **Status:** proposed
+
+One read-only endpoint, added for MVP 2. It projects the queue-depth trend forward and estimates
+time-to-threshold for each reported host — root `CLAUDE.md` §2.1, `services/detection-engine/CLAUDE.md`
+§1.1.
+
+**Early Warning adds nothing to Health Scan and changes nothing in it.** The eight finding types
+are unchanged, `FindingType` does not grow, and no field is added to `Finding` or `Host`. A
+projection is a *separate object on a separate endpoint*, joined to the rest by `host`. That
+separation is the point of §1.4, not an accident of routing.
+
+**Status is `proposed`, not `published`.** Dev C may mock against it now, and the two JSON examples
+in §4 are the bytes to mock — but `earlywarning.schema.json`, `earlywarning.d.ts` and
+`samples/earlywarning-response.json` are **not committed yet**, so nothing validates this shape in
+CI. See §7 for exactly what is missing and what closes it.
+
+---
+
+## 1. `GET /api/earlywarning`
+
+An array with **one entry per reported host**, whether or not that host has a projection. Same
+roster and same filtering as `GET /api/healthscan/hosts` — only application config items appear,
+framework items never do; the count is stated in `healthscan-api.md` §2 and deliberately not
+restated here.
+
+Sorted **alphabetically by `host`**, stable. Not by urgency: sorting by `secondsToThreshold` would
+reorder the list every poll as the fit moves, and half the entries have no urgency key at all
+because their projection is `null`. Dev C can sort client-side if a "most urgent first" layout is
+wanted.
+
+```ts
+/** GET /api/earlywarning returns EarlyWarningResponse. */
+export type EarlyWarningResponse = HostProjection[];
+
+export interface HostProjection {
+  /** Config item name. Always exactly equal to some Host.host — same string, same case. */
+  host: string;
+  /**
+   * The metric being projected. Only 'queued' in MVP 2.
+   * Treat as OPEN: if an unknown name arrives, label the axis from
+   * projection.slopeUnit rather than assuming items.
+   */
+  metric: string;
+  /**
+   * Latest MEASURED value of `metric` for this host. `null` means not measurable
+   * for this host, never zero — the same rule as Host.queued (healthscan Q13).
+   */
+  currentValue: number | null;
+  /**
+   * ISO 8601 UTC. The time of the sample `currentValue` came from — the engine's
+   * poll clock, NOT the request clock. See EW-Q3.
+   */
+  measuredAt: string;
+  /** Samples in the projection fit window. Measured, so present even when projection is null. */
+  fitSampleCount: number;
+  /** Seconds from the first to the last sample in the fit window. 0 when fitSampleCount < 2. */
+  fitSpanSeconds: number;
+  /** The threshold being projected toward, or null when there isn't one. See §1.3. */
+  threshold: Threshold | null;
+  /** The forecast. null whenever we decline to forecast — see §2. */
+  projection: Projection | null;
+  /** Why `projection` is null. null exactly when `projection` is non-null. See §2.1. */
+  projectionUnavailable: ProjectionUnavailableReason | null;
+}
+
+export interface Threshold {
+  /** The value a crossing is projected toward. */
+  value: number;
+  /** Which arm of the queue_buildup gate produced `value`. See §1.3. */
+  basis: 'absoluteFloor' | 'baselineMultiplier';
+  /** The rolling baseline the multiplier arm used. Never null here — no baseline, no threshold. */
+  baselineValue: number;
+  /** The finding type whose gate this is. Only 'queue_buildup' in MVP 2. */
+  findingType: string;
+}
+
+export interface Projection {
+  /**
+   * Literal discriminator. Every number in this object is computed, not observed.
+   * A consumer that has this object in hand cannot claim it did not know. See §1.4.
+   */
+  kind: 'projection';
+  /** How the slope was fitted. Only 'linear-least-squares' in MVP 2. */
+  basis: string;
+  /** Signed rate of change from the fit. Always > 0 when this object exists. */
+  slope: number;
+  /** Units of `slope`, spelled out. 'items/minute' for metric 'queued'. */
+  slopeUnit: string;
+  /** Whole seconds from `measuredAt` to the projected crossing. Integer, > 0. */
+  secondsToThreshold: number;
+  /** ISO 8601 UTC. Exactly measuredAt + secondsToThreshold — do not recompute from Date.now(). */
+  projectedCrossingAt: string;
+  /**
+   * Authoritative human-readable text. Render as-is, do not reconstruct.
+   * Always contains the hedge "at this rate". See §1.4.
+   */
+  message: string;
+}
+
+export type ProjectionUnavailableReason =
+  | 'disabled'
+  | 'metric_unmeasurable'
+  | 'warming'
+  | 'insufficient_samples'
+  | 'already_crossed'
+  | 'not_rising'
+  | 'beyond_horizon';
+```
+
+Every key is always **present**. `currentValue`, `threshold`, `projection` and
+`projectionUnavailable` may be `null`; the rest are always numbers or strings. A missing key is a
+contract violation, a `null` value is not — same rule as `healthscan-api.md` §1.
+
+### 1.1 How the slope is fitted
+
+Ordinary least squares of `value` against sample time (in minutes), unweighted, over every sample
+in the **fit window**: the trailing **300 s**, i.e. up to 60 samples at the shipped 5000 ms engine
+poll. `slope` is that line's gradient.
+
+Three things about that, each a decision rather than an implementation detail:
+
+- **The fit window is 300 s, not the 1800 s baseline window.** A 30-minute least-squares fit over
+  mostly-flat history systematically understates a rise that started two minutes ago — it would
+  hand back a comfortably distant ETA at exactly the moment the queue is running away. The whole
+  claim is "at *this* rate", so the fit has to be over the recent rate.
+- **It is not `(latest - previous) / interval`.** That is a one-sample difference and it is pure
+  noise at this cadence — `window.ts` exposes `latest()` and `previous()` for rate-of-change
+  comparisons and they are the wrong input here. It is also not `(last - first) / span`, which
+  throws away every sample in between.
+- **It needs no new state.** `MetricWindow` already stores `{at, value}` pairs pruned to a time
+  window, so the fit is computable from what the baseline already holds. It needs one new accessor
+  on that class; that is internal to `services/detection-engine/` and is not a contract change.
+
+`300` (fit window) and `1800` (projection horizon, §2.1) are detection numbers, so per ADR 0003
+they live in `thresholds.json` under an `earlyWarning` key and are hot-reloaded. They are **not**
+hard-coded in the projection logic, and this contract states the shipped values rather than
+promising they are the only possible ones.
+
+### 1.2 Rounding, and why it is deliberate
+
+| Field | Rounded to | Reason |
+|---|---|---|
+| `slope` | 1 decimal | `9.63841...` implies precision a 60-sample fit over a bursty queue does not have |
+| `secondsToThreshold` | whole seconds | same |
+| minutes inside `message` | nearest whole minute | the demo line is "~4 min", and a "~3.96 min" reads as a measurement |
+
+A slope that rounds to `0.0` is treated as not rising (§2.2) rather than published as
+`"rising ~0.0/min"`.
+
+### 1.3 What the threshold is, and why it can move
+
+`queue_buildup` fires when depth exceeds **both** its baseline multiplier and its absolute floor —
+`thresholds.json` gives `baselineMultiplier: 5.0` and `absoluteFloor: 50`. So the value a crossing
+is projected toward is:
+
+```
+threshold.value = max(baseline * 5.0, 50)
+```
+
+`threshold.basis` says which arm won, and `threshold.baselineValue` is the baseline that fed the
+multiplier arm. Both are published because `50` and `baseline * 5.0` behave completely differently
+over time:
+
+- **`absoluteFloor`** is fixed. In the MVP 2 scenario `Cloud API` sits at a near-zero queue
+  baseline, so `baseline * 5.0` is ~2 and the floor of 50 wins. The target does not move, and the
+  projection is at its most trustworthy.
+- **`baselineMultiplier`** is a **moving target**. The rolling mean includes the breaching samples
+  (`services/detection-engine/CLAUDE.md` §5.1 — deliberate, pinned by a test), so while a queue
+  climbs, so does `baseline * 5.0`. On a host where that arm is live, `secondsToThreshold` can
+  *increase* from one poll to the next while the queue is rising. That is not a bug in the
+  projection; it is the target receding. A consumer rendering a countdown must tolerate it going
+  up.
+
+`threshold` is `null` when there is no baseline yet — see `warming` in §2.1.
+
+### 1.4 A projection is not a measurement
+
+This is the central rule of this contract, and it is why the response is shaped the way it is
+rather than as a flat object with a `secondsToThreshold` field alongside `currentValue`.
+
+**Every computed number lives inside `projection`. Every observed number lives outside it.**
+`currentValue`, `measuredAt`, `fitSampleCount`, `fitSpanSeconds` and `threshold` are things we read
+or configured. `slope`, `secondsToThreshold`, `projectedCrossingAt` and `message` are things we
+inferred. The nesting plus `kind: 'projection'` means a consumer cannot pick up a forecast value
+without also holding the label that says it is one.
+
+The reason for being this strict: **a forecast presented as a measurement is the same defect class
+as issue #58.** There, `Host.lastActivity` was a required non-nullable date-time, so a host with no
+`iris_interop_last_activity` line got the poll's own clock published in that field. The value was
+well-formed, plausible, and meant "active now" to every reader — while the truth was "has not run
+since production start". Nothing downstream could tell the difference, and `stalled_host` was
+silently unable to fire for such a host: 30 minutes of idle-with-queue produced no finding, ever,
+because the fabricated timestamp advanced with the poll.
+
+The failure was not the arithmetic. It was that a *derived* value was published in a slot that
+promised an *observed* one. `secondsToThreshold` is a much more attractive version of the same
+mistake, because "queue crosses threshold in 4 minutes" is a sentence an operator will act on. So:
+
+- `slope` is **not** published outside `projection`, even when we decline to forecast. A visible
+  "rising ~0.5/min" next to no ETA still implies a forecast we refused to make.
+- there is **no** `secondsToThreshold: 0` for a queue that has already crossed. Zero reads as a
+  measurement of now; the honest answer is `projection: null` with reason `already_crossed` (§2.1).
+- `message` always contains the substring **"at this rate"**. That is a testable invariant, and it
+  is the hedge doing its job inside the one string Dev C renders verbatim.
+
+**Rendering requirement for Dev C:** `message` is authoritative — render it as-is, do not
+reconstruct it from the numbers. Render it inside a container that is visibly labelled as a
+projection, and **not** adjacent to measured values in the same visual group. Do not tick
+`secondsToThreshold` down client-side between polls: the underlying value does not tick, the slope
+is not stable, and an animated countdown would be animating our poll loop rather than the queue.
+Re-render from the served number on each poll and let it jump.
+
+---
+
+## 2. When there is no projection
+
+`projection: null` is a normal, frequent, expected response. Most hosts most of the time have
+nothing approaching a threshold, and **that must not be filled in with a plausible-looking ETA.**
+Never invent a number here; there is a reason code for every case instead.
+
+### 2.1 The seven reasons
+
+| `projectionUnavailable` | Means | `threshold` | Dev C renders |
+|---|---|---|---|
+| `disabled` | `earlyWarning.enabled` is `false` in `thresholds.json` (hot-reloadable, so this can appear mid-run) | may be non-null | nothing — hide the module |
+| `metric_unmeasurable` | `currentValue` is `null`. The metric is not measurable for this host, which is not zero (healthscan Q13) | `null` | `—` |
+| `warming` | No rolling baseline yet, so **no threshold exists to project toward**. Fewer than `minBaselineSamples` (12) in the 1800 s baseline window | `null` | `—`, plus the warming affordance |
+| `insufficient_samples` | Baseline is warm, but the 300 s fit window holds fewer than **12** samples — a newly appeared host, or a gap in polling | non-null | `—` |
+| `already_crossed` | `currentValue >= threshold.value`. There is no time remaining to forecast; the `queue_buildup` finding is the thing to render | non-null | defer to the finding |
+| `not_rising` | Fitted slope is `<= 0` after rounding to 1 decimal. Flat or draining — nothing is approaching anything | non-null | nothing, or a neutral "steady" |
+| `beyond_horizon` | Rising, but the projected crossing is more than **1800 s** away | non-null | nothing |
+
+**The horizon is 1800 s because that is the baseline window.** Do not project further forward than
+the span of history the fit is grounded in — a 90-minute ETA off a 5-minute fit is arithmetic, not
+information. It is also the point where an operator has no reason to care.
+
+`projectionUnavailable` is non-null **exactly when** `projection` is null. Both null, or both
+non-null, is a contract violation.
+
+### 2.2 Precedence — the order the checks run in
+
+A mock and the engine must agree on which reason wins when several apply, or Dev C's fixtures will
+disagree with live in ways that look like bugs. The order is:
+
+1. `disabled`
+2. `metric_unmeasurable` — no reading, nothing else can be evaluated
+3. `warming` — no baseline, therefore no threshold
+4. `insufficient_samples` — threshold exists, fit does not
+5. `already_crossed` — checked **before** the slope, because a crossed threshold makes the slope
+   irrelevant and a draining-but-crossed queue would otherwise report `not_rising`, which reads as
+   "nothing to see"
+6. `not_rising`
+7. `beyond_horizon`
+
+Otherwise: project.
+
+### 2.3 Warm-up, and `X-Healthscan-State`
+
+**The minimum sample count is 12** — `minBaselineSamples` from `thresholds.json`, reused rather
+than a new number, and reused for a reason: `threshold.value` is `max(baseline * 5.0, 50)`, and
+`baseline` is `null` below 12 samples (`baseline/window.ts` returns `null` and callers must not
+substitute a guess, ADR 0002). Below 12 samples there is no target, so there is nothing to project
+toward — not merely a noisy projection, but no projection defined at all.
+
+At the shipped 5000 ms engine poll that is **60 s of data minimum** before any projection can
+appear, and an engine restart resets it, because nothing is persisted (ADR 0002).
+
+Note the two windows are counted separately: 12 samples in the 1800 s **baseline** window gates
+`warming`; 12 samples in the 300 s **fit** window gates `insufficient_samples`. A host can pass the
+first and fail the second after a polling gap.
+
+**This endpoint sends the existing `X-Healthscan-State` header, unchanged, with the same
+engine-wide value the healthscan endpoints get** — `ok`, `warming`, or `stale`. There is
+deliberately **no** `X-Earlywarning-State`: it is the same engine, the same poll loop and the same
+snapshot, so a second header would be a second vocabulary that could disagree with the first.
+
+The header is advisory, exactly as in `healthscan-api.md` §3. `X-Healthscan-State: warming` implies
+every entry carries `projection: null` with reason `warming`; the per-host `projectionUnavailable`
+is the authoritative signal and Dev C may rely on it alone.
+
+---
+
+## 3. Errors and empty states
+
+| Situation | Response |
+|---|---|
+| No host has a projection | `200` + full array, every `projection` null — **never** `404`, never a filtered array |
+| No hosts yet / production stopped | `200` + `[]` |
+| Engine starting, no sample yet | `200` + `[]`, plus `X-Healthscan-State: warming` |
+| Baseline warming, hosts known | `200` + full array, all `projection` null, reason `warming`, plus `X-Healthscan-State: warming` |
+| Upstream proxy unreachable | `200` + last-known payload, plus `X-Healthscan-State: stale`. `measuredAt` does not advance — that is how staleness is visible in the body |
+| `earlyWarning.enabled: false` | `200` + full array, all `projection` null, reason `disabled` |
+| Genuine server fault | `500` + `{"error":"..."}` |
+| Non-`GET` method | `405` + `{"error":"..."}` |
+| `OPTIONS` preflight | `204` |
+| Unknown path | `404` + `{"error":"..."}` — the "never 404" rule is about empty *results*, not about routing |
+
+Same disposition as the findings API: prefer stale-but-labelled over an error, because a blanked
+dashboard is worse on stage than a slightly old one.
+
+**Entries are never omitted to signal absence.** A host with no projection appears with
+`projection: null` and a reason. Dropping it would leave Dev C unable to distinguish "not
+projecting" from "host gone", which is the ambiguity `healthscan-api.md` §2.1 documents for
+discarded alerts and would rather not repeat.
+
+**CORS:** `Access-Control-Allow-Origin: *`, plus `Cache-Control: no-store`, on this endpoint as on
+the other two (healthscan Q9). The dashboard works with or without the Vite dev proxy.
+
+---
+
+## 4. Worked examples
+
+### 4.1 Live projection — the MVP 2 scenario
+
+`Cloud API` at `PoolSize 1` against a ~1s-per-message downstream, so it clears ~1 msg/sec while
+inflow exceeds that. Net queue growth ~9.6/min. Baseline is ~0.4, so `baseline * 5.0` is ~2 and the
+absolute floor of 50 is the live arm.
+
+`200` · `X-Healthscan-State: ok`
+
+```json
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 12,
+    "measuredAt": "2026-08-18T10:14:32Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0.4,
+      "findingType": "queue_buildup"
+    },
+    "projection": {
+      "kind": "projection",
+      "basis": "linear-least-squares",
+      "slope": 9.6,
+      "slopeUnit": "items/minute",
+      "secondsToThreshold": 238,
+      "projectedCrossingAt": "2026-08-18T10:18:30Z",
+      "message": "Queue depth 12 rising ~9.6/min; at this rate it crosses 50 in ~4 min."
+    },
+    "projectionUnavailable": null
+  },
+  {
+    "host": "EMR Source",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-08-18T10:14:32Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  },
+  {
+    "host": "Lab Router",
+    "metric": "queued",
+    "currentValue": 3,
+    "measuredAt": "2026-08-18T10:14:32Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 1.2,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  }
+]
+```
+
+Arithmetic, so a mock can reproduce it: `(50 - 12) / 9.6 = 3.958 min = 237.5 s`, rounded to `238`;
+`10:14:32Z + 238 s = 10:18:30Z`; `3.958 min` rounds to `~4 min` in the message. Note `slope` is
+absent from the two non-projecting entries — §1.4.
+
+### 4.2 Insufficient data — 25 s after engine start
+
+Five samples in, no baseline, therefore no threshold. `currentValue` is a real reading and is
+published; nothing else is.
+
+`200` · `X-Healthscan-State: warming`
+
+```json
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 4,
+    "measuredAt": "2026-08-18T10:09:07Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "threshold": null,
+    "projection": null,
+    "projectionUnavailable": "warming"
+  },
+  {
+    "host": "EMR Source",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-08-18T10:09:07Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "threshold": null,
+    "projection": null,
+    "projectionUnavailable": "warming"
+  },
+  {
+    "host": "Lab Router",
+    "metric": "queued",
+    "currentValue": 1,
+    "measuredAt": "2026-08-18T10:09:07Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "threshold": null,
+    "projection": null,
+    "projectionUnavailable": "warming"
+  }
+]
+```
+
+Five samples at a 5000 ms poll is a 20 s span, and the queue *is* rising in this window — 0 to 4 in
+20 s is 12/min, which would extrapolate to a crossing in ~4 minutes and look exactly like §4.1.
+**That number is not published.** Twelve samples is the floor, and below it the honest response is
+`null` plus a reason.
+
+### 4.3 Already crossed — one entry, for the case a naive implementation gets wrong
+
+`200` · `X-Healthscan-State: ok`
+
+```json
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 128,
+    "measuredAt": "2026-08-18T10:22:12Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 6.1,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "already_crossed"
+  }
+]
+```
+
+No `secondsToThreshold: 0`, and no negative one. The threshold is behind us; the thing to render is
+the `queue_buildup` finding on `/api/healthscan/findings`, which states what is actually true.
+Note `baselineValue` has climbed from 0.4 to 6.1 — that is the self-inflating rolling mean of
+§1.3, and at `6.1 * 5.0 = 30.5` the floor is still the live arm.
+
+---
+
+## 5. Accuracy limits, and what this is not
+
+Stated here rather than left for someone to discover on stage.
+
+**A straight line through a rolling window is a crude model, and this is a crude implementation of
+it.** No confidence interval, no residual, no goodness-of-fit is published, because none is
+computed. `secondsToThreshold` is one number with no error bar, and the honest reading of it is
+"the current trend, if it holds, reaches the threshold around then" — which is what "at this rate"
+in `message` is there to say.
+
+**Queue slope is not stable.** The drain term is roughly constant in the MVP 2 scenario — PoolSize
+1 against a ~1s downstream clears ~1 msg/sec — but the arrival term is whatever load is being sent,
+and in the demo it is closer to a step than a ramp. A slope fitted across a step is an artifact of
+where the fit window happens to sit relative to the step, and it will move substantially between
+polls in the seconds after load changes.
+
+**The target can move as well as the value** — §1.3, whenever `basis` is `baselineMultiplier`.
+
+**Freshness is bounded by the poll intervals, not by this endpoint.** Per ADR 0005, on the shipped
+configuration (proxy 2500 ms, engine 5000 ms, dashboard 2000 ms) the arithmetic worst case from a
+change in IRIS to pixels is ~14.5 s, and the accepted criterion is 20 s with a measured 7.1–11.7 s,
+median 10.8 s, n=12. Two consequences:
+
+- `measuredAt` is already up to 7.5 s old when the response is generated, and up to ~14.5 s old
+  when it is on screen. The projection's starting point is that stale before its arithmetic begins.
+- **a `secondsToThreshold` below ~20 s is inside the pipeline's own latency bound.** It does not
+  mean "you have 15 seconds"; it means "effectively at the threshold already". It is still
+  published — suppressing the most urgent case would be worse — but it must not be rendered as time
+  to act, and a second-by-second countdown at that scale is displaying our poll loop.
+
+Early Warning does **not** shorten any of those intervals and must not be used as an argument to.
+`sustainedSeconds` sets a hard floor under `POLL_INTERVAL_MS` at the shipped 5000 ms
+(ADR 0005 and #64), and lowering it is lowering the false-positive protection MVP §6 names as the
+top risk.
+
+### What this is not
+
+| Not | Which is |
+|---|---|
+| A forecast model | Linear extrapolation of a 300 s window. No seasonality, no anomaly detection, no learning, no per-host tuning |
+| A 30-day baseline | 30 **minutes**, in memory, lost on restart (ADR 0002). `docs/production-guardian-demo.html` says "verified against a 30-day baseline"; that file is a concept demo with scripted data and is not what this is |
+| A health score | A single 0–100 number is **Health Score**, still out of scope (root `CLAUDE.md` §2.2) |
+| A trend chart | Historical trend charts are still out of scope. This endpoint publishes one slope, not a series — there is no time series on the wire and Dev C cannot draw one from it |
+| A finding | No new `FindingType`, no "will breach" pseudo-finding. Findings state what is true now; this states what might be true later, on a different endpoint |
+| A reason to act automatically | Nothing applies unattended. Smart Resolve is human-approved by default (root `CLAUDE.md` §2.1) |
+| Root-cause narrative | AI Detective, and the narrative comes from the agent in IRIS |
+
+---
+
+## 6. The questions this raises, answered up front
+
+Dev C has not raised these yet. `healthscan-api.md` §4 exists because thirteen questions arrived
+after that contract shipped; this section is the attempt to answer the obvious ones before they
+have to be asked.
+
+| # | Question | Answer |
+|---|---|---|
+| **EW-Q1** | Is the endpoint path really `/api/earlywarning` and not `/api/earlywarning/projections`? | As specified, `/api/earlywarning`, on `:3002`. It does break the `/api/<module>/<resource>` shape the healthscan routes use. **Flagged rather than silently changed** — confirm before hardcoding it, because moving it later is a consumer-visible change for a cosmetic reason |
+| **EW-Q2** | Join key to hosts and findings? | `host`, always exactly equal to some `Host.host` and to `Finding.host`. Same string, same case — healthscan Q8 |
+| **EW-Q3** | Is `measuredAt` the request time? | **No.** It is the sample's poll time. Between engine polls the same bytes are served repeatedly and `measuredAt` does not advance; that is how a consumer sees staleness. A timestamp taken from the request clock would make a five-minute-old projection look fresh forever — which is #58 exactly (§1.4) |
+| **EW-Q4** | Are `slope` and `secondsToThreshold` ever negative or zero? | No. Both are `> 0` whenever `projection` exists; the cases that would produce zero or negative are `not_rising` and `already_crossed`, and both yield `projection: null` |
+| **EW-Q5** | Can a host disappear from the array between polls? | Yes — when it leaves the production roster, same as `/api/healthscan/hosts`. It does **not** disappear merely for having no projection |
+| **EW-Q6** | Should the UI interpolate between polls? | No. Re-render from the served numbers; let `secondsToThreshold` jump. §1.4 |
+| **EW-Q7** | Is `metric` a closed enum? | Treat as **open**, same defensive posture as `HostStatus`. Only `queued` in MVP 2; label from `slopeUnit` if an unknown name arrives, and render unknowns neutrally |
+| **EW-Q8** | Does a projection ever contradict a finding? | It can look that way and it is not a contradiction: `queue_buildup` requires a **sustained** breach (`sustainedSamples` 2 **and** `sustainedSeconds` 4), so a queue can cross `threshold.value` and be reported `already_crossed` here for a poll or two before the finding is confirmed. Render the projection and the finding from their own endpoints; do not derive one from the other |
+| **EW-Q9** | Why is there no `confidence` field? | Because nothing computes one. A confidence score is AI Detective's output and comes from the agent; a hand-rolled number here would be a made-up statistic on top of a crude fit |
+
+**Marker convention**, per `README.md`: tag each assumption site inline with the assumption stated,
+not just the number — `// EW-Q1: assumed path /api/earlywarning, unratified` — so reconciliation is
+a `grep` rather than an audit.
+
+---
+
+## 7. What is not committed yet
+
+Named rather than quietly left off the table, the way `README.md` handles the two missing proxy
+samples.
+
+| Missing | Consequence | What closes it |
+|---|---|---|
+| `earlywarning.schema.json` | Nothing in `contracts/` validates this shape; the `contracts` CI job does not know this endpoint exists | A schema with a named `EarlyWarningResponse` definition, plus accept/reject cases in `validate.mjs` — including rejects for `projection` and `projectionUnavailable` both non-null, and for a `secondsToThreshold` outside `projection` |
+| `earlywarning.d.ts` | Dev C transcribes from the TS block in §1 instead of importing | Lift §1 verbatim into a `.d.ts`, hand-maintained against the schema |
+| `samples/earlywarning-response.json` | The §4 examples are the shared bytes, in Markdown rather than in `samples/` | Commit §4.1 as a sample, **captured from a live run** rather than kept as the hand-written numbers it is today |
+
+The §4 values are constructed to be arithmetically consistent and to match the scenario, but they
+are **not a live capture**. `contracts/samples/` was built from real measurements on purpose, and
+this file does not meet that bar yet. Replace them with a capture before this contract moves from
+`proposed` to `published`.
+
+---
+
+## 8. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by every
+other developer. See `README.md` in this directory.
+
+When estimating what a change costs, do not estimate from the size of the edit. **The question is
+not how many lines reference a value, it is whether anything *means* something in terms of it** —
+`README.md` has the worked example, where a one-line enum narrowing cost 83 insertions across 10
+files because fixtures had built a concept on the removed value.
+
+The field most exposed to that here is `projection`. Anything that flattens it, or that adds a
+forecast-derived number outside it, is not a field change: it removes the structural guarantee in
+§1.4 that a consumer holding a forecast also holds the label saying it is one. That is the whole
+contract, and it is cheaper to defend than to reinstate.

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -1,0 +1,865 @@
+# AI Detective investigation API contract
+
+**Owner:** Dev B · **Consumer:** Dev C · **Port:** `3002` · **Status:** published for Day-1 mocking
+
+One endpoint: `POST /api/investigate`. It takes a finding id and returns a structured root-cause
+investigation produced by the AI Hub agent inside the `iris` container.
+
+**The detection engine orchestrates; it does not reason.** The narrative, the evidence and the
+recommendation all originate in the agent (`services/detection-engine/CLAUDE.md` §1.1). The engine
+adds a request envelope, a timeout, a state label and a cache. A `rootCause` string composed by the
+engine would be a contract violation even if it were accurate, because a consumer cannot tell it
+apart from the agent's.
+
+Machine-readable: `investigation.schema.json` and `investigation.d.ts` are **not landed yet**. This
+document is normative until they are, and they must be derived from it rather than the reverse.
+`samples/investigation-response.json` is likewise **not captured yet** — noted rather than quietly
+left off `README.md`'s table. Until it exists, the payloads in §8 are the bytes to mock against, and
+they are illustrative: the numbers are plausible for the scenario but were **not** captured from a
+live run, unlike the Health Scan samples. Replace them with a capture before they become a fixture.
+
+**ASCII inside payload strings, deliberately.** `1 -> 4`, not `1 → 4`. Prose in this file uses
+proper UTF-8 em dashes; payloads do not, because a sample is compared byte for byte and an arrow
+that survives one editor and not another is how both of this project's encoding incidents started.
+
+**Two neighbouring contracts this one leans on.** `earlywarning-api.md` owns the queue-depth slope
+reused as `trend` in §2.2, and `mcp-tools.md` (Dev A) owns the read-tool names quoted in §3.2 and
+`diagnostics.toolCalls`. Tool names here are **not authoritative** — if that catalogue names them
+differently, it wins and this file is amended. `resolve-api.md` consumes `recommendedAction` (§3.3).
+
+**No LLM provider is configured on the instance yet** (`docs/mvp2-aihub-verified-api.md`): nothing
+has called an external model from it. So every claim in this contract about what the *agent* returns
+is a specification of what the engine will accept, not an observation of what an agent produced.
+That cuts both ways — it is why §4.4 discards a malformed agent response entirely rather than
+salvaging fields, and it is why the timings in §4.2 are labelled as chosen rather than measured.
+
+---
+
+## 1. Two hops, and which one this contract governs
+
+There are two request/response pairs, and conflating them is how the data boundary in §2.3 gets
+broken:
+
+```
+Dev C (browser)  --POST /api/investigate-->  detection-engine :3002
+detection-engine --InvestigationRequest--->  AI Hub agent (in the iris container)
+                                             agent --MCP read tools--> IRIS
+                                             agent --prompt----------> external LLM
+```
+
+| Hop | Request | Response | Governed by |
+|---|---|---|---|
+| Browser → engine | §2.1 — a finding id, nothing else | §3.1 `InvestigationResponse` | this contract |
+| Engine → agent | §2.2 `InvestigationRequest` | §3.1 `InvestigationResponse` | this contract |
+| Agent → IRIS | MCP read tool calls | tool results | `mcp-tools.md` (Dev A) |
+| Agent → LLM | prompt built by the agent | completion | AI Hub configuration |
+
+The response shape is deliberately the **same object on both hops**, minus the envelope fields the
+engine fills in (`state`, `source`, `diagnostics.durationMs`). One shape means the mock agent, the
+live agent and the cache are interchangeable, which is what ADR 0004's mock-first bet requires.
+
+**The engine never reaches the LLM and holds no LLM key.** Everything the model sees passes through
+the agent, which is inside IRIS with the credential vault and the audit log. That is the point of
+the architecture and it is why §2.3 is enforceable at all.
+
+## 2. The request
+
+### 2.1 What the dashboard sends
+
+```json
+{ "findingId": "f-1041" }
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `findingId` | string | Must equal a `Finding.id` currently served by `GET /api/healthscan/findings`. |
+
+**That is the whole body.** `additionalProperties: false`. There is no `question`, no `metrics`, no
+`context`, no `prompt`, no `hostOverride`.
+
+This is not minimalism for its own sake — it is the structural half of the data boundary. If the
+dashboard could supply metrics or free text, the browser would become a data source feeding an
+external LLM prompt, and **nothing downstream could distinguish operator-typed text from a measured
+metric.** Because the body is one id, every value the model sees was measured by the engine or read
+by an MCP tool. Adding a field here is both a contract change and a change to the safety argument.
+
+`Content-Type: application/json` is required. A body that is not an object, or that carries any key
+other than `findingId`, is a `400` (§5) — not a best-effort parse.
+
+### 2.2 What the engine sends to the agent — `InvestigationRequest`
+
+The engine builds this from its own in-memory state. It is a closed allowlist:
+`additionalProperties: false` at **every** level.
+
+```json
+{
+  "requestId": "inv-8a31f0",
+  "requestedAt": "2026-08-18T09:14:22Z",
+  "finding": {
+    "id": "f-1041",
+    "host": "Cloud API",
+    "type": "queue_buildup",
+    "severity": "critical",
+    "currentValue": 214,
+    "baselineValue": 3,
+    "detectedAt": "2026-08-18T09:13:48Z",
+    "message": "Queue depth 214 is 71x baseline"
+  },
+  "snapshot": {
+    "host": "Cloud API",
+    "capturedAt": "2026-08-18T09:14:20Z",
+    "status": "OK",
+    "queued": 214,
+    "queuedBaseline": 3,
+    "messagesPerSec": 0.97,
+    "messagesPerSecBaseline": 0.94,
+    "avgProcessingTime": 1.02,
+    "avgProcessingTimeBaseline": 0.05,
+    "avgQueueingTime": 61.4,
+    "avgQueueingTimeBaseline": 0.03,
+    "errored": 0,
+    "lastActivity": "2026-08-18T09:14:19Z",
+    "inboundRatePerSec": 3.04
+  },
+  "trend": {
+    "metric": "queued",
+    "slope": 124.2,
+    "slopeUnit": "items/minute",
+    "thresholdValue": 50,
+    "thresholdCrossed": true,
+    "secondsToThreshold": null
+  }
+}
+```
+
+**Envelope**
+
+| Field | Type | Notes |
+|---|---|---|
+| `requestId` | string | Engine-generated, unique per agent call. Echoed in the response and used to correlate with the AI Hub audit log. Not a finding id. |
+| `requestedAt` | string | ISO 8601 UTC, `Z`-suffixed. Same format as every timestamp in `healthscan-api.md`. |
+| `finding` | object | **Exactly `healthscan.schema.json#/definitions/Finding`, embedded verbatim.** |
+| `snapshot` | object | See below. Always present. |
+| `trend` | object \| **null** | Queue-depth trend from Early Warning's fit, or `null` when there is no usable fit. **Not** Early Warning's `projection` — see below. |
+
+**`finding` is embedded, not reshaped.** It validates against the ratified `Finding` definition
+unchanged — all eight required fields (`id`, `host`, `type`, `severity`, `currentValue`,
+`baselineValue`, `detectedAt`, `message`), `additionalProperties: false`, `baselineValue` still
+nullable. An investigation is *about* a finding, so redefining the shape here would be a second
+transcription of a ratified object, and a second transcription drifts. If the agent needs a field
+`Finding` does not carry, that is a change request against `healthscan-api.md`, not a local addition.
+
+**`snapshot`** — every field is a value **this engine already holds**, derived from the proxy's
+per-host payload and the rolling baseline window:
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Always equal to `finding.host`. |
+| `capturedAt` | string | ISO 8601 UTC. The poll the snapshot came from, not the request time. |
+| `status` | string | As `healthscan-api.md` Q1. Open string. |
+| `queued` | integer \| null | `null` means **not measurable**, never zero (Q13). |
+| `queuedBaseline` | number \| null | `null` while the baseline is warming (Q3). |
+| `messagesPerSec` | number | Completions per second over the last interval. |
+| `messagesPerSecBaseline` | number \| null | |
+| `avgProcessingTime` | number | **Seconds** (Q6). |
+| `avgProcessingTimeBaseline` | number \| null | |
+| `avgQueueingTime` | number | **Seconds** (Q6). |
+| `avgQueueingTimeBaseline` | number \| null | |
+| `errored` | integer \| null | `null` means not measurable, never zero (Q13). |
+| `lastActivity` | string | ISO 8601 UTC, ±10 s (Q11). |
+| `inboundRatePerSec` | number \| null | **Derived, not measured** — see below. |
+
+The baseline fields are not decoration. For this scenario the load-bearing one is
+`avgProcessingTime` against `avgProcessingTimeBaseline`: Cloud API's measured steady state is
+~0.05 s, and the downstream dispatcher's ~1 s throttle shows up as ~1.02 s. The ratio is what the
+"each message ~1s from the downstream dispatcher throttle" evidence bullet rests on. A snapshot
+without baselines would force the agent to assert that number instead of comparing it.
+
+**`inboundRatePerSec` is derived and must be labelled as such wherever it is shown.** No metric
+measures arrival rate at a host's queue. The engine computes `messagesPerSec + trend.slope/60` —
+completions plus the rate the queue is growing. It is `null` when either term is unavailable,
+**including whenever `trend` is `null`**, rather than falling back to `messagesPerSec` and reading as
+"inflow equals throughput", which is precisely the conclusion the finding contradicts. This is the
+same defect class as the coerced `lastActivity` in #58: a computed value presented as a measurement.
+
+It sits in `snapshot` rather than `trend` because it is a rate *now*, not a forecast — but it is the
+one field in `snapshot` that is not measured, so it is the one field in `snapshot` that carries a
+"derived" caveat. If it grows a second consumer, move it out.
+
+**There is no `poolSize` in the snapshot, and that is deliberate.** The engine reads metrics, not
+configuration; it has no path to `Ens.Config.Item`. `PoolSize` reaches the agent through the
+`get_pool_size` MCP read tool. So the central piece of evidence in this scenario is *tool-measured*
+rather than *engine-asserted* — which is exactly why `evidence[].source` (§3.2) exists.
+
+**`trend` is the queue-depth fit, and it is deliberately NOT Early Warning's `projection` object.**
+This is the one place where reusing the neighbouring contract's shape would have been wrong, so the
+reasoning is written down rather than left to be rediscovered:
+
+By the time a `queue_buildup` finding exists, the queue has **already crossed** `threshold.value` —
+that is what made the finding fire. `earlywarning-api.md` §2.1 publishes `projection: null` with
+`projectionUnavailable: "already_crossed"` in exactly that state, because there is no time remaining
+to forecast, and §1.4 forbids publishing `slope` outside `projection` since a visible rate next to no
+ETA implies a forecast it refused to make.
+
+Both rules are right for that endpoint and both are fatal here: **the investigation would receive
+`null` for the one condition it is always invoked on**, and "queue slope positive" is a required
+evidence bullet. So `trend` reuses the *field names and units* and drops the *forecast framing*. It
+is a description of a slope now, not a prediction of a crossing.
+
+| Field | Type | Notes |
+|---|---|---|
+| `metric` | string | `HostProjection.metric`. Only `queued` in MVP 2. Open string. |
+| `slope` | number | Same fit and same units as `Projection.slope` — OLS over the trailing 300 s. **May be zero or negative here**, unlike in `earlywarning-api.md`, because a queue that is draining is a fact the agent should see rather than a forecast to withhold. |
+| `slopeUnit` | string | Spelled out, e.g. `items/minute`. Carried so the agent never has to infer the unit. |
+| `thresholdValue` | number | `Threshold.value` — `max(baseline * 5.0, 50)`. For this scenario the `absoluteFloor` arm of 50 wins, because Cloud API's queue baseline is near zero. |
+| `thresholdCrossed` | boolean | `queued >= thresholdValue`. **Normally `true`** on an investigated finding. Present so the agent never has to infer it from a null ETA. |
+| `secondsToThreshold` | integer \| null | Whole seconds, `> 0`. **`null` whenever `thresholdCrossed` is `true`**, which is the usual case — there is no crossing left to forecast. Never `0`, never negative. |
+
+`trend` is `null` when there is no usable fit at all — a warming baseline, or fewer than 12 samples
+in the fit window. `null` rather than a zero slope, because "not fitted" and "flat" are different
+claims and only one of them is a measurement.
+
+`earlywarning-api.md` still owns the slope's **definition**: the fit window, the estimator and the
+threshold arithmetic are specified there, and if they change there they change here. What this
+contract owns is the decision to carry the slope past the point that contract stops publishing it.
+
+**`kind: 'projection'` is deliberately absent, and the rename is why that is safe.** That
+discriminator exists so a consumer cannot hold a forecast without holding the label saying it is one
+(`earlywarning-api.md` §1.4, issue #58's defect class). `trend` carries no forecast to mislabel: the
+one predictive field is `secondsToThreshold`, and it is `null` in the case this endpoint actually
+serves. **If a field from this object is ever hoisted alongside `snapshot`, or if `secondsToThreshold`
+starts arriving non-null, the discriminator comes back with it.**
+
+### 2.3 The data boundary is part of the schema
+
+**Only metrics and configuration may reach the external LLM. Never message content. Never PHI.**
+Root `CLAUDE.md` §2.1 states this as a rule rather than a preference; this section is where it is
+made structural.
+
+This matters because Production Guardian is a healthcare operations tool sitting on an HL7
+interoperability production, and **the LLM is a third party outside the instance.** Everything else
+in MVP 2 — RBAC, the credential vault, the audit log — is inside IRIS where the data already is. The
+LLM call is the one hop that leaves, so it is the one hop where a leak is not recoverable by
+revoking a role.
+
+The allowlist in §2.2 *is* the enforcement. There are exactly three top-level keys plus the
+envelope, every object is `additionalProperties: false`, and every leaf is a number, a null, a
+timestamp, a host name, a status enum, or `finding.message`.
+
+**A field carrying message bodies is a contract violation, not a configuration mistake.** Named
+explicitly, so no future PR has to infer it:
+
+| Must never appear | Why it is tempting |
+|---|---|
+| HL7 message text, segments, or fields | "the agent could see what is actually queued" |
+| Patient identifiers — MRN, name, DOB, address, account number | rides along inside message text |
+| `Ens.MessageHeader` rows or `Ens.MessageBody` contents | the read tools can reach them |
+| Raw SQL or MCP tool results pasted into the request | "more context helps the model" |
+| Free text originating from an operator or a browser | §2.1 |
+| Session, correlation or trace ids that resolve to a patient encounter | looks like plumbing |
+
+Counts derived from those sources are fine — `errored: 37` is a number, not a message. The rule is
+about content, not about provenance.
+
+**`finding.message` is the one prose field crossing the boundary, so it gets its own rule.** For the
+seven per-host rules the engine authors that string itself and it is metric prose by construction
+("Queue depth 214 is 71x baseline"). It must stay that way: a `message` that quotes message content
+would carry it across the boundary through a field nobody was watching.
+
+**`system_alert` findings are the concrete hole, and §2.4 closes it.** Their `message` copies text
+from `alerts.log`, which the engine did **not** author — IRIS wrote it, and an alert about a failed
+send can name the message it failed to send. That text is not safe to forward unread, and there is
+no reliable way to sanitise arbitrary alert prose. So the engine does not accept those findings at
+all.
+
+### 2.4 Only one finding shape is accepted
+
+`POST /api/investigate` accepts a finding where **`type` is `queue_buildup` and `host` is
+`Cloud API`.** Anything else returns `200` with `state: "unavailable"` and
+`failureReason: "out_of_scope"` (§5).
+
+Two reasons, and both are load-bearing:
+
+1. **Scope.** MVP 2 is one scenario end to end, not a general capability (root `CLAUDE.md` §2.1).
+   One finding type, one host, one action type. An endpoint that accepts all eight types implies
+   eight investigations exist.
+2. **Safety.** It is what makes §2.3's alert-text hole unreachable rather than merely discouraged.
+
+The dashboard should not offer the Investigate button for other findings; the check here is the
+backstop, not the UI's contract. When a second scenario lands, widening this set is a contract change
+that must say what it does about `system_alert`.
+
+## 3. The response
+
+### 3.1 `InvestigationResponse`
+
+```
+{
+  requestId, findingId, state, source, investigatedAt,
+  rootCause, evidence, confidence, recommendedAction, diagnostics
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `requestId` | string | Echoes §2.2. Correlates to the AI Hub audit entries for this investigation. |
+| `findingId` | string | Echoes the requested id. Always present, even when `state` is `unavailable`. |
+| `state` | string | `complete` \| `degraded` \| `unavailable` — see §4.1. Also sent as `X-Investigation-State`. |
+| `source` | string | `agent` \| `cache` \| `canned` \| `none`. Where the content came from — see §4.3. |
+| `investigatedAt` | string | ISO 8601 UTC. **When the content was produced**, not when it was served. For `source: "cache"` this is older than the request, and that gap is what the UI must surface. |
+| `rootCause` | string \| **null** | The agent's narrative. Human-readable and **authoritative — render as-is, do not reconstruct or summarise.** `null` when `state` is `unavailable`. |
+| `evidence` | array | §3.2. May be `[]`. Never `null`, never absent. |
+| `confidence` | number \| **null** | 0.0–1.0. §3.4. |
+| `recommendedAction` | object \| **null** | §3.3. `null` when the agent recommended nothing, and always `null` when `state` is `unavailable`. |
+| `diagnostics` | object | §3.5. Always present. |
+
+Every key is always **present**. `rootCause`, `confidence` and `recommendedAction` may be `null`; a
+missing key is a contract violation, a `null` value is not. This is the same discipline as
+`healthscan-api.md` §1, and for the same reason: a consumer that must distinguish absent from null
+ends up guessing.
+
+`rootCause` is prose *about metrics and configuration*, generated outside the instance. It is safe
+to render but it is not a measurement — §3.2's `source` field is how a reader tells which parts of
+the investigation were measured.
+
+### 3.2 `evidence[]`
+
+```json
+{
+  "label": "Cloud API pool size",
+  "detail": "Cloud API PoolSize = 1",
+  "source": "mcp_tool",
+  "tool": "get_pool_size"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `label` | string | Short noun phrase. For grouping or a table column. |
+| `detail` | string | **The bullet.** Renderable on its own, authoritative, render as-is. |
+| `source` | string | `mcp_tool` \| `snapshot` \| `llm`. Open string: render unknown values as `llm`, the least-trusted value. |
+| `tool` | string \| null | MCP tool name when `source` is `mcp_tool`; otherwise `null`. Name only. |
+
+`evidence` is ordered most-to-least load-bearing, as the agent ranked it. Dev C may render in order
+and need not sort.
+
+**`source` is the field worth having.** A human is about to approve a write to a live production, and
+the single most useful thing to know about a bullet is whether a tool measured it or the model said
+it. `mcp_tool` means an MCP read tool returned it and the call is in the audit log. `snapshot` means
+it came from §2.2, so the engine measured it. `llm` means the model asserted it — it may still be
+right, and it is not evidence in the same sense. Render the distinction; do not flatten these into
+identical bullets.
+
+`evidence: []` with `state: "complete"` is valid and means the agent produced a narrative without
+citing anything. That is a weak investigation, and it should look weak in the UI rather than being
+padded from the snapshot by either side.
+
+### 3.3 `recommendedAction` is a structured object, never prose
+
+```json
+{
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 4
+  },
+  "currentValue": 1,
+  "bounds": { "min": 2, "max": 8 },
+  "reversible": true,
+  "requiresApproval": true,
+  "summary": "increase Cloud API pool 1 -> 4"
+}
+```
+
+**`action` is the part that travels, and it is exactly three keys.** `resolve-api.md` §1.2 requires
+`POST /api/resolve`'s `action` to be a **field-for-field copy** of this object — same three keys, same
+spelling, same types — and §1.1 **refuses unknown keys inside `action`** (`malformed_request`). So
+`action` is nested rather than flat, and the advisory fields are its siblings, not its members.
+
+| Field | Type | Notes |
+|---|---|---|
+| `action` | object | **Passed to `POST /api/resolve` verbatim.** Exactly three keys, `additionalProperties: false`. |
+| `action.type` | string | **Enumerated. Exactly one member for MVP 2: `set_pool_size`.** |
+| `action.host` | string | The config item to act on. Equal to `finding.host`, and `Cloud API` is the only whitelisted value (`resolve-api.md` §3). |
+| `action.size` | integer | Target pool size. **`size`, not `proposedValue`** — the name is `resolve-api.md`'s. |
+| `currentValue` | integer | Pool size now, as read by `get_pool_size`. Not the engine's guess. Feeds `precondition.poolSize` on the resolve call and the reversal target. |
+| `bounds` | object | `{ min: integer, max: integer }`. `2`–`8` per `resolve-api.md` §3. **Advisory** — see below. |
+| `reversible` | boolean | Whether re-applying `currentValue` undoes it. |
+| `requiresApproval` | boolean | **Always `true` for MVP 2.** |
+| `summary` | string | One line for the approval button's label. Authoritative, render as-is. |
+
+`additionalProperties: false` at both levels.
+
+**Dev C must not build a translation layer.** Take `recommendedAction.action` and send it as
+`action`; take `currentValue` and send it as `precondition.poolSize`. Any reshaping between the two
+endpoints is the prose-parsing failure with extra steps, which is `resolve-api.md` §1.2's stated
+concern and the reason the field names here are that contract's and not this one's.
+
+**Why this is not a string.** `recommendedAction` is the input to Smart Resolve, and a human approves
+it before it is applied to a live production. Free prose cannot be validated against a whitelist,
+cannot be bounds-checked, and cannot be turned into a `POST /api/resolve` body without something
+parsing English — which is a second reasoning step in the layer that is explicitly not allowed to
+reason. A structured object can be checked field by field before anything is offered for approval.
+
+**An unknown `action.type` must be rejected, and the shape makes that possible.** It is a closed enum
+with one member, so an unrecognised value is a schema failure rather than a passthrough. Required
+consumer behaviour: treat the whole `recommendedAction` as absent, render "no recommended action
+available", and **disable the approve control**. Do not render the `summary` for an unknown type —
+prose the consumer cannot validate is exactly what a whitelist exists to stop. Same for a `size`
+outside `bounds`, a non-integer `size`, or a `host` that is not `finding.host`.
+
+**`bounds` is advisory and is not authorization.** The authoritative range is `2`–`8`, enforced by
+the engine's resolve endpoint and re-enforced by the `set_pool_size` MCP write tool inside IRIS
+behind RBAC; `resolve-api.md` §3 and `mcp-tools.md` own it. `bounds` is carried here so the UI can
+validate before a round trip. A consumer that treats `bounds` as permission has moved the safety
+check into the browser.
+
+**Note the agent cannot recommend `size: 1`, and that is a real constraint on it, not a formality.**
+`resolve-api.md` §3 sets the lower bound at `2` because `1` is the shipped value, so recommending it
+is a no-op dressed as a fix. An agent that returns `size: 1` produces a `recommendedAction` the
+consumer must reject under the rule above — the correct outcome, and worth knowing when writing the
+agent's prompt rather than discovering at the refusal.
+
+**`requiresApproval: true` is invariant, not a default.** MVP 2 has no unattended path. It is in the
+schema so that a future change making it `false` is visible as a contract change reviewed by
+everyone, rather than a config flag someone flips. §7.3 of the MVP 2 spec floats
+"confidence-gated auto-apply" as a possible enhancement; this contract does not make it possible,
+and §3.4 explains why it should not.
+
+**This endpoint never writes.** `recommendedAction` is a proposal. Applying it is
+`POST /api/resolve`, a separate endpoint under a separate contract, and the write happens in IRIS.
+
+### 3.4 `confidence` — what it is, and what it is not
+
+**Type:** `number | null`. **Range:** `0.0` to `1.0` inclusive. Not a percentage; the UI may render
+one.
+
+**It comes from the LLM. It is not a calibrated probability.** Stated plainly because the field name
+invites the opposite reading:
+
+- It is the model's self-report, produced in the same completion as the narrative it is scoring.
+- Nothing calibrates it. There is no labelled set of investigations, no held-out evaluation, no
+  reliability curve. `0.9` has never been shown to be right nine times in ten, because that
+  measurement has not been made — and with one scenario there is nothing to make it against.
+- Language models are known to be poorly calibrated and to shift with prompt wording and model
+  version. **The model is an AI Hub configuration, not code** (MVP 2 spec §2.2), so the number can
+  move without a single line of this repo changing. It is therefore not even stable across
+  deployments of the same commit.
+
+**Use it to:** display it next to the narrative; sort or de-emphasise; prompt an operator to look
+harder when it is low; log it.
+
+**Do not use it to:** gate the approve control; auto-apply anything; branch on a threshold
+(`>= 0.8` means nothing measurable); average, combine or aggregate across investigations; or present
+it as "N% chance this root cause is correct". **Nothing safety-critical may depend on it.** The
+safety model is human approval plus a bounded whitelist (root `CLAUDE.md` §2.1) — a number the
+system cannot vouch for is not a control.
+
+`confidence: null` is valid on a `complete` investigation and means the agent returned no score.
+Render `—`, never `0` and never `0.5`; a fabricated midpoint is a claim nobody made. Same
+convention as `baselineValue` (Q3).
+
+`confidence` is **not** a health score. That is the Health Score module and it is still out of scope.
+
+### 3.5 `diagnostics`
+
+```json
+{
+  "durationMs": 8421,
+  "agentInvoked": true,
+  "model": "claude-sonnet-4-5",
+  "toolCalls": ["get_host_status", "get_queue_depth", "get_pool_size"],
+  "failureReason": null
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `durationMs` | integer | Engine-measured, end to end, including the LLM round trip. |
+| `agentInvoked` | boolean | `false` for `source: "cache"` and `"canned"`. The honest signal that no live investigation happened. |
+| `model` | string \| null | As reported by AI Hub. `null` when it does not report one. Configuration, not data. |
+| `toolCalls` | array of string | MCP tool **names only**, in call order. `[]` when none. |
+| `failureReason` | string \| null | `null` when `state` is `complete`. §4.1. |
+
+**`toolCalls` carries names, never arguments and never results.** A tool result can contain data that
+has no business being re-exported to a browser, and an echo of it in a diagnostics blob is a leak
+through the back door. **The authoritative record is the AI Hub audit log**, which captures every
+read and write call with its arguments inside IRIS; this array is a convenience for the UI and for
+support, and it is not evidence of what happened.
+
+## 4. Failure discipline: degraded, unavailable, and never invented
+
+The LLM is external and may be slow, unavailable or rate-limited (MVP 2 spec §6 rates this
+*medium* likelihood, *high* impact). A degraded investigation is therefore a **normal response
+shape**, not an error path bolted on afterwards.
+
+**The absolute rule: never invent an explanation.** Serving "could not investigate" is worse for a
+demo and better for everything else. A fabricated root cause on a healthcare production tool is a
+confident wrong attribution that an operator may act on — the same failure mode
+`services/detection-engine/CLAUDE.md` §5.2b refuses for alert matching, and the reasoning transfers
+intact. In particular the engine must not compose a narrative from its own detection rules: it has
+the numbers and could write a fluent paragraph, and doing so would make `source: "agent"` a lie.
+
+### 4.1 The three states
+
+| `state` | Meaning | `rootCause` | `evidence` | `confidence` | `recommendedAction` |
+|---|---|---|---|---|---|
+| `complete` | The agent investigated **this** finding **now** | non-null | may be `[]` | number or `null` | object or `null` |
+| `degraded` | Content is being served, but it is not this investigation of this finding | non-null | may be `[]` | number or `null` | object or `null` |
+| `unavailable` | No investigation. Nothing is being claimed | **`null`** | **`[]`** | **`null`** | **`null`** |
+
+`degraded` exists so the fallback is visible rather than silent. A cached investigation of the same
+condition is usually still true and is worth showing; presenting it as `complete` would hide that
+nothing was measured at request time. `source` and `investigatedAt` say which and how old, and
+`diagnostics.agentInvoked` is `false`. **The UI must label a `degraded` response** — an unlabelled
+cached explanation next to a live queue graph is how a stale conclusion gets acted on.
+
+`unavailable` is the shape that makes "never invent" enforceable: there is no field left to put a
+guess in. A response with `state: "unavailable"` and a non-null `rootCause` is invalid, and the
+schema should reject it.
+
+`failureReason` is set on `degraded` and `unavailable`:
+
+| Value | Meaning |
+|---|---|
+| `agent_unreachable` | The AI Hub agent did not answer at the transport level |
+| `agent_timeout` | The agent accepted the request and did not finish in time (§4.2) |
+| `agent_error` | The agent returned an error |
+| `llm_unavailable` | The agent reported that the external LLM could not be reached |
+| `llm_rate_limited` | The agent reported a rate limit |
+| `malformed_agent_response` | The agent answered but the payload failed validation (§4.4) |
+| `finding_not_found` | No finding with that id is currently active |
+| `out_of_scope` | The finding is outside §2.4 |
+
+Treat as an **open** string and render unknown values neutrally, per the project's convention for
+every other enum on the wire.
+
+### 4.2 Timeouts and retries
+
+- **Hard deadline: 30 s.** The endpoint always answers within roughly that plus HTTP overhead. It
+  never hangs waiting on a model.
+- **Soft deadline: 20 s.** At 20 s the engine stops waiting for the agent and begins the fallback
+  chain in §4.3, so the remaining budget is spent producing a labelled answer rather than waiting.
+- **At most one retry, and only on a transport error** (connection refused, reset, DNS) where it is
+  certain the agent never ran.
+- **Never retry a timeout.** A timeout means the agent may still be working: its MCP read tool calls
+  are already in the audit log, and a retry duplicates them. An audit trail showing two
+  investigations where an operator saw one is worse than a slow answer — attributability is the
+  point of the audit log (root `CLAUDE.md` §2.1).
+- A duplicate `POST` for a finding already under investigation **joins the in-flight call** and
+  receives the same response. It does not start a second agent run. No `202`, no polling endpoint:
+  the call is synchronous and the dashboard awaits it.
+
+**These numbers are not measured against a live agent.** They are chosen to be comfortably above a
+typical LLM round trip and below a demo's patience. They live in engine config, not in
+`thresholds.json` — ADR 0003 governs *detection* numbers, and a timeout is not one. Retuning them
+against the real agent is expected and is not a contract change unless the 30 s guarantee moves.
+
+### 4.3 Fallback order
+
+In order, stopping at the first that produces content:
+
+1. **Live agent** → `state: "complete"`, `source: "agent"`.
+2. **Cache** — the last successful investigation for the same `(host, type)` condition, while that
+   condition is still active. → `state: "degraded"`, `source: "cache"`, `investigatedAt` unchanged
+   from when it was produced.
+3. **Canned response** — the committed fixture for this one scenario, from the engine's fixtures
+   directory. → `state: "degraded"`, `source: "canned"`.
+4. **Nothing** → `state: "unavailable"`, `source: "none"`.
+
+The cache is keyed by `(host, type)` rather than by `finding.id` on purpose: ids are stable for the
+life of a condition (Q4), so those keys are equivalent while the finding persists — and if a
+condition clears and recurs, a new id is correct and reusing the old narrative would not be.
+
+**The cache is in-memory and is dropped on restart**, consistent with ADR 0002's refusal to persist.
+A cold engine has no cache, so step 3 is what a fresh start falls back to.
+
+**The canned response is a fixture, and it is honest about being one.** It is `source: "canned"`, it
+is `degraded`, and its `investigatedAt` is the time it was captured, not now. It is the demo's
+standby (MVP 2 spec §6) and it exists because a scripted fallback beats a blank panel on stage —
+but it is never dressed up as a live investigation. `agentInvoked: false` says so in the payload.
+
+### 4.4 A malformed agent response is a failure, not a partial success
+
+If the agent answers but the payload does not validate — unknown `recommendedAction.action.type`,
+`confidence` out of range, missing `rootCause` on a `complete` claim, extra properties — the engine
+**discards it entirely** and continues down §4.3 with `failureReason: "malformed_agent_response"`.
+
+It does not salvage the fields that parsed. A half-validated investigation is one whose
+recommendation was rejected but whose narrative is still on screen next to an approve button, and
+that is the worst of the available outcomes. Validate the whole object or use none of it.
+
+## 5. Errors and empty states
+
+| Situation | Response |
+|---|---|
+| Investigation succeeded | `200`, `state: "complete"` |
+| Agent slow / unreachable / rate-limited, cache available | `200`, `state: "degraded"`, `source: "cache"` |
+| Agent unavailable, no cache | `200`, `state: "degraded"`, `source: "canned"` |
+| Agent unavailable, no cache, no fixture | `200`, `state: "unavailable"`, `source: "none"` |
+| Finding cleared between the poll and the click | `200`, `state: "unavailable"`, `failureReason: "finding_not_found"` |
+| Finding outside §2.4 | `200`, `state: "unavailable"`, `failureReason: "out_of_scope"` |
+| Malformed body — not JSON, no `findingId`, extra keys | `400` + `{"error":"..."}` |
+| Wrong method on the path | `405` |
+| Genuine server fault | `500` + `{"error":"..."}` |
+
+**Why an unknown `findingId` is `200` and not `404`.** Findings disappear when they clear and carry
+no tombstone (`healthscan-api.md` Q4). An operator reading a finding while it resolves is the
+*expected* lifecycle, not a client bug — the same reasoning that makes zero findings `200` + `[]`
+rather than `404` (`healthscan-api.md` Q7). The dashboard needs to render "this finding is no longer
+active", which is a state, and states travel in the body here.
+
+**Bare `Q<n>` in this file means `healthscan-api.md`'s question list**, which was published first and
+is what "Q13" has meant in this directory since PR #3. §6 numbers its own questions and always names
+the section. Flagged because two overlapping `Q1..Q14` lists in one directory is a footgun, and
+renumbering the ratified one is not an option.
+
+**`400` is genuine, though.** A body the engine cannot parse is a client defect with no meaningful
+state to label, and swallowing it as `200` would hide a Dev C bug behind a plausible-looking empty
+panel. This is the line: a *race* is a state, a *malformed request* is an error.
+
+**`X-Investigation-State`** carries `complete` \| `degraded` \| `unavailable`, mirroring
+`X-Healthscan-State`. Advisory — it duplicates `state` in the body, and a consumer may ignore it.
+
+**CORS, and one thing that is new.** `Access-Control-Allow-Origin: *` is sent, as on the Health Scan
+endpoints (Q9). **But this is a `POST` with `Content-Type: application/json`, which is not a CORS
+simple request** — the browser sends an `OPTIONS` preflight that neither MVP 1 endpoint ever needed.
+The engine answers preflight with `Access-Control-Allow-Methods: POST, OPTIONS` and
+`Access-Control-Allow-Headers: Content-Type`. Called out because "CORS already works" is true of the
+GET endpoints and does not carry over, and the symptom is a request the server never logs.
+
+## 6. The Day-1 questions, answered
+
+Published before Dev C has raised any, so the answers exist when the mock is written. Marked where
+an answer is an assumption rather than a fact.
+
+| # | Question | Answer |
+|---|---|---|
+| **Q1** | What does the dashboard send? | `{"findingId": "..."}` and nothing else (§2.1). Not negotiable — it is half the data-boundary argument. |
+| **Q2** | Is it synchronous? How long? | Synchronous. Hard deadline 30 s, so build the panel for a multi-second spinner, not an instant swap. No polling endpoint. |
+| **Q3** | Can I investigate any finding? | No. `queue_buildup` on `Cloud API` only (§2.4). Anything else is `200` + `out_of_scope`. Hide the button elsewhere. |
+| **Q4** | Is `rootCause` safe to render verbatim? | Yes, and it is authoritative — do not summarise or reflow it. Same rule as `Finding.message`. |
+| **Q5** | Is `evidence[]` strings or objects? | Objects. Render `detail` as the bullet; use `source` to mark what was tool-measured versus model-asserted (§3.2). |
+| **Q6** | Can I bind the approve button straight to `recommendedAction`? | Yes when `action.type` is `set_pool_size` and `action.size` is within `bounds`. Otherwise disable it and render nothing (§3.3). **Send `recommendedAction.action` to `POST /api/resolve` as `action`, unmodified** — it is already that contract's exact shape, and reshaping it is the failure `resolve-api.md` §1.2 warns about. Applying is that endpoint, not this one. |
+| **Q7** | Can I gate the approve button on `confidence`? | **No.** It is an uncalibrated LLM self-report (§3.4). Display it; never branch on it. |
+| **Q8** | What is a nullable field? | `rootCause`, `confidence`, `recommendedAction`, `diagnostics.model`, `diagnostics.failureReason`, `evidence[].tool`. Every key is always present; `evidence` is `[]` rather than `null`. |
+| **Q9** | Does a failed investigation 404 or 500? | Neither. `200` + `state` (§5). `400` on a malformed body, `500` only on a genuine fault. |
+| **Q10** | How do I know a response is cached or canned? | `state: "degraded"`, plus `source`, `investigatedAt` and `diagnostics.agentInvoked: false`. **You must label it.** |
+| **Q11** | Do I need a CORS change? | Yes — this `POST` preflights where the GETs did not (§5). |
+| **Q12** | Is there a `question` field, ever? | No. That is Ask Guardian (§7). |
+| **Q15** | Why is it `trend` and not the `projection` from `earlywarning-api.md`? | Because Early Warning correctly publishes `projection: null` / `already_crossed` for exactly the condition this endpoint investigates, so reusing it would deliver `null` every time (§2.2). Same field names and units, no forecast framing. Read the two panels from their own endpoints; do not derive one from the other. |
+| **Q13** | *(assumption)* Is 30 s enough? | **Unverified against a live agent.** Chosen, not measured — an agent doing several MCP calls plus one LLM completion should land well inside it. Expect retuning; only the 30 s guarantee is contractual. |
+| **Q14** | *(assumption)* Does AI Hub report the model name? | Assumed yes, hence `diagnostics.model`. `null` is a valid answer, so a mock should exercise both. |
+
+## 7. What this is not
+
+- **Not Ask Guardian.** No chat, no conversation, no follow-up turns, no session. The request carries
+  no question and the response is not a reply. One finding in, one investigation out. A `question`
+  field would be both a contract change and a scope change, and it is the single most likely piece of
+  scope creep to arrive at this endpoint.
+- **Not Health Summary.** No report generation, no multi-finding narrative, no export. It investigates
+  one finding. A response that summarised the production would be a different module's output.
+- **Not Smart Resolve.** This endpoint never writes to anything. `recommendedAction` is a proposal a
+  human approves; the write is a governed MCP tool inside IRIS behind RBAC, reached through
+  `POST /api/resolve`.
+- **Not Health Score.** `confidence` scores the explanation, not the production.
+- **Not a general diagnostic engine.** One finding type, one host, one action type, one scenario. It
+  cannot diagnose `slow_processing`, it cannot diagnose Lab Router, and it will not tell you why disk
+  is full. Generalising is later work, and it starts with a contract change here.
+
+## 8. Worked examples
+
+Illustrative, not captured — see the note at the top of this file. ASCII inside payload strings.
+
+### 8.1 `complete` — the pool-size scenario
+
+`POST /api/investigate` → `200`, `X-Investigation-State: complete`
+
+```json
+{
+  "requestId": "inv-8a31f0",
+  "findingId": "f-1041",
+  "state": "complete",
+  "source": "agent",
+  "investigatedAt": "2026-08-18T09:14:31Z",
+  "rootCause": "Cloud API is throughput-bound - PoolSize 1 against a ~1s-per-message downstream dispatcher, so it clears ~1 msg/sec while inflow exceeds that",
+  "evidence": [
+    {
+      "label": "Cloud API pool size",
+      "detail": "Cloud API PoolSize = 1",
+      "source": "mcp_tool",
+      "tool": "get_pool_size"
+    },
+    {
+      "label": "Downstream cost per message",
+      "detail": "each message ~1s from the downstream dispatcher throttle (avg processing time 1.02s against a 0.05s baseline)",
+      "source": "snapshot",
+      "tool": null
+    },
+    {
+      "label": "Inbound rate",
+      "detail": "inflow rate > 1/sec (~3.0 msg/sec against a ~1 msg/sec ceiling)",
+      "source": "snapshot",
+      "tool": null
+    },
+    {
+      "label": "Queue trend",
+      "detail": "queue slope positive - depth 214, rising ~124/min",
+      "source": "snapshot",
+      "tool": null
+    },
+    {
+      "label": "Host health",
+      "detail": "Cloud API status OK with 0 errored messages, so this is a throughput limit and not a fault",
+      "source": "mcp_tool",
+      "tool": "get_host_status"
+    }
+  ],
+  "confidence": 0.86,
+  "recommendedAction": {
+    "action": {
+      "type": "set_pool_size",
+      "host": "Cloud API",
+      "size": 4
+    },
+    "currentValue": 1,
+    "bounds": { "min": 2, "max": 8 },
+    "reversible": true,
+    "requiresApproval": true,
+    "summary": "increase Cloud API pool 1 -> 4"
+  },
+  "diagnostics": {
+    "durationMs": 8421,
+    "agentInvoked": true,
+    "model": "claude-sonnet-4-5",
+    "toolCalls": ["get_host_status", "get_queue_depth", "get_pool_size", "get_processing_time"],
+    "failureReason": null
+  }
+}
+```
+
+Note that the pool size is `source: "mcp_tool"` while the timings are `source: "snapshot"`: the
+engine has no path to configuration (§2.2) and the agent has no need to re-measure what the snapshot
+already carried. The two bullets that read most like a conclusion are the ones a tool measured.
+
+`confidence: 0.86` is displayable and gates nothing. Approval is required regardless.
+
+The `model` string is a **placeholder shaped like a model id, not a chosen model.** No provider is
+configured on the instance yet, and the model is an AI Hub configuration rather than code (MVP 2 spec
+§2.2), so a mock must not treat this value as fixed — and a UI must not parse it. Exercise `null`
+too, per Q14.
+
+### 8.2 `degraded` — LLM rate-limited, cached investigation served
+
+`200`, `X-Investigation-State: degraded`
+
+```json
+{
+  "requestId": "inv-8a3204",
+  "findingId": "f-1041",
+  "state": "degraded",
+  "source": "cache",
+  "investigatedAt": "2026-08-18T09:14:31Z",
+  "rootCause": "Cloud API is throughput-bound - PoolSize 1 against a ~1s-per-message downstream dispatcher, so it clears ~1 msg/sec while inflow exceeds that",
+  "evidence": [
+    {
+      "label": "Cloud API pool size",
+      "detail": "Cloud API PoolSize = 1",
+      "source": "mcp_tool",
+      "tool": "get_pool_size"
+    },
+    {
+      "label": "Queue trend",
+      "detail": "queue slope positive - depth 214, rising ~124/min",
+      "source": "snapshot",
+      "tool": null
+    }
+  ],
+  "confidence": 0.86,
+  "recommendedAction": {
+    "action": {
+      "type": "set_pool_size",
+      "host": "Cloud API",
+      "size": 4
+    },
+    "currentValue": 1,
+    "bounds": { "min": 2, "max": 8 },
+    "reversible": true,
+    "requiresApproval": true,
+    "summary": "increase Cloud API pool 1 -> 4"
+  },
+  "diagnostics": {
+    "durationMs": 20114,
+    "agentInvoked": false,
+    "model": null,
+    "toolCalls": [],
+    "failureReason": "llm_rate_limited"
+  }
+}
+```
+
+`investigatedAt` is 09:14:31 while the request was made minutes later. `agentInvoked` is `false` and
+`toolCalls` is `[]` — nothing was measured for *this* request. `durationMs` of 20114 is the soft
+deadline being spent before the fallback. **The panel must say the investigation is cached and show
+its age**, and it should be visibly the same recommendation rather than a fresh one.
+
+### 8.3 `unavailable` — nothing to serve, and nothing claimed
+
+`200`, `X-Investigation-State: unavailable`
+
+```json
+{
+  "requestId": "inv-8a3299",
+  "findingId": "f-1041",
+  "state": "unavailable",
+  "source": "none",
+  "investigatedAt": "2026-08-18T09:31:07Z",
+  "rootCause": null,
+  "evidence": [],
+  "confidence": null,
+  "recommendedAction": null,
+  "diagnostics": {
+    "durationMs": 30007,
+    "agentInvoked": true,
+    "model": null,
+    "toolCalls": [],
+    "failureReason": "agent_timeout"
+  }
+}
+```
+
+Every content field is null or empty. There is nowhere to put a guess, which is the design. Render
+"could not investigate", offer a retry, and **do not** synthesise a root cause from the finding's own
+numbers — the engine has them and deliberately does not use them (§4).
+
+`agentInvoked: true` with `toolCalls: []` is the honest report of a call that was made and did not
+come back with a usable answer. Whether the agent ran tools is in the AI Hub audit log, which is why
+this array is not evidence of anything (§3.5).
+
+An out-of-scope or cleared finding has the same shape with `agentInvoked: false`, `durationMs` near
+zero, and `failureReason` of `out_of_scope` or `finding_not_found`.
+
+---
+
+## 9. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by every
+other developer. See `README.md` in this directory.
+
+Two developers remain since 2026-08-12, so in practice that is one other person — and GitHub will
+not let an author approve their own PR, which is the point.
+
+**Two kinds of change here are heavier than their diff.** Estimate the cost from attached meaning,
+not from line count (`README.md`, "Estimating what a change costs"):
+
+- **Widening `InvestigationRequest`** is a change to the data-boundary argument in §2.3, not a field
+  addition. It needs the PR to say what the new field can and cannot carry, and why a message body
+  cannot reach it.
+- **Widening `recommendedAction.action.type`**, widening `bounds`, or setting
+  `requiresApproval: false` is a change to the safety model in root `CLAUDE.md` §2.1. It is a scope
+  amendment as well as a contract change, and the two should land together. `action`'s shape is
+  additionally co-owned in effect: `resolve-api.md` refuses unknown keys inside it, so adding one
+  here breaks that endpoint rather than this one.
+
+Everything else — a new `failureReason`, a new `evidence[].source` — is additive, and consumers
+already render unknown enum values neutrally, so it does not break a mock.

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -325,7 +325,17 @@ ERROR <Ens>ErrProductionSettingInvalid: Production setting 'PollInterval' for it
 ```
 
 None of those three contains PHI. That is not the argument for returning them — **it is the argument
-for not deciding case by case.** The tool cannot know which case it is in, so:
+for not deciding case by case.**
+
+**And the case-by-case reading is now measured to be a trap.** Counted on the running instance
+(`docs/mvp2-aihub-verified-api.md`): `Ens_Util.Log` holds **61,772 `Type=4` info rows, every one
+carrying a `PatientID`**, against **66 `Type=2` error rows, none of which do**. So filtering to
+`Type >= 2` and returning the text would pass any test written against today's log — and be wrong
+anyway, because that separation is a property of how `$$$LOGINFO` and `$$$LOGERROR` happen to be
+used in `PatientDemographicsOperation`, not of the log. One `$$$LOGERROR` interpolating a patient
+id puts PHI into the error rows, and that operation already builds `PatientID` strings for its info
+path. A ratio of 61,772 to 66 makes the unsafe case rare rather than absent, which is the worst
+shape a defect can have: it survives review, survives the demo, and shows up in production. The tool cannot know which case it is in, so:
 
 **Sanitisation is an allowlist, never a denylist.** The tool extracts the leading IRIS error token
 and nothing else from the raw text, then looks `summary` up in a fixed in-code catalogue of known

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -208,12 +208,12 @@ one field being absent.
 
 **Worked example.**
 
-```json
+```jsonc
 // -> get_queue_depth
 { "host": "Cloud API" }
 ```
 
-```json
+```jsonc
 // <- during the demo's queue_buildup
 {
   "host": "Cloud API",
@@ -224,7 +224,7 @@ one field being absent.
 }
 ```
 
-```json
+```jsonc
 // <- production stopped: NOT a drained queue
 {
   "host": "Cloud API",
@@ -373,12 +373,12 @@ Raw rows in `Ens_Util.Log` (what the tool reads, and what it must not publish):
   127.0.0.1:59999
 ```
 
-```json
+```jsonc
 // -> get_recent_errors
 { "host": "Cloud API", "sinceMinutes": 15, "limit": 20 }
 ```
 
-```json
+```jsonc
 // <- what the agent, and therefore the external LLM, sees
 {
   "host": "Cloud API",
@@ -553,12 +553,12 @@ the fifth is somebody else's.
 
 **Worked example — applied.**
 
-```json
+```jsonc
 // -> set_pool_size
 { "host": "Cloud API", "size": 4 }
 ```
 
-```json
+```jsonc
 // <-
 {
   "host": "Cloud API",
@@ -575,12 +575,12 @@ the fifth is somebody else's.
 
 **Worked example — the reversal**, which is why the tool's lower bound is `1`:
 
-```json
+```jsonc
 // -> set_pool_size   (the `reversal` object from the response above, replayed)
 { "host": "Cloud API", "size": 1 }
 ```
 
-```json
+```jsonc
 // <-
 {
   "host": "Cloud API",
@@ -599,12 +599,12 @@ the fifth is somebody else's.
 `PG_Resolve`. There is **no result object at all**: the runtime refuses before `%Invoke` runs
 (§5.2), so this is an error response and not a `set_pool_size` payload with `applied: false`.
 
-```json
+```jsonc
 // -> set_pool_size
 { "host": "Cloud API", "size": 4 }
 ```
 
-```json
+```jsonc
 // <-
 {
   "error": "tool_access_denied",

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1,0 +1,936 @@
+# MCP tool catalogue
+
+**Owner:** Dev B (inherited `iris/**` from Dev A) · **Consumer:** Dev B (agent orchestration), Dev C
+(approval UI, indirectly) · **Runs in:** the `pg-iris` container · **Status:** published
+
+Six tools. Five read, one write. They exist so the **AI Detective** agent can gather evidence about
+one condition on one host, and so **Smart Resolve** can apply one bounded action to it. Root
+`CLAUDE.md` §2.1 is the scope boundary; this file is the interface.
+
+The organising principle is **least privilege**: the read tools are granted broadly, the write tool
+is not, and the two are gated separately. The demo the spec asks for is a direct consequence —
+**AI Detective can look without having permission to act.**
+
+Machine-readable: none yet. These tools are ObjectScript classes, and their JSON Schemas are
+*generated* from the class at compile time by `%AI.Tool.Generator` (§7), so a hand-written
+`mcp-tools.schema.json` would be a second source of truth that drifts. The schemas below are what
+the generator will produce from the stated signatures; if generated and stated ever disagree, the
+generated one is what the agent sees and this file is wrong.
+
+**Where this contract sits relative to the other three.** `resolve-api.md` §9 specifies the
+*endpoint* that calls `set_pool_size`; this file specifies the *tool*. They were written in parallel
+and three things were reconciled rather than left to collide — recorded here because a contract that
+silently disagrees with its neighbour is worse than one that is wrong out loud:
+
+| | `resolve-api.md` | here | Why they differ |
+|---|---|---|---|
+| dry-run | a `mode` on the endpoint | **no flag on the tool** | The endpoint's dry-run calls `get_pool_size` and never invokes the write tool. §3.6 |
+| `size` range | `2..8` | `1..8` | The tool must be able to express the reversal to `1`. §3.6 |
+| role names | `%Guardian_Resolve`, "illustrative, not ratified" | **ratified here** | §5.3 is the naming authority; the values match its examples |
+
+`investigation-api.md` is the other consumer: its `evidence[].tool` values are names from §1, and its
+§2.3 data boundary is the same boundary as §6 here, enforced one hop earlier.
+
+---
+
+## 1. The catalogue
+
+| Tool | Class | R/W | Listable to | Executable by | Wraps |
+|---|---|---|---|---|---|
+| `get_host_status` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `Ens.Util.Statistics:EnumerateHostStatus` |
+| `get_queue_depth` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `EnumerateHostStatus`, `Queue` column |
+| `get_pool_size` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `Ens.Config.Production` → `Ens.Config.Item.PoolSize` |
+| `get_recent_errors` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `Ens.Util.Log`, **sanitised** — see §3.4 |
+| `get_processing_time` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `iris_interop_avg_*`, aggregated as the proxy aggregates them |
+| `set_pool_size` | `PG.Tools.Resolve` | **write** | `PG_Read` | **`PG_Resolve`** | `Ens.Config.Production` + `Ens.Director.UpdateProduction()` |
+
+`PG_Read` and `PG_Resolve` are **IRIS resources**, held by roles `%Guardian_Read` and
+`%Guardian_Resolve`. §5 explains the resource-not-role choice and why the write tool is
+**listable to `PG_Read` but executable only by `PG_Resolve`**.
+
+Two classes, not six, because discovery is per class: `%AI.Tool` exposes every public method of a
+subclass as a tool (§7). Splitting read from write across two classes means the write tool can carry
+class-level parameters — `REQUIRESAUTH`, its own `Policy` — that must not apply to the read tools.
+
+---
+
+## 2. Conventions common to every tool
+
+**`host` is the config item name, exactly as IRIS holds it** — `Cloud API`, `EMR Source`,
+`Lab Router`. Spaces intact, no case folding, no trimming. It is the same join key that runs through
+`contracts/proxy.schema.json` and `contracts/healthscan-api.md` (Q8), and it survives unnormalised
+for the same reason: silently mapping `CloudAPI` onto `Cloud API` would attribute one host's queue
+depth to another. A `host` that names no config item in the running production is an **error**, not
+an empty result — see §4.
+
+**Timestamps** are ISO 8601 UTC, `Z`-suffixed, millisecond precision, matching
+`HostStatusDispatcher.UTCTimestamp()` and the `Timestamp` definition in `proxy.schema.json`.
+
+**Required vs optional is expressed in the ObjectScript signature, not in prose.** Read from
+`%AI.Tool.Generator.GenerateDiscover` in the running container: a formal parameter **with a default**
+is omitted from the generated `required` array; a parameter **without** one is required. So
+`sinceMinutes As %Integer = 15` is optional *because* it has a default. Do not document a parameter
+as optional and then declare it without a default — the generated schema, not this table, is what
+the agent obeys.
+
+**Units are seconds**, everywhere a duration appears, matching `healthscan-api.md` Q6. Confirmed
+empirically rather than assumed: `Cloud API` configured at 0.05s latency reports `0.05`.
+
+### 2.1 Nullability: an unmeasurable value is not a small one
+
+This is the rule the project has been bitten by three times — issues #33, #49, #58 — and every read
+tool below repeats it in its own terms because a shared paragraph is not what an implementer reads.
+
+**`null` means "not measurable"; `0` means "measured zero". They are never interchangeable.**
+
+- An unmeasurable **queue depth** is not a shallow queue. #33: coercing `queued: null` to `0` made
+  `stalled_host`'s `requiresQueued && queued <= 0` gate structurally unsatisfiable — a rule silently
+  switched off, with every unit test green.
+- A host with **no activity line** is not "active now". #58: `lastActivity` derived from an absent
+  elapsed-seconds metric reads as the current instant, which is the most confident possible wrong
+  answer.
+- An **absent metric family** is not a zero reading. `services/metrics-proxy/src/parser.js` records
+  a live capture where IRIS emitted no `iris_interop_messages_errored` lines at all, and where the
+  `avg_*` families appeared for exactly one host of thirteen.
+
+Consequences the tools must honour:
+
+1. Every numeric read field is `number | null`. A tool that cannot measure returns `null` in that
+   field and **succeeds** — an unmeasurable value is not a failure (§4).
+2. **No tool substitutes a plausible number for a missing one.** Not a zero, not a last-known value,
+   not a default.
+3. Where `null` and `0` would otherwise be indistinguishable to the *caller*, the tool carries an
+   explicit discriminator — `measured`, `productionState`, `sampleCount` — for the same reason
+   `_meta.hostStatus` exists in the proxy contract: "every depth is null because the source is down"
+   and "every depth is genuinely 0" look identical in the payload alone.
+
+This matters more here than anywhere else in the project, because **the consumer is a language
+model**. A downstream rule that compares a fabricated `0` produces a wrong finding; an LLM handed a
+fabricated `0` produces a fluent, confident, wrong root cause and a recommended action derived from
+it. `null` is the only value that reliably stops that.
+
+---
+
+## 3. The tools
+
+### 3.1 `get_host_status` — read
+
+Current interoperability state of one host, or of every application host.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | optional | Config item name. Omit for every application host. |
+
+Signature: `ClassMethod getHostStatus(host As %String = "") As %DynamicObject` — exposed as
+`get_host_status`. (Snake-case method names are legal here: verified by compiling and invoking a
+class method literally named `get_queue_depth` in the running container.)
+
+**Output**
+
+```json
+{
+  "hosts": [
+    {
+      "host": "Cloud API",
+      "type": "operation",
+      "status": "OK",
+      "statusSource": "EnumerateHostStatus",
+      "lastActivityElapsedSeconds": 3.2,
+      "enabled": true
+    }
+  ],
+  "production": "ProductionGuardian.LabDemo.Production",
+  "productionState": "Running",
+  "sampledAt": "2026-08-18T08:15:08.281Z"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | string | As IRIS reports it. `OK`, `Error`, `Inactive`, `Retry`, `Stopped`, `Unconfigured`, `Disabled`. **There is no `Warning` and no `Active`** (Q1). Treat as open. |
+| `type` | string | `service` \| `process` \| `operation`. Normalised — IRIS says `actor` for a process and that word must not reach a consumer (Q10). |
+| `lastActivityElapsedSeconds` | number \| null | **Elapsed seconds**, not a timestamp. |
+| `enabled` | boolean | `Ens.Config.Item.Enabled`. |
+
+**Wraps** `Ens.Util.Statistics:EnumerateHostStatus`, the same source
+`iris/labdemo/REST/HostStatusDispatcher.cls` publishes and the proxy merges. Framework items
+(`Ens.*`, `EnsLib.*`, `ActivityReporter`) are filtered, matching `healthscan-api.md` §2 — for
+LABDEMO that is three hosts.
+
+**Nullability.** `lastActivityElapsedSeconds` is `null` when IRIS emitted no activity line for the
+host, never `0`: `0` reads as "active this instant", which is #58 exactly. `status` is a string and
+carries `Unknown` when the source did not describe the host — a *stated* unknown rather than a
+guessed `Inactive`, because `Inactive` is in the engine's `DEAD_STATUSES` and guessing it would
+manufacture a `dead_host` finding out of a missing row. A host the source did not describe at all is
+**absent from `hosts`**; it is not synthesised.
+
+### 3.2 `get_queue_depth` — read
+
+Current queue depth for one host.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed, so a result is self-describing in an agent transcript. |
+| `queued` | integer \| null | Depth, `>= 0`. `null` when not measurable. |
+| `measured` | boolean | `false` iff `queued` is `null`. The discriminator — see below. |
+| `productionState` | string | `Running` \| `Stopped` \| `Suspended` \| `Troubled` \| `Unknown`. |
+| `sampledAt` | string | When IRIS sampled, not when the tool was called. |
+
+**Wraps** the `Queue` column of `EnumerateHostStatus`.
+
+**Nullability, and the one place `+` coercion is correct.** `EnumerateHostStatus` returns the **empty
+string** for an idle host, not `"0"`. That is verified in the shipped source of
+`EnumerateHostStatusFetch` (`Set tQueueCount=$G($$$EnsQueue(qHandle,0,"count")) If tQueueCount=0 Set
+tQueueCount=""`) — the global *was* read and *did* hold zero. So empty means **measured zero** and
+`+rs.Get("Queue")` is right, exactly as `HostStatusDispatcher` does it. A truthiness test would read
+the same empty string as "no value", which is the opposite of what it means.
+
+`queued` is `null` in exactly three cases, none of them a zero:
+
+- the query returned no row for this host;
+- **the production is stopped** — `EnumerateHostStatus` returns *zero rows*, indistinguishable from
+  "this production has no hosts" without `productionState`;
+- the query itself failed.
+
+`measured` exists because an agent reasoning over `{"queued": 0}` cannot tell those apart, and
+because `null` is easy for a model to narrate away. Two fields disagreeing is harder to ignore than
+one field being absent.
+
+**Worked example.**
+
+```json
+// -> get_queue_depth
+{ "host": "Cloud API" }
+```
+
+```json
+// <- during the demo's queue_buildup
+{
+  "host": "Cloud API",
+  "queued": 486,
+  "measured": true,
+  "productionState": "Running",
+  "sampledAt": "2026-08-18T08:15:08.281Z"
+}
+```
+
+```json
+// <- production stopped: NOT a drained queue
+{
+  "host": "Cloud API",
+  "queued": null,
+  "measured": false,
+  "productionState": "Stopped",
+  "sampledAt": "2026-08-18T08:15:08.281Z"
+}
+```
+
+The second response is a **success**, not an error. The tool measured nothing and says so.
+
+### 3.3 `get_pool_size` — read
+
+Configured pool size for one host. The read half of the MVP 2 scenario.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `poolSize` | integer \| null | `Ens.Config.Item.PoolSize`. `null` only when the item was not found. |
+| `production` | string | The production the value was read from. |
+| `pendingUpdate` | boolean | `Ens.Director.ProductionNeedsUpdate()` — the saved config differs from what is running. |
+
+**Wraps** `Ens.Config.Production.%OpenId(...)` → the matching `Ens.Config.Item` → its `PoolSize`
+property (`%Library.Integer`, verified against `%Dictionary.CompiledProperty` in the running
+container).
+
+**Limitation, stated rather than papered over: this is the CONFIGURED pool size, not the number of
+running jobs.** `set_pool_size` saves the config and then calls `UpdateProduction()`; between the
+save and the update taking effect, this tool reports the new number while the old jobs are still the
+ones doing the work. `pendingUpdate` is how a caller sees that, and it is why the demo's "pool size
+now shows 4" step should be read after the queue starts draining, not before. Reporting the live job
+count instead would need a different source and is not in MVP 2.
+
+**Nullability.** `poolSize` is `null` **only** when the host is not a config item in this
+production — and that case is an error (§4), so in practice a successful call always carries a
+number. Stated anyway for one reason: **`PoolSize: 0` is a real configured value** with a
+framework-defined meaning, not an unmeasurable one. Coercing `0` to `null` here would be the same
+defect in the opposite direction. Measured live on the running instance: all four LABDEMO items are
+`PoolSize=1`, including `Cloud API`, which is what makes the scenario real rather than staged.
+
+### 3.4 `get_recent_errors` — read, and the one with a data-boundary problem
+
+Recent error events for one host, **sanitised**. Read §6 before implementing this tool.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+| `sinceMinutes` | integer | optional, default `15` | Window, 1..60. |
+| `limit` | integer | optional, default `20` | Max events returned, 1..50. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `windowMinutes` | integer | The window actually applied. |
+| `count` | integer \| null | Events in the window. `null` when the log could not be read. |
+| `errors` | array | At most `limit` entries, newest first. |
+| `truncated` | boolean | `true` when `count > limit`. |
+| `sanitised` | boolean | Always `true`. Present so its absence is conspicuous. |
+
+Each entry:
+
+| Field | Type | Notes |
+|---|---|---|
+| `occurredAt` | string | ISO 8601 UTC. |
+| `errorCode` | string | The IRIS error token only — `<Ens>ErrFailureTimeout`, `#6059`, or `unclassified`. |
+| `sourceClass` | string | Class name from the log row. A class name, never an instance value. |
+| `summary` | string \| null | A **catalogue** string keyed by `errorCode`. `null` when unclassified. |
+
+**Wraps** `Ens.Util.Log` filtered to error and alert types for the host, plus a count of
+`Ens.MessageHeader` rows at `Status = 8` (Error) — the same `MSGSTATUSERROR = 8` that
+`HostStatusDispatcher` reads from the compiled `VALUELIST` rather than guessing.
+
+**Why this tool is dangerous.** Its outputs leave the instance (§6). Error text on this pipeline is
+generated by HL7 message processing, so it can contain payload-derived content — patient
+identifiers, segment fragments, a target URL with a query string. Measured on the running instance,
+`Ens_Util.Log` currently holds these real error texts for `Cloud API` and `EMR Source`:
+
+```
+ERROR <Ens>ErrFailureTimeout: FailureTimeout of 1 seconds exceeded in
+  ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation; status from
+  last attempt was ERROR #6059: U...
+ERROR #6059: Unable to open TCP/IP socket to server 127.0.0.1:59999
+ERROR <Ens>ErrProductionSettingInvalid: Production setting 'PollInterval' for item
+  'EMR Source' is invalid
+```
+
+None of those three contains PHI. That is not the argument for returning them — **it is the argument
+for not deciding case by case.** The tool cannot know which case it is in, so:
+
+**Sanitisation is an allowlist, never a denylist.** The tool extracts the leading IRIS error token
+and nothing else from the raw text, then looks `summary` up in a fixed in-code catalogue of known
+codes. Text that does not match a known code yields `errorCode: "unclassified"` and `summary: null`.
+**No path returns free-form log text**, including text that happens to be safe — the third example
+above is pure configuration and it is still not forwarded verbatim, because a rule with an exception
+is a rule an implementer will widen.
+
+A denylist — regex out anything that looks like an MRN, a date of birth, a name — cannot be shown
+correct, and its failures are silent and unbounded. An allowlist's failure is a visible
+`unclassified` with no text, which is a worse *diagnostic* and a safe *boundary*. That trade is
+deliberate. If the demo needs richer text, the answer is adding a code to the catalogue, in code,
+reviewed — not loosening the filter.
+
+**May return:** counts, ISO timestamps, IRIS error codes, the config item name, class names, and
+catalogue summary strings.
+**Must never return:** message content or any part of it, HL7 segments or fields, patient
+identifiers of any kind, `Ens.MessageBody` or `Ens.MessageHeader` field values other than a count,
+stack traces, and raw `Ens.Util.Log` text.
+
+**Nullability.** `count` is `null` when the log could not be read — never `0`, because "no errors"
+is the single most consequential wrong answer this tool can give an agent diagnosing an error
+condition. An empty `errors` array with `count: 0` is a measurement; an empty array with
+`count: null` is not, and the agent must treat them differently.
+
+**Worked example, showing sanitisation.**
+
+Raw rows in `Ens_Util.Log` (what the tool reads, and what it must not publish):
+
+```
+2026-08-18 07:46:29.533  Cloud API  ERROR <Ens>ErrFailureTimeout: FailureTimeout of 1
+  seconds exceeded in ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation;
+  status from last attempt was ERROR #6059: U...
+2026-08-18 07:46:29.533  Cloud API  ERROR #6059: Unable to open TCP/IP socket to server
+  127.0.0.1:59999
+```
+
+```json
+// -> get_recent_errors
+{ "host": "Cloud API", "sinceMinutes": 15, "limit": 20 }
+```
+
+```json
+// <- what the agent, and therefore the external LLM, sees
+{
+  "host": "Cloud API",
+  "windowMinutes": 15,
+  "count": 42,
+  "truncated": true,
+  "sanitised": true,
+  "errors": [
+    {
+      "occurredAt": "2026-08-18T07:46:29.533Z",
+      "errorCode": "<Ens>ErrFailureTimeout",
+      "sourceClass": "ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation",
+      "summary": "The host did not complete a message within its FailureTimeout."
+    },
+    {
+      "occurredAt": "2026-08-18T07:46:29.533Z",
+      "errorCode": "#6059",
+      "sourceClass": "ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation",
+      "summary": "Could not open a TCP/IP socket to the configured target."
+    }
+  ]
+}
+```
+
+Note what did **not** survive: the `127.0.0.1:59999` target, the timeout value, and every character
+of the original text. `summary` is written by us, indexed by code. The two entries share a timestamp
+because the raw rows do — that is a real property of `Ens.Util.Log`, not a formatting artefact.
+
+### 3.5 `get_processing_time` — read
+
+Average processing and queueing time for one host.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `avgProcessingTime` | number \| null | **Seconds.** |
+| `avgQueueingTime` | number \| null | **Seconds.** |
+| `sampleCount` | integer \| null | Total weight behind the averages. |
+| `aggregated` | boolean | Always `true` — see below. |
+| `unit` | string | `"seconds"`. Stated in the payload because a unit error here is invisible. |
+
+**Wraps** `iris_interop_avg_processing_time` and `iris_interop_avg_queueing_time`, aggregated the
+way `services/metrics-proxy/src/parser.js` aggregates them: IRIS emits one series per
+`(host, messagetype)`, and they are collapsed to one number **weighted by
+`iris_interop_sample_count`**. A plain mean is wrong when one message type dominates;
+last-write-wins is wrong always. `aggregated: true` says so in the payload, because a host handling
+two message types reports their weighted mean and not either one (Q12).
+
+**Nullability.** Both averages are `null` when the host has processed nothing since stats were
+enabled — IRIS emits these families **only** for hosts with activity, and in a live capture they
+appeared for exactly one host of thirteen. `null` here means "not measured", never "instant". A
+`0.0` returned for an idle host would tell an agent diagnosing `slow_processing` that processing is
+infinitely fast, which is the inverse of the truth. `sampleCount` is the discriminator: `null`
+averages with `sampleCount: null` is an absent family; if a build ever emits a real zero, the
+sample count will be non-null and say so.
+
+Reference values, measured not invented: `Cloud API` configured at 0.05s latency reports `0.05`;
+`Lab Router` reports `0.08`.
+
+### 3.6 `set_pool_size` — the only write tool
+
+Set the configured pool size of one host and apply it to the running production.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Must be `Cloud API`. Whitelist of one. |
+| `size` | integer | **required** | `1..8` inclusive — see bounds below. |
+
+**There is no `dryRun` parameter, deliberately.** This tool always writes. Preview is
+`get_pool_size`, a *read* tool. That is a reconciliation with `resolve-api.md` §2, which guarantees
+structurally that a `dry_run` cannot mutate: the engine's dry-run path calls `get_pool_size` and the
+checks, and **never invokes `set_pool_size` at all**, so no code path exists that could write. A
+`dryRun` flag on the privileged tool would weaken that from "the tool was not called" to "the tool
+was called with a flag that made it not write", and would add a non-writing branch to the one tool
+whose entire justification is that it writes. **One tool, one job.**
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `production` | string | The production actually changed. |
+| `previousSize` | integer | The value before the call. **This is what makes the action reversible.** |
+| `requestedSize` | integer | Echoed. |
+| `appliedSize` | integer | Read back from the saved config after the write, not assumed from `requestedSize`. |
+| `applied` | boolean | Always `true` on a successful return; a call that did not apply is an error (§4), not a result with `false`. |
+| `updateProduction` | string | `ok`, or the failure reason from `Ens.Director.UpdateProduction()`. |
+| `reversal` | object | `{"tool": "set_pool_size", "host": ..., "size": <previousSize>}` — the exact call that undoes this one. |
+| `sampledAt` | string | ISO 8601 UTC. |
+
+`applied` is present rather than implied because the audit record and `resolve-api.md`'s `outcome`
+both key off it, and a field that is always `true` on success is cheap insurance against a future
+partial-apply mode being added without a discriminator.
+
+**Wraps** the write path `iris/labdemo/Triggers.cls` already proves in this production:
+`Ens.Config.Production.%OpenId(...)` → locate the `Ens.Config.Item` by name → set `PoolSize` →
+`def.%Save()` → `Ens.Director.UpdateProduction()`. Nothing new; the same three moves as
+`Triggers.SetSetting` / `SetEnabled` followed by `Triggers.UpdateProduction`.
+
+**Guards, and where each one comes from.**
+
+1. **Refuse unless the running production is the expected one**, as
+   `Triggers.CheckProduction()` does. `Ens.Director.GetProductionStatus()` must report
+   `ProductionGuardian.LabDemo.Production`. Rationale from #34: a tool that silently edits the wrong
+   production is worse than one that refuses.
+
+   **And one place this tool must be STRICTER than the proven path.** `CheckProduction()` treats a
+   production that is not Running as a *warning*, not a refusal — "a stopped production accepts
+   config edits that take effect on start, which is confusing rather than wrong". That is right for
+   a trigger that arms a condition for later, and wrong here: against a stopped production `%Save()`
+   succeeds, `UpdateProduction()` changes no running job, `appliedSize` reads back the saved value,
+   and the response says applied — while nothing drains, because nothing is running. True field by
+   field and false as a whole. **State `1` (Running) is required.** Recorded because someone will
+   read `Triggers.cls`, see a warning, and "align" the tool with the proven path; the proven path is
+   proven for a different job. Matches `resolve-api.md`'s `production_not_running` refusal.
+2. **Refuse if the config item is not found.** Track that the *item* was found, not just that a loop
+   completed — the `foundItem` lesson from `Triggers.SetSetting` (#66). A rename in `Production.cls`
+   would otherwise make this method a silent no-op that reports success, and `CheckProduction()` does
+   not catch it because it compares only the production *name*. **A write tool that reports applied
+   and applied nothing is the worst failure in this file.**
+3. **Bounds.** `host` must be `Cloud API`; `size` must be an integer in `1..8`. Anything else is an
+   error, not a clamp — clamping `40` to `8` would apply a change nobody approved, report it as
+   applied, and be indistinguishable in the audit log from someone deliberately choosing `8`.
+4. **Reversibility is returned, not remembered.** `previousSize` and `reversal` are in the response
+   so the caller can undo without the tool holding state. A stateful undo would be a second thing to
+   get wrong.
+5. **Step 3 is a PROPERTY, not a setting.** `PoolSize` is a property of `Ens.Config.Item`
+   (`PoolSize As %Library.Integer`, verified against `%Dictionary.CompiledProperty` on the running
+   instance), so the tool assigns `item.PoolSize` directly. It must **not** go through the `Settings`
+   collection the way `Triggers.SetSetting()` does. `SetSetting` is the closest existing code, and
+   copying it here would add an `Ens.Config.Setting` row named `PoolSize` that changes nothing while
+   reporting success — #66's failure mode in a new place.
+
+**Why `1..8`, and why the tool's range is wider than the endpoint's.** This is deliberate and the
+asymmetry is the point:
+
+| Layer | Range | Why |
+|---|---|---|
+| `POST /api/resolve` (`resolve-api.md` §3) | `2..8` | An operator-facing action. `1` is the shipped value, so approving it is a no-op dressed as a fix. |
+| `set_pool_size` (here) | `1..8` | Must be able to express the **reversal**. `previousSize` is `1`, so a tool that refuses `1` cannot undo its own first call. |
+
+`8` is the shared ceiling, for `resolve-api.md`'s reason: every pool job is a real IRIS process, and
+an unbounded `size` lets one fat-fingered digit — or one hallucinated number — spawn hundreds of jobs
+and denial-of-service the production this tool exists to protect. `4` is the scenario's target and
+`8` leaves the rehearsal headroom MVP 2 §6 asks for.
+
+**`0` is excluded from both.** Its meaning is adapter- and version-dependent and nobody here has
+verified it; on some host classes it means "no dedicated jobs", which would stop the host and produce
+exactly the `dead_host` finding Smart Resolve exists to avoid causing. Excluded rather than reasoned
+about — an unverified claim about IRIS semantics has no place in the bounds check of a write tool.
+
+Widening either range is a **change to a contract**, not a configuration tweak. That is the point of
+writing the bound here rather than in a settings file.
+
+**What this tool does NOT enforce: human approval.** The safety model in root `CLAUDE.md` §2.1 says
+nothing applies unattended, and the tool cannot verify that. It has no way to know whether a human
+clicked Approve; it sees an authorized caller and a bounded argument. **Approval is enforced upstream**,
+at Dev B's `POST /api/resolve` and Dev C's approval UI. Stated plainly because "the write tool is
+governed" invites the reading that approval lives in the tool, and it does not. What the tool
+enforces is *authorization, bounds, target, and reversibility*. Four of the five safety properties;
+the fifth is somebody else's.
+
+**Worked example — applied.**
+
+```json
+// -> set_pool_size
+{ "host": "Cloud API", "size": 4 }
+```
+
+```json
+// <-
+{
+  "host": "Cloud API",
+  "production": "ProductionGuardian.LabDemo.Production",
+  "previousSize": 1,
+  "requestedSize": 4,
+  "appliedSize": 4,
+  "applied": true,
+  "updateProduction": "ok",
+  "reversal": { "tool": "set_pool_size", "host": "Cloud API", "size": 1 },
+  "sampledAt": "2026-08-18T08:16:02.117Z"
+}
+```
+
+**Worked example — the reversal**, which is why the tool's lower bound is `1`:
+
+```json
+// -> set_pool_size   (the `reversal` object from the response above, replayed)
+{ "host": "Cloud API", "size": 1 }
+```
+
+```json
+// <-
+{
+  "host": "Cloud API",
+  "production": "ProductionGuardian.LabDemo.Production",
+  "previousSize": 4,
+  "requestedSize": 1,
+  "appliedSize": 1,
+  "applied": true,
+  "updateProduction": "ok",
+  "reversal": { "tool": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "sampledAt": "2026-08-18T08:22:10.004Z"
+}
+```
+
+**Worked example — denied.** The same apply call from a caller holding `PG_Read` but not
+`PG_Resolve`. There is **no result object at all**: the runtime refuses before `%Invoke` runs
+(§5.2), so this is an error response and not a `set_pool_size` payload with `applied: false`.
+
+```json
+// -> set_pool_size
+{ "host": "Cloud API", "size": 4 }
+```
+
+```json
+// <-
+{
+  "error": "tool_access_denied",
+  "tool": "set_pool_size",
+  "reason": "set_pool_size requires PG_Resolve:USE",
+  "audited": true
+}
+```
+
+The distinction that matters: a denial means the pool size **was not read, was not saved, and
+`UpdateProduction()` was not called**. Nothing partially happened (§5.2). Contrast a *failure* —
+wrong production, item not found — where the tool did run and reports through `%ToolError`. Both are
+audited (§5.5), and `resolve-api.md` maps them to `not_authorized` and `failure.stage` respectively.
+
+---
+
+## 4. Errors, and the three things that are not the same
+
+A caller must be able to tell these apart, and only one of them is an error.
+
+| Outcome | Shape | Meaning |
+|---|---|---|
+| **Could not measure** | a normal, successful result with `null` in the field | The tool ran. The value does not exist on this instance right now. Not an error. |
+| **Call failed** | thrown `%Status`, surfaced as a tool error | The tool could not do its job: item not found, wrong production, out-of-bounds argument, query failure. |
+| **Not authorized** | `$$$AICoreToolAccessDenied` from the authorization policy | The tool **did not run at all**. |
+
+**Failure mechanism: `%AI.Tool` provides `%ToolError`, and that is what a tool uses.** Do not invent
+an error envelope and do not return `{"error": ...}` from a successful `%Invoke`. Verified from the
+compiled method body in the running container, `%AI.Tool.%ToolError(sc As %Status)` is exactly:
+
+```objectscript
+$$$ThrowStatus(sc)
+```
+
+So a tool reports failure by handing a `%Status` to `%ToolError`, which throws it; the runtime turns
+that into the tool-error response and — because auditing wraps execution (§5.4) — records the
+failure. A tool that catches its own errors and returns a cheerful payload defeats both.
+
+**The distinction that costs the most if collapsed** is the first row against the third. Both leave
+the agent without a number. But `queued: null` means *keep investigating with what you have*, while
+a denial means *this avenue is closed to you*. An agent told "could not measure" when it was actually
+refused will retry, narrate around the gap, and reason from an incomplete evidence set without
+knowing it. So a denial must never be rendered as a null field, and an unmeasurable value must never
+be rendered as a failure.
+
+**A refusal carries a reason, and the reason is part of the interface.**
+`%AI.Policy.Authorization.%CanExecute` returns a `%Status`, not a boolean (verified signature, §5.1),
+so a denial can say *why*. That reason is surfaced to the caller because it is what lets Dev C render
+a disabled Approve button with an explanation instead of a dead control. **Constraint on the reason
+string:** it names the tool and the missing privilege and nothing else. No user names, no role
+inventory, no host state, no message content. It crosses the same boundary as §6 and gets the same
+treatment — a reason string is a string an external model may see.
+
+---
+
+## 5. RBAC, and why the columns are separate
+
+### 5.1 The two policy hooks
+
+`%AI.Policy.Authorization` and `%AI.Policy.Audit` are abstract base classes you subclass. Their exact
+signatures, introspected from the running container:
+
+```objectscript
+%AI.Policy.Authorization
+  %CanExecute(tool As %String, call As %DynamicObject, metadata As %DynamicObject) As %Status
+  %CanList(tool As %String, metadata As %DynamicObject) As %Boolean
+
+%AI.Policy.Audit
+  %LogExecution(call As %DynamicObject, metadata As %DynamicObject,
+                result As %DynamicObject, duration As %Integer,
+                status As %Status) As %Status
+```
+
+Register ours with `%AI.ToolMgr.SetAuthPolicy(policy)` and `SetAuditPolicy(policy)`.
+
+**`%CanList` and `%CanExecute` are separate gates.** "Can see that this tool exists" and "can run it"
+are independently controlled. That separation is what makes the spec's demo expressible rather than
+staged, and it is why §1 has two columns instead of one "RBAC role".
+
+### 5.2 The gate is enforced by the runtime, not by the tools
+
+Read from the implementation of `%AI.ToolMgr.ExecuteTool` in the running container — its own comment
+describes what the native layer does:
+
+```
+// Call Rust ToolManager.execute() which:
+// 1. Checks AuthorizationPolicy.can_execute()
+// 2. Executes the tool via provider
+// 3. Calls AuditPolicy.log_execution()
+// 4. Returns result as %DynamicObject
+```
+
+Attributed deliberately: this is read from the shipped implementation, not inferred from the class
+list. **"The classes exist" and "the classes are enforced" are different claims**, and only the
+second one justifies the rest of this section.
+
+Three consequences:
+
+1. **A tool's `%Invoke` must not check permissions itself.** The check is centralised and runs for
+   every tool. Per-tool checks are the pattern that eventually produces the one tool that forgot —
+   and here they would be redundant on top of a check that already ran.
+2. **The check happens before execution**, so a denied call cannot have partially executed. There is
+   no half-applied pool change to reason about.
+3. **Audit is automatic for reads too**, not only for the write. So this contract's claim that
+   *every tool call, read and write, is recorded* is structurally true rather than aspirational.
+
+### 5.3 The role table, and the listable-but-not-executable choice
+
+| Resource | Held by role | Grants |
+|---|---|---|
+| `PG_Read` | `%Guardian_Read` | listing and executing the five read tools; **listing** `set_pool_size` |
+| `PG_Resolve` | `%Guardian_Resolve` | **executing** `set_pool_size` |
+
+**This file is where the names are ratified.** `resolve-api.md` §9.3 defers to it, calling the
+`%Guardian_Resolve` in its own examples "illustrative and not ratified here" and instructing Dev C to
+render `audit.role` as an opaque string and never compare it to a literal. That instruction stands
+even now that the value is fixed: Dev C comparing against a literal is what would make a later rename
+a dashboard change. The names here match `resolve-api.md`'s examples so nothing has to be rewritten.
+
+Resources are named `PG_*` while roles are named `%Guardian_*`, which looks inconsistent and is not:
+the `%` prefix is the IRIS convention for a system-supplied role and is what `resolve-api.md`'s
+examples already carry, while a **custom resource must not use `%`** — that prefix is reserved and
+collides with the shipped `%Ens_*` / `%System_*` namespace. Two different naming rules, applied
+correctly, rather than one applied uniformly and wrongly.
+
+Resources gated with `$SYSTEM.Security.Check("PG_Resolve","USE")` rather than a `$ROLES` string
+match. That is the shape the shipped `%AI.Policy.ConsoleAuth` already uses — read from its
+implementation, it denies with
+`$$$ERROR($$$AICoreToolAccessDenied,"Tool '"_call.name_"' requires %System_Callout:USE")` after
+checking `$SYSTEM.Security.Check("%System_Callout","USE")`. Following the runtime's own pattern beats
+inventing one, and a resource check keeps working when roles are nested or renamed.
+
+**`set_pool_size` is listable to `PG_Read` and executable only by `PG_Resolve`.** `%CanList` returns
+true for it under both resources; `%CanExecute` requires `PG_Resolve`.
+
+Why listable rather than hidden:
+
+- **The demo is the denial.** The spec wants AI Detective shown looking without being able to act. A
+  hidden tool produces an agent that recommends nothing and a UI with no control — indistinguishable
+  from a feature that was not built. A visible, refused tool produces a disabled Approve button with
+  a reason, which is the observable form of least privilege.
+- **The agent should recommend the right action even when it cannot perform it.** AI Detective's job
+  is `recommendedAction`. If `set_pool_size` is invisible, the agent cannot name the action it is
+  supposed to recommend, and the WHY step degrades to prose.
+- **Discovery is not an escalation.** The tool's name, its bounds and its one legal host are in this
+  file, which is in the repo. Hiding the name protects nothing while costing the demo its point.
+
+The cost, stated: an unprivileged caller can see that a write capability exists. That is accepted
+here because the capability's *existence* is public by design and its *use* is gated and audited. If
+a later module adds tools where the name itself is sensitive, `%CanList` is the right lever and this
+decision does not generalise to them.
+
+### 5.4 Two layers of authorization, and they fail differently
+
+A reader will otherwise conflate these.
+
+| Layer | Enforced by | Fails as | Granularity |
+|---|---|---|---|
+| **Transport / service** | `%AI.MCP.Service` — `%IsAuthorized()`, `AccessCheck(*pAuthorized)`, plus web-application authentication on the CSP app hosting it | an HTTP-level rejection before any tool is named | all-or-nothing for the whole MCP endpoint |
+| **Per-tool** | `%CanExecute` inside `%AI.ToolMgr.ExecuteTool` | `$$$AICoreToolAccessDenied` with a reason | per tool, per call, per argument set |
+
+The first says *you may not talk to this MCP service*. The second says *you may talk to it, and you
+may read, and you may not write*. Only the second can produce the demo in §5.3, and only the first
+protects the endpoint from an unauthenticated caller. Both are required; neither substitutes.
+
+### 5.5 Audit
+
+`%LogExecution` receives `status` and `duration`, so **a failed or refused call is audited too**.
+That is the difference between "we log actions" and "we log attempts" — and the second is what makes
+"the AI changed a production setting" reviewable, because the interesting security event is usually
+the one that was blocked.
+
+Every one of the six tools is audited on every call. Not a per-tool setting: it is where the audit
+hook sits in the execution path (§5.2).
+
+The audit record must be sufficient to answer *who acted, what changed, when* — the demo's final
+step. For `set_pool_size` that means the caller identity, the tool name, the arguments including
+`previousSize` and `appliedSize` from the result, the duration, and the status.
+
+**Audit records are subject to §6 as well.** `%LogExecution` receives the full `result` object, and
+for `get_recent_errors` that result is already sanitised — which is a second reason the sanitisation
+lives in the tool rather than in the caller.
+
+### 5.6 Unverified — close these before promising them
+
+Flagged rather than asserted, because this contract's credibility rests on the difference.
+
+- **(a) What an audit record actually contains once written, and whether it is queryable.** The hook
+  and its arguments are verified; the persisted shape is not. Anything in the demo that *shows* an
+  audit entry depends on this. Owner: Dev B, before Day 3.
+- **(b) Whether the default policy permits everything until ours is registered.**
+  `%AI.Policy.ConsoleAuth` and `%AI.Policy.ConsoleAudit` exist alongside the abstract bases, so
+  *some* policy is wired by default — and `ConsoleAuth` is an interactive terminal prompt with an
+  `AlwaysAllow` property, which is not a policy for an unattended service. **Do not assume the
+  default denies.** Registering our own `%AI.Policy.Authorization` subclass is mandatory, and the
+  acceptance test is **an observed denial**, not a passing allow: call `set_pool_size` as a caller
+  without `PG_Resolve` and see it refused. A policy never seen to deny is not known to be enforcing
+  anything — the same argument `contracts/README.md` makes about the validator.
+
+---
+
+## 6. The data boundary
+
+**Tool outputs may reach an external LLM.** The agent runs in IRIS, the model does not. Whatever a
+tool returns can appear in a prompt.
+
+**Metrics and configuration only. Never message content. Never PHI.** Root `CLAUDE.md` §2.1 states
+this as a rule rather than a preference, and it is a rule about *tool return values* specifically,
+because that is the only place in MVP 2 where instance data crosses the boundary by design.
+
+Permitted, for every tool: host names, host types, statuses, queue depths, pool sizes, message
+*counts*, error *counts*, rates, durations, timestamps, production names and states, IRIS error
+codes, and class names.
+
+Forbidden, for every tool: message bodies or any part of one, HL7 segments or fields, patient
+identifiers of any kind, `Ens.MessageBody` contents, `Ens.MessageHeader` field values other than
+counts, `Ens.Util.Log` text, credentials, and stack traces.
+
+**`get_recent_errors` is the tool where this is a live risk** rather than a formality, and §3.4
+specifies its handling in full: an allowlist that extracts only the IRIS error code and maps it to a
+catalogue string, with `unclassified` and no text for anything unrecognised.
+
+Two smaller edges, both worth naming because they are the ones that get missed:
+
+- **Error and refusal reason strings cross the boundary too** (§4). They name a tool and a missing
+  privilege, nothing else.
+- **Counts are not content, but a count of one can be.** A count is permitted at every window size
+  this contract allows. `sinceMinutes` is bounded at 60 and `limit` at 50 partly for that reason —
+  the tool is an evidence source about a *condition*, not a message search interface.
+
+If a future tool needs message content to do its job, that is not a sanitisation problem. It is a
+tool that does not belong in this catalogue.
+
+---
+
+## 7. Implementation notes
+
+Facts introspected from `pg-iris`, `IRIS for UNIX ... 2026.3.0AI (Build 126U)`. InterSystems AI Hub
+is bundled in that image; **there is no separate AI Hub container.**
+
+**A tool is a public method on a subclass of `%AI.Tool`.** `%AI.Tool` is abstract, extends
+`%Library.RegisteredObject`, and provides instance methods `%Invoke`, `%Discover`, `%Encode`,
+`%Decode`, `%ToolError` and class methods `%FromObject`, `%ToObject`, `%TypeMode`. Its own class
+description: *"Base abstraction for a Tool Provider. Automatically exposes public methods as tools
+via introspection."*
+
+**Discovery generates the JSON Schema from the class at compile time**, via
+`%AI.Tool.Generator.GenerateDiscover` / `GenerateInvoke`. Read from that implementation, the rules
+an implementer must work with:
+
+- **Excluded from discovery:** `Private`, `Internal`, `Abstract` methods, and any name starting with
+  `%`. So a helper must be `[ Private ]` or it becomes a tool.
+- **Only methods originating in the class itself** are discovered, unless `DISCOVERYLIMIT` is set
+  explicitly. Inheriting a tool is opt-in.
+- **The first line of the method's description becomes the tool `description`**; the remainder, if
+  separated by a blank line, becomes `instructions`. This is prompt text the model reads — write it
+  for the model, not for a maintainer.
+- **A parameter with a default is optional; one without is required** (§2). This is the only place
+  required/optional is expressed.
+- **The return type generates the `returns` schema.** Returning `%DynamicObject` yields an untyped
+  object, which is why the output tables above are contract prose rather than generated schema.
+- `requires_auth` in the generated spec comes from the class parameter `REQUIRESAUTH`. Set it on
+  `PG.Tools.Resolve`. `%AI.Policy.ConsoleAuth` is the shipped precedent for a policy reading it.
+
+**Runtime registration** goes through `%AI.ToolMgr`:
+
+| Method | Use |
+|---|---|
+| `FindTools(package, includeToolSets, &sc)` | class method; discovers tools in a package |
+| `GetOrCreate(serviceName, *isNew)` | class method; the manager for a service |
+| `AddTool(tool)` / `RegisterToolSet(className)` | register |
+| `SetAuthPolicy(...)` / `SetAuditPolicy(...)` | **register ours — see §5.6(b)** |
+| `ExecuteTool(toolName, arguments)` | the path that checks, executes, audits (§5.2) |
+| `PurgeShared(serviceName)` | class method; clear shared registration |
+
+Also present on this build: `%AI.ToolSet` and `%AI.ToolSet.Specification.*` (declarative XData tool
+sets, including `MCP`, `MCP.Remote`, `MCP.Stdio`), `%AI.Tools.SQL` / `FileSystem` / `ShellTools`,
+`%AI.Utils.ConfigStore` / `SettingStore` / `WalletStore`, `%AI.MCP.Service`, and the `%AI.Agent.*`
+family. **`%AI.Tools.ShellTools` and `%AI.Tools.FileSystem` must not be registered on our tool
+manager.** They are general-purpose and would hand the agent capabilities this catalogue exists to
+withhold.
+
+### 7.1 Compile order — a ToolSet compiled too early discovers nothing, silently
+
+`%AI.ToolSet.Specification.Compiler` validates referenced classes at **compile time**. A ToolSet
+compiled before the classes its `<Include>` targets exist discovers **zero tools, with no error**.
+
+`docker/iris-firstboot.sh` currently loads with `$system.OBJ.LoadDir(..., "ck", ...)` in a single
+pass. A ToolSet class added under `iris/labdemo/` would therefore come up empty depending on load
+order, and the symptom is an agent that reports no tools — which reads as a policy or endpoint
+problem, not a compile-order one. Whatever registers these tools must either compile the tool classes
+in a prior pass or recompile the ToolSet afterwards, and the smoke check must assert the discovered
+tool **count**, not merely that discovery returned successfully.
+
+Same failure class as the `IRIS_BASE_PATH` case in `services/metrics-proxy/CLAUDE.md`: a wrong
+configuration that answers `200` with plausible-looking emptiness.
+
+---
+
+## 8. What this is not
+
+- **Not a general tool catalogue.** Six tools for one scenario: `queue_buildup` on `Cloud API`,
+  caused by `PoolSize 1`, fixed by raising it. A generalised action catalogue is later work
+  (root `CLAUDE.md` §2.2).
+- **Not a remote-execution surface.** There is one mutating operation, on one host, over one
+  setting, within a four-value range. It is not a settings API, not a production editor, and not a
+  path to `Ens.Director.StartProduction` / `StopProduction`.
+- **Not an approval mechanism** (§3.6). Approval lives at `POST /api/resolve` and in the UI.
+- **Not a message search interface** (§6). `get_recent_errors` counts and classifies; it does not
+  retrieve.
+- **Not multi-production.** Every tool is scoped to the single running
+  `ProductionGuardian.LabDemo.Production` and refuses otherwise, following
+  `Triggers.CheckProduction()` and #34.
+
+---
+
+## 9. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by every
+other developer. See `README.md` in this directory.
+
+Two developers remain since 2026-08-12, so in practice that is one other person — and GitHub will
+not let an author approve their own PR, which is the point.
+
+**Ownership.** The MVP 2 spec (§5.1, §5.2) assigns `mcp-tools.md` to **Dev A**, together with the
+MCP tool definitions, the RBAC role, the credential vault entry and the audit configuration. Dev A
+has moved off the project. **Dev B inherited `iris/**` and `services/metrics-proxy/**` and therefore
+owns this contract**, on the same basis as the 2026-08-12 handover recorded in `CHANGELOG.md`. The
+spec's table is left as written rather than mentally reassigned, because a contract whose stated
+owner does not match its actual one is how a review gets skipped.
+
+`README.md` in this directory does not yet list this file in its owner table. Adding it belongs to
+the same PR as publishing this file.
+
+**These changes are contract changes, not configuration:** the `1..8` bound on `size`, the
+`Cloud API` whitelist, the `PG_Read` / `PG_Resolve` split, the listable-but-not-executable decision
+in §5.3, the `get_recent_errors` allowlist and its catalogue policy, and any widening of what a tool
+may return under §6. Each is written here specifically so that changing it requires review rather
+than an edit to a settings file.

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -1,0 +1,1241 @@
+# Smart Resolve API contract
+
+**Owner:** Dev A + Dev B (per MVP 2 §2.4) — **Dev A has left; Dev B inherited `iris/**` on
+2026-08-12, so in practice Dev B holds both halves.** · **Consumer:** Dev C · **Port:** `3002` ·
+**Status:** published
+
+One endpoint, and it is the only thing in this repository that **writes to a live production**.
+Everything else in `contracts/` describes a read. That difference is why this document is longer
+than what it defines: the schema is small, the reasons it is shaped this way are not.
+
+Smart Resolve applies **one** governed, human-approved, reversible corrective action to the
+running production and then tells the caller how to confirm the condition cleared. Root
+`CLAUDE.md` §2.1 already ratifies the safety model as a **scope boundary**, not an
+implementation preference:
+
+- human approval by default — nothing applies unattended
+- exactly one whitelisted action, `set_pool_size` on `Cloud API`, within a bounded range
+- dry-run / preview before apply, and the action is reversible
+- RBAC-gated, so AI Detective can investigate without being able to act
+- every tool call audited, read and write — **authorization and audit are enforced by the AI Hub
+  runtime around every tool call, before and after execution respectively (§9.4), so neither is a
+  convention a tool author can forget**
+- metrics and configuration only ever leave the instance — never message content, never PHI
+
+**The engine does not mutate the production.** `services/detection-engine/CLAUDE.md` §1.1:
+"`POST /api/resolve` proxies the governed MCP write tool. We do not mutate the production
+ourselves — the write happens in IRIS behind RBAC, and this service is a caller that records
+what it asked for and what came back." The engine gained orchestration, not authority. Read §9
+before assuming otherwise.
+
+**No machine-readable artefact yet.** There is no `resolve.schema.json` and no `resolve.d.ts`,
+and no `samples/resolve-*.json`. The JSON in §11 is what Dev C mocks against until those land;
+committing them is a follow-up PR. `contracts` CI counts are unchanged by this document
+(15 accept / 19 reject / 7 capture claims) because it adds no sample for `validate.mjs` to check.
+Stated rather than quietly left off the table, the way `README.md` does for the two `samples/`
+files `CONTRIBUTING.md` §1 promised and nobody wrote.
+
+---
+
+## 1. `POST /api/resolve`
+
+Not under `/api/healthscan/`. Health Scan reads; this writes, and the path should not suggest
+they are the same family of thing.
+
+### 1.1 Request
+
+```json
+{
+  "requestId": "rq-6f2c1e",
+  "mode": "apply",
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 4
+  },
+  "origin": {
+    "findingId": "f-1042",
+    "investigationId": "inv-8801"
+  },
+  "precondition": {
+    "poolSize": 1
+  },
+  "requestedBy": "presenter@laptop"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `requestId` | string | **for `apply`** | Client-generated, opaque, ≤ 64 chars. The replay key — see §6. Optional for `dry_run`, which has nothing to replay. |
+| `mode` | string | **always** | `dry_run` \| `apply`. **No default** — see §2. |
+| `action` | object | **always** | The whitelisted action. Transcribed, never composed — see §1.2. |
+| `action.type` | string | **always** | Exactly `set_pool_size`. Anything else is refused. |
+| `action.host` | string | **always** | Exactly `Cloud API`. Anything else is refused — see §3. |
+| `action.size` | number | **always** | Integer, `2 ≤ size ≤ 8`. Out of range is refused, not clamped — see §3. |
+| `origin` | object | **for `apply`** | What motivated the write. Both ids are opaque strings here. |
+| `origin.findingId` | string | **for `apply`** | The `Finding.id` from `healthscan-api.md` §2. Used for the confirmation contract (§7) and the audit trail (§8). |
+| `origin.investigationId` | string | no | The AI Detective investigation this recommendation came from. Opaque — its shape belongs to `investigation-api.md`. |
+| `precondition` | object | no | Optimistic concurrency. When present, the live value must match or the call is refused. |
+| `precondition.poolSize` | number | no | The pool size the approver believed they were changing *from*. |
+| `requestedBy` | string | no | **Provenance label only. Never used for authorization.** Recorded next to the authenticated actor in the audit block, never in place of it — see §8. |
+
+Unknown top-level fields are **ignored**, not rejected. Unknown fields *inside* `action` are
+**refused** (`malformed_request`). The asymmetry is deliberate: an unrecognised sibling of
+`requestedBy` is harmless metadata, while an unrecognised key inside the action object means the
+caller believes it is asking for something this endpoint is not going to do, and silently
+dropping it would make the response describe a different operation from the request.
+
+`precondition` exists because approval is not instantaneous. Between the investigation rendering
+"PoolSize = 1" and the operator clicking Approve & Apply, a rehearsal reset or a second browser
+tab can move the value. Approving a recommendation computed against `1` when the live value is
+now `6` is approving something the operator did not read.
+
+### 1.2 The action is transcribed, never parsed
+
+`action` is a field-for-field copy of the **structured** `recommendedAction` the AI Detective
+investigation returns (`services/detection-engine/CLAUDE.md` §1.1:
+`{rootCause, evidence[], confidence, recommendedAction}`). Dev C passes it through; nothing
+between the agent and this endpoint reads prose.
+
+**This endpoint does not accept a natural-language action, in any field, ever.** Deriving
+`{type, host, size}` by parsing `"increase Cloud API pool 1 → 4"` out of model output is the
+single most dangerous line anybody could write in MVP 2: it makes the write path depend on LLM
+phrasing, and a phrasing change becomes a wrong write with no failing test anywhere.
+
+**Agreed with the sibling contract.** `contracts/investigation-api.md` §3.3 types
+`recommendedAction.action` as exactly `{ "type": "set_pool_size", "host": "Cloud API", "size": 4 }`
+— the same three keys, same spelling, same types, `additionalProperties: false` — so the dashboard
+hands it here unmodified. It also maps `recommendedAction.currentValue` onto this endpoint's
+`precondition.poolSize`. Both contracts were authored in the same Day-1 batch and both state the
+rule, because a mismatch between them would surface as Dev C writing a translation layer, which is
+the prose-parsing failure with extra steps.
+
+### 1.3 Response
+
+`200` in every case the request was understood. One shape for all five outcomes, so Dev C
+renders from one type rather than from a status code.
+
+```json
+{
+  "resolveId": "rs-19f3",
+  "requestId": "rq-6f2c1e",
+  "mode": "apply",
+  "outcome": "applied",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
+  "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
+  "reversal": {
+    "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
+    "capturedFrom": "live",
+    "automatic": false
+  },
+  "refusal": null,
+  "failure": null,
+  "confirmation": {
+    "status": "pending",
+    "findingId": "f-1042",
+    "clearsWhen": "queue_buildup for Cloud API disappears from GET /api/healthscan/findings",
+    "observeVia": ["GET /api/healthscan/findings", "GET /api/healthscan/hosts"],
+    "expectedWithinSeconds": 60,
+    "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
+  },
+  "audit": {
+    "auditId": "aihub-audit-44812",
+    "actor": "guardian_resolve",
+    "role": "%Guardian_Resolve",
+    "requestedBy": "presenter@laptop",
+    "tool": "set_pool_size",
+    "recordedAt": "2026-08-18T14:06:43Z",
+    "source": "live"
+  },
+  "requestedAt": "2026-08-18T14:06:41Z",
+  "completedAt": "2026-08-18T14:06:43Z",
+  "replayed": false
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `resolveId` | string | Server-generated, unique per *evaluation*. A replay (§6) returns the original. |
+| `requestId` | string \| null | Echoed. `null` when the request omitted it (legal only for `dry_run`). |
+| `mode` | string | Echoed, so a stored response is self-describing. |
+| `outcome` | string | One of the five in §1.4. **The field Dev C branches on.** |
+| `action` | object | Echoed **as evaluated**, not as sent. If the request was refused for being out of bounds, this still shows what was asked for. |
+| `before` | object \| null | Live state read immediately before the write. `null` only when nothing could be read (`wrong_production`, `host_not_in_production`, `not_authorized`). |
+| `after` | object \| null | Live state read back **after** the update. `null` for `previewed` and for refusals. **Populated even on `failed`** — see §4. |
+| `reversal` | object \| null | How to undo. `null` unless `outcome` is `applied`. See §4. |
+| `refusal` | object \| null | Non-null **iff** `outcome` is `refused`. See §5. |
+| `failure` | object \| null | Non-null **iff** `outcome` is `failed`. See §5.2. |
+| `confirmation` | object | Always present. `status: "not_applicable"` for everything except `applied`. See §7. |
+| `audit` | object | Always present, for every outcome including refusals and dry-runs. See §8. |
+| `requestedAt` / `completedAt` | string | ISO 8601 UTC, `Z`-suffixed, matching `healthscan-api.md`. |
+| `replayed` | boolean | `true` when this is a stored result returned for a repeated `requestId`. See §6. |
+
+Every field is always **present**. `before`, `after`, `reversal`, `refusal` and `failure` may be
+`null`; the others are always objects, strings or booleans. A missing key is a contract
+violation, a `null` value is not — same rule as `healthscan-api.md` §1, for the same reason.
+
+Advisory response header: `X-Resolve-Outcome`, carrying the same string as `outcome`. Advisory
+because the body is authoritative; a consumer may ignore the header entirely.
+
+**CORS.** `Access-Control-Allow-Origin: *` as on the two GETs (Q9). The engine's current
+`Access-Control-Allow-Methods` is `GET, OPTIONS` and its preflight sends no
+`Access-Control-Allow-Headers`, so implementing this endpoint means widening both to admit
+`POST` and `Content-Type`. Noted because the write endpoint will otherwise fail preflight while
+the two reads keep working, which looks like a Dev C bug and is not one. See §13 for the
+security question `*` raises on a write endpoint.
+
+### 1.4 `outcome` — the five terminal states
+
+| `outcome` | Meaning | Wrote? |
+|---|---|---|
+| `previewed` | A `dry_run` completed. Every check passed; nothing was written. | **No** |
+| `applied` | The pool size changed. `before` ≠ `after`. | Yes |
+| `no_change` | Every check passed and the live value already equalled `action.size`. | **No** — see §6 |
+| `refused` | The request was understood and declined. Expected, not an error. | **No** |
+| `failed` | Checks passed, the write was attempted, and it did not complete. | **Unknown — read `after`** |
+
+Treat the set as **closed**, unlike `HostStatus` in `healthscan-api.md`. A `HostStatus` can grow
+with an IRIS version, so the dashboard renders unknown values neutrally. An unknown `outcome`
+here means the contract changed underneath the UI on the one endpoint that writes, and the
+correct rendering is a hard "unrecognised result — verify the pool size by hand", not a neutral
+badge. Defensive rendering means *safe*, not *quiet*.
+
+---
+
+## 2. Dry-run is a mode, not a flag
+
+`mode` is **required and has no default.** A defaulted mode means an omitted field, a typo, or a
+half-written client becomes a live write to a production. Fail closed: a request with no `mode`
+is `refused` / `malformed_request`, and the engine never infers intent.
+
+It is a `mode` rather than a `dryRun: true` boolean for the same reason. A boolean has a falsy
+default in every serialization path — absent, `null`, `""`, `0`, and `"false"` all collapse to
+"not a dry run" somewhere between a React state hook and `JSON.parse`. `"apply"` cannot be
+arrived at by accident.
+
+**A `dry_run` mutates nothing.** Guaranteed, and the guarantee is structural rather than
+promised: in `dry_run` the engine calls the **read** tool `get_pool_size` and the whitelist,
+bounds, production and RBAC checks — it never calls `set_pool_size`, so no code path exists that
+could write. The privileged tool is not invoked at all, which is a stronger statement than "it
+is invoked with a flag that makes it not write".
+
+What a `dry_run` returns:
+
+- `outcome: "previewed"` if every check passes, or `refused` with the real reason if any fails.
+  **A dry-run that would be refused is refused** — that is the entire point of previewing.
+- `before` — the live pool size, measured now.
+- `after` — **`null`**, not the projected value. A predicted number in a field named `after` is
+  the `lastActivity` coercion defect from #58 and the "forecast presented as a measurement"
+  problem `services/detection-engine/CLAUDE.md` §1.1 names for Early Warning. The projected
+  value is already in `action.size`; the UI can render "1 → 4" from `before.poolSize` and
+  `action.size` without a field that pretends to have been observed.
+- `reversal: null` — nothing changed, so there is nothing to reverse. Offering a reversal for a
+  no-op invites a "restore" that writes a value nobody measured.
+- `confirmation.status: "not_applicable"`.
+- `audit` — **present**. Dry-runs are audited too (§8).
+
+RBAC is checked in `dry_run`. A preview that succeeds and an apply that then denies is the worst
+possible ordering on stage; it also means Dev C can disable the Approve & Apply button from the
+preview response rather than discovering the denial on the click that matters.
+
+---
+
+## 3. The whitelist and the bounds
+
+Exactly one action type, exactly one host, one bounded integer range.
+
+| | Allowed | Refusal if not |
+|---|---|---|
+| `action.type` | `set_pool_size` | `not_whitelisted_action` |
+| `action.host` | `Cloud API` | `not_whitelisted_host` |
+| `action.size` | integer, `2`–`8` inclusive | `out_of_bounds` |
+
+**`Cloud API` and no other host.** `EMR Source` and `Lab Router` are real hosts in the
+production (`iris/labdemo/Production.cls` is the authoritative `<Item>` set) and both have a
+`PoolSize`, and neither is whitelisted. `Lab Router` is an
+`EnsLib.HL7.MsgRouter.RoutingEngine`: giving a routing engine more jobs lets it process messages
+concurrently, and message ordering is not something a performance fix gets to trade away
+quietly. Whether that matters for this pipeline is beside the point — MVP 2 is one scenario, and
+a host is out until somebody has a reason to put it in.
+
+**`size` lower bound is 2, not 0 or 1.** `1` is the shipped value
+(`PoolSize="1"` on the `Cloud API` item), so setting it is a no-op dressed as a fix and reaches
+§6 anyway. `0` is excluded because its meaning is adapter- and version-dependent and nobody here
+has verified it: on some host classes it means "no dedicated jobs", which would stop the host
+processing and produce exactly the `dead_host` finding Smart Resolve exists to avoid causing. It
+is excluded rather than reasoned about — an unverified claim about IRIS semantics has no place in
+the bounds check of a write tool.
+
+**`size` upper bound is 8.** The recommended action is `4`. The range leaves rehearsal headroom,
+because MVP 2 §6 names "pool change does not drain fast enough on stage" as a risk whose
+mitigation is "pre-tune the bombard rate and target pool size". It is capped because every pool
+job is a real IRIS process: an unbounded `size` lets one fat-fingered digit — or one hallucinated
+number — spawn hundreds of jobs and denial-of-service the production this tool is supposed to be
+protecting.
+
+**Out of range is refused, never clamped.** Clamping `40` to `8` would apply a change the
+operator did not approve, report it as `applied`, and be indistinguishable in the audit log from
+someone deliberately choosing `8`. A refusal is legible; a silent correction is not.
+
+### 3.1 Why an allow-list and not a blocklist
+
+A blocklist is only as good as the enumeration of harm that existed when it was written, and it
+**fails open**: anything nobody thought of is permitted. An allow-list **fails closed**: a new
+action type, a renamed host, a new setting, a typo, and a model that invents a plausible-sounding
+tool all land in the same place — refused, with a reason.
+
+That property is load-bearing here specifically because **the action is proposed by an LLM**. The
+set of strings a model can produce is not enumerable in advance, so "block the dangerous ones" is
+not a strategy that can be completed. It is also why the whitelist is compared by **exact
+equality**, not by pattern, prefix or case-insensitive match: `"Cloud API "`, `"cloud api"` and
+`"Cloud API/2"` are all refused. A matcher generous enough to accept those is generous enough to
+accept something else.
+
+The same reasoning applies to the repo's own history: the whitelist is the mechanism that would
+have caught #34, where the instance ran an unrelated `LABDEMO.Production` and a tool that edited
+"the production" by name would have edited the wrong one.
+
+### 3.2 Which check is authoritative
+
+Both sides check. Only one of them counts.
+
+- The **engine** validates the whitelist and bounds before calling anything. This is a **UX
+  affordance**: it lets Dev C render a refusal without a round trip and keeps a malformed request
+  off the privileged path.
+- The **MCP write tool inside IRIS** re-validates all of it — whitelist, bounds, production,
+  item existence — and its verdict is the one that decides whether a byte changes.
+
+The engine is **not a trust boundary.** It holds no IRIS role of its own, it has no write path in
+it (`services/detection-engine/CLAUDE.md` §1.1: "it cannot change a production setting even if a
+bug tried to"), and anything reaching `POST /api/resolve` has already crossed an unauthenticated
+HTTP hop. A validation that only exists in the caller is a validation an attacker skips by
+calling the tool directly. If the two disagree, IRIS wins and the response reports IRIS's reason.
+
+---
+
+## 4. Reversibility — capture the actual prior value
+
+`before.poolSize` is read from the **live** `Ens.Config.Item.PoolSize` immediately before the
+write, inside the same call, and returned. `reversal.action` is then a fully formed request body
+naming that measured value:
+
+```json
+"reversal": {
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
+  "capturedFrom": "live",
+  "automatic": false
+}
+```
+
+Dev C can POST it back verbatim to undo. `capturedFrom` is always `"live"`; the field exists so
+that a future value like `"assumed"` would be visible rather than inferred, and so a mock that
+cannot read the live value has to say so instead of emitting a plausible `1`.
+
+**Never hardcode the restore value.** This is not a hypothetical — it is a bug that was found and
+fixed in the exact write path this tool wraps. `Triggers.ErrorRate()` points `Cloud API` at a
+closed port, and its restore path used to set the port back to the literal `80`. From
+`iris/labdemo/Triggers.cls`:
+
+> Capture the real port BEFORE overwriting it. `Production.cls` says HTTPServer/HTTPPort/
+> Credentials are the only settings that depend on the deployment and should be overridden per
+> environment — so "restore it to 80" would silently break any environment that followed that
+> instruction. **Reproduced: with the port at 8443, arm-then-Reset() left it at 80.**
+
+`Reset()` now restores `^ProductionGuardian.Trigger("PortWas")`, and — the part most likely to be
+missed — when nothing was stashed it *leaves the setting alone*, because "the port is whatever the
+environment configured and must be left alone; touching it would be this method inventing a
+deployment setting."
+
+Applied here: `PoolSize` is `1` in `Production.cls` **today**, so a hardcoded `"restore to 1"`
+would be right today and silently wrong the first time anyone rehearses at `2`, ships a tuned
+default, or runs the demo twice without a reset. A hardcoded restore value is not a shortcut; it
+is a second write, to a value nobody measured, disguised as an undo.
+
+Two further consequences:
+
+- **`before` is measured, never inherited.** It does not come from `precondition.poolSize`, from
+  the finding's `currentValue`, or from the investigation payload — all three are claims made
+  earlier by something else. It comes from `get_pool_size` at the moment of the call.
+- **There is no automatic rollback on failure**, hence `automatic: false`. A failed
+  `Ens.Director.UpdateProduction()` may have already `%Save()`d the config, so the live state
+  after a failure is genuinely unknown, and a blind rollback write is a second unverified
+  mutation on top of the first. Instead, `after` is **always read back**, including on `failed`,
+  so the caller learns the real state and a human decides. Reversal is an operator action with an
+  audit entry of its own, not an error handler.
+
+---
+
+## 5. Refusals — ten distinguishable states
+
+A refusal is `200`, `outcome: "refused"`, and a populated `refusal`:
+
+```json
+"refusal": {
+  "reason": "out_of_bounds",
+  "message": "size 40 is outside the allowed range 2-8 for set_pool_size",
+  "bounds": { "min": 2, "max": 8 },
+  "checkedBy": "iris"
+}
+```
+
+| `reason` | Fires when | `before` populated? |
+|---|---|---|
+| `not_authorized` | The resolved actor does not hold the write role — see §5.1 | no |
+| `not_whitelisted_action` | `action.type` is not exactly `set_pool_size` | no |
+| `not_whitelisted_host` | `action.host` is not exactly `Cloud API` | no |
+| `out_of_bounds` | `action.size` is not an integer in `2`–`8` | yes |
+| `wrong_production` | The running production is not `ProductionGuardian.LabDemo.Production` | no |
+| `production_not_running` | The right production exists but is not in state Running — see §9.2 | no |
+| `host_not_in_production` | Whitelisted host name is absent from the running config — see §9.2 | no |
+| `precondition_failed` | `precondition.poolSize` does not equal the live value | **yes** |
+| `unattributable` | No IRIS principal could be resolved for the call — see §8 | no |
+| `malformed_request` | Missing `mode`, missing `action`, missing `requestId` on an `apply`, wrong types, unknown key inside `action` | no |
+
+`refusal.message` is **human-readable and authoritative** — render it as-is, do not reconstruct
+it, exactly as `Finding.message` works in `healthscan-api.md` §2. `refusal.reason` is what code
+branches on. `refusal.checkedBy` is `"engine"` or `"iris"` and is diagnostic only (§3.2);
+`bounds` appears only for `out_of_bounds`.
+
+The list is longer than it needs to be to *stop* a bad write, and that is the point. Every one of
+these could be a single `refused` with a sentence, and then the UI could only ever say "no". They
+are separate because the correct next action differs: `not_authorized` means find someone with
+the role, `precondition_failed` means re-read and re-approve, `wrong_production` means the
+instance is not the one you think it is, and `host_not_in_production` means somebody renamed an
+item. Collapsing them makes the dashboard's denied state a shrug.
+
+Treat this set as **closed**, per §1.4. An unrecognised `reason` should render
+`refusal.message` verbatim and still show the request as refused — never as applied.
+
+**`400` is reserved for one case:** a body that is not parseable JSON, or a missing/incorrect
+`Content-Type`. There is no request to evaluate, so there is no `outcome` to report and no audit
+subject. A *well-formed* body with bad contents is always `200` + `refused` /
+`malformed_request`, because that request was understood, evaluated and declined.
+
+### 5.1 RBAC denial is a normal response, not an error
+
+`not_authorized` is `200`. It is not `403`, and it is not a `500`.
+
+Three reasons, in ascending order of how much they cost when ignored:
+
+1. **The demo requires it to be renderable.** MVP 2 §5.4 lists "disabled if unauthorized" as a
+   deliverable and its acceptance criterion is "the RBAC-denied state is visible". A state that
+   is visible has to arrive in a shape the UI can lay out, with a message next to it.
+2. **A status code carries one bit and gets swallowed.** Dev C's client branches on `res.ok`;
+   every generic fetch wrapper turns a non-2xx into a thrown error and a generic banner. The
+   specific, informative refusal becomes "something went wrong" in the layer above the one that
+   knew.
+3. **It matches the precedent already ratified in this directory.** `healthscan-api.md` §3:
+   zero findings is `200` + `[]`, never `404`; an unreachable upstream is `200` + labelled stale
+   data, because "a blanked dashboard is worse on stage than a slightly old one". `500` is for a
+   genuine fault. A refusal is not a fault — it is the safety model working.
+
+An authorized caller and an unauthorized one differ **only** in `outcome`, `refusal` and the
+absence of `before`/`after`. Same endpoint, same status, same shape. Dev C mocks the denied state
+by changing two fields.
+
+The demo depends on this being real rather than cosmetic: MVP 2 §2.2 wants to show that "AI
+Detective can look without having permission to act". The read tools (`get_host_status`,
+`get_queue_depth`, `get_pool_size`, `get_recent_errors`, `get_processing_time`) are granted more
+broadly; only `set_pool_size` needs the privileged role. So an unauthorized caller can still get
+a full `dry_run` refusal *with* `before` unavailable and a complete investigation — which is the
+point being demonstrated, not a degraded mode.
+
+### 5.2 A refusal is not a failure
+
+`refused` and `failed` are different outcomes and must not be merged in the UI.
+
+- **`refused`** — the system decided not to act. Nothing was written. **The safety model
+  worked.** The operator's next step is to change something about the request or the environment.
+- **`failed`** — the system decided to act, tried, and did not complete. Something is wrong with
+  the instance, not with the request.
+
+```json
+"failure": {
+  "stage": "update_production",
+  "message": "ERROR #5001: Ens.Director.UpdateProduction() returned an error",
+  "liveStateVerified": true
+}
+```
+
+| `failure.stage` | Where it broke | What `after` means |
+|---|---|---|
+| `transport` | The engine could not reach the MCP tool at all | `null` — nothing was attempted |
+| `authorize` | Role resolution itself errored (distinct from a clean denial) | `null` |
+| `save` | `%Save()` on the config failed | Read back; probably unchanged |
+| `update_production` | Config saved, `UpdateProduction()` failed | Read back; **config and running state may disagree** |
+| `verify` | The write returned OK but the read-back did not show `action.size` | Read back; trust `after` over the write |
+
+`liveStateVerified` says whether `after` is a real read or whether even the read-back failed.
+`false` means the response cannot tell you what the pool size is, and a human must look — which
+is a worse outcome than a refusal and should be rendered as such. A `verify` failure in
+particular is why the read-back exists at all: "the write returned OK" and "the production has
+the new value" are two claims, and only the second one is the one anybody cares about.
+
+---
+
+## 6. Idempotency and double-apply
+
+The demo will hit this. A presenter clicks Approve & Apply, nothing visibly happens for two
+seconds, and they click again.
+
+**Two independent mechanisms, because they answer different questions.**
+
+**1. The action is absolute, so applying it twice is harmless.** `set_pool_size(host, size)` sets
+a value; it does not adjust one. There is deliberately no `increase_pool_size(by: 3)` in the
+vocabulary: a relative action applied twice compounds, and a retried relative write is unbounded
+— exactly the failure the §3 cap exists to prevent, arriving through the front door. An absolute
+setter applied N times leaves the same state as applying it once.
+
+**2. Already at the target is `no_change`, not `applied`.**
+
+```json
+{ "outcome": "no_change", "before": { "poolSize": 4 }, "after": { "poolSize": 4 }, "reversal": null }
+```
+
+`no_change` is a distinct outcome and not a flavour of `applied` for two reasons:
+
+- An operator shown "applied" for a call that changed nothing cannot distinguish a working fix
+  from a no-op, and the second click on stage is precisely when that distinction matters.
+- **`no_change` guarantees `Ens.Director.UpdateProduction()` was not called.** That is a real
+  behavioural promise, not bookkeeping: `UpdateProduction()` restarts affected pool jobs, so
+  re-applying `4` over `4` would briefly drop `Cloud API` throughput to zero — during the drain,
+  in front of an audience, undoing the thing being demonstrated. Not calling it is the safe
+  behaviour; `no_change` is how the caller knows it was not called.
+
+`reversal` is `null` on `no_change` for the §4 reason: reversing to a value that was never
+changed means writing a number nobody measured.
+
+**3. The same `requestId` twice returns the first result.** `requestId` is required for `apply`
+and is the replay key. A repeat within the replay window returns the **stored original response
+verbatim** — same `resolveId`, same `before`/`after`, same `audit.auditId` — with
+`replayed: true`. It does not re-evaluate and does not re-call the tool.
+
+This is what makes the double-click correct rather than merely harmless. Without it, the second
+click *would* return `no_change` (which is fine) but would also mint a second audit entry for one
+human decision, and MVP 2 §3's final demo step is showing the audit log. One approval, one audit
+event.
+
+Constraints, stated rather than implied:
+
+- **The replay window is in-memory and bounded** — 10 minutes, most-recent-N. It is not
+  persisted, consistent with ADR 0002's "nothing persisted" stance for this service. **An engine
+  restart forgets it**, so a `requestId` replayed across a restart is evaluated as a fresh
+  request. That is acceptable because mechanism 1 and 2 make re-evaluation safe; it is written
+  down because "idempotent" without a stated window is a promise the implementation is not
+  making.
+- A **different** `requestId` with the same `action` is a genuinely new request and is evaluated
+  normally — landing on `no_change` if the value already matches. Deliberate: two operators
+  independently deciding the same thing are two decisions, and both belong in the audit log.
+- Reusing a `requestId` with a **different** `action` is `refused` / `malformed_request`. Returning
+  the stored result would answer a question that was not asked; evaluating it would make the
+  replay key meaningless.
+
+---
+
+## 7. Confirmation is asynchronous, and this contract says so out loud
+
+The requirement is "confirm the condition clears" (MVP 2 §1.1). **This response cannot do that**,
+and pretending otherwise would be the most consequential lie in the contract: the caller would
+render "fixed" on the strength of a config write.
+
+`Ens.Director.UpdateProduction()` returns in well under a second. The queue then drains over tens
+of seconds, and the `queue_buildup` finding disappears only after the rule stops breaching —
+which is gated by the engine's poll interval (5000 ms) and the sustained-breach gates in
+`thresholds.json` (`sustainedSamples: 2`, `sustainedSeconds: 4`). So the earliest a cleared
+finding can *possibly* be observed is measurably after the write returns, by construction.
+
+Therefore `confirmation` **hands the caller the observation path instead of a verdict**:
+
+```json
+"confirmation": {
+  "status": "pending",
+  "findingId": "f-1042",
+  "clearsWhen": "queue_buildup for Cloud API disappears from GET /api/healthscan/findings",
+  "observeVia": ["GET /api/healthscan/findings", "GET /api/healthscan/hosts"],
+  "expectedWithinSeconds": 60,
+  "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
+}
+```
+
+| `status` | When |
+|---|---|
+| `pending` | `outcome: "applied"`. The write landed; clearing is now observed elsewhere. |
+| `not_applicable` | Every other outcome. Nothing was changed, so there is nothing to confirm. |
+
+`clearsWhen` is authoritative human-readable text (same rule as `Finding.message`).
+`expectedWithinSeconds` is **advisory and explicitly not a promise** — MVP 2 §6 lists "pool
+change does not drain fast enough on stage" as a live risk whose drain rate "depends on the
+dispatcher hang value and the chosen target pool size". A countdown rendered from this number
+must degrade to "still draining" rather than to "failed", because the number is a rehearsal
+estimate and the finding path is the truth.
+
+There is deliberately **no callback, no webhook, and no `GET /api/resolve/{id}` poll**.
+Confirmation already exists: it is `healthscan-api.md`, which Dev C already polls and already
+renders, and where a finding disappearing is already the documented signal for "condition cleared"
+(Q4: findings vanish when cleared, no tombstones). Adding a second channel that says the same
+thing creates a way for the two to disagree.
+
+**And one honest caveat, because it would otherwise be discovered on stage.**
+`services/detection-engine/CLAUDE.md` §5.1 documents baseline self-inflation: the rolling mean
+includes the breaching samples, so a sustained problem becomes the new normal and its comparative
+finding clears **while the bad value persists**. `queue_buildup` is a comparative rule. So:
+
+> **A cleared `queue_buildup` finding is necessary but not sufficient evidence that the fix
+> worked.** The finding can clear because the baseline caught up rather than because the queue
+> drained.
+
+That is why `directEvidence` exists and names `hosts[].queued`. The queue depth falling is the
+direct measurement; the finding clearing is the derived signal. A confirmation UI that shows both
+is honest and — since the demo's whole claim is "the queue drains on screen" — also more
+convincing than a badge.
+
+---
+
+## 8. Audit — the contract does not permit an unattributed write
+
+**Every call produces exactly one attributable audit event: applies, refusals, and dry-runs
+alike.** `audit` is present in every response.
+
+**This is a property of the runtime, not of our discipline.** `%AI.Policy.Audit`'s
+`%LogExecution(call, metadata, result, duration, status)` is called by the tool-invocation path
+after every execution (§9.4), and it takes `status` and `duration` as parameters — so a refusal, a
+dry-run, and a failure are all first-class auditable events, not just a successful write.
+**"We audit attempts" is a stronger claim than "we audit changes",** and it is the one the
+signature supports: a `status` field only earns its place if non-success is recorded. A preview
+that leaves no trace is not reviewable.
+
+```json
+"audit": {
+  "auditId": "aihub-audit-44812",
+  "actor": "guardian_resolve",
+  "role": "%Guardian_Resolve",
+  "requestedBy": "presenter@laptop",
+  "tool": "set_pool_size",
+  "recordedAt": "2026-08-18T14:06:43Z",
+  "source": "live"
+}
+```
+
+| Field | Notes |
+|---|---|
+| `auditId` | Handle for the AI Hub audit entry, so the UI can link to the record MVP 2 §3's last demo step shows. `null` when the record could not be written — and if it could not be written for an `apply`, that is `failed` / `verify`, not a silent success. **Whether an entry is retrievable by this handle is unverified — §13.4.** |
+| `actor` | **The authenticated IRIS principal, resolved server-side.** The identity the RBAC decision was made about. |
+| `role` | The role that authorized (or, on `not_authorized`, the role that was required). Lets the UI say *what* is missing. |
+| `requestedBy` | The request's advisory label, echoed. Recorded **next to** `actor`, never in place of it. |
+| `tool` | `set_pool_size` on an apply, `get_pool_size` on a dry-run. Which privileged tool was actually invoked, per §2. |
+| `recordedAt` | ISO 8601 UTC. |
+| `source` | `"live"` \| `"mock"`. |
+
+**`actor` is not a request field, and a caller cannot name itself.** `requestedBy` is a string a
+browser typed; treating it as identity would make the audit log a record of what the client
+claimed rather than of who acted, which is worse than no audit log because it is trusted. The
+actor is resolved from the credential the IRIS-side tool authenticates with, and it is returned
+so the operator can see which identity acted.
+
+**If no principal resolves, nothing is written.** `outcome: "refused"`, `refusal.reason:
+"unattributable"`. There is no path through this contract that mutates the production without a
+named actor — an unattributed write is not a degraded mode, it is a contract violation. MVP 2
+§2.2 is explicit that the purpose of the audit trail is that "the AI changed a production
+setting" is a reviewable, attributable event; an anonymous write defeats the entire reason the
+tool lives in IRIS instead of in the engine.
+
+**Dry-runs are audited.** Two reasons. A preview reads live production configuration, and reads
+are audited by design (MVP 2 §2.2: "every MCP tool call, read and write"). And "who was probing
+the production, and when" is part of the same story as "who changed it" — an audit log with a
+hole where the reconnaissance was is a partial account. It is also not optional: the dry-run path
+invokes `get_pool_size` through the same governed tool path, so `%LogExecution` runs for it
+whether or not anyone wanted it to.
+
+**Refusals are audited.** Including `not_authorized`. A denied attempt is the security-relevant
+event in the set — an audit trail that records only what succeeded cannot answer "did anything try
+to write to the production", which is the question a healthcare operations review actually asks.
+This is why §11.3's RBAC-denied example carries a populated `audit` block naming the refused
+identity.
+
+**`source: "mock"` is mandatory for the mock resolve.** ADR 0004 keeps mock-first, and MVP 2 §5.3
+ships a mock resolve. A mock response that reports `"live"` produces a screenshot, a rehearsal
+recording, or a support ticket in which a simulated write is indistinguishable from an audited
+one. The mock also carries `auditId: null` — it has no audit entry, and inventing an id that
+resolves to nothing is worse than admitting there is none. This is `never invent data` (root
+`CLAUDE.md` §6) applied to the field where inventing it matters most.
+
+**The LLM boundary, for completeness.** The resolve path sends nothing to the external model at
+all — it is a deterministic tool call over a structured action (§1.2). The reasoning already
+happened in AI Detective. Root `CLAUDE.md` §2.1's rule still binds everything upstream: metrics
+and configuration only, never message content, never PHI.
+
+---
+
+## 9. The MCP write-tool boundary
+
+### 9.1 What `set_pool_size(host, size)` wraps
+
+One mutating tool, in IRIS, in the AI Hub instance. It wraps the path
+`iris/labdemo/Triggers.cls` already proves in this production:
+
+1. `##class(Ens.Config.Production).%OpenId("ProductionGuardian.LabDemo.Production")`
+2. Find the `Ens.Config.Item` whose `.Name` equals `host`
+3. Set `item.PoolSize`
+4. `def.%Save()`
+5. `##class(Ens.Director).UpdateProduction()`
+6. Read `item.PoolSize` back and return it as `after`
+
+The tool is a **`%AI.Tool` subclass implementing `%Invoke`**. `%AI.Tool` is abstract and supplies
+`%Invoke` / `%Discover` / `%Encode` / `%Decode` / `%ToolError` on the instance and
+`%FromObject` / `%ToObject` / `%TypeMode` on the class, so the tool inherits an error convention
+rather than needing one invented: **`%ToolError` is the failure mechanism**, and §5.2's
+`failure.stage` values are a mapping of it onto the wire, not a parallel scheme.
+
+**Step 3 is a property, not a setting.** `PoolSize` is a property of `Ens.Config.Item`
+(`PoolSize As %Library.Integer`, alongside `Name`, `Enabled`, `Category`, `Settings`), so the
+tool assigns `item.PoolSize` directly. It does **not** go through the `Settings` collection the
+way `Triggers.SetSetting()` does, and it does not add an `Ens.Config.Setting` row named
+`PoolSize`. Worth stating because `SetSetting` is the closest existing code and copying it here
+would produce a setting row that changes nothing while reporting success — the exact failure mode
+#66 was filed about, in a new place. Verified against `Ens.Config.Item` on the live instance, not
+assumed from the `PoolSize="1"` attribute in the XData, which is a different serialization.
+
+The engine's role is limited to: validate, call, record the request, record the response, and
+return this document's shape. `services/detection-engine/CLAUDE.md` §1.1 again — the engine is a
+caller, not an author of change.
+
+### 9.2 The guards, and one deliberate divergence from `Triggers.cls`
+
+The write tool must carry the guards `Triggers.cls` earned the hard way. Each maps to a §5
+refusal reason:
+
+| Guard | Modelled on | Refusal |
+|---|---|---|
+| The running production must be `ProductionGuardian.LabDemo.Production` | `Triggers.CheckProduction()` | `wrong_production` |
+| The named item must exist in the running config | `Triggers.SetSetting()`'s `foundItem` | `host_not_in_production` |
+| Whitelist and bounds | §3, re-checked in IRIS | `not_whitelisted_*`, `out_of_bounds` |
+| Role check before any read of live config | §5.1 | `not_authorized` |
+
+**The production check.** `CheckProduction()` exists because "the instance ran an unrelated
+LABDEMO.Production until 2026-08-12, and a trigger that silently edits the wrong production is
+worse than one that refuses (#34)". Same reasoning, higher stakes: these triggers manipulate a
+demo, this tool answers to an approval click.
+
+**The item check.** `SetSetting()` tracks whether the *item* was found, not just the setting,
+because without it "an unknown item makes this method a silent no-op, so a rename in
+`Production.cls` would have `ErrorRate()` print ARMED having changed nothing — and
+`CheckProduction()` would not catch it, since it only compares the production NAME". The same
+sentence rewritten for this endpoint is: a rename would have `POST /api/resolve` return
+`applied` having changed nothing. `host_not_in_production` is the refusal that makes it loud. The
+generalisation from #66 is worth keeping in one line: **a tool that reports success having done
+nothing is the worst failure it can have.**
+
+**And one place this tool must be STRICTER than the proven path.** `CheckProduction()` treats a
+production that is not Running as a *warning*, not a refusal:
+
+```objectscript
+// state 1 is Running. A stopped production accepts config edits that take effect on
+// start, which is confusing rather than wrong -- so warn instead of refusing.
+if state '= 1 {
+    write "NOTE  production state is ", state, ", not Running. Changes apply on start."
+}
+```
+
+That is right for a trigger that arms a condition for later. It is **wrong here**, and
+`production_not_running` is a refusal rather than a warning. This contract promises `after` is a
+read-back of live state and that `confirmation` leads to a condition clearing. Against a stopped
+production, `%Save()` succeeds, `UpdateProduction()` changes no running job, `after` reports the
+saved value, and the response says `applied` — while nothing drains, because nothing is running.
+The response would be true field by field and false as a whole.
+
+**This divergence is deliberate and is called out because it is a divergence.** Someone will read
+`Triggers.CheckProduction()`, see a warning, and "align" the tool with the proven path. The
+proven path is proven for a different job.
+
+### 9.3 RBAC, and where the check actually happens
+
+- **One dedicated IRIS role gates `set_pool_size`.** Nothing else needs it, and no read tool has
+  it. Least privilege, and it is what makes MVP 2 §2.2's demonstration real: AI Detective can
+  look and cannot act.
+- **The read tools are granted more broadly** — `get_host_status`, `get_queue_depth`,
+  `get_pool_size`, `get_recent_errors`, `get_processing_time`. The dry-run path uses only
+  `get_pool_size` (§2).
+- **The role name, its grants, and the tool catalogue belong to `contracts/mcp-tools.md`**, which
+  MVP 2 §2.4 makes a separate contract. Dev C must render `audit.role` as an opaque string and
+  never compare it to a literal — this contract deliberately does not fix its value, so that
+  choosing it later is not a breaking change to the dashboard.
+
+  **Reconciled with `mcp-tools.md` §1 after both landed, and they agree** — but only once you read
+  the distinction it draws, which is easy to miss and looks like drift:
+
+  | | `mcp-tools.md` calls it | appears in this contract as |
+  |---|---|---|
+  | IRIS **resource** — what is gated | `PG_Resolve` (write), `PG_Read` (read) | not published; internal to the gate |
+  | IRIS **role** — what a caller holds | `%Guardian_Resolve`, `%Guardian_Read` | `audit.role` |
+
+  So `audit.role: "%Guardian_Resolve"` in §11 and "executable by `PG_Resolve`" in the catalogue are
+  the same rule stated from two ends, not two names for one thing. A reader grepping for one string
+  and finding the other should not "fix" it. The resource is the thing `%CanExecute` tests; the role
+  is the thing an audit record can attribute an action to, which is why only the latter is in this
+  contract's response shape.
+
+### 9.4 Authorization and audit are enforced by the runtime, not by the tool
+
+Source for everything in this section: `docs/mvp2-aihub-verified-api.md`, introspected from the
+running `pg-iris` container. Cited rather than restated, so there is one place this is maintained.
+
+The two governance hooks are AI Hub policy classes:
+
+```
+%AI.Policy.Authorization
+  %CanExecute(tool, call, metadata) -> %Status
+  %CanList(tool, metadata)          -> %Boolean
+
+%AI.Policy.Audit
+  %LogExecution(call, metadata, result, duration, status) -> %Status
+```
+
+**They are invoked by the runtime around every tool execution, in a fixed order.** This is read
+from the shipped implementation of `%AI.ToolMgr.ExecuteTool` in the running container, whose own
+comment states that the call into the Rust tool manager:
+
+```
+// 1. Checks AuthorizationPolicy.can_execute()
+// 2. Executes the tool via provider
+// 3. Calls AuditPolicy.log_execution()
+// 4. Returns result as %DynamicObject
+```
+
+Three consequences, and they are the reason this contract can make promises it otherwise could
+not:
+
+1. **A tool author cannot forget to check permissions.** `%CanExecute` is not something
+   `set_pool_size`'s `%Invoke` calls; it is something the invocation path calls before `%Invoke`
+   runs at all. So this contract states as a **guarantee, not a convention**: every call to the
+   write tool is authorization-checked and audited. Not "every call we remembered to gate" — a
+   carelessly written `%Invoke` is still gated.
+2. **Authorization precedes execution, so a denied call cannot have partially mutated the
+   production.** This is why `not_authorized` always has `before: null` and `after: null` (§5) and
+   why the refusal is safe to render as "nothing happened" rather than "state unknown". On an
+   endpoint that writes to a live production, "the check runs first" and "the check runs" are
+   different claims and only the first one closes the partial-write question.
+3. **Read from the implementation, not inferred from the class list.** Stated that way
+   deliberately: "the policy classes exist" and "the policy classes are enforced" are different
+   claims, and only the second is worth anything on a live production. This documents the second.
+
+**`%CanExecute` returns `%Status`, not a boolean** — so a denial carries a machine-readable
+reason, which is what makes §5.1's renderable denied state possible at all rather than a bare
+"no". That reason is what fills `refusal.message`, subject to one constraint: **the message must
+not leak detail a denied caller should not have.** It names what was required (the role) and what
+was refused (the tool). It must not enumerate who does hold the role, echo credential material,
+or report live configuration — which is the other reason `before` is `null` on `not_authorized`.
+
+**`%CanList` is separate from `%CanExecute`, so visibility and executability are gated
+independently.** This contract requires the action be **listable to an unauthorized caller and not
+executable** — present-but-denied, not hidden.
+
+Two reasons. A hidden action is indistinguishable from a broken dashboard: the operator sees no
+Smart Resolve panel and has no way to learn that a fix exists and that they lack the role to apply
+it, which is worse operationally than a disabled button with a reason. And MVP 2 §5.4's acceptance
+criterion is that "the RBAC-denied state is **visible**" — a hidden action cannot satisfy it. The
+demo point being made (§5.1) is that AI Detective can look without being able to act, and that is
+only demonstrable if the thing it cannot do is on screen.
+
+**What is NOT yet settled: whether the configured policy actually denies.** `%AI.Policy.Authorization`
+and `%AI.Policy.Audit` are abstract bases, and `%AI.Policy.ConsoleAuth` / `%AI.Policy.ConsoleAudit`
+exist alongside them, so *some* policy is wired by default. Whether the default permits everything
+until a real one is registered is **unverified** (§13.3). "Enforced by the runtime" is a safety
+property only if the policy it enforces denies something. So this contract requires two things of
+the IRIS side, and they are acceptance criteria rather than notes:
+
+- **Our own Authorization policy is registered**, not left on whatever ships as the default.
+- **Denial is tested.** An unauthorized caller must be observed being refused, with the refusal
+  arriving in this document's shape. `services/detection-engine/CLAUDE.md` §8 already states the
+  general form of this — "a schema test that only checks valid input proves nothing; prove
+  rejection too" — and on the write path it is the only test that proves the safety model exists.
+
+---
+
+## 10. What Smart Resolve is NOT
+
+| Not this | Why / where it belongs |
+|---|---|
+| **Autonomous remediation** | Human approval by default (root `CLAUDE.md` §2.1; MVP 2 §1.3). There is no `mode` that acts unattended, no confidence threshold that skips approval, and no scheduler. `apply` is only ever the direct consequence of a click. |
+| **A general action catalogue** | One action type, one host, one bounded range (§3). A catalogue is later work — MVP 2 §7.3 lists "a second recommended action type" as an *optional enhancement, once the first is proven end to end.* |
+| **Multiple action types** | `action.type` has exactly one legal value. Adding a second is a contract PR, not a config change (§12). |
+| **A remediation engine, a runbook runner, or a tuning advisor** | Tuning advice is Performance Coach; a 0–100 score is Health Score; summaries are Health Summary; chat is Ask Guardian (root `CLAUDE.md` §2.2). |
+| **A restart / stop / start control** | Nothing here starts, stops, disables or enables anything. `set_pool_size` is the only mutation, and `size: 0`-as-stealth-disable is excluded by the bounds (§3). |
+| **Root-cause analysis** | AI Detective's job, in IRIS. This endpoint receives a decision; it does not make one. |
+| **A confirmation oracle** | It cannot tell you the condition cleared (§7). It tells you where to look. |
+| **A trust boundary** | The engine validates for convenience; IRIS decides (§3.2). |
+
+---
+
+## 11. Worked examples
+
+Four, matching the four states Dev C's Smart Resolve panel has to render. These are the mock
+payloads until `samples/` files land.
+
+### 11.1 Dry-run / preview — nothing written
+
+Request:
+
+```json
+{
+  "mode": "dry_run",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "origin": { "findingId": "f-1042", "investigationId": "inv-8801" }
+}
+```
+
+Response `200`, `X-Resolve-Outcome: previewed`:
+
+```json
+{
+  "resolveId": "rs-19f2",
+  "requestId": null,
+  "mode": "dry_run",
+  "outcome": "previewed",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:12Z" },
+  "after": null,
+  "reversal": null,
+  "refusal": null,
+  "failure": null,
+  "confirmation": {
+    "status": "not_applicable",
+    "findingId": "f-1042",
+    "clearsWhen": "queue_buildup for Cloud API disappears from GET /api/healthscan/findings",
+    "observeVia": ["GET /api/healthscan/findings", "GET /api/healthscan/hosts"],
+    "expectedWithinSeconds": 60,
+    "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
+  },
+  "audit": {
+    "auditId": "aihub-audit-44810",
+    "actor": "guardian_resolve",
+    "role": "%Guardian_Resolve",
+    "requestedBy": null,
+    "tool": "get_pool_size",
+    "recordedAt": "2026-08-18T14:06:12Z",
+    "source": "live"
+  },
+  "requestedAt": "2026-08-18T14:06:12Z",
+  "completedAt": "2026-08-18T14:06:12Z",
+  "replayed": false
+}
+```
+
+Note `after: null` and `tool: "get_pool_size"` — the privileged tool was never invoked (§2). The
+UI renders "1 → 4" from `before.poolSize` and `action.size`.
+
+### 11.2 Apply — succeeded, with before and after
+
+Request:
+
+```json
+{
+  "requestId": "rq-6f2c1e",
+  "mode": "apply",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "origin": { "findingId": "f-1042", "investigationId": "inv-8801" },
+  "precondition": { "poolSize": 1 },
+  "requestedBy": "presenter@laptop"
+}
+```
+
+Response `200`, `X-Resolve-Outcome: applied` — the full payload is the one in §1.3. The
+load-bearing parts:
+
+```json
+{
+  "outcome": "applied",
+  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
+  "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
+  "reversal": {
+    "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
+    "capturedFrom": "live",
+    "automatic": false
+  },
+  "confirmation": { "status": "pending", "findingId": "f-1042" },
+  "audit": { "actor": "guardian_resolve", "auditId": "aihub-audit-44812", "source": "live" }
+}
+```
+
+`reversal.action.size` is `1` because `before.poolSize` was **measured as** `1` — not because
+`Production.cls` says `PoolSize="1"` (§4).
+
+### 11.3 RBAC-denied — a normal response
+
+Same request as §11.2, from a caller without the write role. Response `200`,
+`X-Resolve-Outcome: refused`:
+
+```json
+{
+  "resolveId": "rs-19f4",
+  "requestId": "rq-6f2c1e",
+  "mode": "apply",
+  "outcome": "refused",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
+  "before": null,
+  "after": null,
+  "reversal": null,
+  "refusal": {
+    "reason": "not_authorized",
+    "message": "caller is not authorized to invoke set_pool_size; the write role is required",
+    "checkedBy": "iris"
+  },
+  "failure": null,
+  "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
+  "audit": {
+    "auditId": "aihub-audit-44813",
+    "actor": "guardian_readonly",
+    "role": "%Guardian_Resolve",
+    "requestedBy": "presenter@laptop",
+    "tool": "set_pool_size",
+    "recordedAt": "2026-08-18T14:07:02Z",
+    "source": "live"
+  },
+  "requestedAt": "2026-08-18T14:07:02Z",
+  "completedAt": "2026-08-18T14:07:02Z",
+  "replayed": false
+}
+```
+
+`200`, not `403` (§5.1). `audit.actor` is the identity that was *refused* — a denial is an
+attributable event too. `audit.role` names what was required, so the UI can say what is missing.
+`before` is `null`: an unauthorized caller does not get a live configuration read out of a
+refusal.
+
+### 11.4 Out of bounds — refused, not clamped
+
+Request (`size: 40`):
+
+```json
+{
+  "requestId": "rq-6f2c22",
+  "mode": "apply",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 40 },
+  "origin": { "findingId": "f-1042" }
+}
+```
+
+Response `200`, `X-Resolve-Outcome: refused`:
+
+```json
+{
+  "resolveId": "rs-19f5",
+  "requestId": "rq-6f2c22",
+  "mode": "apply",
+  "outcome": "refused",
+  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 40 },
+  "before": { "poolSize": 1, "readAt": "2026-08-18T14:07:20Z" },
+  "after": null,
+  "reversal": null,
+  "refusal": {
+    "reason": "out_of_bounds",
+    "message": "size 40 is outside the allowed range 2-8 for set_pool_size",
+    "bounds": { "min": 2, "max": 8 },
+    "checkedBy": "engine"
+  },
+  "failure": null,
+  "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
+  "audit": {
+    "auditId": "aihub-audit-44814",
+    "actor": "guardian_resolve",
+    "role": "%Guardian_Resolve",
+    "requestedBy": null,
+    "tool": "set_pool_size",
+    "recordedAt": "2026-08-18T14:07:20Z",
+    "source": "live"
+  },
+  "requestedAt": "2026-08-18T14:07:20Z",
+  "completedAt": "2026-08-18T14:07:20Z",
+  "replayed": false
+}
+```
+
+`action.size` still echoes `40` — the request as sent, not a corrected version — and `after` is
+`null` because nothing was written. `checkedBy: "engine"` shows the engine caught it first;
+IRIS would have refused identically (§3.2).
+
+---
+
+## 12. The Day-1 questions, answered before they were asked
+
+`healthscan-api.md` §4 answers questions Dev C raised on issue #1. These are answered in advance,
+because this contract is published on Day 1 against no implementation and the questions are
+predictable. Marked `R` and not `Q`: the dashboard already carries `// CONTRACT-Q<n>` markers
+that mean Health Scan question `n`, and a colliding marker would make the grep-based
+reconciliation `README.md` describes ambiguous on the one contract where being sure matters.
+Convention: `// RESOLVE-R<n>: <the assumption, stated inline>` — naming only the number sends the
+reader back to this table.
+
+| # | Question | Answer |
+|---|---|---|
+| **R1** | Is dry-run a separate call or a flag? | A required `mode` with no default (§2). `dry_run` never invokes the write tool at all. |
+| **R2** | What HTTP status does a denial use? | `200`, always, with `outcome: "refused"` (§5.1). `400` only for an unparseable body; `500` only for a genuine engine fault. |
+| **R3** | Can I distinguish "not allowed" from "broke"? | Yes — `refused` vs `failed`, and ten `refusal.reason` values (§5). Do not merge them (§5.2). |
+| **R4** | Does the response prove the queue drained? | **No** (§7). It returns `confirmation.status: "pending"` and the path to observe. Clearing is seen on `/api/healthscan/findings`, and `hosts[].queued` is the direct evidence. |
+| **R5** | What happens if I click Approve twice? | Nothing bad, by three mechanisms (§6): the action is absolute, already-at-target is `no_change` with **no** `UpdateProduction()` call, and a repeated `requestId` replays the stored result with `replayed: true`. |
+| **R6** | Where do I get the reversal value? | `reversal.action`, a ready-to-POST body carrying the **measured** prior value (§4). Never hardcode `1`. |
+| **R7** | Do I need to send who the user is? | No, and you cannot. `actor` is resolved server-side; `requestedBy` is an advisory label recorded beside it (§8). |
+| **R8** | Which host names may I offer in the UI? | Exactly one: `Cloud API`. `EMR Source` and `Lab Router` are real hosts and are **not** whitelisted (§3). Offer no host picker. |
+| **R9** | Can I clamp the size in the UI and skip the refusal path? | Clamp for input convenience if you like, but **the refusal path must still be implemented and reachable** — the authoritative check is in IRIS (§3.2), and a UI-only bound is not a bound. |
+| **R10** | How do I tell a mock apply from a real one? | `audit.source` is `"mock"` and `audit.auditId` is `null` (§8). Render the difference; a screenshot must not be ambiguous. |
+| **R11** | Is `audit.role` safe to compare against a string? | **No.** Opaque string. The role name belongs to `mcp-tools.md` and is not ratified here (§9.3). |
+| **R12** | Is `outcome` open like `HostStatus`? | **No — closed** (§1.4). An unrecognised value renders as an explicit "unrecognised result, verify by hand", never as a neutral badge and never as applied. |
+| **R13** | Should the Smart Resolve panel be hidden when I lack the role? | **No — present-but-denied.** `%CanList` and `%CanExecute` are gated independently and the action stays listable (§9.4). A hidden panel is indistinguishable from a broken dashboard, and MVP 2 §5.4 requires the denied state be *visible*. |
+| **R14** | Can I fetch the audit record by `auditId`? | **Unverified — do not build on it** (§13.4). Render the `audit` block from the response body, which is guaranteed present. Treat `auditId` as a correlation token until read-back is confirmed. |
+
+### 12.1 What this asks of the other Day-1 contracts
+
+Two dependencies, both inside the same Day-1 batch, recorded so they are agreed rather than
+discovered:
+
+1. **`investigation-api.md`** — **agreed and landed.** §3.3 types `recommendedAction.action` as
+   exactly `{type, host, size}`, the object §1.1's `action` is a copy of (§1.2), and maps
+   `currentValue` onto `precondition.poolSize`. Without that agreement something has to parse prose
+   to build a write.
+2. **`mcp-tools.md`** owns the write role's name and grants, the read-tool list, and the tool
+   input/output shapes. This contract references them and fixes none of them (§9.3).
+
+Neither `healthscan-api.md` nor `proxy-api.md` changes. MVP 2 §2.4 says so, and nothing here
+needs a new field from either: `origin.findingId` uses the existing `Finding.id`, and
+`confirmation` points at the two existing endpoints.
+
+---
+
+## 13. Open items — decisions, not defects
+
+Five things this contract does not settle. Each needs a decision or a measurement from someone,
+and picking a side unilaterally on the endpoint that writes is worse here than anywhere else in
+`contracts/`. The last two are open **unknowns about AI Hub**, flagged rather than asserted
+because MVP 2's safety story rests on them and an honest contract is worth more than a confident
+one.
+
+### 13.1 How the actor is authenticated — the one thing to settle first
+
+§8 fixes the *shape* (`actor` resolved server-side, never client-supplied) and deliberately does
+not fix the *mechanism*. Two candidates:
+
+- **Service account.** The engine authenticates to IRIS as a configured user holding the write
+  role. Simple, works with today's dashboard, and MVP 2 ships no login. But then `actor` is the
+  same string for every call, and "who approved this" is only ever `requestedBy` — a client
+  claim, which §8 says is not identity. The audit log becomes attributable to a process, not a
+  person.
+- **Pass-through credential.** The dashboard sends an `Authorization` header, the engine forwards
+  it, IRIS resolves the real principal. Genuinely attributable and makes §5.1's demonstration
+  real rather than staged, at the cost of a login the dashboard does not have.
+
+**Assumption in force until decided:** the service-account model, with `actor` reporting the
+configured IRIS user and `requestedBy` recorded beside it. That is what the §11 examples show.
+Nothing in the response *shape* changes if the decision goes the other way — only which string
+lands in `actor` — which is why the mechanism can be deferred and the shape cannot.
+
+### 13.2 `Access-Control-Allow-Origin: *` on an endpoint that writes
+
+Q9 sends `*` unconditionally on the two GETs so the dev proxy stays optional, and §1.3 keeps it
+here for consistency. On a write endpoint that is a different proposition: any page in the
+browser can POST to `:3002`.
+
+It is tolerable — not fine — for three reasons: the compose stack runs on a laptop, the engine
+holds no authority of its own, and IRIS re-checks everything (§3.2). But under 13.1's
+service-account model the engine holds a credential that *does* have the write role, which makes
+it a confused deputy: the browser cannot write, and the engine can, and `*` lets the browser ask
+it to. The options are binding `:3002` to localhost, an origin allow-list for `POST` only, or the
+pass-through credential in 13.1 — which removes the standing privilege and closes this at the
+same time. Raised rather than resolved, and it is the second-strongest argument for the
+pass-through model.
+
+### 13.3 UNVERIFIED — whether the default policy denies anything
+
+`%AI.Policy.ConsoleAuth` and `%AI.Policy.ConsoleAudit` exist alongside the abstract bases, so a
+policy is wired by default. **Whether that default permits everything until a real one is
+registered has not been observed.**
+
+This is the one open unknown that could invert a safety claim rather than merely leave a gap.
+§9.4 establishes that the runtime *enforces* a policy; if the enforced policy is permissive, the
+enforcement is real and the gate is open. "Enforced by the runtime" is a safety property only if
+the configured policy actually denies.
+
+Hence §9.4's two requirements — register our own Authorization policy, and **test denial** — are
+acceptance criteria, not notes. Until an unauthorized caller has been observed being refused,
+`not_authorized` is a shape this contract defines and not a behaviour it has seen. Dev C can mock
+against the shape today; nobody should describe the RBAC gate as working until that observation
+exists.
+
+### 13.4 UNVERIFIED — what an audit record contains, and whether it is queryable
+
+`%LogExecution`'s **signature** is verified (§8). What it *writes* is not: neither the fields of a
+stored record nor whether one can be read back by `auditId`.
+
+That matters to two things in this document. `audit.auditId` is defined as a handle the UI can
+link to, and MVP 2 §5.4 makes "show AI Hub audit entry for the action (read-only view)" a Dev C
+deliverable with a dependency literally named "audit available". If records turn out not to be
+queryable, the demo's final step needs a different source and `auditId` becomes a correlation
+token rather than a link — a response-shape change, so it is better closed before Day 1 than
+after.
+
+**What is safe to build against now:** that a call produces an audit event (verified — the runtime
+calls `%LogExecution`), and that `audit` is present in every response with `actor` resolved
+server-side (this contract's own rule, §8). **What is not:** any claim about the *contents* of the
+stored record. Dev C should render the `audit` block from the response body — which this contract
+guarantees — rather than from a lookup that may not exist.
+
+### 13.5 Nothing here has been executed
+
+Every other document in `contracts/` documents shipped code. This one describes an endpoint that
+does not exist, against an MCP tool that does not exist. `proxy-api.md` was written from merged
+code; `healthscan-api.md`'s units were "confirmed empirically, not assumed".
+
+What is verified here, and what is not:
+
+- **Verified.** `PoolSize` is a property of `Ens.Config.Item` (§9.1) — introspected, not inferred
+  from XData. `Cloud API` is `PoolSize="1"` at `iris/labdemo/Production.cls:76`. The
+  `Ens.Config.Production` + `%Save()` + `Ens.Director.UpdateProduction()` path works on this
+  instance, because `Triggers.cls` uses it. `CheckProduction()` warns rather than refuses on a
+  non-Running production (§9.2). The `Triggers.ErrorRate()` hardcoded-restore bug and its
+  reproduction at port 8443 (§4). The poll interval and sustained-breach gates behind §7's
+  asynchrony.
+- **Verified on the AI Hub side, on the running `pg-iris` container.** The signatures of
+  `%AI.Policy.Authorization` (`%CanExecute` returning `%Status`, `%CanList` returning `%Boolean`)
+  and `%AI.Policy.Audit` (`%LogExecution` taking `status` and `duration`). That `%AI.Tool` is
+  abstract and supplies `%Invoke` / `%ToolError`. And — read from the shipped implementation of
+  `%AI.ToolMgr.ExecuteTool`, not inferred from the class list — that the runtime checks
+  authorization, then executes, then logs, around every tool call (§9.4).
+- **Not verified.** That `set_pool_size` drains the queue at `4`; MVP 2 §6 flags exactly this as
+  a risk to rehearse. That `size: 0` disables the host — which is why §3 excludes it rather than
+  reasoning about it. **Whether the default AI Hub policy denies anything (§13.3), and what a
+  written audit record contains or whether it is queryable (§13.4)** — the two open unknowns, both
+  EAP, both being closed by Dev B.
+
+The numbers in §11 are illustrative and labelled as such. **The first live apply should be
+diffed against this document**, and where they disagree the document is what is wrong.
+
+---
+
+## 14. Changing this contract
+
+Never edit in place. A change is a PR to `contracts/` with a `CHANGELOG.md` entry, reviewed by
+every other developer. See `README.md` in this directory. Two developers remain since
+2026-08-12, so in practice that is one other person — and GitHub will not let an author approve
+their own PR, which is the point.
+
+**This contract is co-owned on paper and singly-held in practice.** MVP 2 §2.4 assigns it to
+Dev A + Dev B: Dev A for the IRIS-side write tool and RBAC, Dev B for the endpoint. Dev A left on
+2026-08-12 and Dev B inherited `iris/**`, so both halves sit with one person. `proxy-api.md` §7
+already records what that costs: "with Dev A gone, this contract has no author to arbitrate it.
+That makes the changelog entry matter more, not less." The same applies here with a sharper edge —
+the two-owner split was itself a safety property. The read/write boundary in §9 was meant to be
+argued across a team boundary, and now it is not.
+
+So, for this file specifically:
+
+- **Adding an action type, a host, or widening the bounds is a safety change, not a feature.** It
+  must say in the `CHANGELOG.md` entry what the new bound protects against and who reviewed the
+  refusal path — not just what the new value is.
+- **Do not estimate the cost of a change from the size of the edit.** `README.md`'s worked
+  example: removing `Warning` from `HostStatus` was one line in a union and cost 83 insertions
+  across 10 files, because seven fixtures *meant* something in terms of it. Adding a second
+  `action.type` is a smaller diff than that and reaches further — it turns §3's "exactly one"
+  into a list, which is the moment the whitelist stops being a whitelist and starts being a
+  catalogue.
+- **Loosening a check is never a bug fix.** If a live run is refused and the refusal looks wrong,
+  the first hypothesis is that the request is wrong. §3.1's argument for an allow-list is also an
+  argument against quietly widening one.

--- a/docs/mvp2-aihub-verified-api.md
+++ b/docs/mvp2-aihub-verified-api.md
@@ -1,0 +1,160 @@
+# AI Hub API surface, verified on our image
+
+Working notes for MVP 2, not a contract. Everything here was **introspected from the running
+`pg-iris` container**, not read from documentation — because the `aihub-eap` skill documents
+build **162** and we run build **126**, and the skill itself records that builds 141 → 159 → 161
+→ 162 each broke something. Assuming a version's API is how you spend a day on
+`<PROPERTY DOES NOT EXIST>`.
+
+```
+IRIS for UNIX (Ubuntu Server LTS for x86-64 Containers) 2026.3.0AI
+  (Shelves 8246870 9296934 9324128) (Build 126U) Tue Jul 21 2026
+```
+
+## What we have, and it is more than expected
+
+Build 126 carries the classes the skill lists as **new in 162**, including the ones it warns are
+absent on enterprise 161. So the skill's newest patterns apply to us:
+
+| Group | Present |
+|---|---|
+| Agent core | `%AI.Agent`, `%AI.Agent.Session`, `%AI.Agent.Skill`, `%AI.Agent.SubAgent` |
+| Tools | `%AI.Tool`, `%AI.ToolMgr`, `%AI.Tool.Generator`, `%AI.Tool.Resolver`, `%AI.Tool.Schema` |
+| ToolSet spec | `%AI.ToolSet` + `%AI.ToolSet.Specification.*` (incl. `MCP`, `MCP.Remote`, `MCP.Stdio`) |
+| Built-in tools | `%AI.Tools.SQL`, `%AI.Tools.FileSystem`, `%AI.Tools.ShellTools` |
+| Governance | `%AI.Policy.Authorization`, `%AI.Policy.Audit`, `%AI.Policy.Discovery` |
+| MCP service | `%AI.MCP.Service` |
+| Config / secrets | `%AI.Utils.ConfigStore`, `%AI.Utils.SettingStore`, `%AI.Utils.WalletStore`, `%ConfigStore.Configuration` |
+| LLM | `%AI.Provider`, `%AI.LLM.Context`, `%AI.LLM.Response`, `%AI.LLM.ContentPart` |
+| RAG | `%AI.RAG.*` — present, and out of scope for MVP 2 |
+
+## `%AI.Agent` — the methods and properties we will actually use
+
+Introspected signatures, not guessed:
+
+```
+%Init(context:%DynamicObject = {})        -> %Status     REQUIRED before the first Chat
+%OnInit()                                 -> %Status     the subclass hook
+CreateSession(config:%DynamicObject = "") -> %AI.Agent.Session
+Chat(session, input:%String, feedback)    -> %AI.LLM.Response
+ChatWithContent(session, content:%DynamicArray, feedback) -> %AI.LLM.Response
+Run(session, goal:%String, maxIterations = ..MaxIterations, callbackOref) -> %AI.LLM.Response
+StreamChat(session, input, callbackObj, callbackMethod)   -> %AI.LLM.Response
+UseToolSet(className:%String)             -> %Status
+UseSkill(skillOrClassName)                -> %Status
+CreateSubAgent(systemPrompt = "")         -> %AI.Agent
+```
+
+Properties: `Provider` (`%AI.Provider`), `Model`, `SystemPrompt`, `Temperature`,
+`MaxIterations`, `ToolSets`, `Skills`, `ToolManager` (`%AI.ToolMgr`), `Session`,
+`InstructionsTemplate`, `AutoCompactOnTokenLimit`.
+
+**There is no `LLMConfig` property.** The skill flags it as removed after build 141 and that
+holds here — confirmed by its absence from the introspected property list, not by trying it.
+
+`Run(session, goal, ...)` is worth noting: an agentic loop with a goal and an iteration cap,
+which fits AI Detective better than a single `Chat` turn, since the agent needs to call several
+read tools before concluding.
+
+## `%AI.Tool` — how a tool is implemented
+
+```
+Abstract class, extends %Library.RegisteredObject
+  instance:  %Invoke, %Discover, %Encode, %Decode, %ToolError
+  class:     %FromObject, %ToObject, %TypeMode
+```
+
+So an MCP tool is a **subclass of `%AI.Tool` implementing `%Invoke`**, and `%ToolError` is the
+built-in way to report failure — which is what `contracts/mcp-tools.md` should specify rather
+than inventing an error convention.
+
+`%AI.ToolMgr` class methods: `FindTools(package, includeToolSets, &sc)`,
+`GetOrCreate(serviceName, *isNew)`, `PurgeShared(serviceName)`.
+
+## Two warnings from the skill that we must respect
+
+**1. Compile order for ToolSets.** `%AI.ToolSet.Specification.Compiler` validates referenced
+classes at compile time, so a ToolSet compiled before its `<Include>` targets discovers **zero
+tools** — silently. The skill's three-step pattern:
+
+```objectscript
+do $system.OBJ.LoadDir("/pg-src/...", "k", , 0)     // load, do not compile
+do $system.OBJ.CompilePackage("ProductionGuardian", "ck")
+do $system.OBJ.Compile("<the ToolSet class>", "ck") // recompile the ToolSet LAST
+```
+
+This matters for us specifically: `docker/iris-firstboot.sh` currently loads with `"ck"` in one
+pass. Adding a ToolSet to `iris/labdemo/` without changing that would produce a ToolSet with no
+tools, and nothing would report an error.
+
+**2. `AutheEnabled=96` for MCP over HTTP.** The MCP service endpoint is requested
+*unauthenticated*; `64` (password only) answers 500. Our web applications are already 96
+(`FirstBoot.RegisterWebApps`), so this is satisfied — but a new MCP web application would need
+the same, and #78 established that 96 is deliberate rather than incidental.
+
+## Enforcement is automatic — the single most important finding
+
+`%AI.ToolMgr.ExecuteTool(toolName, arguments)` is the invocation path, and its shipped
+implementation settles the question that MVP 2's whole safety story rests on:
+
+```objectscript
+// Call Rust ToolManager.execute() which:
+// 1. Checks AuthorizationPolicy.can_execute()
+// 2. Executes the tool via provider
+// 3. Calls AuditPolicy.log_execution()
+// 4. Returns result as %DynamicObject
+Return $ZF(-6, $$$IrisLLMLibrary, 50, ..%token, toolName, argsJson)
+```
+
+**The authorization check and the audit write happen in the runtime, not in each tool.** A tool
+author cannot forget to call them, and cannot bypass them by implementing `%Invoke` carelessly.
+That is a much stronger guarantee than "every tool is expected to check permissions", and it is
+what lets `contracts/resolve-api.md` promise that *every* call is gated and audited rather than
+*every call we remembered to gate*.
+
+Read from the compiled method body rather than inferred from the class list, because "the classes
+exist" and "the classes are enforced" are different claims and only the second one is worth
+anything on a live production.
+
+Corollary: the audit log records the call whether it succeeded, failed, or was refused —
+`%LogExecution` takes both `status` and `duration`. So "we audit attempts", not just "we audit
+changes".
+
+`%AI.MCP.Service` additionally carries `%IsAuthorized()` and `AccessCheck(*pAuthorized)` for the
+HTTP surface, and `HandleToolRequest` / `RouteToolRequest` / `ToolCall` for dispatch — so there
+are two layers: web-application authentication at the service, then per-tool authorization at
+execution.
+
+## What is NOT yet verified
+
+- **No LLM provider is configured.** No `%AI.Provider` instance, no ConfigStore entry, no API
+  key. Nothing has called an external model from this instance. The provider/key path is real
+  work, not a checkbox.
+- **What an audit record CONTAINS, and whether it is queryable.** Enforcement is confirmed (see
+  above), but the written record has not been observed, and Dev C needs to display one. This is
+  now the highest-value remaining unknown.
+- **Which policy implementation is active by default.** `%AI.Policy.ConsoleAuth` and
+  `%AI.Policy.ConsoleAudit` exist alongside the abstract bases, so something is wired out of the
+  box -- whether it permits everything until configured is unknown, and "enforced by the runtime"
+  is only a safety property if the configured policy actually denies.
+- **`@{wallet.*}` substitution** was broken on build 159 per the skill (only `env` and `config`
+  registered). Unknown on 126. `%AI.Utils.WalletStore` exists, but existence is not function.
+
+## The MCP dev connection
+
+`iris-agentic-dev` reads **`~/.iris-agentic-dev.toml`** — the home directory, *not* a
+repo-local copy. A repo-local file is silently ignored, which is worth knowing before someone
+commits one and expects it to take effect.
+
+It is now pointed at the compose stack:
+
+```toml
+host = "localhost"   web_port = 52773   namespace = "LABDEMO"
+```
+
+Previously `localhost:80` — the hand-built `iris-webinar` instance, saved at
+`~/.iris-agentic-dev.toml.bak-mvp2`. **Both instances have a LABDEMO namespace**, so the wrong
+target does not fail; it answers plausibly about the wrong production. That is why the port is
+named explicitly rather than relying on `container =` port discovery.
+
+The config hot-reloads on the next tool call — no restart needed.

--- a/docs/mvp2-aihub-verified-api.md
+++ b/docs/mvp2-aihub-verified-api.md
@@ -158,3 +158,47 @@ target does not fail; it answers plausibly about the wrong production. That is w
 named explicitly rather than relying on `container =` port discovery.
 
 The config hot-reloads on the next tool call — no restart needed.
+
+## `Ens_Util.Log` carries PHI right now — measured, not hypothesised
+
+`get_recent_errors` reads `Ens_Util.Log`, and on the running instance that table contains patient
+identifiers in plain text. Counted 2026-08-18 on `pg-iris`:
+
+| `Type` | Meaning | Rows | Contains `PatientID` |
+|---|---|---|---|
+| 4 | info | 61,772 | **yes — every one** |
+| 2 | error | 66 | no |
+
+A sample of the info rows:
+
+```
+PatientDemographicsOperation: upserted PatientID=309191
+PatientDemographicsOperation: upserted PatientID=145662
+```
+
+and of the error rows:
+
+```
+ERROR #6059: Unable to open TCP/IP socket to server 127.0.0.1:59999
+ERROR <Ens>ErrFailureTimeout: FailureTimeout of 1 seconds exceeded
+ERROR <Ens>ErrProductionSettingInvalid: Production setting 'PollInterval' for item 'EMR Source' is invalid
+```
+
+**This is the strongest possible argument for `mcp-tools.md`'s allowlist, and it is also a trap.**
+Filtering to `Type >= 2` happens to exclude every `PatientID` today, so a naive implementation
+would pass any test written against the current log and look correct. It is wrong anyway:
+
+- the separation is a property of what `$$$LOGINFO` and `$$$LOGERROR` are *currently used for* in
+  `PatientDemographicsOperation`, not a property of the log. One `$$$LOGERROR` that interpolates a
+  patient id — and the operation already builds strings containing `PatientID` for its info path —
+  puts PHI straight into the error rows.
+- 61,772 to 66 is a ratio that makes the unsafe case rare rather than absent, which is the worst
+  shape for a defect: it survives review, survives the demo, and appears in production.
+
+So the rule has to be "extract an allowlisted error token, never return log text" rather than
+"filter to error rows and return the text". `mcp-tools.md` §3.4 specifies the former, and this
+measurement is why it should not be relaxed to the latter on the grounds that the error rows look
+clean. They do look clean. That is not the same as being clean by construction.
+
+Related: the same reasoning is why `count` must be `null` rather than `0` when the log is
+unreadable — "no errors" is the worst wrong answer to give an agent diagnosing an error condition.

--- a/services/detection-engine/thresholds.json
+++ b/services/detection-engine/thresholds.json
@@ -6,6 +6,13 @@
   "sustainedSeconds": 4,
   "minBaselineSamples": 12,
   "baselineWindowSeconds": 1800,
+  "earlyWarning": {
+    "enabled": true,
+    "fitWindowSeconds": 300,
+    "horizonSeconds": 1800,
+    "minFitSamples": 12
+  },
+  "_comment_earlyWarning": "MVP 2. Projects a rising metric forward to its threshold; see contracts/earlywarning-api.md. fitWindowSeconds 300 rather than the full baselineWindowSeconds: a least-squares fit over 1800s systematically UNDERSTATES a rise that started two minutes ago, which is exactly the case Early Warning exists to catch -- the older half of the window is flat and drags the slope toward zero. horizonSeconds equals baselineWindowSeconds deliberately: do not project further forward than the span of history the fit is grounded in, because a 90-minute ETA off a 5-minute fit is arithmetic rather than information. minFitSamples reuses minBaselineSamples (12) and is not independently chosen -- below 12 the baseline is null, so max(baseline x multiplier, absoluteFloor) has no baseline arm and there is no target to project toward; a projection with no threshold is meaningless rather than merely imprecise. REACHABILITY, the same invariant sustainedSeconds has: fitWindowSeconds / (POLL_INTERVAL_MS/1000) must exceed minFitSamples with margin. At the shipped 5000ms poll that is 60 samples available against 12 required, so 5x headroom, and first projection ~60s after engine start. Shortening fitWindowSeconds below 60s at that poll rate makes a projection structurally impossible and the module would go silent with no error -- the #64 failure mode in a new place.",
   "rules": {
     "dead_host": {
       "enabled": true,


### PR DESCRIPTION
**The Day-1 parallelisation gate: all four MVP 2 contracts.** @tanifgit — these are what you mock against, so the useful review is "can I build a panel from this", and per root `CLAUDE.md` §4 nothing implements against them until you approve.

**Additive only.** `healthscan-api.md`, `proxy-api.md` and both schemas are **byte-identical** — verified with a diff against `main`, not asserted. `validate.mjs` unchanged at 15 accept / 19 reject / 7 capture claims and still passing.

| New | Owner | Consumers |
|---|---|---|
| `earlywarning-api.md` | Dev B | Dev C |
| `investigation-api.md` | Dev B | Dev C |
| `resolve-api.md` | Dev B (spec: Dev A + Dev B; Dev A left, we inherited `iris/**`) | Dev C |
| `mcp-tools.md` | Dev B (spec: Dev A; same reason) | Dev B, the agent |

All four are **`proposed`**, not published. Each names what is missing: a `.schema.json`, a `.d.ts`, and a sample **captured from a live run**. The worked examples are hand-constructed and arithmetically consistent — which is *not* the bar `contracts/samples/` was built to, and every file says so at the top. CI does not yet know these endpoints exist.

## Three design rules, and they are the point

**A projection is not a measurement** (`earlywarning-api.md` §1.4). Computed numbers nest inside `projection` with `kind: "projection"`; observed numbers sit outside, so a consumer cannot hold a forecast without the label. There is deliberately **no `secondsToThreshold: 0`** for an already-crossed queue, because zero reads as a measurement of now. This is the **#58 defect class** — a derived value in a slot promising an observed one — and it is more dangerous here, because "crosses threshold in 4 minutes" is a sentence an operator acts on. Also: **do not tick the countdown client-side.** The value does not tick and the slope is not stable; an animated countdown would animate our poll loop rather than the queue.

**The data boundary is structural.** The browser sends `{"findingId": "..."}` and nothing else, `additionalProperties: false` — so every value the external model sees was engine-measured or tool-read, and **a browser cannot inject text into an LLM prompt.**

**A recommended action is a structured object, never prose.** It is the input to a live production write a human approves; free text cannot be bounds-checked or whitelisted.

## The finding I would most like you to check

`get_recent_errors` reads `Ens_Util.Log`. I counted what is in that table on the running instance:

```
Type=4 (info)    61,772 rows   EVERY ONE carries a PatientID
Type=2 (error)       66 rows   none do

  "PatientDemographicsOperation: upserted PatientID=309191"
```

**PHI is in that table now**, not hypothetically. And the obvious implementation is a trap: filtering to `Type >= 2` excludes every `PatientID` *today*, so it would pass any test written against the current log and look correct. It is still wrong — the separation is a property of how `$$$LOGINFO`/`$$$LOGERROR` happen to be used in `PatientDemographicsOperation`, not of the log, and that operation already builds `PatientID` strings for its info path. **61,772 to 66 makes the unsafe case rare rather than absent**, which is the worst shape a defect can have: survives review, survives the demo, appears in production.

So the rule is "extract an allowlisted error token, never return log text" — never "filter to error rows and return the text". The measurement sits next to the rule so nobody relaxes it later on the grounds that the error rows look clean. They do look clean.

## Three cross-contract conflicts, found because these were written together

Each would have been a live integration bug had they been written in sequence:

1. **`recommendedAction` shape.** `resolve-api.md` refuses unknown keys *inside* `action`, so a flat action object carrying advisory fields would have been rejected as `malformed_request` — forcing you to write the translation layer that contract explicitly warns is "the prose-parsing failure with extra steps". Advisory fields are now siblings of `action`, not members.
2. **Bounds disagreed**, `1`–`4` vs `2`–`8`. Settled **`2`–`8`**: the lower bound excludes `1` because `1` is the *shipped* value, so recommending it is a no-op dressed as a fix.
3. **Reusing the Early Warning `projection` inside an investigation would have been `null` every single time.** It publishes `projection: null` / `already_crossed` exactly when a queue has crossed — which is the state that made `queue_buildup` fire, i.e. the only condition an investigation is ever requested for. Renamed to `trend`, same fields and units, forecast framing dropped. Without it the "queue slope positive" evidence bullet was unobtainable.

Verified across files rather than trusted: `recommendedAction.action` is `{type, host, size}` and a **field-for-field match** with what `resolve-api.md` accepts, so there is no translation layer for you; all six tool names are consistent in all four documents.

## `resource` vs `role` — a distinction, not a disagreement

`mcp-tools.md` gates on IRIS **resources** (`PG_Read`, `PG_Resolve`); `resolve-api.md` publishes the **role** holding one (`%Guardian_*`) in `audit.role`. I added a table because grepping for one and finding the other looks exactly like the **#84** stale-copy pattern and invites a "fix" that would break it. **Render `audit.role` as an opaque string** — do not compare it to a literal.

## What is asserted about the runtime, and how

Authorization and audit are stated as a **guarantee**, read from the shipped body of `%AI.ToolMgr.ExecuteTool` in the container:

```
// 1. Checks AuthorizationPolicy.can_execute()
// 2. Executes the tool via provider
// 3. Calls AuditPolicy.log_execution()
```

The runtime does both around every execution, so a tool cannot forget them — and because the check **precedes** execution, a denied call cannot have partially mutated the production. Read from the implementation rather than inferred from the class list, because "the classes exist" and "the classes are enforced" are different claims and only the second is worth anything on a live production.

`%CanList` and `%CanExecute` are separate, so `set_pool_size` is **listable but not executable** to an unprivileged caller — which is what lets you render a disabled Approve button *with a reason*, and is the "AI Detective can look without acting" demo.

**Two things are explicitly unverified**, flagged in the files rather than assumed: what an audit record contains once written (you have to display one), and whether the default policy actually **denies** — `%AI.Policy.ConsoleAuth`/`ConsoleAudit` are wired out of the box, and runtime enforcement is only a safety property if the configured policy refuses. `resolve-api.md` makes registering our own policy and **observing a denial** acceptance criteria.

## Two things that will bite implementation, named here

- **`POST /api/resolve` cannot work as the engine stands.** It sends `Access-Control-Allow-Methods: GET, OPTIONS` and no `Allow-Headers`, so a browser preflight for a JSON POST fails while every GET keeps working. Verified live. Engine code, not a contract, so not fixed here — but you would otherwise find it from a dashboard that silently cannot submit an approval.
- **`PoolSize` is a property of `Ens.Config.Item`, not a `Settings` row.** Copying `Triggers.SetSetting` would write a setting that changes nothing *while reporting success* — a silent no-op in the one action MVP 2 exists to perform. Confirmed by introspection.

## Verification

`contracts` validate **15/19/7 unchanged and passing**; engine **179/179**; proxy **103/103**. All four files LF, valid UTF-8, zero U+FFFD. Every JSON example parses (the five that look broken in `resolve-api.md` are deliberate single-field fragments).

Also adds the `earlyWarning` block to `thresholds.json` with its reachability invariant written down — at the shipped 5000 ms poll, 60 samples available against 12 required. Shortening `fitWindowSeconds` below 60 s makes a projection structurally impossible and the module would go silent with no error: the **#64 failure mode in a new place.** The loader allow-lists known keys, so it is inert until wired; confirmed the live engine hot-reloaded it and still reports `state: ok`.

Working notes on the AI Hub API surface, all introspected from `pg-iris` build 126U rather than taken from documentation, are in `docs/mvp2-aihub-verified-api.md`.

Refs #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)
