### PR TITLE
feat: MVP 2 WHY and FIX — AI Detective orchestration and Smart Resolve (#72, #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,35 +247,66 @@ jobs:
       # Flat copy on purpose: iris/ does not mirror the package layout, and LoadDir reads
       # each class's declared name from the file rather than from its path.
       #
-      # EXCLUDES iris/labdemo/Tools/, and this is the day the comment above predicted. Those
-      # classes extend %AI.Tool, which does not exist in this image -- verified by starting
-      # `intersystems/irishealth-community:latest-em` and asking it:
+      # EXCLUDES the AI-Hub-dependent classes, and this is the day the comment above predicted.
+      # They reference %AI.Tool / %AI.Agent, which do not exist in this image -- verified by
+      # starting `intersystems/irishealth-community:latest-em` and asking it:
       #
       #     %AI.Tool exists: 0
       #     %AI.Agent exists: 0
       #
       # So compiling them here would fail on CORRECT code. Taking option 1 of the three ranked
       # above -- exclude and SAY WHICH -- rather than dropping the job, which is the cheapest
-      # response and the worst one: the other 11 classes stay covered, and this comment plus the
+      # response and the worst one: every other class stays covered, and this comment plus the
       # step output below name the gap so it is not silently assumed.
       #
-      # WHAT THAT COSTS, stated plainly: the AI Hub tool classes get NO compile check in CI. They
-      # are verified only against the EAP image on a developer machine, which is #70's
+      # SELECTED BY CONTENT, NOT BY PATH. This was `-not -path 'iris/labdemo/Tools/*'` until
+      # AgentDispatcher.cls landed in iris/labdemo/REST/ and failed the job on correct code
+      # (#92). The path rule encoded "AI Hub classes live in Tools/", which was true when
+      # written and false as soon as the HTTP entry point was added -- and a third hardcoded
+      # path in three places is a rule that goes stale again the next time. Grepping for the
+      # dependency itself cannot: a new class that touches %AI. is excluded automatically, and
+      # one that stops touching it is picked back up.
+      #
+      # iris/test/ stays a path exclusion because StubPolicy.cls names no %AI. class itself --
+      # it EXTENDS one that does, so it is transitively dependent and a content grep misses it.
+      # Following Extends chains properly is a compiler's job, not a shell one-liner's; the
+      # directory is the honest boundary for test doubles.
+      #
+      # WHAT THAT COSTS, stated plainly: the AI Hub classes get NO compile check in CI. They are
+      # verified only against the EAP image on a developer machine, which is #70's
       # single-machine problem returning in a narrower form. Option 2 (a self-hosted runner with
       # the EAP image) fixes both and is the real answer when someone has the time.
       - name: Copy classes into the container
         if: steps.guard.outputs.present == 'true'
         run: |
           docker exec pg-iris bash -c 'mkdir -p /tmp/pg-iris-src'
-          find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' -not -path 'iris/test/*' -exec docker cp {} pg-iris:/tmp/pg-iris-src/ \;
+          # ONE list, computed once, used for both the copy and the count -- so the notice can
+          # never disagree with what was actually compiled. Deriving the two separately is how a
+          # report drifts from the thing it reports on.
+          #
+          # Two rules, unioned: any class that NAMES an %AI. class, plus everything under
+          # iris/test/. See the comment above for why the second one cannot also be a grep.
+          skip_list=$({ grep -rl '%AI\.' --include='*.cls' iris/; find iris/test -name '*.cls'; } | sed '/^$/d' | sort -u)
+          all_list=$(find iris -name '*.cls' | sort)
+          copy_list=$(comm -23 <(echo "$all_list") <(echo "$skip_list"))
+          # `while read` in a PIPELINE runs in a subshell, so an `exit 1` inside it would not fail
+          # this step -- a copy that silently did not happen would show up as a class not compiled
+          # rather than as an error. Fed by a here-string instead, so the shell is the same one.
+          while read -r f; do
+            [ -n "$f" ] || continue
+            docker cp "$f" pg-iris:/tmp/pg-iris-src/ || { echo "::error::failed to copy $f"; exit 1; }
+          done <<< "$copy_list"
           docker cp tools/ci-compile-iris.txt pg-iris:/tmp/ci-compile-iris.txt
-          copied=$(find iris -name '*.cls' -not -path 'iris/labdemo/Tools/*' -not -path 'iris/test/*' | wc -l)
-          skipped=$(find iris -name '*.cls' \( -path 'iris/labdemo/Tools/*' -o -path 'iris/test/*' \) | wc -l)
+          copied=$(echo "$copy_list" | sed '/^$/d' | wc -l)
+          skipped=$(echo "$skip_list" | sed '/^$/d' | wc -l)
           echo "copied $copied classes"
-          echo "::notice::skipped $skipped AI-Hub-dependent class(es) under iris/labdemo/Tools/ and iris/test/ — %AI.Tool is absent from this image, so they are compile-checked only against the EAP image (see the comment on this step and #77)"
-      # Greps for the marker rather than trusting the exit status: `iris session` exits 0
-      # even when the script inside reported a compile error, which would make this job
-      # exactly the kind of check that passes while verifying nothing.
+          # Names the files, not just the count. "skipped 4" tells a reader nothing about WHICH
+          # coverage they lack, and this list is the gap -- so it should be readable without
+          # re-deriving the find expression.
+          echo "$skip_list" | sed 's/^/  skipped: /'
+          # `paste -sd' '` rather than `tr` for the one-line form: a literal newline inside a
+          # YAML block scalar is what a `tr` argument would need, and it breaks the block.
+          echo "::notice::skipped $skipped AI-Hub-dependent class(es) — %AI.Tool and %AI.Agent are absent from this image, so they are compile-checked only against the EAP image (see the comment on this step and #77): $(echo "$skip_list" | paste -sd ' ' -)"
       - name: Compile
         if: steps.guard.outputs.present == 'true'
         run: |

--- a/apps/dashboard/nginx.conf.template
+++ b/apps/dashboard/nginx.conf.template
@@ -31,7 +31,28 @@ server {
         try_files $uri /index.html;
     }
 
-    location /api/healthscan/ {
+    # /api/ AND NOT /api/healthscan/, which is what this was until 2026-08-19.
+    #
+    # The narrower prefix meant every MVP 2 endpoint fell through to `location /` and was served
+    # index.html: /api/earlywarning, /api/investigate and /api/resolve all returned the SPA. A GET
+    # answered 200 with an HTML body, so a curl check on the status code looked healthy -- measured:
+    #
+    #     GET  /api/healthscan/findings  -> 200 JSON
+    #     GET  /api/earlywarning         -> 200 <!doctype html>
+    #     POST /api/resolve              -> 405 from nginx, never reaching the engine
+    #
+    # The POST is the one that matters: `location /` is a static file handler, and nginx refuses
+    # POST to it before the request goes anywhere. So the approve button could not have worked in
+    # the containerised dashboard at all, and the failure would have surfaced as nginx's own 405
+    # page rather than as anything in the engine's log -- which is exactly the invisible-failure
+    # shape resolve-api.md warned about for the CORS preflight, arriving by a different route.
+    #
+    # Widened rather than adding three more blocks: the engine owns everything under /api and
+    # answers 404 for a path it does not have (verified -- GET /api/nope -> 404, not a fallthrough),
+    # so a per-endpoint list here would be a second copy of its routing table. That is the #84
+    # stale-copy pattern, and it is what caused this bug: the block was written when
+    # /api/healthscan/* was the only route family and never revisited when MVP 2 added three more.
+    location /api/ {
         # RESOLVE AT REQUEST TIME, NOT AT CONFIG LOAD. A literal hostname in proxy_pass is
         # resolved when nginx reads its config, so this container refused to start at all
         # while the engine was absent -- `host not found in upstream`, exit before serving
@@ -67,7 +88,17 @@ server {
         # nginx default of 60s. Shorter than the poll interval would abort healthy
         # requests; this is comfortably above it and well below the default.
         proxy_connect_timeout 5s;
-        proxy_read_timeout 10s;
+        # 10s WOULD CUT OFF AN INVESTIGATION. /api/investigate is an LLM round trip with several
+        # tool calls inside it -- measured at ~6s against gpt-4o-mini, and the engine's own hard
+        # timeout is 30s. A 10s read timeout here would abort the slower half of real
+        # investigations and return 504, which reads as "the AI is broken" rather than "the proxy
+        # gave up". 35s leaves the engine's own timeout as the one that fires, so the failure is
+        # reported by the component that knows what failed.
+        #
+        # The cost is a hung upstream holding a worker for 35s instead of 10s on this path. That is
+        # acceptable here and would not be on the poll path -- but the poll aborts client-side
+        # every 2s regardless, so it never reaches this limit.
+        proxy_read_timeout 35s;
 
         # Findings change every poll. A cached 200 here would freeze the dashboard while
         # it looked live, which is the one failure mode worse than an error banner.

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -13,7 +13,14 @@ export default defineConfig({
     proxy: {
       // Proxying in dev means CORS is never the dashboard's problem, and Dev B's
       // findings API can be Node or Python without a change here.
-      '/api/healthscan': {
+      //
+      // '/api' AND NOT '/api/healthscan' -- the narrower prefix left every MVP 2 endpoint
+      // (/api/earlywarning, /api/investigate, /api/resolve) unproxied, so Vite served index.html
+      // for them and a GET looked like a 200. Same defect as the nginx template had; both were
+      // written when /api/healthscan/* was the only family. One prefix, because the engine owns
+      // everything under /api and 404s what it does not have -- listing endpoints here would be a
+      // second copy of its routing table, which is how this broke in the first place.
+      '/api': {
         target: process.env.VITE_HEALTHSCAN_TARGET ?? 'http://localhost:3002',
         changeOrigin: true,
       },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,6 +227,22 @@ services:
       # sustainedSeconds must be reachable within sustainedSamples polls with margin (#64).
       # Shortening this means retuning sustainedSeconds in the same change.
       POLL_INTERVAL_MS: "5000"
+      # AGENT_MODE is SEPARATE from PROXY_MODE, and defaults to mock even though the proxy is
+      # live. Two independent switches because the proxy and the LLM fail independently: a
+      # rate-limited or unreachable model must not take the findings API down with it, and the
+      # useful default for a fresh `compose up` is live metrics with a canned investigation.
+      #
+      # `live` needs the AI Hub provider configured in IRIS (docs/mvp2-aihub-verified-api.md)
+      # and an API key in the wallet. Neither the key nor the model name is here: the engine
+      # holds no LLM credential, and turning this to `live` without the provider gives a 503
+      # from the dispatcher rather than a broken investigation.
+      AGENT_MODE: ${PG_AGENT_MODE:-mock}
+      IRIS_BASE_URL: http://iris:52773
+      # The ENGINE's IRIS credentials, for the RBAC-gated dispatcher. Same variables as the
+      # proxy above, so one override moves both. These authenticate to IRIS; they carry no
+      # authority over what may be written -- Tools.Resolve's policy decides that.
+      IRIS_USER: ${PG_IRIS_USER:-superuser}
+      IRIS_PASS: ${PG_IRIS_PASS:-SYS}
     volumes:
       # Hot-reloaded (ADR 0003), so mounting it lets an operator tune thresholds without a
       # rebuild. Read-only: the engine only ever reads it.

--- a/docs/mvp2-aihub-verified-api.md
+++ b/docs/mvp2-aihub-verified-api.md
@@ -127,9 +127,8 @@ execution.
 
 ## What is NOT yet verified
 
-- **No LLM provider is configured.** No `%AI.Provider` instance, no ConfigStore entry, no API
-  key. Nothing has called an external model from this instance. The provider/key path is real
-  work, not a checkbox.
+- ~~No LLM provider is configured.~~ **CLOSED** -- see the provider section at the end of this
+  file. A real OpenAI call and an agent tool call have both been made from this instance.
 - **What an audit record CONTAINS, and whether it is queryable.** Enforcement is confirmed (see
   above), but the written record has not been observed, and Dev C needs to display one. This is
   now the highest-value remaining unknown.
@@ -202,3 +201,70 @@ clean. They do look clean. That is not the same as being clean by construction.
 
 Related: the same reasoning is why `count` must be `null` rather than `0` when the log is
 unreadable — "no errors" is the worst wrong answer to give an agent diagnosing an error condition.
+
+## The LLM provider is configured, and an agent has used our tools
+
+Closed 2026-08-18. Previously listed here as "No LLM provider is configured ... real work, not a
+checkbox".
+
+**The key is in the AI Hub wallet, not in this repo and not in an env var.** Following the
+`aihub-eap` skill's production pattern -- Wallet holds the secret, ConfigStore references it:
+
+```objectscript
+Security.Resources.Create("AI.Secrets", ...)
+%Wallet.Collection.Create("PGSecrets", {"UseResource":"AI.Secrets","EditResource":"AI.Secrets"})
+%Wallet.KeyValue.Create("PGSecrets.openai", {"Usage":"CUSTOM","Secret":{"apikey":"<the key>"}})
+%ConfigStore.Configuration.Create("AI","LLM","","pgdetective", {
+    "model_provider": "openai",
+    "model":          "gpt-4o-mini",
+    "api_key":        "secret://PGSecrets.openai#apikey"
+})
+```
+
+`GetDetails("AI.LLM.pgdetective", .d, 0, 1)` -- the trailing `1` is `resolveSecrets` -- returns the
+real key. Verified it resolves rather than handing back the `secret://` string, because the failure
+mode is a provider that authenticates with a literal URI and reports an auth error rather than a
+config error.
+
+**A real call, from inside IRIS:**
+
+```
+provider created: %AI.Provider
+%Init: OK
+response: AIHUB LIVE
+```
+
+**And an agent using OUR MCP tools, which is the whole AI Detective mechanism:**
+
+```
+UseToolSet("ProductionGuardian.LabDemo.Tools.Read")  -> OK
+Run(session, "What is the pool size of the host named Cloud API? ...")
+answer: 1          <- the real configured value
+tool calls: 1
+```
+
+That is the loop MVP 2 needs: agent -> MCP read tool -> live production -> LLM -> structured answer.
+Nothing hardcoded, nothing mocked.
+
+### Pattern notes worth keeping
+
+- `%AI.Provider.Create(providerName, detailsObject)` takes the whole ConfigStore details object; it
+  reads `api_key` from it directly. No separate key argument.
+- `%Init()` before the first `Chat()` or `Run()`, as the skill says. Without it the provider and
+  tools are unwired.
+- `Run(session, goal, maxIterations)` rather than `Chat` for AI Detective: it is an agentic loop, so
+  the model can call several read tools before concluding. `Chat` is one turn.
+- `session.GetStats()."total_tool_calls"` is how to prove a tool was actually used rather than the
+  model answering from its own guess -- worth asserting, since a plausible wrong number looks
+  identical to a correct one in the response text.
+
+### Two security notes
+
+**The key must be rotated.** It was pasted into a chat transcript to reach me, so it should be
+treated as exposed regardless of where it now lives. MVP 2 §6 already lists "rotate after the demo"
+as the mitigation for credential exposure; this is that case.
+
+**`gpt-4o-mini` is a deliberate choice, not a default.** AI Detective sends metrics and
+configuration only -- no message content, no PHI (root `CLAUDE.md` §2.1) -- so the reasoning task is
+small and structured. A larger model would cost more per investigation and add latency to a loop
+that already sits inside the ADR 0005 budget.

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -31,11 +31,23 @@
 /// broken. `evidence[].source` is the distinction: `mcp_tool` is NOW, `snapshot` is THEN. Worth
 /// stating because the transcript looks like a defect otherwise.
 ///
-/// THIS CLASS ADDS NO AUTHORITY. `/labdemo/resolve` calls `Tools.Resolve.SetPoolSize`, which is
-/// gated by `%AI.ToolMgr.ExecuteTool`'s authorization check and audited by the same runtime path.
-/// Every guard -- the single whitelisted host, the 2..8 bounds, the production checks -- lives in
-/// the tool, not here. A bug in this file cannot widen what may be written; it can only fail to
-/// reach the tool.
+/// THIS CLASS ADDS NO AUTHORITY -- BUT IT MUST GO THROUGH `Tools.Governance` TO HAVE NONE.
+///
+/// This comment previously said the write was "gated by `%AI.ToolMgr.ExecuteTool`'s authorization
+/// check and audited by the same runtime path". That was FALSE as written (@kskubach, #92).
+/// `ExecuteTool` does consult a policy -- but policies attach per manager INSTANCE, in memory, and
+/// a freshly constructed `%AI.ToolMgr` has none. It therefore asked a policy that permits
+/// everything and audited into nothing, while this comment asserted the opposite.
+///
+/// An unimplemented guard is a gap. A guard DOCUMENTED as present is a trap, because a reviewer
+/// reading this comment has no reason to check. This was the second kind, which is why the
+/// correction is here in full rather than quietly dropped.
+///
+/// The correct statement is conditional. Every guard -- the single whitelisted host, the 2..8
+/// bounds, the production checks, the PG_Resolve requirement, the audit row -- lives in the tool
+/// and its policies, not here. What this file must not do is build its own manager; that is the
+/// one way a bug here could widen what may be written. `Tools.Governance` is the only documented
+/// way to obtain a manager that cannot.
 Class ProductionGuardian.LabDemo.REST.AgentDispatcher Extends %CSP.REST
 {
 
@@ -114,28 +126,63 @@ ClassMethod Resolve() As %Status
             return ..Fail(400, "host and size are required")
         }
 
-        // THROUGH %AI.ToolMgr, not by calling the class method directly. That indirection IS the
-        // safety property: ExecuteTool checks the authorization policy before executing and writes
-        // the audit record after, so a call routed around it would be an unauthorised, unaudited
-        // production write that looked identical from here.
-        // RegisterToolSet, not AddToolSetInstance -- the latter is PRIVATE and throws
-        // <PRIVATE METHOD> at runtime while compiling cleanly. Checked the method list for the
-        // public entry point rather than guessing a second time.
-        set mgr = ##class(%AI.ToolMgr).%New()
-        set sc = mgr.RegisterToolSet("ProductionGuardian.LabDemo.Tools.Resolve")
-        if $$$ISERR(sc) {
-            return ..Fail(500, "could not register the write tool: " _ $system.Status.GetErrorText(sc))
-        }
+        // THROUGH Tools.Governance, not through a bare %AI.ToolMgr. This line is the difference
+        // between a governed write and an ungoverned one, and the earlier version of this method
+        // was the latter while its class comment claimed otherwise (@kskubach, #92).
+        //
+        // WHY A BARE MANAGER IS UNSAFE. Policies are attached PER INSTANCE, in memory, to the Rust
+        // manager behind that object's %token -- there is no persisted setting and no default that
+        // denies. So ##class(%AI.ToolMgr).%New() reports `AuthPolicy: <none>` and executes
+        // SetPoolSize against the live production with no PG_Resolve check and no audit row.
+        // Reproduced on this branch before changing it:
+        //
+        //     AuthPolicy : <none>
+        //     AuditPolicy: <none>
+        //     ExecuteTool: SUCCEEDED -> {"outcome":"previewed","before":{"poolSize":1},...}
+        //
+        // It works perfectly, which is what makes it dangerous: forgetting to attach a policy is
+        // not a visible mistake.
+        //
+        // Invoke() rather than ToolManager() + ExecuteTool, for the auditId. The handle is only
+        // knowable after the call, and resolve-api.md §8 requires it in every response -- a caller
+        // that executes and then forgets to read it publishes a response claiming an audit entry
+        // it cannot point at.
         set args = {"host": (host), "size": (+size), "dryRun": (dryRun)}
-        set result = mgr.ExecuteTool("SetPoolSize", args)
+        set governed = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("SetPoolSize", args)
 
-        if '$isobject(result) {
+        if '$isobject(governed) {
             return ..Fail(502, "write tool returned no result")
         }
+        // A DENIAL IS 403, NOT 500. The policy refused a caller lacking PG_Resolve -- that is the
+        // boundary working, and reporting it as a server fault would send someone to debug the
+        // production instead of granting a role. The auditId is included because the denial IS
+        // audited: AuthPolicy writes that row itself, since the runtime throws before its own
+        // audit hook runs.
+        if governed.outcome = "denied" {
+            set %response.Status = 403
+            set denial = {"outcome": "refused", "refusal": {"code": "not_authorized", "detail": (governed.error)}, "audit": {"auditId": (governed.auditId)}}
+            write denial.%ToJSON()
+            return $$$OK
+        }
+        if governed.outcome '= "executed" {
+            return ..Fail(503, "write tool unavailable: " _ governed.%Get("error", "unknown"))
+        }
+
         // ExecuteTool wraps the tool's return in {"timing":..., "value":...}. Unwrap here rather
         // than in the engine: the wrapper is an AI Hub implementation detail, and leaking it across
         // the HTTP boundary would make contracts/resolve-api.md's shape depend on it.
-        set payload = $select($isobject(result.%Get("value")): result.value, 1: result)
+        set result = governed.result
+        set payload = result
+        if $isobject(result), $isobject(result.%Get("value")) {
+            set payload = result.value
+        }
+        if '$isobject(payload) {
+            return ..Fail(502, "write tool returned an unreadable result")
+        }
+        // The audit handle travels WITH the outcome, in one object. §8 requires it on every
+        // response, and a null one on an applied write is what tells the engine to treat the write
+        // as unverified rather than as a silent success.
+        set payload.audit = {"auditId": (governed.auditId)}
         write payload.%ToJSON()
         return $$$OK
     } catch ex {
@@ -159,16 +206,26 @@ ClassMethod BuildAgent(Output pStatus As %Status) As %AI.Agent [ Private ]
     set agent.Model = details."model"
     set agent.SystemPrompt = ..SystemPrompt()
 
-    // Read tools ONLY. The agent investigates; it does not act. Wiring Tools.Resolve here would
-    // let a model call the write tool as part of its reasoning loop, with no human between the
-    // recommendation and the production -- which is the single thing root CLAUDE.md §2.1 forbids.
-    set pStatus = agent.UseToolSet("ProductionGuardian.LabDemo.Tools.Read")
+    // %Init() FIRST, then govern. That is the REVERSE of what this method used to do, and the
+    // order is forced: %Init builds the agent's ToolManager, and GovernAgent attaches the policies
+    // to that object. There is nothing to govern before %Init has run, and GovernAgent says so
+    // rather than attaching to nothing and reporting success.
+    set pStatus = agent.%Init()
     if $$$ISERR(pStatus) {
         quit $$$NULLOREF
     }
-    // AFTER UseToolSet: %Init wires the provider and the tools, so tools added later are not
-    // registered. Verified in the skill and by the introspected method list.
-    set pStatus = agent.%Init()
+
+    // GovernAgent, NOT UseToolSet. UseToolSet delegates straight to
+    // ..ToolManager.RegisterToolSet, so it registers tools on a manager with NO policies --
+    // meaning every read the agent performed was unaudited, while MVP 2 §2.2 promises "every MCP
+    // tool call, read AND write, is recorded". The natural call is the ungoverned one (#94).
+    //
+    // pIncludeWrite = 0: read tools only. The agent investigates; it does not act. Registering
+    // Tools.Resolve here would let a model call the write tool inside its own reasoning loop with
+    // no human between the recommendation and the production -- the single thing root CLAUDE.md
+    // §2.1 forbids. This is defence in depth rather than the boundary: AuthPolicy refuses
+    // SetPoolSize without PG_Resolve even when the tool IS registered. Both hold.
+    set pStatus = ##class(ProductionGuardian.LabDemo.Tools.Governance).GovernAgent(agent, 0)
     if $$$ISERR(pStatus) {
         quit $$$NULLOREF
     }

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -1,0 +1,254 @@
+/// REST bridge from the detection engine to the AI Hub agent and the governed write tool.
+///
+/// The engine runs outside IRIS (ADR 0001) and the agent, tools, RBAC and audit all run inside it.
+/// This class is the seam. Two routes, both POST:
+///
+///   /labdemo/investigate   finding + snapshot  -> structured investigation
+///   /labdemo/resolve       action + dryRun     -> the governed set_pool_size result
+///
+/// WHY A DISPATCHER RATHER THAN THE MCP HTTP SERVICE. `%AI.MCP.Service` exposes tools over MCP for
+/// an MCP *client* to consume. The engine is not one: it needs one agent turn and one governed
+/// write, not tool discovery and a session protocol. A dispatcher is the smaller surface, and it
+/// keeps the agent's system prompt and iteration budget in IRIS where the model configuration
+/// already lives -- rather than making the engine assemble prompts, which is exactly the
+/// "we orchestrate, we do not reason" line in services/detection-engine/CLAUDE.md §1.1.
+///
+/// VERIFIED LIVE, and one behaviour worth knowing before you read a transcript. On a real run:
+///
+///   model: gpt-4o-mini   toolCalls: 6   confidence: 0.9
+///   rootCause: "The Cloud API host has a configured pool size of 1, which means it can only
+///               process one message at a time..."
+///   recommendedAction: {"action":{"type":"set_pool_size","host":"Cloud API","size":2}}
+///
+/// The agent diagnosed the bottleneck and chose a bounded action on its own -- nothing about pool
+/// size is in the system prompt beyond the permitted action type and range.
+///
+/// THE AGENT'S TOOL READINGS ARE LIVE; THE SNAPSHOT IS FROM WHEN THE FINDING FIRED. Those can
+/// disagree, and did: the snapshot said queued=198 while `get_queue_depth` returned 0, because the
+/// production had been reset between detection and investigation. Neither is wrong -- they answer
+/// different questions -- but it means an investigation can carry a bullet that contradicts the
+/// finding it explains, and a reader assuming both were taken at the same instant will think one is
+/// broken. `evidence[].source` is the distinction: `mcp_tool` is NOW, `snapshot` is THEN. Worth
+/// stating because the transcript looks like a defect otherwise.
+///
+/// THIS CLASS ADDS NO AUTHORITY. `/labdemo/resolve` calls `Tools.Resolve.SetPoolSize`, which is
+/// gated by `%AI.ToolMgr.ExecuteTool`'s authorization check and audited by the same runtime path.
+/// Every guard -- the single whitelisted host, the 2..8 bounds, the production checks -- lives in
+/// the tool, not here. A bug in this file cannot widen what may be written; it can only fail to
+/// reach the tool.
+Class ProductionGuardian.LabDemo.REST.AgentDispatcher Extends %CSP.REST
+{
+
+/// The ConfigStore entry naming the provider and model. The API key is resolved from the AI Hub
+/// wallet by GetDetails(..., resolveSecrets=1) -- it is never in this class, in the engine, or in
+/// the repo.
+Parameter LLMCONFIG = "AI.LLM.pgdetective";
+
+/// Iteration cap for an investigation. The agent needs several read-tool calls before concluding,
+/// and an unbounded loop against a metered API is a cost incident rather than a better diagnosis.
+Parameter MAXITERATIONS = 8;
+
+XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
+{
+<Routes>
+<Route Url="/investigate" Method="POST" Call="Investigate"/>
+<Route Url="/resolve" Method="POST" Call="Resolve"/>
+</Routes>
+}
+
+/// Run one investigation and return the structured result the engine validates.
+ClassMethod Investigate() As %Status
+{
+    set %response.ContentType = "application/json"
+    try {
+        set body = ##class(%DynamicObject).%FromJSON(%request.Content)
+
+        set agent = ..BuildAgent(.sc)
+        if $$$ISERR(sc) {
+            return ..Fail(503, "agent unavailable: " _ $system.Status.GetErrorText(sc))
+        }
+
+        // The GOAL is built from the request's measured values, and it asks for JSON back. Asking
+        // the model to produce the shape directly rather than parsing prose out of a narrative:
+        // the engine validates strictly, and a model that returns text would fail that validation
+        // every time -- which is the honest outcome but a useless one.
+        set goal = ..BuildGoal(body)
+        set session = agent.CreateSession()
+        set r = agent.Run(session, goal, ..#MAXITERATIONS)
+        if '$isobject(r) {
+            return ..Fail(502, "agent returned no response")
+        }
+
+        // The model is asked for JSON but may wrap it in prose or a fenced block. Extract rather
+        // than trust -- and if extraction fails, say so instead of forwarding something the engine
+        // will reject with a less specific message.
+        set parsed = ..ExtractJson(r.Content)
+        if '$isobject(parsed) {
+            return ..Fail(502, "agent reply was not JSON")
+        }
+        // Attach what only IRIS knows: which model answered and how many tools it actually called.
+        // toolCalls is the honest check that evidence was gathered rather than guessed -- a
+        // plausible narrative with zero tool calls is a model reasoning from its own priors.
+        set parsed.model = agent.Model
+        set stats = session.GetStats()
+        set parsed.toolCalls = $select($isobject(stats): stats."total_tool_calls", 1: "")
+
+        write parsed.%ToJSON()
+        return $$$OK
+    } catch ex {
+        return ..Fail(500, "investigation failed: " _ ex.DisplayString())
+    }
+}
+
+/// Invoke the governed write tool. Every guard is the tool's, not this class's.
+ClassMethod Resolve() As %Status
+{
+    set %response.ContentType = "application/json"
+    try {
+        set body = ##class(%DynamicObject).%FromJSON(%request.Content)
+        set host = body.%Get("host", "")
+        set size = body.%Get("size", "")
+        set dryRun = ''body.%Get("dryRun", 0)
+
+        if (host = "") || (size = "") {
+            return ..Fail(400, "host and size are required")
+        }
+
+        // THROUGH %AI.ToolMgr, not by calling the class method directly. That indirection IS the
+        // safety property: ExecuteTool checks the authorization policy before executing and writes
+        // the audit record after, so a call routed around it would be an unauthorised, unaudited
+        // production write that looked identical from here.
+        // RegisterToolSet, not AddToolSetInstance -- the latter is PRIVATE and throws
+        // <PRIVATE METHOD> at runtime while compiling cleanly. Checked the method list for the
+        // public entry point rather than guessing a second time.
+        set mgr = ##class(%AI.ToolMgr).%New()
+        set sc = mgr.RegisterToolSet("ProductionGuardian.LabDemo.Tools.Resolve")
+        if $$$ISERR(sc) {
+            return ..Fail(500, "could not register the write tool: " _ $system.Status.GetErrorText(sc))
+        }
+        set args = {"host": (host), "size": (+size), "dryRun": (dryRun)}
+        set result = mgr.ExecuteTool("SetPoolSize", args)
+
+        if '$isobject(result) {
+            return ..Fail(502, "write tool returned no result")
+        }
+        // ExecuteTool wraps the tool's return in {"timing":..., "value":...}. Unwrap here rather
+        // than in the engine: the wrapper is an AI Hub implementation detail, and leaking it across
+        // the HTTP boundary would make contracts/resolve-api.md's shape depend on it.
+        set payload = $select($isobject(result.%Get("value")): result.value, 1: result)
+        write payload.%ToJSON()
+        return $$$OK
+    } catch ex {
+        return ..Fail(500, "resolve failed: " _ ex.DisplayString())
+    }
+}
+
+/// Build and initialise the agent from ConfigStore. Private.
+ClassMethod BuildAgent(Output pStatus As %Status) As %AI.Agent [ Private ]
+{
+    set pStatus = ##class(%ConfigStore.Configuration).GetDetails(..#LLMCONFIG, .details, 0, 1)
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    set provider = ##class(%AI.Provider).Create(details."model_provider", details)
+    if '$isobject(provider) {
+        set pStatus = $$$ERROR($$$GeneralError, "could not create provider")
+        quit $$$NULLOREF
+    }
+    set agent = ##class(%AI.Agent).%New(provider)
+    set agent.Model = details."model"
+    set agent.SystemPrompt = ..SystemPrompt()
+
+    // Read tools ONLY. The agent investigates; it does not act. Wiring Tools.Resolve here would
+    // let a model call the write tool as part of its reasoning loop, with no human between the
+    // recommendation and the production -- which is the single thing root CLAUDE.md §2.1 forbids.
+    set pStatus = agent.UseToolSet("ProductionGuardian.LabDemo.Tools.Read")
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    // AFTER UseToolSet: %Init wires the provider and the tools, so tools added later are not
+    // registered. Verified in the skill and by the introspected method list.
+    set pStatus = agent.%Init()
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    quit agent
+}
+
+/// The agent's role and output contract. Private.
+ClassMethod SystemPrompt() As %String [ Private ]
+{
+    set p = "You diagnose InterSystems IRIS interoperability production problems. "
+    set p = p _ "Use the provided tools to gather evidence BEFORE concluding; do not guess values you can look up. "
+    set p = p _ "You are given metrics and configuration only. You never see message content and must not speculate about it. "
+    set p = p _ "Reply with ONLY a JSON object, no prose around it, with these keys: "
+    set p = p _ "rootCause (string, 2-3 sentences explaining WHY in operator language), "
+    set p = p _ "evidence (array of {label, detail, source, tool} where source is ""mcp_tool"" for a value you read with a tool "
+    set p = p _ "or ""snapshot"" for one given to you, and tool is the tool name or null), "
+    set p = p _ "confidence (number 0-1, your own judgement), "
+    set p = p _ "recommendedAction ({action: {type, host, size}}) or null. "
+    set p = p _ "The only action type you may recommend is set_pool_size, with size between 2 and 8, "
+    set p = p _ "and host must be the host under investigation. Recommend nothing if no bounded action fits."
+    quit p
+}
+
+/// Turn the request into a goal string. Private.
+ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
+{
+    set f = body.finding, s = body.snapshot
+    set g = "A monitoring rule fired on this production. Diagnose it."
+    if $isobject(f) {
+        set g = g _ " Finding: type=" _ f.%Get("type", "?") _ ", host=" _ f.%Get("host", "?")
+        set g = g _ ", message=" _ f.%Get("message", "?")
+    }
+    if $isobject(s) {
+        // Passed as JSON rather than re-narrated: the engine already built this as an allowlist of
+        // metric and configuration fields, and re-describing it here would be a second place where
+        // a field could be added without review.
+        set g = g _ " Current metrics: " _ s.%ToJSON()
+    }
+    if $isobject(body.trend) {
+        set g = g _ " Trend: " _ body.trend.%ToJSON()
+    }
+    set g = g _ " Use the tools to confirm the configuration before concluding."
+    quit g
+}
+
+/// Pull a JSON object out of a model reply that may be fenced or padded. Private.
+ClassMethod ExtractJson(text As %String) As %DynamicObject [ Private ]
+{
+    if text = "" {
+        quit $$$NULLOREF
+    }
+    // Take the outermost braces rather than stripping fences by pattern: models wrap JSON in
+    // ```json, in plain ```, in "Here is the JSON:", or in nothing, and a fence-specific rule
+    // fails on the next variation. The first { to the last } is stable across all of them.
+    set start = $find(text, "{") - 1
+    if start < 1 {
+        quit $$$NULLOREF
+    }
+    set end = $length(text)
+    while (end > start) && ($extract(text, end) '= "}") {
+        set end = end - 1
+    }
+    if end <= start {
+        quit $$$NULLOREF
+    }
+    set candidate = $extract(text, start, end)
+    try {
+        set obj = ##class(%DynamicObject).%FromJSON(candidate)
+    } catch {
+        return $$$NULLOREF
+    }
+    quit obj
+}
+
+/// Emit a JSON error with a status code. Private.
+ClassMethod Fail(code As %Integer, message As %String) As %Status [ Private ]
+{
+    set %response.Status = code
+    write {"error": (message)}.%ToJSON()
+    quit $$$OK
+}
+
+}

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -153,14 +153,54 @@ ClassMethod Resolve() As %Status
         if '$isobject(governed) {
             return ..Fail(502, "write tool returned no result")
         }
-        // A DENIAL IS 403, NOT 500. The policy refused a caller lacking PG_Resolve -- that is the
-        // boundary working, and reporting it as a server fault would send someone to debug the
-        // production instead of granting a role. The auditId is included because the denial IS
-        // audited: AuthPolicy writes that row itself, since the runtime throws before its own
-        // audit hook runs.
+        // A DENIAL IS 200 WITH `outcome: "refused"`. NOT 403, and the contract forbids it by name
+        // (resolve-api.md §5.1: "`not_authorized` is `200`. It is not `403`, and it is not a
+        // `500`.").
+        //
+        // I wrote 403 first, on the reasoning that a policy refusal is not a server fault
+        // (@kskubach, #92 -- who noted they would have written 403 too). The reasoning is fine and
+        // the conclusion breaks the demo: Dev C's client branches on `res.ok`, so every generic
+        // fetch wrapper turns a non-2xx into a thrown error and a generic banner. The specific,
+        // informative refusal becomes "something went wrong" in the layer above the one that knew
+        // -- and MVP 2 §5.4's acceptance criterion is that the RBAC-denied state is VISIBLE. A
+        // thrown error is not a visible state.
+        //
+        // SAME SHAPE AS THE AUTHORIZED PATH, which is the other half of §5.1: an authorized caller
+        // and an unauthorized one differ only in `outcome`, `refusal`, and `before`/`after` being
+        // null. Every other field is present, because Dev C mocks the denied state by changing two
+        // fields rather than by handling a second shape.
         if governed.outcome = "denied" {
-            set %response.Status = 403
-            set denial = {"outcome": "refused", "refusal": {"code": "not_authorized", "detail": (governed.error)}, "audit": {"auditId": (governed.auditId)}}
+            // Describe() reads back the row the denial WROTE -- AuthPolicy writes it itself,
+            // because the runtime throws before its own audit hook. So `audit.actor` names the
+            // identity that was REFUSED, which §8 requires and which is the entire point of
+            // auditing denials.
+            set audit = ##class(ProductionGuardian.LabDemo.Audit.Entry).Describe(governed.auditId)
+            // denialReason, not governed.error. The raw error is
+            // `ERROR <%AICore>ToolAccessDenied: Tool access denied: Global policy denied: ERROR
+            // #5001: ...` -- fine in a log, poor as a UI message. The audit row carries the clean
+            // sentence, and it is free of instance data by construction, which matters because
+            // this crosses the same boundary as any other output.
+            set message = governed.error
+            if $isobject(audit), audit.%Get("denialReason", "") '= "" {
+                set message = audit.denialReason
+            }
+            set denial = {
+                "outcome": "refused",
+                "before": null,
+                "after": null,
+                "reversal": null,
+                "refusal": {
+                    "reason": "not_authorized",
+                    "message": (message),
+                    "checkedBy": "iris"
+                },
+                "failure": null,
+                // §3 marks confirmation always present. `not_applicable` rather than null: nothing
+                // was written, so there is no clearance to wait for, and a null would read as
+                // "unknown" to a UI deciding whether to poll.
+                "confirmation": { "status": "not_applicable" },
+                "audit": (audit)
+            }
             write denial.%ToJSON()
             return $$$OK
         }
@@ -179,10 +219,16 @@ ClassMethod Resolve() As %Status
         if '$isobject(payload) {
             return ..Fail(502, "write tool returned an unreadable result")
         }
-        // The audit handle travels WITH the outcome, in one object. §8 requires it on every
-        // response, and a null one on an applied write is what tells the engine to treat the write
-        // as unverified rather than as a silent success.
-        set payload.audit = {"auditId": (governed.auditId)}
+        // The full §8 audit block, not just the handle -- same reason as the denial branch: §8
+        // wants actor, role, tool, recordedAt and source, and Describe() returns them straight from
+        // the row this call wrote. A handle alone makes a consumer perform a second lookup it has
+        // no endpoint for.
+        //
+        // Falls back to the bare handle if the row cannot be read. A null audit on an applied write
+        // is what tells the engine to treat the write as unverified rather than as a silent
+        // success, so degrading to less information is right and inventing any is not.
+        set audit = ##class(ProductionGuardian.LabDemo.Audit.Entry).Describe(governed.auditId)
+        set payload.audit = $select($isobject(audit): audit, 1: {"auditId": (governed.auditId)})
         write payload.%ToJSON()
         return $$$OK
     } catch ex {

--- a/iris/labdemo/Tools/Resolve.cls
+++ b/iris/labdemo/Tools/Resolve.cls
@@ -181,7 +181,20 @@ ClassMethod Refuse(out As %DynamicObject, code As %String, detail As %String) As
     // The reason is surfaced because it is what lets a UI explain WHY Approve is disabled, but it
     // names only the rule and the bound -- never instance data, since a refusal string crosses the
     // same boundary to the model as any other tool output.
-    set out.refusal = { "code": (code), "detail": (detail) }
+    // §5 FIELD NAMES: reason, message, checkedBy. This emitted { code, detail } until
+    // 2026-08-19 -- a drift from the ratified contract in the object Dev C renders when Approve is
+    // refused, so their banner read `undefined` (@kskubach, #92). The parameter names are kept as
+    // code/detail because that is what every call site passes; only the wire shape was wrong.
+    //
+    // checkedBy is "iris" unconditionally, and it is a fact rather than a label: this method only
+    // runs inside the tool, so a refusal carrying it WAS decided by the production's own guard and
+    // not by the engine's convenience validation.
+    set out.refusal = { "reason": (code), "message": (detail), "checkedBy": "iris" }
+    // §5 carries the range on an out_of_bounds refusal so a UI can state it without hardcoding a
+    // copy -- which is the #84 stale-number pattern waiting to happen.
+    if code = "out_of_bounds" {
+        set out.refusal.bounds = { "min": (..#MINSIZE), "max": (..#MAXSIZE) }
+    }
     quit out
 }
 

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -19,7 +19,27 @@ export interface ServerOptions {
   /** Reads the engine's current state. Called per request, never cached. */
   snapshot: () => EngineSnapshot;
   log?: (msg: string) => void;
+  /**
+   * Handles `POST /api/investigate`. Absent means the endpoint answers 503 rather than 404 --
+   * "not configured here" and "no such endpoint" are different facts, and a dashboard that gets
+   * 404 will conclude the feature does not exist rather than that this deployment lacks an agent.
+   */
+  investigate?: (findingId: string) => Promise<unknown>;
+  /** Handles `POST /api/resolve`. Same 503-not-404 reasoning. */
+  resolve?: (body: unknown) => Promise<unknown>;
 }
+
+/**
+ * The GET routes, as a set, so the POST branch can tell "wrong method on a real endpoint" from
+ * "no such endpoint". Kept adjacent to the switch below -- a second list is a thing that goes
+ * stale, and this one going stale would turn a 405 back into a misleading 404.
+ */
+const GET_PATHS = new Set([
+  '/api/healthscan/hosts',
+  '/api/healthscan/findings',
+  '/api/healthscan/health',
+  '/api/earlywarning',
+]);
 
 export function createFindingsServer(options: ServerOptions): Server {
   const log = options.log ?? console.error;
@@ -33,6 +53,62 @@ export function createFindingsServer(options: ServerOptions): Server {
       // Preflight, in case Dev C points at us without the Vite proxy.
       writeHead(res, 204, 'ok');
       res.end();
+      return;
+    }
+
+    if (req.method === 'POST') {
+      // The two MVP 2 write-ish endpoints. Handled before the GET guard because they are the only
+      // non-GET routes and they are async, which the GET path deliberately is not.
+      const handler =
+        path === '/api/investigate'
+          ? options.investigate === undefined
+            ? undefined
+            : async (body: unknown) => options.investigate!(readFindingId(body))
+          : path === '/api/resolve'
+            ? options.resolve
+            : null;
+
+      if (handler === null) {
+        // A POST to a path that exists as a GET route is 405, not 404 -- the endpoint is real, the
+        // method is not allowed on it. Returning 404 here was a regression I introduced by putting
+        // the POST branch ahead of the method guard, and the existing "405s a non-GET method" test
+        // caught it. Worth the extra branch: 404 tells a caller the endpoint does not exist, which
+        // for /api/healthscan/findings is simply false.
+        const isKnownGetPath = GET_PATHS.has(path);
+        sendJson(
+          res,
+          isKnownGetPath ? 405 : 404,
+          isKnownGetPath
+            ? { error: `method POST not allowed on ${path}` }
+            : { error: `no such endpoint: ${path}` },
+          'ok',
+        );
+        return;
+      }
+      if (handler === undefined) {
+        // 503, not 404: the route exists in this build but this deployment has no agent wired.
+        sendJson(
+          res,
+          503,
+          { error: `${path} is not configured on this deployment` },
+          options.snapshot().state,
+        );
+        return;
+      }
+
+      readJsonBody(req)
+        .then(async (body) => {
+          const result = await handler(body);
+          sendJson(res, 200, result, options.snapshot().state);
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          log(`POST ${path} failed: ${message}`);
+          // 400 for a body we could not read, 500 for a genuine fault. Distinguished because one is
+          // the caller's problem and the other is ours.
+          const status = message.startsWith('bad request') ? 400 : 500;
+          sendJson(res, status, { error: message }, 'stale');
+        });
       return;
     }
 
@@ -99,6 +175,57 @@ function sendJson(
   const payload = JSON.stringify(body);
   writeHead(res, status, state, Buffer.byteLength(payload));
   res.end(payload);
+}
+
+/**
+ * Read and parse a JSON request body, with a size cap.
+ *
+ * CAPPED at 64 KB. Every legitimate body here is a findingId or a small action object, so anything
+ * larger is a mistake or an attack, and an uncapped read is an unbounded allocation on a public
+ * port. Rejecting is the honest response rather than buffering whatever arrives.
+ */
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const MAX = 64 * 1024;
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    size += buf.length;
+    if (size > MAX) throw new Error('bad request: body exceeds 64 KB');
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (raw.trim() === '') throw new Error('bad request: empty body');
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error('bad request: body is not valid JSON');
+  }
+}
+
+/**
+ * Extract `findingId` from an investigate body.
+ *
+ * The contract makes the body EXACTLY `{"findingId": "..."}` with `additionalProperties: false`, and
+ * that is the structural half of the data boundary: because the body is one id, every value the
+ * model sees was engine-measured or tool-read. Extra keys are rejected rather than ignored -- a
+ * tolerated `prompt` field would be a text-injection path into an LLM prompt.
+ */
+function readFindingId(body: unknown): string {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('bad request: body must be an object');
+  }
+  const keys = Object.keys(body);
+  if (keys.length !== 1 || keys[0] !== 'findingId') {
+    throw new Error(
+      `bad request: body must contain exactly findingId, got [${keys.join(', ')}]`,
+    );
+  }
+  const id = (body as Record<string, unknown>)['findingId'];
+  if (typeof id !== 'string' || id.trim() === '') {
+    throw new Error('bad request: findingId must be a non-empty string');
+  }
+  return id;
 }
 
 function writeHead(res: ServerResponse, status: number, state: string, length?: number): void {

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -48,6 +48,76 @@ const GET_PATHS = new Set([
 
 const POST_PATHS = new Set(['/api/investigate', '/api/resolve']);
 
+/**
+ * Origins permitted to POST — the fix for `resolve-api.md` §13.2's confused deputy.
+ *
+ * THE PROBLEM, MEASURED rather than reasoned about. `Access-Control-Allow-Origin: *` on a write
+ * endpoint means any page open in the browser can POST to `:3002`. Verified against the running
+ * stack before changing anything:
+ *
+ *     POST /api/resolve   Origin: https://evil.example.com
+ *     -> HTTP 200  {"outcome":"previewed","after":{"poolSize":8}}
+ *     OPTIONS      -> Access-Control-Allow-Origin: *, Allow-Methods: GET, POST, OPTIONS
+ *
+ * §13.2 calls that "tolerable — not fine" partly because "the engine holds no authority of its
+ * own". Under §13.1's service-account model that is no longer true: the engine authenticates to
+ * IRIS with a credential that HOLDS the write role. So the browser cannot write, the engine can,
+ * and `*` lets any page ask it to. That is the confused deputy exactly.
+ *
+ * WHY AN ALLOW-LIST AND NOT THE OTHER TWO OPTIONS. §13.2 lists three. Binding `:3002` to localhost
+ * would break the compose network, where the dashboard reaches the engine by service name. The
+ * pass-through credential closes this properly and is the right long-term answer -- it removes the
+ * standing privilege rather than guarding it -- but it needs a login the dashboard does not have,
+ * so it is a decision (§13.1) rather than a patch. An origin allow-list is what can be done inside
+ * this service today without deciding that.
+ *
+ * WHAT IT DOES NOT DO, stated plainly so nobody reads it as more than it is. CORS is enforced by
+ * the BROWSER, so this stops a malicious PAGE and stops nothing else: curl, a script, or anything
+ * that does not honour CORS reaches the endpoint unchanged. It closes the drive-by, not the
+ * network path. The real fix is still §13.1.
+ *
+ * GETs keep `*`. They are reads, they are CORS-simple, and Q9's reason for `*` -- the dev proxy
+ * stays optional -- applies to them and not to a write.
+ */
+const DEFAULT_WRITE_ORIGINS = [
+  // The dashboard's dev server and its containerised form. Both, because Dev C runs Vite directly
+  // and the compose stack serves the built bundle from nginx on 5173.
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+];
+
+/**
+ * Resolve the permitted write origins. `PG_WRITE_ORIGINS` overrides, comma-separated.
+ *
+ * `*` is accepted as an explicit opt-out, and it is deliberately something you have to TYPE. A
+ * deployment that needs it can have it; nobody gets it by default, and it appears in the startup
+ * log so an operator can see the endpoint is open.
+ */
+function writeOrigins(): { list: string[]; open: boolean } {
+  const raw = process.env['PG_WRITE_ORIGINS'];
+  if (raw === undefined || raw.trim() === '') return { list: DEFAULT_WRITE_ORIGINS, open: false };
+  const list = raw.split(',').map((o) => o.trim()).filter((o) => o !== '');
+  return { list, open: list.includes('*') };
+}
+
+const WRITE_ORIGINS = writeOrigins();
+
+/**
+ * Is this origin allowed to POST?
+ *
+ * A MISSING Origin header is ALLOWED, and that is not a loophole being left open -- it is the
+ * distinction between the two threats. Browsers always send `Origin` on a cross-origin POST, so a
+ * request without one is not a page: it is curl, the dashboard's own server-side proxy, or a
+ * health check. Rejecting those would break the dev proxy and every scripted verification while
+ * stopping nothing, because anything that can omit the header can also forge it.
+ */
+function mayWrite(origin: string | undefined): boolean {
+  if (WRITE_ORIGINS.open) return true;
+  if (origin === undefined || origin === '') return true;
+  return WRITE_ORIGINS.list.includes(origin);
+}
+
+
 export function createFindingsServer(options: ServerOptions): Server {
   const log = options.log ?? console.error;
 
@@ -58,12 +128,35 @@ export function createFindingsServer(options: ServerOptions): Server {
 
     if (req.method === 'OPTIONS') {
       // Preflight, in case Dev C points at us without the Vite proxy.
-      writeHead(res, 204, 'ok');
+      //
+      // The preflight must AGREE with the POST branch. If it advertised POST to an origin the POST
+      // branch then rejects, the browser would pass the preflight and fail the real request -- and
+      // the visible symptom would be a 403 with no explanation of which check refused it. So a
+      // disallowed origin is told POST is unavailable here, which is the truth for it.
+      writeHead(res, 204, 'ok', undefined, mayWrite(req.headers.origin));
       res.end();
       return;
     }
 
     if (req.method === 'POST') {
+      // ORIGIN CHECK FIRST, before routing and before any handler. A rejected origin must not
+      // reach the write tool, and it must not even learn which routes exist -- so this precedes
+      // the 404/405 distinction below.
+      const origin = req.headers.origin;
+      if (!mayWrite(origin)) {
+        log(`refused POST ${path} from origin ${String(origin)}`);
+        // 403, and here it IS the right code -- unlike a policy refusal (resolve-api.md §5.1),
+        // which is a 200 because the CALLER is legitimate and the answer is informative. This is
+        // not a legitimate caller: no operator sees this response, only a page that should not
+        // have asked. There is nothing for a UI to render.
+        sendJson(
+          res,
+          403,
+          { error: `origin ${String(origin)} is not permitted to POST to this engine` },
+          'ok',
+        );
+        return;
+      }
       // The two MVP 2 write-ish endpoints. Handled before the GET guard because they are the only
       // non-GET routes and they are async, which the GET path deliberately is not.
       const handler = !POST_PATHS.has(path)
@@ -244,10 +337,18 @@ function readFindingId(body: unknown): string {
   return id;
 }
 
-function writeHead(res: ServerResponse, status: number, state: string, length?: number): void {
+function writeHead(
+  res: ServerResponse,
+  status: number,
+  state: string,
+  length?: number,
+  allowWrite = true,
+): void {
   res.writeHead(status, {
     'Content-Type': 'application/json; charset=utf-8',
-    // Contract Q9: sent unconditionally, so the dev proxy is optional not required.
+    // Contract Q9: sent unconditionally, so the dev proxy is optional not required. Still `*`:
+    // the GETs are reads and CORS-simple, and Q9's reasoning applies to them. Only the METHODS
+    // advertised below narrow for a disallowed origin -- which is what actually gates the write.
     'Access-Control-Allow-Origin': '*',
     // POST is advertised for the MVP 2 endpoints (`/api/investigate`, `/api/resolve`), and
     // Allow-Headers is what a JSON POST actually needs: a cross-origin request carrying
@@ -262,7 +363,11 @@ function writeHead(res: ServerResponse, status: number, state: string, length?: 
     // Advertised BEFORE the routes exist on purpose. A method in Allow-Methods with no route
     // behind it answers 405, which is a clear, correct answer to "can I POST here yet". The
     // reverse -- a route with the header missing -- is the invisible failure.
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    //
+    // POST is advertised only to an origin permitted to use it (§13.2 -- see WRITE_ORIGINS). A
+    // browser that is not on the list is told GET and OPTIONS, which is accurate for it rather
+    // than a refusal it has to discover by trying.
+    'Access-Control-Allow-Methods': allowWrite ? 'GET, POST, OPTIONS' : 'GET, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'X-Healthscan-State': state,
     // Findings change every poll; a cached response would defeat the 10s bar.

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -30,9 +30,14 @@ export interface ServerOptions {
 }
 
 /**
- * The GET routes, as a set, so the POST branch can tell "wrong method on a real endpoint" from
- * "no such endpoint". Kept adjacent to the switch below -- a second list is a thing that goes
- * stale, and this one going stale would turn a 405 back into a misleading 404.
+ * The routes, split by method, so each branch can tell "wrong method on a real endpoint" from "no
+ * such endpoint". Kept adjacent to the switch below -- a second list is a thing that goes stale,
+ * and either one going stale would turn a 405 back into a misleading 404.
+ *
+ * BOTH sets are needed, not just the GET one. With only GET_PATHS, `GET /api/resolve` answered 404
+ * -- the same defect as the `POST /api/healthscan/findings` regression, mirrored: the endpoint is
+ * real and only the method is wrong, and 404 tells a caller it does not exist. Found by asking for
+ * the symmetric case rather than by a failing test, because no test covered a GET to a POST route.
  */
 const GET_PATHS = new Set([
   '/api/healthscan/hosts',
@@ -40,6 +45,8 @@ const GET_PATHS = new Set([
   '/api/healthscan/health',
   '/api/earlywarning',
 ]);
+
+const POST_PATHS = new Set(['/api/investigate', '/api/resolve']);
 
 export function createFindingsServer(options: ServerOptions): Server {
   const log = options.log ?? console.error;
@@ -59,14 +66,13 @@ export function createFindingsServer(options: ServerOptions): Server {
     if (req.method === 'POST') {
       // The two MVP 2 write-ish endpoints. Handled before the GET guard because they are the only
       // non-GET routes and they are async, which the GET path deliberately is not.
-      const handler =
-        path === '/api/investigate'
+      const handler = !POST_PATHS.has(path)
+        ? null
+        : path === '/api/investigate'
           ? options.investigate === undefined
             ? undefined
             : async (body: unknown) => options.investigate!(readFindingId(body))
-          : path === '/api/resolve'
-            ? options.resolve
-            : null;
+          : options.resolve;
 
       if (handler === null) {
         // A POST to a path that exists as a GET route is 405, not 404 -- the endpoint is real, the
@@ -153,9 +159,19 @@ export function createFindingsServer(options: ServerOptions): Server {
             snapshot.state,
           );
           return;
-        default:
-          sendJson(res, 404, { error: `no such endpoint: ${path}` }, snapshot.state);
+        default: {
+          // Symmetric with the POST branch: a GET to a POST-only route is 405, not 404.
+          const isKnownPostPath = POST_PATHS.has(path);
+          sendJson(
+            res,
+            isKnownPostPath ? 405 : 404,
+            isKnownPostPath
+              ? { error: `method GET not allowed on ${path}` }
+              : { error: `no such endpoint: ${path}` },
+            snapshot.state,
+          );
           return;
+        }
       }
     } catch (err) {
       // A genuine fault is the one case that gets a 5xx (contract §3).

--- a/services/detection-engine/src/detect/agents.ts
+++ b/services/detection-engine/src/detect/agents.ts
@@ -1,0 +1,124 @@
+/**
+ * The two agent callers behind one interface: live AI Hub, and a canned mock.
+ *
+ * ADR 0004 and MVP 2 §6 both ask for a mock agent as a hot standby — "never block the demo on live
+ * AI". The point of putting both behind the same `callAgent` signature is that the orchestration in
+ * `investigate.ts` is ONE code path: the mock exercises the same validation, the same failure
+ * discipline, and the same response shape as the live agent. Two branches would drift, and the one
+ * that drifts is always the one only used in a fallback.
+ */
+
+import type { InvestigateDeps } from './investigate.ts';
+
+/**
+ * Live agent, over HTTP to the IRIS instance.
+ *
+ * The AGENT runs in IRIS, not here. This service holds no LLM key and no model configuration —
+ * `iris/labdemo/Tools/` owns the tools and AI Hub owns the provider, so all this does is hand over a
+ * request and validate what comes back. That separation is why a bug in this file cannot leak a
+ * credential or call a model directly.
+ */
+export function liveAgent(baseUrl: string, log?: (m: string) => void): InvestigateDeps['callAgent'] {
+  return async (request, timeoutMs) => {
+    // AbortSignal rather than a Promise.race: race leaves the fetch running and its socket open, so
+    // a slow agent would accumulate connections across polls. Aborting actually cancels it.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}/labdemo/investigate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+      if (!res.ok) throw new Error(`agent returned HTTP ${res.status}`);
+      return await res.json();
+    } catch (err) {
+      // Distinguish a timeout from a refusal in the log, because they need different responses: a
+      // timeout is retryable and a 4xx is not.
+      if (err instanceof Error && err.name === 'AbortError') {
+        log?.(`agent timed out after ${timeoutMs}ms`);
+        throw new Error(`agent timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Mock agent: the canned investigation for the one MVP 2 scenario.
+ *
+ * WHAT IT IS FOR. Dev C's investigation panel, the offline demo fallback, and the hot standby when
+ * the LLM is rate-limited or unreachable. It returns the shape the live agent returns, so swapping
+ * one for the other changes no downstream code.
+ *
+ * IT READS THE REQUEST RATHER THAN IGNORING IT. The numbers in the response come from the snapshot
+ * the engine measured — the host name, the queue depth, the pool size. A mock that returned a fixed
+ * string would drift from reality the moment the scenario changed, and would show `Cloud API` while
+ * the panel displayed a different host. The NARRATIVE is canned; the FACTS are live.
+ *
+ * WHAT IT MUST NOT DO. It must not be mistaken for a real investigation. `source: "canned"` is what
+ * the response carries, and `investigate.ts` sets `state` from that — so the UI can label it, which
+ * `investigation-api.md` §4.3 requires. A mock that presented itself as `agent` would be the same
+ * defect class as a projection published as a measurement.
+ */
+export function mockAgent(): InvestigateDeps['callAgent'] {
+  return async (request) => {
+    const snapshot = request.snapshot as Record<string, unknown>;
+    const trend = request.trend as Record<string, unknown> | null;
+    const host = String(snapshot['host'] ?? 'Cloud API');
+    const queued = snapshot['queued'];
+    const poolSize = snapshot['poolSize'];
+    const slope = trend?.['slope'] ?? null;
+
+    // The recommendation is 4 because that is the one whitelisted target for this scenario, and
+    // because 4 workers against a ~1s downstream clears ~4/sec — enough to drain a queue built at
+    // ~2/sec. Not an arbitrary "bigger number".
+    return {
+      rootCause:
+        `${host} is throughput-bound. It runs at PoolSize 1 against a downstream dispatcher that ` +
+        `takes about a second per message, so it clears roughly 1 message/sec while inbound volume ` +
+        `exceeds that. The host itself is healthy — it is outnumbered, not broken.`,
+      evidence: [
+        {
+          label: `${host} pool size`,
+          detail: `${host} PoolSize = ${poolSize ?? 1}`,
+          source: 'mcp_tool',
+          tool: 'get_pool_size',
+        },
+        {
+          label: 'Queue depth',
+          detail: queued === null || queued === undefined
+            ? 'queue depth not measurable'
+            : `${queued} message(s) queued`,
+          source: 'snapshot',
+          tool: null,
+        },
+        {
+          label: 'Downstream latency',
+          detail: `average processing time ${snapshot['avgProcessingTime'] ?? '~1'}s per message`,
+          source: 'mcp_tool',
+          tool: 'get_processing_time',
+        },
+        {
+          label: 'Queue slope',
+          detail: slope === null ? 'queue rising' : `queue rising ~${String(slope)}/min`,
+          source: 'snapshot',
+          tool: null,
+        },
+      ],
+      // A FIXED number, and stated as such rather than dressed up. This is a canned response, so
+      // there is no model self-report to pass through -- inventing a varying one would imply a
+      // judgement nothing made. 0.9 reflects that this single scenario is unambiguous, not a
+      // calibrated probability (contract §3.4 says the live one is not calibrated either).
+      confidence: 0.9,
+      recommendedAction: {
+        action: { type: 'set_pool_size', host, size: 4 },
+      },
+      model: null,
+      toolCalls: null,
+    };
+  };
+}

--- a/services/detection-engine/src/detect/agents.ts
+++ b/services/detection-engine/src/detect/agents.ts
@@ -9,6 +9,7 @@
  */
 
 import type { InvestigateDeps } from './investigate.ts';
+import type { ResolveDeps } from './resolve.ts';
 
 /**
  * Live agent, over HTTP to the IRIS instance.
@@ -18,16 +19,26 @@ import type { InvestigateDeps } from './investigate.ts';
  * request and validate what comes back. That separation is why a bug in this file cannot leak a
  * credential or call a model directly.
  */
-export function liveAgent(baseUrl: string, log?: (m: string) => void): InvestigateDeps['callAgent'] {
+export function liveAgent(
+  baseUrl: string,
+  user: string,
+  pass: string,
+  log?: (m: string) => void,
+): InvestigateDeps['callAgent'] {
+  const auth = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
   return async (request, timeoutMs) => {
     // AbortSignal rather than a Promise.race: race leaves the fetch running and its socket open, so
     // a slow agent would accumulate connections across polls. Aborting actually cancels it.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await fetch(`${baseUrl}/labdemo/investigate`, {
+      // /labdemo/agent/investigate -- the web application is /labdemo/agent and the ROUTE is
+      // /investigate. I first wrote /labdemo/investigate, which is the dispatcher's route without
+      // its application prefix: it would have 404'd against the patients dispatcher rather than
+      // failing to resolve, so the error would have named the wrong component.
+      const res = await fetch(`${baseUrl}/labdemo/agent/investigate`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Authorization: auth },
         body: JSON.stringify(request),
         signal: controller.signal,
       });
@@ -120,5 +131,79 @@ export function mockAgent(): InvestigateDeps['callAgent'] {
       model: null,
       toolCalls: null,
     };
+  };
+}
+
+/**
+ * Live write tool caller, over HTTP to the dispatcher in IRIS.
+ *
+ * Requires credentials, because the tool is RBAC-gated and an unauthenticated request is refused by
+ * the web application before the policy is even consulted. The credentials are the ENGINE's, not a
+ * human's -- which is why `resolve-api.md` §13.1 flags "which actor lands in the audit record" as
+ * the thing to settle: right now it is a service account, so the audit attributes the change to the
+ * engine rather than to the person who approved it. That is a real limitation, not a detail.
+ */
+export function liveResolveTool(
+  baseUrl: string,
+  user: string,
+  pass: string,
+  log?: (m: string) => void,
+): ResolveDeps['callTool'] {
+  const auth = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+  return async (action, dryRun, timeoutMs) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}/labdemo/agent/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: auth },
+        body: JSON.stringify({ host: action.host, size: action.size, dryRun }),
+        signal: controller.signal,
+      });
+      // A refusal comes back as HTTP 200 with outcome:"refused" -- it is a normal response, not an
+      // error. Only a transport or server fault is thrown here, so a policy refusal reaches the
+      // caller as data and can be rendered rather than surfaced as a stack trace.
+      if (!res.ok) throw new Error(`write tool returned HTTP ${res.status}`);
+      return await res.json();
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        log?.(`write tool timed out after ${timeoutMs}ms`);
+        throw new Error(`write tool timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Mock write tool: reports what would happen without an IRIS instance.
+ *
+ * Tracks a pool size in memory so `apply` then `apply` gives `applied` then `no_change`, matching
+ * the real tool's idempotency. A mock that returned `applied` twice would let Dev C build an
+ * approve button that never exercises the double-click path -- which a demo WILL hit.
+ */
+export function mockResolveTool(initialPoolSize = 1): ResolveDeps['callTool'] {
+  let pool = initialPoolSize;
+  return async (action, dryRun) => {
+    const before = pool;
+    const reversal = { host: action.host, size: before, capturedFrom: 'mock' };
+    if (action.size < 2 || action.size > 8) {
+      return {
+        outcome: 'refused',
+        before: { poolSize: before },
+        after: null,
+        refusal: { code: 'out_of_bounds', detail: 'size must be an integer between 2 and 8' },
+      };
+    }
+    if (before === action.size) {
+      return { outcome: 'no_change', before: { poolSize: before }, after: { poolSize: before }, reversal };
+    }
+    if (dryRun) {
+      return { outcome: 'previewed', before: { poolSize: before }, after: { poolSize: action.size }, reversal };
+    }
+    pool = action.size;
+    return { outcome: 'applied', before: { poolSize: before }, after: { poolSize: pool }, reversal };
   };
 }

--- a/services/detection-engine/src/detect/agents.ts
+++ b/services/detection-engine/src/detect/agents.ts
@@ -186,24 +186,47 @@ export function liveResolveTool(
  */
 export function mockResolveTool(initialPoolSize = 1): ResolveDeps['callTool'] {
   let pool = initialPoolSize;
+  let auditSeq = 0;
   return async (action, dryRun) => {
     const before = pool;
     const reversal = { host: action.host, size: before, capturedFrom: 'mock' };
+    // A §8 audit block on every mock reply, with `source: "mock"` -- which is the field that keeps
+    // it honest. Omitting audit here would let Dev C build the approve flow against responses with
+    // no attribution and then meet it for the first time against a live production. Emitting it
+    // with `source: "live"` would be worse: an audit entry claiming to be real.
+    auditSeq += 1;
+    const audit = {
+      auditId: `mock-audit-${auditSeq}`,
+      actor: 'mock',
+      role: 'Guardian_Resolve',
+      tool: dryRun ? 'get_pool_size' : 'set_pool_size',
+      recordedAt: '2026-08-19T00:00:00Z',
+      source: 'mock',
+    };
     if (action.size < 2 || action.size > 8) {
       return {
         outcome: 'refused',
         before: { poolSize: before },
         after: null,
-        refusal: { code: 'out_of_bounds', detail: 'size must be an integer between 2 and 8' },
+        // Contract §5 field names, matching the real tool exactly -- a mock that emitted
+        // `{code, detail}` would let Dev C build a banner against fields the live path does not
+        // send, which is how a demo fails only when it goes live.
+        refusal: {
+          reason: 'out_of_bounds',
+          message: 'size must be an integer between 2 and 8',
+          checkedBy: 'iris',
+          bounds: { min: 2, max: 8 },
+        },
+        audit,
       };
     }
     if (before === action.size) {
-      return { outcome: 'no_change', before: { poolSize: before }, after: { poolSize: before }, reversal };
+      return { outcome: 'no_change', before: { poolSize: before }, after: { poolSize: before }, reversal, audit };
     }
     if (dryRun) {
-      return { outcome: 'previewed', before: { poolSize: before }, after: { poolSize: action.size }, reversal };
+      return { outcome: 'previewed', before: { poolSize: before }, after: { poolSize: action.size }, reversal, audit };
     }
     pool = action.size;
-    return { outcome: 'applied', before: { poolSize: before }, after: { poolSize: pool }, reversal };
+    return { outcome: 'applied', before: { poolSize: before }, after: { poolSize: pool }, reversal, audit };
   };
 }

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -1,0 +1,341 @@
+/**
+ * AI Detective orchestration — the WHY stage.
+ *
+ * Implements `contracts/investigation-api.md`. That contract is authoritative; where this file and
+ * it disagree, the contract is right and this is a bug.
+ *
+ * WE ORCHESTRATE, WE DO NOT REASON. The narrative comes from an AI Hub agent running inside IRIS.
+ * This module builds a request from measured values, calls the agent, validates what comes back,
+ * and serves it. It does not generate root causes, does not summarise them, and does not fill gaps
+ * — `services/detection-engine/CLAUDE.md` §1.1 draws that line, and it is the reason no LLM key
+ * reaches this service.
+ *
+ * NEVER INVENT AN EXPLANATION. That is the single rule this file exists to enforce. An investigation
+ * that cannot be produced returns `state: "unavailable"` with `rootCause: null` — not a plausible
+ * guess, not a generic "the host may be slow". A fabricated root cause is worse than no root cause,
+ * because a human approves a production write on the strength of it.
+ */
+
+import type { Finding, Host } from '../types/healthscan.ts';
+import type { HostProjection } from './earlywarning.ts';
+
+/** Where the served content came from. Contract §3.1. */
+export type InvestigationSource = 'agent' | 'cache' | 'canned' | 'none';
+
+/** Contract §4.1. */
+export type InvestigationState = 'complete' | 'degraded' | 'unavailable';
+
+export interface EvidenceItem {
+  label: string;
+  detail: string;
+  /** How this bullet was obtained. `llm` means the model asserted it — see §3.2. */
+  source: 'mcp_tool' | 'snapshot' | 'llm';
+  tool: string | null;
+}
+
+/**
+ * The action, and it is EXACTLY three keys.
+ *
+ * `resolve-api.md` §1.1 refuses unknown keys inside `action`, so anything advisory has to be a
+ * sibling rather than a member. Getting this wrong would make every recommendation
+ * `malformed_request` at the resolve endpoint and force a translation layer that contract
+ * explicitly warns against.
+ */
+export interface ResolveAction {
+  type: 'set_pool_size';
+  host: string;
+  size: number;
+}
+
+export interface RecommendedAction {
+  action: ResolveAction;
+  currentValue: number | null;
+  bounds: { min: number; max: number };
+  reversible: boolean;
+  requiresApproval: boolean;
+  summary: string;
+}
+
+export interface InvestigationResponse {
+  requestId: string;
+  findingId: string;
+  state: InvestigationState;
+  source: InvestigationSource;
+  investigatedAt: string;
+  rootCause: string | null;
+  evidence: EvidenceItem[];
+  confidence: number | null;
+  recommendedAction: RecommendedAction | null;
+  diagnostics: {
+    model: string | null;
+    toolCalls: number | null;
+    durationMs: number | null;
+    note: string | null;
+  };
+}
+
+/** What the engine sends the agent. Contract §2.2. */
+interface InvestigationRequest {
+  requestId: string;
+  requestedAt: string;
+  finding: Finding;
+  snapshot: Record<string, unknown>;
+  trend: Record<string, unknown> | null;
+}
+
+export interface InvestigateDeps {
+  /**
+   * Calls the AI Hub agent. Injected so the endpoint is testable without an LLM, and so the
+   * mock and the live path are the same code path rather than two branches that drift.
+   */
+  callAgent(request: InvestigationRequest, timeoutMs: number): Promise<unknown>;
+  /**
+   * Which source `callAgent` represents. REQUIRED, and not inferable here: the orchestrator cannot
+   * tell a canned response from a real one, and defaulting to 'agent' would publish a mocked
+   * investigation as a real one -- the same defect class as a projection published as a
+   * measurement. The caller knows which it wired, so the caller states it.
+   */
+  source: Extract<InvestigationSource, 'agent' | 'canned'>;
+  now?: () => number;
+  log?: (message: string) => void;
+}
+
+/** §4.2. Hard timeout; the soft one is the agent's own iteration budget. */
+const TIMEOUT_MS = 30_000;
+
+/** §3.3. Must match resolve-api.md §3 exactly — an out-of-bounds recommendation is unusable. */
+const BOUNDS = { min: 2, max: 8 } as const;
+
+function isoSeconds(ms: number): string {
+  return `${new Date(Math.round(ms / 1000) * 1000).toISOString().slice(0, 19)}Z`;
+}
+
+/**
+ * The metric and configuration fields the agent may see — an ALLOWLIST, built field by field.
+ *
+ * THIS IS THE DATA BOUNDARY IN CODE, not a comment about one. Root `CLAUDE.md` §2.1 makes it a rule
+ * that metrics and configuration only ever leave the instance: never message content, never PHI.
+ * Passing the host object through with a spread would satisfy today's shape and silently forward
+ * whatever a future field carries — so every value is named. Adding a field here is a decision, and
+ * a decision is the point.
+ */
+function buildSnapshot(host: Host, projection: HostProjection | undefined): Record<string, unknown> {
+  return {
+    host: host.host,
+    type: host.type,
+    status: host.status,
+    queued: host.queued,
+    messagesPerSec: host.messagesPerSec,
+    errored: host.errored,
+    avgProcessingTime: host.avgProcessingTime,
+    avgQueueingTime: host.avgQueueingTime,
+    lastActivity: host.lastActivity,
+    // From Early Warning, and measured rather than forecast: the threshold and current depth are
+    // observations. The projection itself is deliberately NOT sent -- see buildTrend.
+    thresholdValue: projection?.threshold?.value ?? null,
+    thresholdBasis: projection?.threshold?.basis ?? null,
+  };
+}
+
+/**
+ * Trend context, and the reason it is not called `projection`.
+ *
+ * Early Warning publishes `projection: null` with reason `already_crossed` exactly when a queue has
+ * crossed its threshold — which is the state that made `queue_buildup` fire, i.e. the only condition
+ * an investigation is ever requested for. So reusing that object would hand the agent `null` every
+ * single time and the "queue slope positive" evidence bullet would be unobtainable.
+ *
+ * Same field names and units as `earlywarning-api.md`, with the forecast framing dropped:
+ * `thresholdCrossed: true` and `secondsToThreshold: null` is the normal case here, not an error.
+ */
+function buildTrend(projection: HostProjection | undefined): Record<string, unknown> | null {
+  if (projection === undefined) return null;
+  const slope = projection.projection?.slope ?? null;
+  const threshold = projection.threshold?.value ?? null;
+  if (slope === null && threshold === null) return null;
+  return {
+    metric: projection.metric,
+    slope,
+    slopeUnit: projection.projection?.slopeUnit ?? 'items/minute',
+    thresholdValue: threshold,
+    thresholdCrossed:
+      projection.currentValue !== null && threshold !== null
+        ? projection.currentValue >= threshold
+        : null,
+    secondsToThreshold: projection.projection?.secondsToThreshold ?? null,
+  };
+}
+
+/** §4.1 + §4.4. A response we cannot validate is a failure, not a partial success. */
+function unavailable(
+  requestId: string,
+  findingId: string,
+  at: number,
+  note: string,
+): InvestigationResponse {
+  return {
+    requestId,
+    findingId,
+    state: 'unavailable',
+    source: 'none',
+    investigatedAt: isoSeconds(at),
+    // NULL, not a placeholder narrative. The whole point of the state.
+    rootCause: null,
+    evidence: [],
+    confidence: null,
+    recommendedAction: null,
+    diagnostics: { model: null, toolCalls: null, durationMs: null, note },
+  };
+}
+
+/**
+ * Validate the agent's reply into the published shape, or return null to signal failure.
+ *
+ * STRICT ON THE ACTION, LENIENT ON THE PROSE. `rootCause` is free text by design and we render it
+ * verbatim, so there is nothing to validate beyond "is it a non-empty string". `recommendedAction`
+ * is the input to a live production write that a human approves, so every field is checked: a wrong
+ * `size`, a wrong `host`, or an unknown `type` must be dropped rather than forwarded.
+ *
+ * A dropped action does NOT invalidate the investigation. The narrative can be useful while the
+ * recommendation is unusable, and `recommendedAction: null` on a `complete` investigation is legal
+ * (§3.1). Silently forwarding a malformed action would be the worse failure.
+ */
+function parseAgentReply(
+  raw: unknown,
+  finding: Finding,
+  currentPoolSize: number | null,
+): { rootCause: string; evidence: EvidenceItem[]; confidence: number | null; action: RecommendedAction | null } | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+
+  const rootCause = obj['rootCause'];
+  if (typeof rootCause !== 'string' || rootCause.trim() === '') return null;
+
+  const evidence: EvidenceItem[] = [];
+  if (Array.isArray(obj['evidence'])) {
+    for (const item of obj['evidence']) {
+      if (typeof item !== 'object' || item === null) continue;
+      const e = item as Record<string, unknown>;
+      const label = typeof e['label'] === 'string' ? e['label'] : null;
+      const detail = typeof e['detail'] === 'string' ? e['detail'] : null;
+      if (label === null || detail === null) continue;
+      // DEFAULTS TO 'llm', the least trusted source. An agent that omits the field is asserting
+      // rather than citing, and treating an unlabelled bullet as measured would let a model's
+      // guess appear next to a tool reading with equal standing -- which is what a human approving
+      // a write is looking at.
+      const source =
+        e['source'] === 'mcp_tool' || e['source'] === 'snapshot' ? e['source'] : 'llm';
+      evidence.push({
+        label,
+        detail,
+        source,
+        tool: typeof e['tool'] === 'string' ? e['tool'] : null,
+      });
+    }
+  }
+
+  let confidence: number | null = null;
+  const rawConfidence = obj['confidence'];
+  if (typeof rawConfidence === 'number' && Number.isFinite(rawConfidence)) {
+    // Clamped, not rejected: a model returning 1.2 meant "very confident", and discarding the
+    // whole investigation over it would be worse than bounding it. Out-of-range is a model quirk,
+    // not a corrupt response.
+    confidence = Math.min(1, Math.max(0, rawConfidence));
+  }
+
+  let action: RecommendedAction | null = null;
+  const rawAction = obj['recommendedAction'];
+  if (typeof rawAction === 'object' && rawAction !== null) {
+    const ra = rawAction as Record<string, unknown>;
+    const inner = (ra['action'] ?? ra) as Record<string, unknown>;
+    const type = inner['type'];
+    const host = inner['host'];
+    const size = inner['size'];
+    const sizeOk =
+      typeof size === 'number' && Number.isInteger(size) && size >= BOUNDS.min && size <= BOUNDS.max;
+    // host must match the FINDING's host. An agent recommending a change to a different host than
+    // the one under investigation is a reasoning failure, and forwarding it would hand a human an
+    // approve button for something they did not ask about.
+    if (type === 'set_pool_size' && host === finding.host && sizeOk) {
+      action = {
+        action: { type: 'set_pool_size', host: finding.host, size: size as number },
+        currentValue: currentPoolSize,
+        bounds: { ...BOUNDS },
+        reversible: true,
+        requiresApproval: true,
+        summary: `increase ${finding.host} pool ${currentPoolSize ?? '?'} -> ${size as number}`,
+      };
+    }
+  }
+
+  return { rootCause, evidence, confidence, action };
+}
+
+/**
+ * Investigate one finding.
+ *
+ * Returns a valid response in every case, including failure — the contract serves 200 with a
+ * labelled state rather than an error, because a blanked panel is worse on stage than a panel
+ * saying "could not investigate" (§5).
+ */
+export async function investigate(
+  finding: Finding,
+  host: Host,
+  projection: HostProjection | undefined,
+  currentPoolSize: number | null,
+  deps: InvestigateDeps,
+): Promise<InvestigationResponse> {
+  const now = deps.now ?? Date.now;
+  const started = now();
+  // Deterministic and correlatable: this id appears in the AI Hub audit entries for the tool calls
+  // this investigation makes, which is how a reviewer ties an action back to the reasoning.
+  const requestId = `inv-${finding.id}-${started}`;
+
+  const request: InvestigationRequest = {
+    requestId,
+    requestedAt: isoSeconds(started),
+    finding,
+    snapshot: buildSnapshot(host, projection),
+    trend: buildTrend(projection),
+  };
+
+  let raw: unknown;
+  try {
+    raw = await deps.callAgent(request, TIMEOUT_MS);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.log?.(`investigation ${requestId} failed: ${message}`);
+    return unavailable(requestId, finding.id, now(), `agent call failed: ${message}`);
+  }
+
+  const parsed = parseAgentReply(raw, finding, currentPoolSize);
+  if (parsed === null) {
+    // §4.4: a malformed reply is a FAILURE, not a partial success. Serving half a parsed
+    // investigation would put unvalidated model output in front of an approve button.
+    deps.log?.(`investigation ${requestId}: agent reply did not validate`);
+    return unavailable(requestId, finding.id, now(), 'agent reply did not match the contract');
+  }
+
+  const finished = now();
+  return {
+    requestId,
+    findingId: finding.id,
+    state: 'complete',
+    source: deps.source,
+    investigatedAt: isoSeconds(finished),
+    rootCause: parsed.rootCause,
+    evidence: parsed.evidence,
+    confidence: parsed.confidence,
+    recommendedAction: parsed.action,
+    diagnostics: {
+      model: typeof (raw as Record<string, unknown>)['model'] === 'string'
+        ? ((raw as Record<string, unknown>)['model'] as string)
+        : null,
+      toolCalls: typeof (raw as Record<string, unknown>)['toolCalls'] === 'number'
+        ? ((raw as Record<string, unknown>)['toolCalls'] as number)
+        : null,
+      durationMs: finished - started,
+      note: null,
+    },
+  };
+}

--- a/services/detection-engine/src/detect/resolve.ts
+++ b/services/detection-engine/src/detect/resolve.ts
@@ -1,0 +1,258 @@
+/**
+ * Smart Resolve orchestration — the FIX stage.
+ *
+ * Implements `contracts/resolve-api.md`. That contract is authoritative; where this file and it
+ * disagree, the contract is right and this is a bug.
+ *
+ * THIS SERVICE DOES NOT MUTATE THE PRODUCTION. It validates a request, forwards it to the governed
+ * MCP write tool in IRIS, and returns what came back. The write happens behind RBAC, inside a
+ * runtime that authorises and audits every tool call — `services/detection-engine/CLAUDE.md` §1.1
+ * draws that line, and it is why this module holds no `Ens.*` call and no credential.
+ *
+ * SO THE VALIDATION HERE IS A CONVENIENCE, NOT THE SAFETY BOUNDARY. Everything checked below is
+ * checked again in `Tools.Resolve`, which is the only place that can actually refuse. Validating
+ * early gives a caller a fast, specific answer; it does not make this service trusted. If these two
+ * ever disagree, the tool wins — it is the one holding the production.
+ */
+
+import type { ResolveAction } from './investigate.ts';
+
+/** Contract §1.4. Closed set. */
+export type ResolveOutcome = 'previewed' | 'applied' | 'no_change' | 'refused' | 'failed';
+
+export type ResolveMode = 'dry_run' | 'apply';
+
+export interface ResolveRequest {
+  requestId?: string;
+  mode: ResolveMode;
+  action: ResolveAction;
+  origin?: { findingId?: string; investigationId?: string };
+  precondition?: { poolSize?: number };
+  requestedBy?: string;
+}
+
+export interface ResolveResponse {
+  resolveId: string;
+  requestId: string | null;
+  mode: ResolveMode;
+  outcome: ResolveOutcome;
+  action: ResolveAction | null;
+  before: { poolSize: number } | null;
+  after: { poolSize: number } | null;
+  reversal: { host: string; size: number; capturedFrom: string } | null;
+  refusal: { code: string; detail: string } | null;
+  failure: { stage: string; message: string; liveStateVerified: boolean } | null;
+  confirmation: {
+    status: string;
+    findingId: string | null;
+    observeVia: string;
+    expectedWithinSeconds: number;
+    directEvidence: boolean;
+  } | null;
+  requestedAt: string;
+  completedAt: string;
+}
+
+export interface ResolveDeps {
+  /** Invokes the governed MCP write tool in IRIS. Injected so the endpoint is testable. */
+  callTool(action: ResolveAction, dryRun: boolean, timeoutMs: number): Promise<unknown>;
+  now?: () => number;
+  log?: (message: string) => void;
+}
+
+const TIMEOUT_MS = 30_000;
+
+/**
+ * Confirmation is ASYNCHRONOUS and the contract says so (§7).
+ *
+ * The write returns as soon as the production is updated, but the condition clearing is observed
+ * through the existing findings path on the next poll — the queue has to actually drain. Claiming
+ * "resolved" in this response would be claiming an outcome we have not seen. So the response says
+ * where to look and roughly when, and `directEvidence: false` states plainly that this is not it.
+ */
+const EXPECTED_CLEAR_SECONDS = 120;
+
+function isoSeconds(ms: number): string {
+  return `${new Date(Math.round(ms / 1000) * 1000).toISOString().slice(0, 19)}Z`;
+}
+
+/**
+ * Validate the request into a typed shape, or throw with a `bad request:` prefix.
+ *
+ * REJECTS UNKNOWN KEYS INSIDE `action`, matching §1.1. That strictness is the point rather than
+ * pedantry: `action` is transcribed into a production write, so a tolerated extra key is a field
+ * somebody believes is being honoured when it is being dropped.
+ */
+export function parseResolveRequest(body: unknown): ResolveRequest {
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('bad request: body must be an object');
+  }
+  const b = body as Record<string, unknown>;
+
+  // REQUIRED, with no default. A missing mode must not become `apply` -- that would turn a caller's
+  // omission into a live production write. It must not silently become `dry_run` either, because
+  // then an approval would preview and the operator would wonder why nothing happened.
+  const mode = b['mode'];
+  if (mode !== 'dry_run' && mode !== 'apply') {
+    throw new Error(`bad request: mode must be "dry_run" or "apply", got ${JSON.stringify(mode)}`);
+  }
+
+  const rawAction = b['action'];
+  if (typeof rawAction !== 'object' || rawAction === null) {
+    throw new Error('bad request: action must be an object');
+  }
+  const a = rawAction as Record<string, unknown>;
+  const extra = Object.keys(a).filter((k) => k !== 'type' && k !== 'host' && k !== 'size');
+  if (extra.length > 0) {
+    throw new Error(`bad request: action carries unknown key(s) [${extra.join(', ')}]`);
+  }
+  if (a['type'] !== 'set_pool_size') {
+    throw new Error(`bad request: action.type must be "set_pool_size", got ${JSON.stringify(a['type'])}`);
+  }
+  if (typeof a['host'] !== 'string' || a['host'] === '') {
+    throw new Error('bad request: action.host must be a non-empty string');
+  }
+  if (typeof a['size'] !== 'number' || !Number.isInteger(a['size'])) {
+    throw new Error('bad request: action.size must be an integer');
+  }
+
+  const out: ResolveRequest = {
+    mode,
+    action: { type: 'set_pool_size', host: a['host'], size: a['size'] },
+  };
+  if (typeof b['requestId'] === 'string') out.requestId = b['requestId'];
+  if (typeof b['requestedBy'] === 'string') out.requestedBy = b['requestedBy'];
+  if (typeof b['origin'] === 'object' && b['origin'] !== null) {
+    const o = b['origin'] as Record<string, unknown>;
+    out.origin = {};
+    if (typeof o['findingId'] === 'string') out.origin.findingId = o['findingId'];
+    if (typeof o['investigationId'] === 'string') out.origin.investigationId = o['investigationId'];
+  }
+  if (typeof b['precondition'] === 'object' && b['precondition'] !== null) {
+    const p = b['precondition'] as Record<string, unknown>;
+    if (typeof p['poolSize'] === 'number') out.precondition = { poolSize: p['poolSize'] };
+  }
+  return out;
+}
+
+/** Read a `{poolSize: n}` shape out of the tool's reply, tolerating absence. */
+function poolShape(value: unknown): { poolSize: number } | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const p = (value as Record<string, unknown>)['poolSize'];
+  return typeof p === 'number' ? { poolSize: p } : null;
+}
+
+/**
+ * Apply or preview a resolve action by calling the governed tool.
+ *
+ * Returns a valid response for every outcome including refusal and failure. A refusal is a NORMAL
+ * response, not an error (§5.2): the caller asked something the policy forbids, which is
+ * information, and a 500 would make it indistinguishable from the production being broken.
+ */
+export async function resolve(
+  request: ResolveRequest,
+  deps: ResolveDeps,
+): Promise<ResolveResponse> {
+  const now = deps.now ?? Date.now;
+  const started = now();
+  const dryRun = request.mode === 'dry_run';
+
+  const base = {
+    resolveId: `res-${request.action.host.replace(/\s+/g, '-')}-${started}`,
+    requestId: request.requestId ?? null,
+    mode: request.mode,
+    requestedAt: isoSeconds(started),
+  };
+
+  let raw: unknown;
+  try {
+    raw = await deps.callTool(request.action, dryRun, TIMEOUT_MS);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.log?.(`resolve ${base.resolveId} failed: ${message}`);
+    return {
+      ...base,
+      outcome: 'failed',
+      action: request.action,
+      before: null,
+      after: null,
+      reversal: null,
+      refusal: null,
+      // liveStateVerified FALSE, and this is the honest and important part: the call did not come
+      // back, so we do not know whether the production changed. Claiming it did not would be a
+      // guess, and a reader deciding whether to retry needs to know we cannot tell.
+      failure: { stage: 'tool_call', message, liveStateVerified: false },
+      confirmation: null,
+      completedAt: isoSeconds(now()),
+    };
+  }
+
+  const r = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+  const outcome = r['outcome'];
+  const validOutcomes = ['previewed', 'applied', 'no_change', 'refused', 'failed'];
+  if (typeof outcome !== 'string' || !validOutcomes.includes(outcome)) {
+    // The tool answered with something we cannot classify. Reported as `failed` with
+    // liveStateVerified false rather than guessed at: an unrecognised outcome from the one
+    // component that can mutate a production is exactly when not to assume.
+    deps.log?.(`resolve ${base.resolveId}: tool returned unrecognised outcome ${String(outcome)}`);
+    return {
+      ...base,
+      outcome: 'failed',
+      action: request.action,
+      before: poolShape(r['before']),
+      after: poolShape(r['after']),
+      reversal: null,
+      refusal: null,
+      failure: {
+        stage: 'tool_reply',
+        message: `unrecognised outcome from the write tool: ${JSON.stringify(outcome)}`,
+        liveStateVerified: false,
+      },
+      confirmation: null,
+      completedAt: isoSeconds(now()),
+    };
+  }
+
+  const refusal =
+    typeof r['refusal'] === 'object' && r['refusal'] !== null
+      ? (r['refusal'] as { code: string; detail: string })
+      : null;
+  const reversal =
+    typeof r['reversal'] === 'object' && r['reversal'] !== null
+      ? (r['reversal'] as { host: string; size: number; capturedFrom: string })
+      : null;
+
+  return {
+    ...base,
+    outcome: outcome as ResolveOutcome,
+    action: request.action,
+    before: poolShape(r['before']),
+    after: poolShape(r['after']),
+    reversal,
+    refusal,
+    failure:
+      outcome === 'failed' && typeof r['failure'] === 'object' && r['failure'] !== null
+        ? {
+            stage: String((r['failure'] as Record<string, unknown>)['stage'] ?? 'unknown'),
+            message: String((r['failure'] as Record<string, unknown>)['message'] ?? ''),
+            liveStateVerified: false,
+          }
+        : null,
+    // Only an APPLIED change has something to confirm. A preview changed nothing, a refusal was
+    // rejected, and a no_change was already true -- attaching a confirmation to any of those would
+    // tell a UI to watch for a clearance that is never coming.
+    confirmation:
+      outcome === 'applied'
+        ? {
+            status: 'pending',
+            findingId: request.origin?.findingId ?? null,
+            observeVia: 'GET /api/healthscan/findings',
+            expectedWithinSeconds: EXPECTED_CLEAR_SECONDS,
+            // FALSE: this response is evidence the write landed, not evidence the problem cleared.
+            // The queue has to drain, which is observed on a later poll (§7).
+            directEvidence: false,
+          }
+        : null,
+    completedAt: isoSeconds(now()),
+  };
+}

--- a/services/detection-engine/src/detect/resolve.ts
+++ b/services/detection-engine/src/detect/resolve.ts
@@ -40,7 +40,21 @@ export interface ResolveResponse {
   before: { poolSize: number } | null;
   after: { poolSize: number } | null;
   reversal: { host: string; size: number; capturedFrom: string } | null;
-  refusal: { code: string; detail: string } | null;
+  /**
+   * Contract §5: `reason`, `message`, `checkedBy` -- NOT `code`/`detail`.
+   *
+   * This said `{code, detail}` until 2026-08-19, which is a field-name drift from a ratified
+   * contract in the one object Dev C renders when Approve is refused: §5 instructs consumers to
+   * "render `refusal.message` verbatim" for an unrecognised reason, so the banner would have read
+   * `undefined`. Caught in review on #92 (@kskubach) rather than by a test, because nothing here
+   * validated the shape -- the type was a cast, and a cast asserts rather than checks.
+   *
+   * `reason` is a CLOSED set in §5's table. Typed as a string anyway: an unrecognised reason must
+   * reach the UI to be rendered rather than be dropped by a narrow union, which is exactly what §5
+   * asks for. The closed set is documented in the contract; enforcing it here would turn a new
+   * refusal code into a swallowed one.
+   */
+  refusal: { reason: string; message: string; checkedBy: string; bounds?: { min: number; max: number } } | null;
   failure: { stage: string; message: string; liveStateVerified: boolean } | null;
   confirmation: {
     status: string;
@@ -48,6 +62,27 @@ export interface ResolveResponse {
     observeVia: string;
     expectedWithinSeconds: number;
     directEvidence: boolean;
+  } | null;
+  /**
+   * Contract §8. PRESENT ON EVERY RESPONSE -- applies, refusals and dry-runs alike.
+   *
+   * Was missing entirely until 2026-08-19: the dispatcher returned it and this module dropped it,
+   * so every response claimed §8 compliance while carrying no attribution at all. §8's opening line
+   * is "the contract does not permit an unattributed write", and MVP 2 §2.2's whole reason for
+   * putting the write tool in IRIS is that "the AI changed a production setting" be a reviewable,
+   * attributable event. Dropping this field defeated that while looking correct.
+   *
+   * `null` is legal and MEANINGFUL rather than a blank: it means the record could not be written,
+   * and §8 makes that `failed` / verify on an apply rather than a silent success.
+   */
+  audit: {
+    auditId: string | null;
+    actor: string | null;
+    role: string | null;
+    requestedBy: string | null;
+    tool: string | null;
+    recordedAt: string | null;
+    source: string | null;
   } | null;
   requestedAt: string;
   completedAt: string;
@@ -135,6 +170,72 @@ export function parseResolveRequest(body: unknown): ResolveRequest {
   return out;
 }
 
+/**
+ * Read the contract's refusal object out of the tool's reply.
+ *
+ * Contract §5 field names, and `message` is the load-bearing one: Dev C renders it verbatim for
+ * any reason they do not recognise, so losing it turns an informative refusal into a blank banner.
+ * A refusal with no readable message still returns an object rather than null -- `outcome:
+ * "refused"` with `refusal: null` would tell the UI something was refused for no stated reason,
+ * which is worse than a generic sentence.
+ */
+function parseRefusal(value: unknown): ResolveResponse['refusal'] {
+  if (typeof value !== 'object' || value === null) return null;
+  const r = value as Record<string, unknown>;
+  const reason = typeof r['reason'] === 'string' && r['reason'] !== '' ? r['reason'] : 'unknown';
+  const message =
+    typeof r['message'] === 'string' && r['message'] !== ''
+      ? r['message']
+      : `refused (${reason})`;
+  // `checkedBy` says WHICH component refused, which matters when the answer is "not the one you
+  // are looking at": a refusal from `iris` is the production's policy, not this service's
+  // validation. Defaults to `iris` because that is the only thing that can refuse a real write.
+  const checkedBy = typeof r['checkedBy'] === 'string' && r['checkedBy'] !== '' ? r['checkedBy'] : 'iris';
+  const out: NonNullable<ResolveResponse['refusal']> = { reason, message, checkedBy };
+  // §5 carries `bounds` on an `out_of_bounds` refusal so the UI can state the range without
+  // hardcoding it. Forwarded when present, never synthesised: a guessed range that disagreed with
+  // the tool's would be worse than none.
+  const bounds = r['bounds'];
+  if (typeof bounds === 'object' && bounds !== null) {
+    const b = bounds as Record<string, unknown>;
+    if (typeof b['min'] === 'number' && typeof b['max'] === 'number') {
+      out.bounds = { min: b['min'], max: b['max'] };
+    }
+  }
+  return out;
+}
+
+/**
+ * Read the §8 audit block out of the tool's reply.
+ *
+ * FIELD BY FIELD, and every field defaults to `null` rather than to a placeholder. An audit record
+ * is the one object in this response where a plausible-looking value is worse than an absent one:
+ * a fabricated `actor` would make the log a record of what we assumed rather than of who acted,
+ * which §8 calls "worse than no audit log because it is trusted".
+ *
+ * `requestedBy` comes from the REQUEST, not from the tool -- §8 is explicit that it is "a string a
+ * browser typed" and is recorded next to `actor`, never in place of it. So it is threaded in here
+ * rather than read from the reply, which is also why a caller cannot name itself as the actor.
+ */
+function parseAudit(value: unknown, requestedBy: string | null): ResolveResponse['audit'] {
+  if (typeof value !== 'object' || value === null) return null;
+  const a = value as Record<string, unknown>;
+  const str = (key: string): string | null => (typeof a[key] === 'string' && a[key] !== '' ? (a[key] as string) : null);
+  const auditId = str('auditId');
+  // No handle at all means nothing was written, which is a null audit rather than an object full of
+  // nulls -- the distinction the engine's caller acts on.
+  if (auditId === null) return null;
+  return {
+    auditId,
+    actor: str('actor'),
+    role: str('role'),
+    requestedBy,
+    tool: str('tool'),
+    recordedAt: str('recordedAt'),
+    source: str('source'),
+  };
+}
+
 /** Read a `{poolSize: n}` shape out of the tool's reply, tolerating absence. */
 function poolShape(value: unknown): { poolSize: number } | null {
   if (typeof value !== 'object' || value === null) return null;
@@ -183,6 +284,9 @@ export async function resolve(
       // guess, and a reader deciding whether to retry needs to know we cannot tell.
       failure: { stage: 'tool_call', message, liveStateVerified: false },
       confirmation: null,
+      // NULL, and this is the honest reading: the call did not come back, so we do not know whether
+      // an audit row exists. Claiming one we cannot name would be the fabrication §8 warns about.
+      audit: null,
       completedAt: isoSeconds(now()),
     };
   }
@@ -209,14 +313,19 @@ export async function resolve(
         liveStateVerified: false,
       },
       confirmation: null,
+      // Forwarded even here. The reply was unreadable as an OUTCOME, but if it named an audit
+      // handle that handle is still the pointer to what actually happened -- which is exactly what
+      // someone investigating an unrecognised outcome needs.
+      audit: parseAudit(r['audit'], request.requestedBy ?? null),
       completedAt: isoSeconds(now()),
     };
   }
 
-  const refusal =
-    typeof r['refusal'] === 'object' && r['refusal'] !== null
-      ? (r['refusal'] as { code: string; detail: string })
-      : null;
+  // READ FIELD BY FIELD, not cast. The previous version cast the tool's object straight to a
+  // typed shape, which is why a field-name mismatch was invisible: a cast asserts the shape and
+  // checks nothing, so `{code, detail}` type-checked cleanly as `{reason, message}` and produced
+  // `undefined` at the UI. Reading each field is what makes a drift surface here instead of there.
+  const refusal = parseRefusal(r['refusal']);
   const reversal =
     typeof r['reversal'] === 'object' && r['reversal'] !== null
       ? (r['reversal'] as { host: string; size: number; capturedFrom: string })
@@ -253,6 +362,7 @@ export async function resolve(
             directEvidence: false,
           }
         : null,
+    audit: parseAudit(r['audit'], request.requestedBy ?? null),
     completedAt: isoSeconds(now()),
   };
 }

--- a/services/detection-engine/src/index.ts
+++ b/services/detection-engine/src/index.ts
@@ -29,7 +29,11 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createFindingsServer } from './api/server.ts';
 import { investigate } from './detect/investigate.ts';
-import { liveAgent, mockAgent } from './detect/agents.ts';
+import { liveAgent, mockAgent, liveResolveTool, mockResolveTool } from './detect/agents.ts';
+// Aliased: `resolve` is already node:path's, used for every path in this file. Importing ours
+// under the same name compiles as a duplicate-identifier error rather than shadowing -- but had it
+// shadowed, `resolve(serviceRoot, 'thresholds.json')` would have called the write orchestrator.
+import { parseResolveRequest, resolve as runResolve } from './detect/resolve.ts';
 import { DEFAULT_POLL_INTERVAL_MS, ThresholdStore } from './config/thresholds.ts';
 import { DetectionEngine } from './detect/engine.ts';
 import { HttpProxyClient } from './proxy/client.ts';
@@ -95,9 +99,22 @@ async function poll(): Promise<void> {
 const AGENT_MODE = process.env['AGENT_MODE'] ?? 'mock';
 const IRIS_BASE_URL = process.env['IRIS_BASE_URL'] ?? 'http://localhost:52773';
 
+// The engine's own IRIS credentials, for the dispatcher's web application. The engine holds these
+// because the tool is RBAC-gated; it holds NO LLM key, which stays in the AI Hub wallet.
+const IRIS_USER = process.env['IRIS_USER'] ?? 'superuser';
+const IRIS_PASS = process.env['IRIS_PASS'] ?? 'SYS';
+
 const agentSource = AGENT_MODE === 'live' ? 'agent' : 'canned';
 const callAgent =
-  AGENT_MODE === 'live' ? liveAgent(IRIS_BASE_URL, (m) => console.error(m)) : mockAgent();
+  AGENT_MODE === 'live'
+    ? liveAgent(IRIS_BASE_URL, IRIS_USER, IRIS_PASS, (m: string) => console.error(m))
+    : mockAgent();
+// Same switch, separate caller: with AGENT_MODE=mock the resolve endpoint previews and applies
+// against an in-memory pool size, so Dev C can build the approve flow with no IRIS at all.
+const callTool =
+  AGENT_MODE === 'live'
+    ? liveResolveTool(IRIS_BASE_URL, IRIS_USER, IRIS_PASS, (m: string) => console.error(m))
+    : mockResolveTool();
 
 const server = createFindingsServer({
   port: PORT,
@@ -126,6 +143,11 @@ const server = createFindingsServer({
       log: (m) => console.error(m),
     });
   },
+  resolve: async (body) =>
+    // parseResolveRequest throws `bad request: ...` for anything malformed, which the server maps
+    // to 400. Validated here rather than inside resolve() so the endpoint answers a bad body
+    // without ever reaching the write tool.
+    runResolve(parseResolveRequest(body), { callTool, log: (m) => console.error(m) }),
 });
 
 server.listen(PORT, () => {

--- a/services/detection-engine/src/index.ts
+++ b/services/detection-engine/src/index.ts
@@ -28,6 +28,8 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createFindingsServer } from './api/server.ts';
+import { investigate } from './detect/investigate.ts';
+import { liveAgent, mockAgent } from './detect/agents.ts';
 import { DEFAULT_POLL_INTERVAL_MS, ThresholdStore } from './config/thresholds.ts';
 import { DetectionEngine } from './detect/engine.ts';
 import { HttpProxyClient } from './proxy/client.ts';
@@ -79,12 +81,62 @@ async function poll(): Promise<void> {
   }
 }
 
-const server = createFindingsServer({ port: PORT, snapshot: () => engine.snapshot() });
+/**
+ * AGENT_MODE selects the AI Detective backend, separately from PROXY_MODE.
+ *
+ * Two independent switches on purpose: the proxy and the agent fail independently, and the useful
+ * combination during development is live metrics with a canned investigation. Folding them into one
+ * flag would force a choice nobody wants -- either mock the metrics you have, or block on an LLM you
+ * do not.
+ *
+ * Defaults to `mock`, matching PROXY_MODE and ADR 0004: the engine must stand up and serve with
+ * nothing else running.
+ */
+const AGENT_MODE = process.env['AGENT_MODE'] ?? 'mock';
+const IRIS_BASE_URL = process.env['IRIS_BASE_URL'] ?? 'http://localhost:52773';
+
+const agentSource = AGENT_MODE === 'live' ? 'agent' : 'canned';
+const callAgent =
+  AGENT_MODE === 'live' ? liveAgent(IRIS_BASE_URL, (m) => console.error(m)) : mockAgent();
+
+const server = createFindingsServer({
+  port: PORT,
+  snapshot: () => engine.snapshot(),
+  log: (m) => console.error(m),
+  investigate: async (findingId) => {
+    const snap = engine.snapshot();
+    const finding = snap.findings.find((f) => f.id === findingId);
+    if (finding === undefined) {
+      // Deliberately an error rather than an `unavailable` investigation: an unknown id is the
+      // CALLER being wrong, and dressing it as "we could not investigate" would hide a bug in
+      // whatever built the request.
+      throw new Error(`bad request: no current finding with id ${findingId}`);
+    }
+    const host = snap.hosts.find((h) => h.host === finding.host);
+    if (host === undefined) {
+      throw new Error(`no host state for ${finding.host}`);
+    }
+    const projection = snap.projections.find((p) => p.host === finding.host);
+    // Pool size comes from the projection's own threshold basis where available; the authoritative
+    // read is get_pool_size, which the AGENT calls. Passing null rather than guessing keeps this
+    // service out of the business of reading production config.
+    return investigate(finding, host, projection, null, {
+      callAgent,
+      source: agentSource,
+      log: (m) => console.error(m),
+    });
+  },
+});
 
 server.listen(PORT, () => {
   console.error(
+    // agent=<mode> is in the startup line because a canned investigation is indistinguishable
+    // from a real one at a glance, and the operator most likely to be misled is the one reading
+    // logs during a demo. The response carries `source` for the same reason.
     `detection-engine listening on :${PORT} (proxy=${PROXY_MODE}` +
-      `${PROXY_MODE === 'live' ? ` ${PROXY_BASE_URL}` : ''}, poll=${POLL_INTERVAL_MS}ms)`,
+      `${PROXY_MODE === 'live' ? ` ${PROXY_BASE_URL}` : ''}` +
+      `, agent=${AGENT_MODE}${AGENT_MODE === 'live' ? ` ${IRIS_BASE_URL}` : ''}` +
+      `, poll=${POLL_INTERVAL_MS}ms)`,
   );
 });
 

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -191,6 +191,30 @@ describe('routing', () => {
     const res = await fetch(`${base}/api/healthscan/findings`, { method: 'POST' });
     assert.equal(res.status, 405);
   });
+
+  it('405s a GET to a POST-only route, in BOTH directions', async () => {
+    // The mirror of the test above, and it was missing -- which is how `GET /api/resolve` answered
+    // 404 for a real endpoint. Same defect as the POST-to-a-GET-route regression, in the other
+    // direction, and no test covered it because the suite only ever asked one way round.
+    //
+    // Asserted for both POST routes, not just one: the two are wired through different branches
+    // (investigate builds a handler, resolve passes one through), so covering one proves nothing
+    // about the other.
+    for (const path of ['/api/resolve', '/api/investigate']) {
+      const res = await fetch(`${base}${path}`);
+      assert.equal(res.status, 405, `GET ${path} should be 405`);
+      const body = (await res.json()) as { error: string };
+      // The message must name the METHOD as the problem. "no such endpoint" would send a reader
+      // looking for a missing route that is in fact present.
+      assert.match(body.error, /method GET not allowed/);
+    }
+  });
+
+  it('still 404s a GET to a path that is neither', async () => {
+    // The 405 above is only meaningful if a genuinely absent path is distinguishable.
+    const res = await fetch(`${base}/api/investigation`);
+    assert.equal(res.status, 404);
+  });
 });
 
 describe('faults', () => {

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -142,18 +142,31 @@ describe('headers', () => {
     );
   });
 
-  it('advertised-but-unrouted POST answers 405, not a CORS failure', async () => {
-    // POST is advertised before /api/investigate and /api/resolve exist. Pinning the
-    // consequence: the request REACHES the engine and gets a clear 405. A reader seeing 405
-    // knows the route is missing; a reader seeing a preflight failure learns nothing and looks
-    // in the wrong place. This is the deliberate half of advertising a method early.
+  it('a real POST route with no handler answers 503, not 404 or 405', async () => {
+    // SUPERSEDES an earlier version of this test that asserted 405, from when POST was advertised
+    // in Allow-Methods before any POST route existed. /api/resolve is now a real route, so 405
+    // would be wrong -- and this suite caught the change rather than passing through it.
+    //
+    // 503 rather than 404 is the deliberate part: "this deployment has no agent wired" and "no
+    // such endpoint" are different facts. A dashboard seeing 404 concludes the feature does not
+    // exist and stops asking; 503 says try a deployment that has it.
     const res = await fetch(`${base}/api/resolve`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ mode: 'dry_run' }),
     });
-    assert.equal(res.status, 405);
+    assert.equal(res.status, 503);
     assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('an unknown POST path still answers 404', async () => {
+    // The distinction above is only meaningful if a genuinely unknown path behaves differently.
+    const res = await fetch(`${base}/api/nope`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 404);
   });
 });
 

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -236,3 +236,81 @@ describe('faults', () => {
     await new Promise<void>((resolve) => failing.close(() => resolve()));
   });
 });
+
+describe('write-origin allow-list (resolve-api.md §13.2)', () => {
+  it('a foreign origin cannot POST, and is told so with 403', async () => {
+    // The confused deputy, closed. Verified against the running stack before the fix that
+    // `Origin: https://evil.example.com` got HTTP 200 and a real preview -- because the engine
+    // holds a credential with the write role while the browser does not, and `*` let any page ask
+    // it to act. §13.2 names this and ranks the options.
+    const res = await fetch(`${base}/api/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'https://evil.example.com' },
+      body: JSON.stringify({ mode: 'dry_run', action: { type: 'set_pool_size', host: 'Cloud API', size: 8 } }),
+    });
+    // 403 is correct HERE and wrong for a policy refusal (§5.1). The difference is who is asking:
+    // a refused operator needs an informative 200 they can render; a page that should not have
+    // asked has no UI to show it, and there is nothing legitimate to render.
+    assert.equal(res.status, 403);
+    const body = (await res.json()) as { error: string };
+    assert.match(body.error, /not permitted to POST/);
+  });
+
+  it('the preflight AGREES with the POST branch rather than promising and refusing', async () => {
+    // If the preflight advertised POST to an origin the POST branch then rejects, the browser
+    // would pass the preflight and fail the real request -- surfacing as a bare 403 with no clue
+    // which check refused it.
+    const denied = await fetch(`${base}/api/resolve`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.example.com', 'Access-Control-Request-Method': 'POST' },
+    });
+    const deniedMethods = denied.headers.get('access-control-allow-methods') ?? '';
+    assert.ok(!deniedMethods.includes('POST'), `must not advertise POST, got "${deniedMethods}"`);
+    assert.ok(deniedMethods.includes('GET'), 'reads stay available');
+
+    const allowed = await fetch(`${base}/api/resolve`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'http://localhost:5173', 'Access-Control-Request-Method': 'POST' },
+    });
+    assert.ok((allowed.headers.get('access-control-allow-methods') ?? '').includes('POST'));
+  });
+
+  it('the dashboard origin still works, both loopback forms', async () => {
+    // Dev C runs Vite directly on localhost:5173 and the compose stack serves the built bundle
+    // from nginx on the same port. Breaking either would be worse than the hole this closes.
+    for (const origin of ['http://localhost:5173', 'http://127.0.0.1:5173']) {
+      const res = await fetch(`${base}/api/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Origin: origin },
+        body: JSON.stringify({ mode: 'dry_run', action: { type: 'set_pool_size', host: 'Cloud API', size: 4 } }),
+      });
+      // 503 because this test server wires no resolve handler -- the point is that it got PAST the
+      // origin check, which a 403 would not have.
+      assert.notEqual(res.status, 403, `${origin} must be allowed to POST`);
+    }
+  });
+
+  it('a request with NO Origin is allowed — it is not a browser', async () => {
+    // Deliberate, and the distinction that makes this fix meaningful rather than theatre. Browsers
+    // always send Origin on a cross-origin POST, so a request without one is curl, the dev proxy,
+    // or a health check. Rejecting those breaks every scripted verification while stopping nothing:
+    // anything that can omit the header can forge it. This closes the drive-by, not the network
+    // path -- the real fix is §13.1's pass-through credential.
+    const res = await fetch(`${base}/api/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: 'dry_run', action: { type: 'set_pool_size', host: 'Cloud API', size: 4 } }),
+    });
+    assert.notEqual(res.status, 403);
+  });
+
+  it('GETs are unaffected — Q9 keeps its unconditional CORS', async () => {
+    // Q9's reasoning (the dev proxy stays optional) applies to reads. Narrowing them would break
+    // the dashboard for no security gain, since a read is not the confused-deputy risk.
+    const res = await fetch(`${base}/api/healthscan/findings`, {
+      headers: { Origin: 'https://evil.example.com' },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+});

--- a/services/detection-engine/test/mvp2-contract-drift.test.ts
+++ b/services/detection-engine/test/mvp2-contract-drift.test.ts
@@ -1,0 +1,134 @@
+/**
+ * MVP 2 contract drift guard — read against the MARKDOWN, because there is no `.d.ts` yet.
+ *
+ * WHY THIS FILE EXISTS. `contract-drift.test.ts` compares our types to `contracts/healthscan.d.ts`
+ * and validates output against `healthscan.schema.json`, and it has held. The four MVP 2 contracts
+ * have **neither** — each one says so at the top, and `validate.mjs` does not know these endpoints
+ * exist. So the shape they specify was guarded by nothing at all, and a field-name drift in the one
+ * object Dev C renders when Approve is refused reached review rather than a test (#92):
+ *
+ *     ours:      { code: 'out_of_bounds', detail: '...' }
+ *     contract:  { reason, message, checkedBy }
+ *
+ * §5 tells consumers to "render `refusal.message` verbatim" for an unrecognised reason, so the
+ * denied banner would have read `undefined`. It type-checked cleanly because the parser CAST the
+ * tool's object to a typed shape, and a cast asserts rather than checks.
+ *
+ * WHAT THIS CAN AND CANNOT DO. Grepping prose for field names is weaker than validating against a
+ * schema, and it is deliberately narrow: it pins the field NAMES of the two objects a UI renders,
+ * and the closed `reason` set. It does not pin types, nesting, or optionality. When
+ * `resolve-api.md` gains a `.schema.json`, this file should be replaced by schema validation
+ * rather than extended — a prose grep is a stopgap, and pretending otherwise is how a weak check
+ * gets trusted like a strong one.
+ *
+ * Skipped when `contracts/` is absent, matching ADR 0004: the engine stays buildable standalone.
+ */
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { mockResolveTool } from '../src/detect/agents.ts';
+import { resolve as runResolve } from '../src/detect/resolve.ts';
+
+const serviceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const contractsDir = resolve(serviceRoot, '../../contracts');
+const resolveApiPath = resolve(contractsDir, 'resolve-api.md');
+const haveContract = existsSync(resolveApiPath);
+
+const ACTION = { type: 'set_pool_size', host: 'Cloud API', size: 4 } as const;
+
+describe('MVP 2 contract drift', { skip: haveContract ? false : 'contracts/ not present' }, () => {
+  it('the refusal object uses the contract field names, not ours', async () => {
+    const contract = readFileSync(resolveApiPath, 'utf8');
+
+    // Pulled from the contract text rather than hardcoded here -- a copy in this file would be the
+    // #84 stale-value pattern, in the very test meant to catch drift.
+    for (const field of ['reason', 'message', 'checkedBy']) {
+      assert.match(
+        contract,
+        new RegExp(`"${field}"\\s*:`),
+        `resolve-api.md should specify refusal.${field}`,
+      );
+    }
+
+    // WHAT THIS ASSERTION DOES AND DOES NOT CATCH -- measured, by reintroducing the drift and
+    // watching which tests failed. Only ONE of the four did, and it was not this one.
+    //
+    // `parseRefusal` NORMALISES: it reads each field and substitutes a default when one is absent,
+    // so the engine's output carries `reason`/`message`/`checkedBy` no matter what the tool sent.
+    // That is right for the engine -- Dev C should never receive a half-shaped refusal -- and it
+    // means this assertion pins OUR output contract and cannot see upstream drift at all.
+    //
+    // Upstream drift surfaces as `reason: "unknown"`, which the next test catches because `unknown`
+    // is not a row in §5's table. Recording the division here because a guard whose reach you have
+    // not measured is a guard you will over-trust: this one proves the engine never emits `code`,
+    // and the next one proves the tool never sends something unrecognised.
+    const deps = { callTool: mockResolveTool(1), now: () => 1_760_000_000_000 };
+    const refused = await runResolve({ mode: 'apply', action: { ...ACTION, size: 99 } }, deps);
+    assert.equal(refused.outcome, 'refused');
+    const refusal = refused.refusal as unknown as Record<string, unknown>;
+    assert.ok('reason' in refusal, 'refusal must carry reason');
+    assert.ok('message' in refusal, 'refusal must carry message');
+    assert.ok('checkedBy' in refusal, 'refusal must carry checkedBy');
+    assert.ok(!('code' in refusal), 'refusal must NOT carry the retired `code` field');
+    assert.ok(!('detail' in refusal), 'refusal must NOT carry the retired `detail` field');
+  });
+
+  it('every reason we emit is in the contract table', async () => {
+    const contract = readFileSync(resolveApiPath, 'utf8');
+    // §5's table treats the reason set as CLOSED. Emitting one that is absent from it is a contract
+    // change, not an implementation detail -- so it should fail here rather than reach Dev C as a
+    // string they were told to expect from a fixed list.
+    const deps = { callTool: mockResolveTool(1), now: () => 1_760_000_000_000 };
+    const refused = await runResolve({ mode: 'apply', action: { ...ACTION, size: 99 } }, deps);
+    const reason = refused.refusal?.reason ?? '';
+    assert.notEqual(reason, '');
+    // `unknown` is what parseRefusal substitutes when the tool sends a shape it cannot read, so
+    // this doubles as the upstream-drift detector -- and `unknown` is deliberately NOT a row in
+    // §5's table, which is what makes the assertion below fail instead of passing vacuously.
+    assert.notEqual(reason, 'unknown', 'the tool sent a refusal this engine could not read');
+    assert.match(
+      contract,
+      new RegExp(`\\|\\s*\`${reason}\``),
+      `\`${reason}\` is not a row in resolve-api.md §5's reason table`,
+    );
+  });
+
+  it('a refusal never carries a confirmation, and an apply always does', async () => {
+    // §3 + §7. Not a field-name check but the same class of defect: a confirmation on a refusal
+    // tells the UI to poll for a clearance that is never coming, and its absence on an applied
+    // write loses the only pointer to where the outcome becomes visible.
+    const deps = { callTool: mockResolveTool(1), now: () => 1_760_000_000_000 };
+    const refused = await runResolve({ mode: 'apply', action: { ...ACTION, size: 99 } }, deps);
+    assert.equal(refused.confirmation, null);
+
+    const applied = await runResolve(
+      { mode: 'apply', action: ACTION, origin: { findingId: 'f-1' } },
+      deps,
+    );
+    assert.equal(applied.outcome, 'applied');
+    assert.equal(applied.confirmation?.status, 'pending');
+    // §7: this response is evidence the write landed, not that the condition cleared.
+    assert.equal(applied.confirmation?.directEvidence, false);
+  });
+
+  it('the contract forbids 403 for not_authorized, and says why', () => {
+    const contract = readFileSync(resolveApiPath, 'utf8');
+    // Pinned because I broke it: the dispatcher answered 403 for a policy denial, on the reasoning
+    // that a refusal is not a server fault. The reasoning is fine; the consequence is that Dev C's
+    // client branches on `res.ok`, so a non-2xx becomes a thrown error and a generic banner --
+    // and MVP 2 §5.4's acceptance criterion is that the RBAC-denied state is VISIBLE.
+    //
+    // Asserting the PROSE, not our behaviour, because the behaviour lives in ObjectScript that
+    // this suite cannot reach. What this catches is the contract being weakened to permit 403 --
+    // at which point the reasoning above needs revisiting rather than silently losing.
+    assert.match(contract, /is not `403`/, 'resolve-api.md §5.1 must keep forbidding 403');
+    assert.match(
+      contract,
+      /branches on `res\.ok`/,
+      'the reason 403 is forbidden must stay in the contract, not just the rule',
+    );
+  });
+});

--- a/services/detection-engine/test/resolve.test.ts
+++ b/services/detection-engine/test/resolve.test.ts
@@ -178,13 +178,22 @@ test('a refusal is a NORMAL response carrying the code, not an error', async () 
     outcome: 'refused',
     before: { poolSize: 1 },
     after: null,
-    refusal: { code: 'host_not_permitted', detail: 'only Cloud API may be adjusted' },
+    refusal: {
+      reason: 'not_whitelisted_host',
+      message: 'this tool may only change Cloud API',
+      checkedBy: 'iris',
+    },
   });
   // §5.2. A 500 would make "the policy forbids this" indistinguishable from "the production is
   // broken", and the operator's next action differs completely between those two.
   const res = await resolve({ mode: 'apply', action: { ...ACTION, host: 'EMR Source' } }, deps);
   assert.equal(res.outcome, 'refused');
-  assert.equal(res.refusal?.code, 'host_not_permitted');
+  // §5 field names. `reason` from the contract's closed set, `message` rendered verbatim by the
+  // UI, `checkedBy` naming which component decided -- `iris` means the production's own guard
+  // refused, not this service's convenience validation.
+  assert.equal(res.refusal?.reason, 'not_whitelisted_host');
+  assert.equal(res.refusal?.checkedBy, 'iris');
+  assert.match(res.refusal?.message ?? '', /Cloud API/);
   assert.equal(res.after, null);
   assert.equal(res.confirmation, null);
   assert.equal(res.failure, null);
@@ -333,7 +342,9 @@ test('mockResolveTool refuses out-of-bounds like the real tool does', async () =
   for (const size of [1, 0, -4, 9, 64]) {
     const res = await resolve({ mode: 'apply', action: { ...ACTION, size } }, deps);
     assert.equal(res.outcome, 'refused', `size ${size} should be refused`);
-    assert.equal(res.refusal?.code, 'out_of_bounds');
+    assert.equal(res.refusal?.reason, 'out_of_bounds');
+    // §5 carries the range on this refusal so the UI states it without keeping its own copy.
+    assert.deepEqual(res.refusal?.bounds, { min: 2, max: 8 });
   }
   // 1 is refused specifically because it is the SHIPPED value -- "setting it to 1" is a no-op
   // dressed as a fix, and the real tool's MINSIZE=2 exists for that reason.
@@ -346,4 +357,113 @@ test('mockResolveTool accepts the whole legal range', async () => {
     assert.equal(res.outcome, 'applied', `size ${size} should apply`);
     assert.deepEqual(res.after, { poolSize: size });
   }
+});
+
+// ---------------------------------------------------------------------------
+// The §8 audit block — attribution, and what a missing one means
+// ---------------------------------------------------------------------------
+
+const AUDIT = {
+  auditId: 'pg-audit-42',
+  actor: 'pg_service',
+  role: 'Guardian_Resolve',
+  tool: 'set_pool_size',
+  recordedAt: '2026-08-19T11:00:00Z',
+  source: 'live',
+};
+
+test('the audit block is forwarded on every outcome, not just applies', async () => {
+  // §8: "Every call produces exactly one attributable audit event: applies, refusals, and dry-runs
+  // alike." Dry-runs specifically -- "who was probing the production, and when" is part of the same
+  // story as who changed it, and an audit log with a hole where the reconnaissance was is a partial
+  // account.
+  for (const outcome of ['previewed', 'applied', 'no_change', 'refused'] as const) {
+    const { deps } = stub({
+      outcome,
+      before: { poolSize: 1 },
+      after: outcome === 'refused' ? null : { poolSize: 4 },
+      refusal: outcome === 'refused'
+        ? { reason: 'not_authorized', message: 'requires PG_Resolve', checkedBy: 'iris' }
+        : undefined,
+      audit: AUDIT,
+    });
+    const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+    assert.equal(res.outcome, outcome);
+    assert.equal(res.audit?.auditId, 'pg-audit-42', `${outcome} must carry the audit handle`);
+    assert.equal(res.audit?.actor, 'pg_service', `${outcome} must name the actor`);
+  }
+});
+
+test('requestedBy comes from the REQUEST and never replaces actor', async () => {
+  // §8: "a caller cannot name itself". requestedBy is a string a browser typed; treating it as
+  // identity would make the log a record of what the client CLAIMED, which §8 calls worse than no
+  // audit log because it is trusted. So it is recorded NEXT TO actor, and actor is resolved
+  // server-side.
+  const { deps } = stub({
+    outcome: 'applied',
+    before: { poolSize: 1 },
+    after: { poolSize: 4 },
+    audit: AUDIT,
+  });
+  const res = await resolve(
+    { mode: 'apply', action: ACTION, requestedBy: 'presenter@laptop' },
+    deps,
+  );
+  assert.equal(res.audit?.requestedBy, 'presenter@laptop');
+  assert.equal(res.audit?.actor, 'pg_service', 'actor must stay the server-resolved principal');
+});
+
+test('a caller-supplied actor in the reply cannot override the tool-reported one', async () => {
+  // The tool is the only thing that can resolve a principal. A reply whose audit block omits actor
+  // yields null rather than falling back to requestedBy -- the fallback is the defect §8 describes.
+  const { deps } = stub({
+    outcome: 'applied',
+    before: { poolSize: 1 },
+    after: { poolSize: 4 },
+    audit: { auditId: 'pg-audit-9' },
+  });
+  const res = await resolve({ mode: 'apply', action: ACTION, requestedBy: 'someone' }, deps);
+  assert.equal(res.audit?.auditId, 'pg-audit-9');
+  assert.equal(res.audit?.actor, null, 'a missing actor is null, never the caller-supplied label');
+  assert.equal(res.audit?.requestedBy, 'someone');
+});
+
+test('no audit handle means audit is null, not an object of nulls', async () => {
+  // §8: auditId null "when the record could not be written -- and if it could not be written for an
+  // apply, that is failed / verify, not a silent success". The engine's caller branches on the
+  // whole object being absent, so an object full of nulls would read as "audited, details unknown".
+  for (const audit of [undefined, null, {}, { actor: 'x' }, 'nope'] as unknown[]) {
+    const { deps } = stub({ outcome: 'applied', before: { poolSize: 1 }, after: { poolSize: 4 }, audit });
+    const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+    assert.equal(res.audit, null, `audit ${JSON.stringify(audit)} should normalise to null`);
+  }
+});
+
+test('a failed tool call reports no audit rather than an assumed one', async () => {
+  const deps: ResolveDeps = {
+    callTool: async () => {
+      throw new Error('write tool timed out after 30000ms');
+    },
+    now: () => 1_760_000_000_000,
+  };
+  const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(res.outcome, 'failed');
+  // Consistent with liveStateVerified: false. We do not know whether a row exists, so we name none.
+  assert.equal(res.audit, null);
+});
+
+test('mockResolveTool emits an audit block marked source mock', async () => {
+  // A mock that omitted audit would let Dev C build the approve flow against responses with no
+  // attribution and meet it for the first time against a live production. One that claimed
+  // source:"live" would be worse -- an audit entry asserting it is real.
+  const deps: ResolveDeps = { callTool: mockResolveTool(1), now: () => 1_760_000_000_000 };
+  const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(res.audit?.source, 'mock');
+  assert.match(res.audit?.auditId ?? '', /^mock-audit-\d+$/);
+  // A distinct handle per call, like the real one: a fixed id would let a UI dedupe two real
+  // actions into one row.
+  const second = await resolve({ mode: 'dry_run', action: { ...ACTION, size: 8 } }, deps);
+  assert.notEqual(second.audit?.auditId, res.audit?.auditId);
+  // tool reflects what was actually invoked -- get_pool_size on a dry-run, per §8's table.
+  assert.equal(second.audit?.tool, 'get_pool_size');
 });

--- a/services/detection-engine/test/resolve.test.ts
+++ b/services/detection-engine/test/resolve.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Smart Resolve orchestration tests.
+ *
+ * THE NEGATIVE CASES ARE THE POINT HERE, more than for any other module in this service. Every
+ * other endpoint answers a question wrongly at worst; this one forwards a request that changes a
+ * running production. So the tests that matter are the ones proving a malformed request is REFUSED
+ * before the tool is reached, and that an unclear outcome is reported as unclear rather than
+ * guessed.
+ *
+ * `CLAUDE.md` §8: "A schema test that only checks valid input proves nothing — prove rejection
+ * too." Counted: 14 of the 21 cases below are rejections or failure paths.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { parseResolveRequest, resolve } from '../src/detect/resolve.ts';
+import { mockResolveTool } from '../src/detect/agents.ts';
+import type { ResolveDeps } from '../src/detect/resolve.ts';
+
+const ACTION = { type: 'set_pool_size', host: 'Cloud API', size: 4 } as const;
+
+/** A tool stub that records what it was asked and returns a fixed reply. */
+function stub(reply: unknown): { deps: ResolveDeps; calls: unknown[] } {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    deps: {
+      callTool: async (action, dryRun) => {
+        calls.push({ action, dryRun });
+        return reply;
+      },
+      now: () => 1_760_000_000_000,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseResolveRequest — rejection
+// ---------------------------------------------------------------------------
+
+test('parseResolveRequest rejects a non-object body', () => {
+  for (const body of [null, undefined, 'apply', 42, []] as unknown[]) {
+    // An array IS an object in JS, so it passes the typeof guard and fails on `mode` instead --
+    // still rejected, which is what matters, but the message differs. Asserted as "throws" rather
+    // than on the message so the test does not pin which guard catches it.
+    assert.throws(() => parseResolveRequest(body), /bad request/);
+  }
+});
+
+test('parseResolveRequest requires mode with NO default', () => {
+  // The single most important rejection in this file. A missing mode must not become `apply` (a
+  // caller's omission would become a live production write) and must not become `dry_run` (an
+  // approval would silently preview and the operator would wonder why nothing happened).
+  assert.throws(() => parseResolveRequest({ action: ACTION }), /mode must be/);
+  assert.throws(() => parseResolveRequest({ mode: 'APPLY', action: ACTION }), /mode must be/);
+  assert.throws(() => parseResolveRequest({ mode: '', action: ACTION }), /mode must be/);
+  assert.throws(() => parseResolveRequest({ mode: true, action: ACTION }), /mode must be/);
+});
+
+test('parseResolveRequest rejects unknown keys inside action', () => {
+  // §1.1. A tolerated extra key is a field somebody believes is being honoured while it is being
+  // dropped -- and this object is transcribed into a production write.
+  assert.throws(
+    () => parseResolveRequest({ mode: 'apply', action: { ...ACTION, force: true } }),
+    /unknown key\(s\) \[force\]/,
+  );
+  assert.throws(
+    () => parseResolveRequest({ mode: 'apply', action: { ...ACTION, size2: 9, why: 'x' } }),
+    /unknown key\(s\) \[size2, why\]/,
+  );
+});
+
+test('parseResolveRequest rejects a wrong or missing action type', () => {
+  assert.throws(
+    () => parseResolveRequest({ mode: 'apply', action: { type: 'restart_host', host: 'Cloud API', size: 4 } }),
+    /action\.type must be/,
+  );
+  assert.throws(
+    () => parseResolveRequest({ mode: 'apply', action: { host: 'Cloud API', size: 4 } }),
+    /action\.type must be/,
+  );
+});
+
+test('parseResolveRequest rejects a bad host or size', () => {
+  const bad: unknown[] = [
+    { type: 'set_pool_size', host: '', size: 4 },
+    { type: 'set_pool_size', host: 42, size: 4 },
+    { type: 'set_pool_size', size: 4 },
+    { type: 'set_pool_size', host: 'Cloud API', size: '4' },
+    { type: 'set_pool_size', host: 'Cloud API', size: 4.5 },
+    { type: 'set_pool_size', host: 'Cloud API' },
+  ];
+  for (const action of bad) {
+    assert.throws(() => parseResolveRequest({ mode: 'apply', action }), /bad request/);
+  }
+});
+
+test('parseResolveRequest does NOT bound-check size — the tool does', () => {
+  // Deliberate: an out-of-range size parses and is forwarded, and `Tools.Resolve` refuses it with a
+  // named code. Rejecting it here too would be harmless, but this test pins WHERE the boundary is,
+  // so nobody later reads the parser's acceptance as permission. resolve.ts's header says the same:
+  // the validation here is a convenience, not the safety boundary.
+  const parsed = parseResolveRequest({ mode: 'apply', action: { ...ACTION, size: 64 } });
+  assert.equal(parsed.action.size, 64);
+});
+
+// ---------------------------------------------------------------------------
+// parseResolveRequest — acceptance
+// ---------------------------------------------------------------------------
+
+test('parseResolveRequest keeps only the three action keys', () => {
+  const parsed = parseResolveRequest({ mode: 'dry_run', action: ACTION });
+  assert.deepEqual(Object.keys(parsed.action).sort(), ['host', 'size', 'type']);
+});
+
+test('parseResolveRequest carries optional fields through and drops malformed ones', () => {
+  const parsed = parseResolveRequest({
+    mode: 'apply',
+    action: ACTION,
+    requestId: 'req-1',
+    requestedBy: 'dev-c',
+    origin: { findingId: 'f-1', investigationId: 7 },
+    precondition: { poolSize: 1 },
+  });
+  assert.equal(parsed.requestId, 'req-1');
+  assert.equal(parsed.requestedBy, 'dev-c');
+  assert.equal(parsed.origin?.findingId, 'f-1');
+  // A non-string investigationId is DROPPED rather than coerced to "7". Coercion here is how #58's
+  // lastActivity defect happened: a value that looks right and is not what was sent.
+  assert.equal(parsed.origin?.investigationId, undefined);
+  assert.equal(parsed.precondition?.poolSize, 1);
+});
+
+// ---------------------------------------------------------------------------
+// resolve() — outcomes
+// ---------------------------------------------------------------------------
+
+test('dry_run forwards dryRun=true and returns previewed with no confirmation', async () => {
+  const { deps, calls } = stub({
+    outcome: 'previewed',
+    before: { poolSize: 1 },
+    after: { poolSize: 4 },
+    reversal: { host: 'Cloud API', size: 1, capturedFrom: 'live production' },
+  });
+  const res = await resolve({ mode: 'dry_run', action: ACTION }, deps);
+  assert.equal((calls[0] as { dryRun: boolean }).dryRun, true);
+  assert.equal(res.outcome, 'previewed');
+  assert.deepEqual(res.after, { poolSize: 4 });
+  // A preview changed nothing, so there is nothing to confirm. A confirmation here would tell the
+  // UI to watch for a clearance that is never coming.
+  assert.equal(res.confirmation, null);
+  assert.equal(res.reversal?.size, 1);
+});
+
+test('apply forwards dryRun=false and attaches a PENDING confirmation, not a resolved one', async () => {
+  const { deps, calls } = stub({
+    outcome: 'applied',
+    before: { poolSize: 1 },
+    after: { poolSize: 4 },
+    reversal: { host: 'Cloud API', size: 1, capturedFrom: 'live production' },
+  });
+  const res = await resolve(
+    { mode: 'apply', action: ACTION, origin: { findingId: 'queue_buildup:Cloud API' } },
+    deps,
+  );
+  assert.equal((calls[0] as { dryRun: boolean }).dryRun, false);
+  assert.equal(res.outcome, 'applied');
+  assert.equal(res.confirmation?.status, 'pending');
+  assert.equal(res.confirmation?.findingId, 'queue_buildup:Cloud API');
+  // FALSE, and this is the honest bit: the response is evidence the WRITE landed, not evidence the
+  // problem cleared. The queue still has to drain, observed on a later poll (§7).
+  assert.equal(res.confirmation?.directEvidence, false);
+  assert.equal(res.confirmation?.observeVia, 'GET /api/healthscan/findings');
+});
+
+test('a refusal is a NORMAL response carrying the code, not an error', async () => {
+  const { deps } = stub({
+    outcome: 'refused',
+    before: { poolSize: 1 },
+    after: null,
+    refusal: { code: 'host_not_permitted', detail: 'only Cloud API may be adjusted' },
+  });
+  // §5.2. A 500 would make "the policy forbids this" indistinguishable from "the production is
+  // broken", and the operator's next action differs completely between those two.
+  const res = await resolve({ mode: 'apply', action: { ...ACTION, host: 'EMR Source' } }, deps);
+  assert.equal(res.outcome, 'refused');
+  assert.equal(res.refusal?.code, 'host_not_permitted');
+  assert.equal(res.after, null);
+  assert.equal(res.confirmation, null);
+  assert.equal(res.failure, null);
+});
+
+test('no_change gets no confirmation either', async () => {
+  const { deps } = stub({
+    outcome: 'no_change',
+    before: { poolSize: 4 },
+    after: { poolSize: 4 },
+    reversal: { host: 'Cloud API', size: 4, capturedFrom: 'live production' },
+  });
+  const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(res.outcome, 'no_change');
+  // It was already true; there is no state change to observe clearing.
+  assert.equal(res.confirmation, null);
+});
+
+// ---------------------------------------------------------------------------
+// resolve() — failure honesty
+// ---------------------------------------------------------------------------
+
+test('a thrown tool call reports liveStateVerified FALSE', async () => {
+  const deps: ResolveDeps = {
+    callTool: async () => {
+      throw new Error('write tool timed out after 30000ms');
+    },
+    now: () => 1_760_000_000_000,
+  };
+  const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(res.outcome, 'failed');
+  assert.equal(res.failure?.stage, 'tool_call');
+  // THE ASSERTION THIS FILE EXISTS FOR. The call did not come back, so we do not know whether the
+  // production changed. Claiming it did not would be a guess, and someone deciding whether to
+  // retry an apply needs to know we cannot tell.
+  assert.equal(res.failure?.liveStateVerified, false);
+  assert.equal(res.before, null);
+  assert.equal(res.after, null);
+  assert.equal(res.confirmation, null);
+});
+
+test('an unrecognised outcome is failed-and-unverified, never assumed', async () => {
+  for (const bogus of [undefined, null, 'ok', 'success', 42, {}] as unknown[]) {
+    const { deps } = stub({ outcome: bogus, before: { poolSize: 1 } });
+    const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+    assert.equal(res.outcome, 'failed');
+    assert.equal(res.failure?.stage, 'tool_reply');
+    assert.equal(res.failure?.liveStateVerified, false);
+  }
+});
+
+test('a garbage tool reply does not throw', async () => {
+  // The endpoint must answer. A reply we cannot read is a `failed` response, not a 500 from an
+  // unhandled property access.
+  for (const junk of [null, 'nope', 42, []] as unknown[]) {
+    const { deps } = stub(junk);
+    const res = await resolve({ mode: 'dry_run', action: ACTION }, deps);
+    assert.equal(res.outcome, 'failed');
+  }
+});
+
+test('a non-numeric poolSize in the reply becomes null rather than NaN', async () => {
+  const { deps } = stub({
+    outcome: 'applied',
+    before: { poolSize: '1' },
+    after: { poolSize: null },
+  });
+  const res = await resolve({ mode: 'apply', action: ACTION }, deps);
+  // Not `Number('1')`. A coerced number is indistinguishable from a measured one, and `before`
+  // feeds the reversal a human would use to undo the change.
+  assert.equal(res.before, null);
+  assert.equal(res.after, null);
+});
+
+// ---------------------------------------------------------------------------
+// Response shape
+// ---------------------------------------------------------------------------
+
+test('every response carries the full contract shape', async () => {
+  const { deps } = stub({ outcome: 'previewed', before: { poolSize: 1 }, after: { poolSize: 4 } });
+  const res = await resolve({ mode: 'dry_run', action: ACTION, requestId: 'r-9' }, deps);
+  for (const key of [
+    'resolveId',
+    'requestId',
+    'mode',
+    'outcome',
+    'action',
+    'before',
+    'after',
+    'reversal',
+    'refusal',
+    'failure',
+    'confirmation',
+    'requestedAt',
+    'completedAt',
+  ]) {
+    assert.ok(key in res, `missing ${key}`);
+  }
+  assert.equal(res.requestId, 'r-9');
+  assert.equal(res.mode, 'dry_run');
+  // Second-precision ISO with a Z, matching every other timestamp this service publishes.
+  assert.match(res.requestedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  assert.match(res.completedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+});
+
+test('requestId is null when the caller omitted one, not invented', async () => {
+  const { deps } = stub({ outcome: 'previewed', before: { poolSize: 1 }, after: { poolSize: 4 } });
+  const res = await resolve({ mode: 'dry_run', action: ACTION }, deps);
+  assert.equal(res.requestId, null);
+  // resolveId is ours and always present -- it is what ties this call to the AI Hub audit record.
+  assert.match(res.resolveId, /^res-Cloud-API-\d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// mockResolveTool — the mock must not be easier than the real thing
+// ---------------------------------------------------------------------------
+
+test('mockResolveTool: apply then apply gives applied then no_change', async () => {
+  const tool = mockResolveTool(1);
+  const deps: ResolveDeps = { callTool: tool, now: () => 1_760_000_000_000 };
+
+  const first = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(first.outcome, 'applied');
+  assert.deepEqual(first.after, { poolSize: 4 });
+
+  // Idempotency, matching the real tool. A mock that returned `applied` twice would let Dev C ship
+  // an approve button whose double-click path is never exercised -- which a live demo WILL hit.
+  const second = await resolve({ mode: 'apply', action: ACTION }, deps);
+  assert.equal(second.outcome, 'no_change');
+  assert.equal(second.confirmation, null);
+});
+
+test('mockResolveTool: a dry run does not move the pool', async () => {
+  const tool = mockResolveTool(1);
+  const deps: ResolveDeps = { callTool: tool, now: () => 1_760_000_000_000 };
+  await resolve({ mode: 'dry_run', action: ACTION }, deps);
+  const applied = await resolve({ mode: 'apply', action: ACTION }, deps);
+  // before is still 1 -- the preview left it alone.
+  assert.deepEqual(applied.before, { poolSize: 1 });
+  assert.equal(applied.outcome, 'applied');
+});
+
+test('mockResolveTool refuses out-of-bounds like the real tool does', async () => {
+  const tool = mockResolveTool(1);
+  const deps: ResolveDeps = { callTool: tool, now: () => 1_760_000_000_000 };
+  for (const size of [1, 0, -4, 9, 64]) {
+    const res = await resolve({ mode: 'apply', action: { ...ACTION, size } }, deps);
+    assert.equal(res.outcome, 'refused', `size ${size} should be refused`);
+    assert.equal(res.refusal?.code, 'out_of_bounds');
+  }
+  // 1 is refused specifically because it is the SHIPPED value -- "setting it to 1" is a no-op
+  // dressed as a fix, and the real tool's MINSIZE=2 exists for that reason.
+});
+
+test('mockResolveTool accepts the whole legal range', async () => {
+  for (const size of [2, 3, 4, 5, 6, 7, 8]) {
+    const deps: ResolveDeps = { callTool: mockResolveTool(1), now: () => 1_760_000_000_000 };
+    const res = await resolve({ mode: 'apply', action: { ...ACTION, size } }, deps);
+    assert.equal(res.outcome, 'applied', `size ${size} should apply`);
+    assert.deepEqual(res.after, { poolSize: size });
+  }
+});


### PR DESCRIPTION
Closes #72, closes #73.

Completes the MVP 2 loop: **WHAT** (Health Scan, shipped) → **WHY** (`POST /api/investigate`) → **FIX** (`POST /api/resolve`).

## The architectural line, and where it is enforced

This service gained **orchestration**, not **authority** (`services/detection-engine/CLAUDE.md` §1.1).

| | Lives in the engine | Lives in IRIS |
|---|---|---|
| WHY | builds the request, validates the reply | the agent, the LLM key, the read tools |
| FIX | validates the request, reports the outcome | the write, the policy, the audit record |

No LLM credential reaches this service — the key is in the AI Hub wallet, referenced by a `secret://` URI from ConfigStore. No `Ens.*` call exists in the engine. A bug in `resolve.ts` cannot widen what may be written; it can only fail to reach the tool.

`test/resolve.test.ts` pins *where* the boundary is: an out-of-range size **parses** in the engine and is **refused** by the tool. That is deliberate, so nobody later reads the parser's acceptance as permission.

## What was verified live, with a real LLM

Four-container stack, `PG_AGENT_MODE=live`, `gpt-4o-mini`:

```
armed PoolBottleneck            -> queue 151 -> queue_buildup fired
POST /api/investigate           -> 6 tool calls, confidence 0.95, 6.0s
                                   all 6 evidence bullets source=mcp_tool, none llm-asserted
                                   independently recommended set_pool_size Cloud API 4
POST /api/resolve dry_run       -> previewed 1 -> 4;  production still read 1
POST /api/resolve apply         -> applied;           production read 4
queue 222 -> 205 -> 176 -> 154 -> 124 -> 105 -> 75 -> 16 -> 0
finding cleared; second apply   -> no_change
Reset()                         -> pool restored to 1
```

The agent chose the action itself. Nothing about pool size is in the system prompt beyond the permitted action type and its range.

## Refusals came from the real tool, not from our validation

| Request | Outcome |
|---|---|
| `EMR Source`, `Lab Router`, unknown host | `refused / not_whitelisted_host` |
| size `0`, `-4`, `99` | `refused / out_of_bounds` |
| size **`1`** | `refused / out_of_bounds` — it is the *shipped* value, so a no-op dressed as a fix |
| size `8` | `previewed` (upper bound is legal) |

Pool read `4` throughout: no refusal moved anything.

## Failure honesty — the part most worth reviewing

- A tool call that does not come back reports **`liveStateVerified: false`**. We do not know whether the production changed, and someone deciding whether to retry an apply needs to know we cannot tell. Verified by pointing `IRIS_BASE_URL` at a dead port: `failed / tool_call / liveStateVerified: false`.
- An **unrecognised outcome** from the one component that can mutate a production is reported as `failed`, never guessed at.
- **`confirmation` is attached only to `applied`**, with `directEvidence: false`. This response is evidence the *write* landed, not evidence the *problem* cleared — the queue still has to drain, observed on a later poll. A confirmation on a preview or a refusal would tell the UI to watch for a clearance that is never coming.
- A malformed reply from the agent is `state: "unavailable"` with `rootCause: null`. **Never a plausible guess** — a human approves a production write on the strength of that narrative.

## Bugs found and fixed in the course of this

- **`GET /api/resolve` answered 404** — a real endpoint reported as absent, the mirror of the `POST /api/healthscan/findings` regression from the previous commit. No test covered it because the suite only ever asked one way round. Both directions are now pinned, for both POST routes (they are wired through different branches, so covering one proves nothing about the other). Found by asking for the symmetric case, not by a failing test.
- **`liveAgent` posted to `/labdemo/investigate`**, missing the web application prefix. It would have reached the patient dispatcher and 404'd — naming the wrong component in the error.
- **`resolve` collides with `node:path`'s `resolve`** in `index.ts`. It compiled as a duplicate-identifier error, but had it shadowed, `resolve(serviceRoot, 'thresholds.json')` would have called the write orchestrator. Aliased to `runResolve`.

- **The CI iris job failed on correct code.** `AgentDispatcher.cls` references `%AI.Agent`, which is absent from the community image CI uses, and the exclusion was a hardcoded `-not -path 'iris/labdemo/Tools/*'` — it encoded "AI Hub classes live in `Tools/`", true when written and false as soon as the HTTP entry point was added. Now selected **by content** (`grep -rl '%AI\.'`), so a new class touching `%AI.` is excluded automatically. `iris/test/` stays a path rule because `StubPolicy.cls` *extends* an excluded class without naming one, which a content grep misses. The notice now names the skipped files rather than only counting them.

## Notes for review

- **`AGENT_MODE` defaults to `mock`** even though `PROXY_MODE` is `live`. Two independent switches because the proxy and the LLM fail independently, and a clone has no provider configured. `mockResolveTool` tracks a pool size in memory so apply-then-apply gives `applied` then `no_change` — a mock that returned `applied` twice would let Dev C ship an approve button whose double-click path is never exercised, which a live demo will hit.
- **The agent's tool readings are live; the finding's snapshot is from when it fired.** These can legitimately disagree — in one run the snapshot said `queued: 198` while `get_queue_depth` returned `0`, because the production had been reset in between. Neither is wrong; `evidence[].source` is the distinction (`mcp_tool` = now, `snapshot` = then). Documented in `AgentDispatcher.cls` because the transcript reads as a defect otherwise.
- **Known limitation, flagged rather than hidden:** the engine authenticates to the dispatcher with its *own* service credentials, so the AI Hub audit record attributes the change to the engine rather than to the person who approved it. `resolve-api.md` §13.1 names this as unsettled. It is a real gap, not a detail.

## Checks

- `npm run typecheck` — clean, strict, no `any`
- `npm test` — **221 pass, 0 fail** (22 new in `resolve.test.ts`, 14 of them rejections or failure paths)
- ADR 0004 holds: engine starts and serves `POST /api/resolve` with no IRIS and no proxy reachable
- **All five CI jobs green**, including `iris — compile ObjectScript`: 12 classes compiled, 5 skipped and named

Requesting @kskubach (Dev A) — the `iris/` files here are `AgentDispatcher.cls`, which is your area, and it is worth your eyes specifically because it is the HTTP entry point to a governed production write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
