### PR TITLE
feat(iris): the six MCP tools — five read, one governed write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,12 +267,12 @@ jobs:
         if: steps.guard.outputs.present == 'true'
         run: |
           docker exec pg-iris bash -c 'mkdir -p /tmp/pg-iris-src'
-          find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*'             -exec docker cp {} pg-iris:/tmp/pg-iris-src/ \;
+          find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' -not -path 'iris/test/*' -exec docker cp {} pg-iris:/tmp/pg-iris-src/ \;
           docker cp tools/ci-compile-iris.txt pg-iris:/tmp/ci-compile-iris.txt
-          copied=$(find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' | wc -l)
-          skipped=$(find iris -name '*.cls' -path 'iris/labdemo/Tools/*' | wc -l)
+          copied=$(find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' -not -path 'iris/test/*' | wc -l)
+          skipped=$(find iris -name '*.cls' \( -path 'iris/labdemo/Tools/*' -o -path 'iris/test/*' \) | wc -l)
           echo "copied $copied classes"
-          echo "::notice::skipped $skipped AI-Hub-dependent class(es) under iris/labdemo/Tools/ — %AI.Tool is absent from this image, so they are compile-checked only against the EAP image (see the comment on this step and #77)"
+          echo "::notice::skipped $skipped AI-Hub-dependent class(es) under iris/labdemo/Tools/ and iris/test/ — %AI.Tool is absent from this image, so they are compile-checked only against the EAP image (see the comment on this step and #77)"
       # Greps for the marker rather than trusting the exit status: `iris session` exits 0
       # even when the script inside reported a compile error, which would make this job
       # exactly the kind of check that passes while verifying nothing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,13 +246,33 @@ jobs:
           docker logs pg-iris | tail -40; exit 1
       # Flat copy on purpose: iris/ does not mirror the package layout, and LoadDir reads
       # each class's declared name from the file rather than from its path.
+      #
+      # EXCLUDES iris/labdemo/Tools/, and this is the day the comment above predicted. Those
+      # classes extend %AI.Tool, which does not exist in this image -- verified by starting
+      # `intersystems/irishealth-community:latest-em` and asking it:
+      #
+      #     %AI.Tool exists: 0
+      #     %AI.Agent exists: 0
+      #
+      # So compiling them here would fail on CORRECT code. Taking option 1 of the three ranked
+      # above -- exclude and SAY WHICH -- rather than dropping the job, which is the cheapest
+      # response and the worst one: the other 11 classes stay covered, and this comment plus the
+      # step output below name the gap so it is not silently assumed.
+      #
+      # WHAT THAT COSTS, stated plainly: the AI Hub tool classes get NO compile check in CI. They
+      # are verified only against the EAP image on a developer machine, which is #70's
+      # single-machine problem returning in a narrower form. Option 2 (a self-hosted runner with
+      # the EAP image) fixes both and is the real answer when someone has the time.
       - name: Copy classes into the container
         if: steps.guard.outputs.present == 'true'
         run: |
           docker exec pg-iris bash -c 'mkdir -p /tmp/pg-iris-src'
-          find iris -name '*.cls' -exec docker cp {} pg-iris:/tmp/pg-iris-src/ \;
+          find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*'             -exec docker cp {} pg-iris:/tmp/pg-iris-src/ \;
           docker cp tools/ci-compile-iris.txt pg-iris:/tmp/ci-compile-iris.txt
-          echo "copied $(find iris -name '*.cls' | wc -l) classes"
+          copied=$(find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' | wc -l)
+          skipped=$(find iris -name '*.cls' -path 'iris/labdemo/Tools/*' | wc -l)
+          echo "copied $copied classes"
+          echo "::notice::skipped $skipped AI-Hub-dependent class(es) under iris/labdemo/Tools/ — %AI.Tool is absent from this image, so they are compile-checked only against the EAP image (see the comment on this step and #77)"
       # Greps for the marker rather than trusting the exit status: `iris session` exits 0
       # even when the script inside reported a compile error, which would make this job
       # exactly the kind of check that passes while verifying nothing.

--- a/iris/labdemo/Tools/AuthPolicy.cls
+++ b/iris/labdemo/Tools/AuthPolicy.cls
@@ -1,0 +1,130 @@
+/// Authorization policy for the Production Guardian MCP tools.
+///
+/// WHY THIS CLASS HAS TO EXIST, and it is not a formality. `contracts/resolve-api.md` §9.4 states
+/// that authorization is enforced by the runtime, which is true -- `%AI.ToolMgr.ExecuteTool` calls
+/// `AuthorizationPolicy.can_execute()` before every invocation. But that claim is VACUOUS by
+/// default, and I confirmed it rather than assuming the shipped behaviour was safe:
+///
+///     %AI.ToolMgr.%New().AuthPolicy   ->  <none>
+///     %AI.Policy.Authorization::%CanExecute  ->  Return $$$OK
+///
+/// So with no policy registered, the runtime faithfully asks a policy that permits everything.
+/// "Enforced by the runtime" is only a safety property if the configured policy REFUSES, and
+/// nothing configured one. Every guard inside `Tools.Resolve` still applies -- the whitelist, the
+/// bounds, the production checks -- but they are the tool defending itself, not an authorisation
+/// boundary. This class is the boundary.
+///
+/// NOT `%AI.Policy.ConsoleAuth`, which is the other shipped option and looks like the obvious
+/// choice. Reading it settles that: it writes an ANSI-coloured "Authorization Request" box to the
+/// terminal and waits for a human to answer. That is correct for `%AI.Shell.Console` and wrong
+/// here -- an agent invoked over HTTP has no terminal, so the prompt would either block forever or
+/// be answered by nobody. It also gates on `%System_Callout:USE`, which is a privilege about
+/// calling out of IRIS, not about changing a production.
+///
+/// THE MODEL: least privilege, split two ways, because `%CanList` and `%CanExecute` are separate
+/// hooks and that separation is the demo the spec asks for.
+///
+///   read tools    listable and executable with PG_Read
+///   set_pool_size LISTABLE with PG_Read, EXECUTABLE only with PG_Resolve
+///
+/// Listable-but-not-executable is deliberate. Hiding the write tool from an unauthorised caller
+/// would make "you may not do this" indistinguishable from "this product cannot do this", and the
+/// agent could not even name the action it recommends. Showing it and refusing execution is what
+/// lets a dashboard render a disabled Approve button WITH A REASON -- and it is precisely the
+/// "AI Detective can look without having permission to act" story.
+///
+/// OBSERVED DENIAL, which resolve-api.md §9.4 makes an acceptance criterion rather than an
+/// assumption. Measured against ProductionGuardian.Test.StubPolicy:
+///
+///   holds PG_Read only     SetPoolSize    DENIED, "requires PG_Resolve:USE"
+///                          SetPoolSize    listable = 1   <- visible but denied
+///                          GetQueueDepth  allowed
+///   holds both             SetPoolSize    allowed
+///   holds nothing          GetQueueDepth  DENIED, "requires PG_Read:USE"
+///                          GetQueueDepth  listable = 0
+///
+/// The deny branch is unreachable from any session that can run this code: $SYSTEM.Security.Check
+/// returns 1 for every resource when the caller holds %All, including resources that do not exist.
+/// So the test injects the resource set rather than manufacturing an unprivileged user, and the
+/// stub class says what that does and does not prove.
+///
+/// ROLE NAMES CANNOT START WITH `%`. contracts/mcp-tools.md and resolve-api.md both write
+/// `%Guardian_Read` / `%Guardian_Resolve`; IRIS refuses those with `ERROR #887: Invalid role name`
+/// -- the `%` prefix is reserved for system roles. The created roles are `Guardian_Read` and
+/// `Guardian_Resolve`, unprefixed, and the contracts need correcting. Recorded here because the
+/// contracts are ratified and a silent divergence is worse than a noted one.
+Class ProductionGuardian.LabDemo.Tools.AuthPolicy Extends %AI.Policy.Authorization
+{
+
+/// IRIS resource required to see any Production Guardian tool.
+Parameter READRESOURCE = "PG_Read";
+
+/// IRIS resource required to EXECUTE the one mutating tool.
+Parameter WRITERESOURCE = "PG_Resolve";
+
+/// The tool that mutates a live production. Named rather than pattern-matched: a rule like
+/// "anything containing Set" would silently start gating a future GetSettings, and worse, would
+/// silently STOP gating a rename to ApplyPoolSize.
+Parameter WRITETOOL = "SetPoolSize";
+
+/// May this caller see the tool at all?
+///
+/// Everything Production Guardian exposes needs PG_Read to be listed, including the write tool --
+/// see the class comment for why the write tool is listable rather than hidden.
+Method %CanList(tool As %String, metadata As %DynamicObject) As %Boolean
+{
+    quit ..HasResource(..#READRESOURCE)
+}
+
+/// May this caller run it?
+///
+/// Returns %Status rather than a boolean, which is what lets a refusal carry a REASON -- and the
+/// reason is what a UI needs in order to explain a disabled button instead of just disabling it.
+Method %CanExecute(tool As %String, call As %DynamicObject, metadata As %DynamicObject) As %Status
+{
+    // Tool NAME from the call, not from `tool`, which arrives as a JSON descriptor string in the
+    // shipped ConsoleAuth implementation. Reading the wrong one would compare a name against a
+    // blob and never match -- a gate that silently permits everything, which is the exact defect
+    // this class exists to fix.
+    set name = ""
+    if $isobject(call) {
+        set name = call.%Get("name", "")
+    }
+    if name = "" {
+        // FAIL CLOSED. A call we cannot identify is not a call we can authorise, and defaulting to
+        // allow here would reintroduce the permissive default in a subtler form.
+        quit $$$ERROR($$$GeneralError, "tool call carried no name, so it cannot be authorised")
+    }
+
+    // Every tool needs PG_Read. Checked first so an unprivileged caller gets one clear answer
+    // rather than a different one per tool.
+    if '..HasResource(..#READRESOURCE) {
+        quit $$$ERROR($$$GeneralError, "'" _ name _ "' requires " _ ..#READRESOURCE _ ":USE")
+    }
+
+    // The mutating tool needs the privileged resource ON TOP of PG_Read.
+    if name = ..#WRITETOOL {
+        if '..HasResource(..#WRITERESOURCE) {
+            // The message names the rule and the missing privilege, and NOTHING else. A refusal
+            // string crosses the same boundary to the model as any other tool output, so it must
+            // not carry instance data -- no host names, no queue depths, no user identity.
+            // One line: a $$$ macro cannot span lines -- MPP5612 "Referenced macro missing right
+            // paren". Building the message first keeps it readable without breaking the macro.
+            set why = "'" _ name _ "' modifies a live production and requires " _ ..#WRITERESOURCE _ ":USE"
+            quit $$$ERROR($$$GeneralError, why)
+        }
+    }
+
+    quit $$$OK
+}
+
+/// True when the current user holds USE on a resource. Private.
+///
+/// $SYSTEM.Security.Check is the same mechanism the shipped ConsoleAuth uses, so this follows the
+/// platform's own convention rather than inventing one.
+Method HasResource(resource As %String) As %Boolean [ Private ]
+{
+    quit ''$SYSTEM.Security.Check(resource, "USE")
+}
+
+}

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -1,0 +1,315 @@
+/// MCP read tools for AI Detective — evidence gathering, no mutation.
+///
+/// Implements the five read tools in `contracts/mcp-tools.md`. That contract is authoritative;
+/// where this class and the contract disagree, the contract is right and this is a bug.
+///
+/// HOW A TOOL IS DEFINED, verified by reading %AI.Tool.Generator rather than assumed: every
+/// public, non-internal, non-abstract ClassMethod not starting with `%` becomes a tool. The
+/// method's DESCRIPTION becomes the tool description the model reads, and argument descriptions
+/// come from the formal spec. `%Invoke` and `%Discover` are GENERATED at compile time — do not
+/// write them, and do not add helper ClassMethods here unless they are meant to be callable by
+/// an LLM. A private helper is fine; a public one silently becomes a sixth tool.
+///
+/// RETURNS %DynamicObject THROUGHOUT. The generator produces an untyped schema from the return
+/// value, so the field names below are a prose contract rather than an enforced one — which is
+/// exactly why `contracts/mcp-tools.md` spells them out and why changing one here is a contract
+/// change (@tanifgit flagged this; see that file's §7).
+///
+/// NULLABILITY IS THE RULE, NOT AN EDGE CASE. Every tool that can fail to measure returns null
+/// for the value and states so, never a plausible zero. This project has been bitten three times
+/// by the opposite (#33 an unmeasurable queue read as a small one; #49 an absent metric deflating
+/// a baseline into a fake 6.5x warning; #58 a host that had never run published as "active now").
+/// An agent diagnosing an error condition is the worst possible audience for a fabricated zero.
+///
+/// THE DATA BOUNDARY. Tool return values reach an external LLM, so nothing here may return
+/// message content or PHI — only metrics and configuration. `GetRecentErrors` is where that is a
+/// live risk rather than a formality: `Ens_Util.Log` on this instance currently holds 61,772 rows
+/// carrying `PatientID` in plain text. See its own comment.
+Class ProductionGuardian.LabDemo.Tools.Read Extends %AI.Tool
+{
+
+/// The production these tools report on. Same value as Triggers.#PRODUCTION, and deliberately
+/// NOT imported from it: a tool that silently followed a change to the trigger class would start
+/// reporting on a different production than the one it was authorised for.
+Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
+
+/// Report the configured and observed status of one interoperability host.
+///
+/// Returns status as IRIS reports it, plus whether the host is enabled in the production. Use
+/// this to establish whether a host is running at all before interpreting its other metrics.
+ClassMethod GetHostStatus(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "found": false, "status": null, "enabled": null }
+    set item = ..FindItem(host)
+    if '$isobject(item) {
+        set out.error = "no such config item in " _ ..#PRODUCTION
+        quit out
+    }
+    set out.found = 1
+    set out.enabled = ''item.Enabled
+    // Status comes from EnumerateHostStatus, not from Enabled: an enabled host can be in Error
+    // or Retry, and those are the states worth reporting.
+    do ..HostStatusRow(host, .row)
+    set out.status = $select($data(row("Status")): row("Status"), 1: "")
+    quit out
+}
+
+/// Report the current queue depth for one interoperability host.
+///
+/// Returns null rather than zero when the depth cannot be measured, because an unmeasurable
+/// depth is not a small one -- treating the two the same produced a false warning in #33.
+ClassMethod GetQueueDepth(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "queued": null, "measured": false }
+    do ..HostStatusRow(host, .row)
+    if '$data(row("Queue")) {
+        set out.reason = "host status unavailable"
+        quit out
+    }
+    set out.queued = +row("Queue")
+    set out.measured = 1
+    quit out
+}
+
+/// Report the configured pool size (worker count) for one interoperability host.
+///
+/// Pool size is the number of concurrent workers. A host with pool 1 processes one message at a
+/// time regardless of how many are queued, so this is the first thing to check when a queue is
+/// building behind a host that is otherwise healthy.
+ClassMethod GetPoolSize(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "poolSize": null, "found": false }
+    set item = ..FindItem(host)
+    if '$isobject(item) {
+        set out.error = "no such config item in " _ ..#PRODUCTION
+        quit out
+    }
+    set out.found = 1
+    // PoolSize is a PROPERTY of Ens.Config.Item, not a row in its Settings collection. Reading it
+    // from Settings would return "" on a host that has a pool size, which reads as "not
+    // configured" rather than "read from the wrong place".
+    set out.poolSize = +item.PoolSize
+    quit out
+}
+
+/// Report recent error counts for one interoperability host, classified by IRIS error code.
+///
+/// Returns COUNTS and error CODES only -- never log text. Error text can contain patient data,
+/// so this tool classifies rather than quotes.
+ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %DynamicObject
+{
+    // BOUNDED, and the bound is part of the data boundary rather than politeness. A count is not
+    // content, but a count of one nearly is: "1 error for patient X in the last 5 seconds" is
+    // identifying in a way "40 errors in 15 minutes" is not. 60 minutes is the ceiling because
+    // this tool answers questions about a CONDITION, not a message search interface.
+    if (sinceMinutes < 1) || (sinceMinutes > 60) {
+        quit { "host": (host), "error": "sinceMinutes must be between 1 and 60", "sanitised": true }
+    }
+
+    set out = { "host": (host), "sinceMinutes": (sinceMinutes), "count": null, "sanitised": true, "byCode": [] }
+
+    // THE PHI BOUNDARY, and this is measured rather than cautious. Ens_Util.Log on this instance
+    // holds 61,772 Type=4 rows every one of which carries a PatientID in plain text, against 66
+    // Type=2 rows carrying none. Filtering to Type>=2 and returning the text would therefore pass
+    // every test written against today's log and STILL be wrong: that separation is a property of
+    // how $$$LOGINFO and $$$LOGERROR happen to be used in PatientDemographicsOperation, not of the
+    // log, and that operation already builds PatientID strings for its info path. One $$$LOGERROR
+    // interpolating a patient id moves PHI into the error rows.
+    //
+    // 61,772 to 66 makes the unsafe case RARE RATHER THAN ABSENT, which is the worst shape a
+    // defect can have -- it survives review, survives the demo, and shows up in production. So:
+    // extract an allowlisted error token, never return text. No exceptions, including for text
+    // that happens to be safe, because a rule with an exception is one an implementer widens.
+    // $ztimestamp is "days,seconds" -- subtracting a fractional day from it produces a value
+    // $zdatetime rejects with <ILLEGAL VALUE> rather than a wrong answer, which is at least loud.
+    // Decompose, subtract seconds, and borrow a day if it goes negative.
+    set days = $piece($ztimestamp, ",", 1)
+    set secs = $piece($ztimestamp, ",", 2) - (sinceMinutes * 60)
+    if secs < 0 {
+        set days = days - 1
+        set secs = secs + 86400
+    }
+    set since = $zdatetime(days _ "," _ secs, 3)
+    set sql = "SELECT Text FROM Ens_Util.Log WHERE ConfigName = ? AND Type <= 2 AND TimeLogged >= ?"
+    set rs = ##class(%SQL.Statement).%ExecDirect(, sql, host, since)
+    if rs.%SQLCODE < 0 {
+        set out.reason = "log unreadable (SQLCODE " _ rs.%SQLCODE _ ")"
+        // NULL, not 0. "No errors" is the worst possible wrong answer to an agent diagnosing an
+        // error condition -- it would conclude the host is healthy from a failed read.
+        quit out
+    }
+
+    set total = 0
+    kill codes
+    while rs.%Next() {
+        set total = total + 1
+        set code = ..ClassifyError(rs.%Get("Text"))
+        set codes(code) = $get(codes(code), 0) + 1
+    }
+    set out.count = total
+    set code = ""
+    for {
+        set code = $order(codes(code), 1, n)
+        quit:code=""
+        do out.byCode.%Push({ "errorCode": (code), "count": (n) })
+    }
+    quit out
+}
+
+/// Report average processing and queueing time in seconds for one interoperability host.
+///
+/// These are the times a message spends being handled and waiting to be handled. A high queueing
+/// time with a normal processing time means the host is keeping up per message but is outnumbered.
+ClassMethod GetProcessingTime(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "avgProcessingTime": null, "avgQueueingTime": null, "measured": false }
+
+    // READS THE PROMETHEUS FAMILIES, not EnumerateHostStatus. That query returns exactly eight
+    // columns -- Name, Type, Status, AdapterState, LastActivity, ElapsedTime, Queue, Count -- and
+    // NONE of them is a processing or queueing time. I assumed TimeProcessing/TimeQueued existed
+    // and they do not; checked with GetColumnName() rather than continuing to guess. Neither
+    // EnumerateMetrics (Name, LastUpdate, IsRunning) nor EnumerateCounters (Category, Item, Count)
+    // carries per-host timing either.
+    //
+    // So the only source is `iris_interop_avg_*` on /api/monitor/metrics, which is what
+    // contracts/mcp-tools.md says this wraps: "aggregated as the proxy aggregates them". Read
+    // locally over the instance's own web server -- the same endpoint the proxy polls, so the two
+    // cannot disagree about what a host's timing is.
+    set families = $listbuild("iris_interop_avg_processing_time", "iris_interop_avg_queueing_time")
+    set fields = $listbuild("avgProcessingTime", "avgQueueingTime")
+    for i = 1:1:$listlength(families) {
+        set value = ..ScrapeGauge($list(families, i), host)
+        if value '= "" {
+            do out.%Set($list(fields, i), +value)
+        }
+    }
+    // measured is false when NEITHER could be read. Both stay null rather than 0: IRIS omits these
+    // families entirely for a host that has not processed anything, and a zero would read as
+    // "instant" rather than "never measured" -- the #49 shape.
+    set out.measured = ((out.avgProcessingTime '= "") || (out.avgQueueingTime '= ""))
+    quit out
+}
+
+/// Sum one Prometheus gauge family for a host, or "" when absent. Private.
+///
+/// SUMS ACROSS messagetype, matching how the proxy aggregates: IRIS emits one series per
+/// (host, messagetype), so a host handling two message types has two series and reading only the
+/// first would understate it. Returns "" rather than 0 for an absent family, because those are
+/// different facts and #49 is what conflating them costs.
+ClassMethod ScrapeGauge(family As %String, host As %String) As %String [ Private ]
+{
+    set req = ##class(%Net.HttpRequest).%New()
+    set req.Server = "127.0.0.1"
+    set req.Port = 52773
+    set req.Timeout = 5
+    set sc = req.Get("/api/monitor/metrics")
+    if $$$ISERR(sc) {
+        quit ""
+    }
+    if (req.HttpResponse.StatusCode < 200) || (req.HttpResponse.StatusCode > 299) {
+        quit ""
+    }
+    set body = req.HttpResponse.Data.Read(2000000)
+    set total = "", needle = family _ "{"
+    for i = 1:1:$length(body, $char(10)) {
+        set line = $piece(body, $char(10), i)
+        // Skip HELP/TYPE/UNIT comment lines, which contain the family name too.
+        if $extract(line) = "#" {
+            continue
+        }
+        if '(line [ needle) {
+            continue
+        }
+        // The host label is quoted, so match host="<name>" exactly rather than a substring --
+        // "Cloud API" must not match a hypothetical "Cloud API v2".
+        if '(line [ ("host=""" _ host _ """")) {
+            continue
+        }
+        set value = $piece(line, " ", $length(line, " "))
+        if value = "" {
+            continue
+        }
+        set total = $select(total = "": +value, 1: total + value)
+    }
+    quit total
+}
+
+/// Find a config item by name. Private so the tool generator does not expose it.
+ClassMethod FindItem(host As %String) As Ens.Config.Item [ Private ]
+{
+    set def = ##class(Ens.Config.Production).%OpenId(..#PRODUCTION)
+    if '$isobject(def) {
+        quit $$$NULLOREF
+    }
+    // Explicit result variable: a bare `quit` breaks the FOR and leaves the loop variable holding
+    // the last item examined whether or not it matched, which would return another host's
+    // configuration for an unknown name.
+    set result = $$$NULLOREF
+    for i = 1:1:def.Items.Count() {
+        set item = def.Items.GetAt(i)
+        if item.Name = host {
+            set result = item
+            quit
+        }
+    }
+    quit result
+}
+
+/// One row of EnumerateHostStatus for a host, as a local array. Private.
+ClassMethod HostStatusRow(host As %String, ByRef row) As %Status [ Private ]
+{
+    kill row
+    set rs = ##class(%ResultSet).%New("Ens.Util.Statistics:EnumerateHostStatus")
+    set sc = rs.Execute()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    while rs.Next() {
+        // `Name`, not `ConfigName`. EnumerateHostStatus returns 8 columns -- Name, Type, Status,
+        // AdapterState, LastActivity, ElapsedTime, Queue, Count -- and rs.Data("ConfigName") threw
+        // <UNDEFINED> at runtime while compiling cleanly, which is the same runtime-only class as
+        // #37 and the EnumerateConfigItems ConfigName/Name mix-up in EnableMetrics. Read from
+        // GetColumnName() rather than assumed.
+        if rs.Data("Name") '= host {
+            continue
+        }
+        set col = ""
+        for {
+            set col = $order(rs.Data(col), 1, val)
+            quit:col=""
+            set row(col) = val
+        }
+        quit
+    }
+    quit $$$OK
+}
+
+/// Map error text to an allowlisted code, or "unclassified". Private.
+///
+/// ALLOWLIST, never a denylist. Anything unrecognised yields "unclassified" and NO text, so a
+/// novel error message cannot leak through a gap in a pattern list. A denylist would need to
+/// anticipate every shape PHI can take in a log line, which is not a bet worth taking on a
+/// healthcare system.
+ClassMethod ClassifyError(text As %String) As %String [ Private ]
+{
+    set known = $listbuild(
+        "<Ens>ErrFailureTimeout",
+        "<Ens>ErrConnectionLost",
+        "<Ens>ErrHTTPStatus",
+        "<Ens>ErrGeneral",
+        "<Ens>ErrProductionSettingInvalid",
+        "<Ens>ErrTCPTerminatedReadTimeoutExpired",
+        "#6059",
+        "#5001",
+        "#5021")
+    set ptr = 0
+    while $listnext(known, ptr, token) {
+        if text [ token {
+            quit
+        }
+        set token = ""
+    }
+    quit $select(token '= "": token, 1: "unclassified")
+}
+
+}

--- a/iris/labdemo/Tools/Resolve.cls
+++ b/iris/labdemo/Tools/Resolve.cls
@@ -1,0 +1,206 @@
+/// The single governed MCP WRITE tool — Smart Resolve's action.
+///
+/// Implements `set_pool_size` from `contracts/mcp-tools.md` and the guards from
+/// `contracts/resolve-api.md`. Those contracts are authoritative; where this class and they
+/// disagree, they are right and this is a bug.
+///
+/// SEPARATE CLASS FROM THE READ TOOLS, and that separation is the security boundary rather than
+/// tidiness. `%AI.Tool` parameters and any per-class policy apply to the whole class, so the write
+/// tool needs its own in order to carry a privileged RBAC requirement the read tools must not
+/// inherit. One class holding both would mean either the reads are over-privileged or the write is
+/// under-privileged, and there is no third option.
+///
+/// EXACTLY ONE PUBLIC CLASSMETHOD. Every public method here becomes an LLM-callable tool
+/// (verified in `%AI.Tool.Generator`), so a second one is a second way to mutate a live
+/// production. Helpers are Private. If this class ever discovers two tools, that is a defect.
+///
+/// AUTHORIZATION AND AUDIT ARE NOT IMPLEMENTED HERE, deliberately, and this is worth stating
+/// because their absence looks like an omission. `%AI.ToolMgr.ExecuteTool` performs both around
+/// every invocation -- read from its shipped body:
+///
+///     // 1. Checks AuthorizationPolicy.can_execute()
+///     // 2. Executes the tool via provider
+///     // 3. Calls AuditPolicy.log_execution()
+///
+/// So a tool cannot forget to check permissions, cannot bypass the check by implementing %Invoke
+/// carelessly, and cannot execute before being authorised -- the ordering means a denied call
+/// cannot have partially mutated anything. Re-implementing the check here would add a second
+/// place to keep in agreement and a reader unsure which one is authoritative.
+///
+/// UNVERIFIED, and flagged rather than assumed: whether the DEFAULT policy actually denies.
+/// `%AI.Policy.ConsoleAuth` and `%AI.Policy.ConsoleAudit` exist out of the box, and "enforced by
+/// the runtime" is only a safety property if the configured policy refuses. Registering our own
+/// Authorization policy and OBSERVING a denial is an acceptance criterion in
+/// `contracts/resolve-api.md` §9.4, not something to infer from the classes existing.
+Class ProductionGuardian.LabDemo.Tools.Resolve Extends %AI.Tool
+{
+
+/// The production this tool may act on. The ONLY production it may act on.
+Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
+
+/// The only host whose pool size this tool may change.
+///
+/// An allow-list of one, not a blocklist. A blocklist has to anticipate every host that must not
+/// be touched, including ones added after this was written; an allow-list fails closed when the
+/// production grows. MVP 2 needs exactly one action on exactly one host, so the narrowest
+/// possible list is also the correct one.
+Parameter ALLOWEDHOST = "Cloud API";
+
+/// Bounds on the requested pool size, from `contracts/resolve-api.md` §3.
+///
+/// The lower bound is 2, not 1, and that is not an off-by-one. 1 is the SHIPPED value, so
+/// "set the pool to 1" is a no-op dressed as a fix -- it would report success, change nothing,
+/// and leave an operator believing the problem was addressed. Reversal to 1 is Reset()'s job,
+/// through a path that is not LLM-callable.
+Parameter MINSIZE = 2;
+
+Parameter MAXSIZE = 8;
+
+/// Change the worker pool size of an interoperability host, after human approval.
+///
+/// This is the only tool that modifies the live production. It is bounded to one host and a
+/// small size range, it reports the value it replaced so the change can be reversed, and it
+/// refuses rather than guessing when anything is out of range. Set dryRun to true to preview
+/// the change without applying it.
+ClassMethod SetPoolSize(host As %String, size As %Integer, dryRun As %Boolean = 0) As %DynamicObject
+{
+    set out = {
+        "tool": "set_pool_size",
+        "host": (host),
+        "requestedSize": (size),
+        "mode": ($select(dryRun: "dry_run", 1: "apply")),
+        "outcome": null,
+        "before": null,
+        "after": null,
+        "reversal": null,
+        "refusal": null
+    }
+
+    // EVERY GUARD BEFORE ANY WRITE, and each refusal names itself. A generic failure would leave
+    // the caller -- and the human reading the dashboard -- unable to tell "you asked for something
+    // forbidden" from "the production is broken", which are opposite situations.
+    if host '= ..#ALLOWEDHOST {
+        quit ..Refuse(out, "not_whitelisted_host",
+            "this tool may only change '" _ ..#ALLOWEDHOST _ "'")
+    }
+    if (size '= (size \ 1)) || (size < ..#MINSIZE) || (size > ..#MAXSIZE) {
+        quit ..Refuse(out, "out_of_bounds",
+            "size must be an integer between " _ ..#MINSIZE _ " and " _ ..#MAXSIZE)
+    }
+
+    do ##class(Ens.Director).GetProductionStatus(.running, .state)
+    if running '= ..#PRODUCTION {
+        quit ..Refuse(out, "wrong_production",
+            "'" _ running _ "' is running, not " _ ..#PRODUCTION)
+    }
+    // STRICTER THAN Triggers.CheckProduction(), which only WARNS on a stopped production because a
+    // config edit there is confusing rather than wrong. For a governed write it is wrong: the
+    // caller is told the pool changed, the audit records that it changed, and the running system
+    // is unaffected until someone restarts. Called out so nobody "aligns" the two later.
+    if state '= 1 {
+        quit ..Refuse(out, "production_not_running",
+            "production state is " _ state _ ", not Running")
+    }
+
+    set def = ##class(Ens.Config.Production).%OpenId(..#PRODUCTION)
+    if '$isobject(def) {
+        quit ..Refuse(out, "wrong_production", "cannot open " _ ..#PRODUCTION)
+    }
+    set item = $$$NULLOREF
+    for i = 1:1:def.Items.Count() {
+        set candidate = def.Items.GetAt(i)
+        if candidate.Name = host {
+            set item = candidate
+            quit
+        }
+    }
+    if '$isobject(item) {
+        quit ..Refuse(out, "host_not_in_production",
+            host _ " is whitelisted but not present in the running production")
+    }
+
+    // Capture the ACTUAL prior value, never a literal. #66 established what the alternative costs:
+    // ErrorRate() restored a hardcoded port and destroyed a deployment that legitimately used a
+    // different one. The same mistake with a pool size would silently discard whatever an operator
+    // had tuned.
+    set before = +item.PoolSize
+    set out.before = { "poolSize": (before) }
+    set out.reversal = { "host": (host), "size": (before), "capturedFrom": "live production" }
+
+    if before = size {
+        // Not an error and not a refusal: the requested state is already true. A demo will hit
+        // this by clicking Approve twice, and reporting failure there would look like the tool
+        // broke when it is the one case where doing nothing is correct.
+        set out.outcome = "no_change"
+        set out.after = { "poolSize": (before) }
+        quit out
+    }
+
+    if dryRun {
+        // Guaranteed not to mutate, structurally: this returns before the write. The `after` value
+        // is what WOULD result, and it is inside a response whose mode says dry_run -- the caller
+        // cannot mistake a preview for an application.
+        set out.outcome = "previewed"
+        set out.after = { "poolSize": (size) }
+        quit out
+    }
+
+    set item.PoolSize = size
+    set sc = def.%Save()
+    if $$$ISERR(sc) {
+        set out.outcome = "failed"
+        set out.failure = { "stage": "save", "message": ($system.Status.GetErrorText(sc)) }
+        quit out
+    }
+    // UpdateProduction is what makes the change take effect in the RUNNING production. Without it
+    // the save persists and the workers are unchanged -- success reported, nothing different, which
+    // is the silent no-op this whole class exists to avoid.
+    set sc = ##class(Ens.Director).UpdateProduction(10)
+    if $$$ISERR(sc) {
+        set out.outcome = "failed"
+        set out.failure = {
+            "stage": "update",
+            "message": ($system.Status.GetErrorText(sc)),
+            "liveStateVerified": false
+        }
+        quit out
+    }
+
+    // Re-read rather than echoing the request. Reporting the value we ASKED for would make a
+    // partial failure indistinguishable from success, and this is the one field a human uses to
+    // confirm the fix landed.
+    set out.after = { "poolSize": (..ReadPoolSize(host)) }
+    set out.outcome = "applied"
+    quit out
+}
+
+/// Attach a named refusal and return. Private.
+ClassMethod Refuse(out As %DynamicObject, code As %String, detail As %String) As %DynamicObject [ Private ]
+{
+    set out.outcome = "refused"
+    // The reason is surfaced because it is what lets a UI explain WHY Approve is disabled, but it
+    // names only the rule and the bound -- never instance data, since a refusal string crosses the
+    // same boundary to the model as any other tool output.
+    set out.refusal = { "code": (code), "detail": (detail) }
+    quit out
+}
+
+/// Current pool size for a host, or "" when unreadable. Private.
+ClassMethod ReadPoolSize(host As %String) As %String [ Private ]
+{
+    set def = ##class(Ens.Config.Production).%OpenId(..#PRODUCTION)
+    if '$isobject(def) {
+        quit ""
+    }
+    set result = ""
+    for i = 1:1:def.Items.Count() {
+        set item = def.Items.GetAt(i)
+        if item.Name = host {
+            set result = +item.PoolSize
+            quit
+        }
+    }
+    quit result
+}
+
+}

--- a/iris/test/StubPolicy.cls
+++ b/iris/test/StubPolicy.cls
@@ -1,0 +1,27 @@
+/// Test double for AuthPolicy: replaces the IRIS resource check with an injectable set.
+///
+/// WHY THIS EXISTS. AuthPolicy's only input is $SYSTEM.Security.Check, and every session that can
+/// compile and run code here holds %All -- which makes Check return 1 for EVERY resource, including
+/// ones that do not exist. So the deny branch is unreachable from a privileged session, and
+/// "observe a denial" cannot be satisfied by calling the real policy as superuser.
+///
+/// Creating an unprivileged user instead needs %DB_* resources that do not exist on this instance
+/// and a working REST path for that user -- several steps of RBAC plumbing to test three lines of
+/// branching. Overriding the one seam is the smaller, more direct instrument.
+///
+/// WHAT THIS DOES NOT PROVE, stated so nobody reads more into it: that $SYSTEM.Security.Check
+/// returns 0 for a user lacking the resource. That is IRIS's behaviour, not ours. What it proves is
+/// that OUR policy denies when the check says no, which is the part we wrote and the part that
+/// could be wrong.
+Class ProductionGuardian.Test.StubPolicy Extends ProductionGuardian.LabDemo.Tools.AuthPolicy
+{
+
+/// Comma-separated resources this fake caller "holds".
+Property Granted As %String;
+
+Method HasResource(resource As %String) As %Boolean [ Private ]
+{
+    quit ''(("," _ ..Granted _ ",") [ ("," _ resource _ ","))
+}
+
+}


### PR DESCRIPTION
All six MCP tools — the five read tools plus the governed write tool. **Stacked on #88**, which is stacked on #87. Review order: **#87 → #88 → this**.

## How a tool is actually defined — not what the class shape suggests

Read from `%AI.Tool.Generator` rather than assumed. **`%Invoke` and `%Discover` are generated at compile time** — you do not implement them. Every public, non-internal ClassMethod not starting with `%` becomes a tool, its `Description` becomes the description the model reads, and argument descriptions come from the formal spec.

**So a public helper silently becomes an extra tool.** Both helper methods in each class are `Private` for exactly that reason, and the discovery count is asserted: **5 for the read class, 1 for the write class.**

## Verified live — the five read tools

```
GetHostStatus     {"host":"Cloud API","found":1,"status":"OK","enabled":1}
GetQueueDepth     {"host":"Cloud API","queued":0,"measured":1}
GetPoolSize       {"host":"Cloud API","poolSize":1,"found":1}
GetProcessingTime {"avgProcessingTime":0.01,"avgQueueingTime":0,"measured":1}
GetRecentErrors   {"count":28,"sanitised":true,"byCode":[...]}
unknown host      {"poolSize":null,"found":false,"error":"no such config item ..."}
```

**The PHI boundary holds under real conditions**, which is the point rather than a formality. I armed `ErrorRate()` to generate genuine failures, then checked the tool's own output:

```
contains 'PatientID': no      contains 'socket':    no
contains 'Patient':   no      contains '127.0.0.1': no
```

28 errors classified into three codes, **no log text of any kind**. Necessary rather than cautious — `Ens_Util.Log` on this instance holds 61,772 rows carrying `PatientID` in plain text.

## Verified live — the write tool, every path

```
wrong host    refused  not_whitelisted_host    before=null (nothing read or touched)
size 1        refused  out_of_bounds
size 99       refused  out_of_bounds
size 2.5      refused  out_of_bounds
dry run       previewed  before=1 after=4  -- pool was STILL 1 afterwards
apply         applied    before=1 after=4  -- pool verified 4
apply again   no_change  before=4 after=4  -- not a failure
```

Four decisions worth flagging:

- **The lower bound is 2, not 1**, and that is not an off-by-one. `1` is the *shipped* value, so "set the pool to 1" is a no-op dressed as a fix — success reported, nothing changed, operator believes it is handled. Reversal to 1 goes through `Triggers.Reset()`, which is not LLM-callable.
- **Separate class from the read tools is the security boundary**, not tidiness. `%AI.Tool` parameters and per-class policy apply to the whole class, so the write tool needs its own to carry a privileged RBAC requirement the reads must not inherit. One class means either the reads are over-privileged or the write is under-privileged.
- **Stricter than `Triggers.CheckProduction()`**, which only *warns* on a stopped production. For a governed write that is wrong: the caller is told the pool changed, the audit records it changed, and the running system is unaffected until someone restarts. Flagged so nobody aligns the two later.
- **`after` is re-read, not echoed.** Reporting the requested value would make a partial failure indistinguishable from success, and it is the one field a human uses to confirm the fix landed.

## Three bugs found by running it — each compiled cleanly first

1. **`rs.Data("ConfigName")` → `<UNDEFINED>`.** `EnumerateHostStatus` returns eight columns and the host one is **`Name`**. Same runtime-only class as #37 and the `ConfigName`/`Name` mix-up in `EnableMetrics`.
2. **`GetProcessingTime` read columns that do not exist.** There is no per-host timing in `EnumerateHostStatus`, nor in `EnumerateMetrics` (`Name, LastUpdate, IsRunning`), nor `EnumerateCounters` (`Category, Item, Count`). Checked with `GetColumnName()` rather than guessing a fourth time. It now scrapes `iris_interop_avg_*` from the instance's own metrics endpoint — which is what the contract says it wraps, and means the tool and the proxy cannot disagree about a host's timing.
3. **`$zdatetime($ztimestamp - fraction)` → `<ILLEGAL VALUE>`.** `$ztimestamp` is `"days,seconds"`, so a fractional subtraction is not a time. Decomposed with a day borrow.

All three are the class of defect the `iris-compile` job explicitly documents itself as *not* catching.

## The CI change, and #77 called this day in advance

**These classes cannot compile in CI**, and I verified rather than assumed it — started `intersystems/irishealth-community:latest-em` and asked:

```
%AI.Tool exists: 0
%AI.Agent exists: 0
```

#77 pre-registered this exact situation with three ranked options. I took **option 1 — exclude and say which** — over option 3 (drop the job), because a red build on correct code is the situation where the cheapest response is the worst one. The other **12 classes stay covered**, and the step emits a `::notice::` naming the gap.

**What that costs, stated rather than buried:** these two classes get *no* CI compile check at all. They are verified only against the EAP image on a developer machine — **#70's single-machine problem in a narrower form.** Option 2, a self-hosted runner with the EAP image, fixes both and is the real answer when someone has time.

## Still unverified, and flagged in the code rather than assumed

**Whether the default policy actually denies.** `%AI.ToolMgr.ExecuteTool` performs authorization and audit around every invocation — read from its shipped body — so a tool cannot forget the check or bypass it. But `%AI.Policy.ConsoleAuth` exists out of the box, and *"enforced by the runtime"* is only a safety property if the configured policy **refuses**. Registering our own policy and **observing a denial** is an acceptance criterion in `resolve-api.md` §9.4, not something to infer from a class list. That is my next task.

Refs #72, #77, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
