### PR TITLE
contracts: correct the role names — no `%` prefix

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,48 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-18 — role names corrected: no `%` prefix (Dev B)
+
+**Two files, values only, no shape change.** `mcp-tools.md` and `resolve-api.md`:
+`%Guardian_Read` → `Guardian_Read`, `%Guardian_Resolve` → `Guardian_Resolve`. 14 occurrences. No
+field added, removed or retyped; no schema and no sample affected (these two contracts still have
+neither). `validate.mjs` unchanged and passing.
+
+**The ratified names could not be created.** IRIS refuses them:
+
+```
+ERROR #887: Invalid role name '%Guardian_Read'
+```
+
+`%` marks a role as **system-supplied**, so a custom role may not use it. Resources follow the same
+rule, which is why `PG_Read` / `PG_Resolve` were always fine.
+
+**The reasoning in `mcp-tools.md` §5 was backwards, and that is the part worth reading.** It argued
+that roles carry `%` *because* it is the convention for a system-supplied role — a true premise
+supporting the opposite conclusion — and presented the `PG_*` / `%Guardian_*` split as "two
+different naming rules, applied correctly, rather than one applied uniformly and wrongly". It is in
+fact one rule applied wrongly. The paragraph has been rewritten rather than just having its values
+swapped, because a corrected value under intact bad reasoning invites the next person to "fix" it
+back.
+
+**Found by trying to create the roles, not by review.** The passage reads as a considered decision,
+complete with a rationale for the apparent inconsistency, which is exactly why it survived
+ratification by three people. A confident explanation is harder to doubt than a bare value —
+`AuthPolicy.cls` recorded the divergence in a class comment when it hit the error, and this entry
+closes it.
+
+**Verified against the running instance** rather than assumed from the error message:
+
+```
+RES   PG_Read           RES   PG_Resolve
+ROLE  Guardian_Read     ROLE  Guardian_Resolve
+```
+
+`resolve-api.md` §9.3's instruction to Dev C — render `audit.role` as an **opaque string** and never
+compare it to a literal — is what kept this from being a dashboard change, and is the reason it
+stays in force now that the values are settled.
+
+
 ## 2026-08-18 — four new MVP 2 contracts (Dev B)
 
 **Additive only. The two MVP 1 contracts are untouched** — `healthscan-api.md` and
@@ -77,6 +119,12 @@ the **role** that holds one (`%Guardian_Read`, `%Guardian_Resolve`) in `audit.ro
 after both landed, with a table in `resolve-api.md` §9.3, because grepping for one string and
 finding the other looks exactly like the #84 stale-copy pattern and invites a "fix" that would
 break it.
+
+> **The role names in the line above were corrected on 2026-08-18** to `Guardian_Read` /
+> `Guardian_Resolve` — see that day's second entry. Left as written here rather than rewritten: a
+> changelog records what a contract *said*, and silently updating a past entry would erase the fact
+> that the ratified names were unimplementable. The **resource/role distinction** the paragraph
+> makes is unaffected and still correct.
 
 ### What is asserted about the runtime, and how it was established
 

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -26,7 +26,7 @@ silently disagrees with its neighbour is worse than one that is wrong out loud:
 |---|---|---|---|
 | dry-run | a `mode` on the endpoint | **no flag on the tool** | The endpoint's dry-run calls `get_pool_size` and never invokes the write tool. §3.6 |
 | `size` range | `2..8` | `1..8` | The tool must be able to express the reversal to `1`. §3.6 |
-| role names | `%Guardian_Resolve`, "illustrative, not ratified" | **ratified here** | §5.3 is the naming authority; the values match its examples |
+| role names | `Guardian_Resolve`, "illustrative, not ratified" | **ratified here** | §5.3 is the naming authority; the values match its examples |
 
 `investigation-api.md` is the other consumer: its `evidence[].tool` values are names from §1, and its
 §2.3 data boundary is the same boundary as §6 here, enforced one hop earlier.
@@ -44,8 +44,8 @@ silently disagrees with its neighbour is worse than one that is wrong out loud:
 | `get_processing_time` | `PG.Tools.Read` | read | `PG_Read` | `PG_Read` | `iris_interop_avg_*`, aggregated as the proxy aggregates them |
 | `set_pool_size` | `PG.Tools.Resolve` | **write** | `PG_Read` | **`PG_Resolve`** | `Ens.Config.Production` + `Ens.Director.UpdateProduction()` |
 
-`PG_Read` and `PG_Resolve` are **IRIS resources**, held by roles `%Guardian_Read` and
-`%Guardian_Resolve`. §5 explains the resource-not-role choice and why the write tool is
+`PG_Read` and `PG_Resolve` are **IRIS resources**, held by roles `Guardian_Read` and
+`Guardian_Resolve`. §5 explains the resource-not-role choice and why the write tool is
 **listable to `PG_Read` but executable only by `PG_Resolve`**.
 
 Two classes, not six, because discovery is per class: `%AI.Tool` exposes every public method of a
@@ -715,20 +715,31 @@ Three consequences:
 
 | Resource | Held by role | Grants |
 |---|---|---|
-| `PG_Read` | `%Guardian_Read` | listing and executing the five read tools; **listing** `set_pool_size` |
-| `PG_Resolve` | `%Guardian_Resolve` | **executing** `set_pool_size` |
+| `PG_Read` | `Guardian_Read` | listing and executing the five read tools; **listing** `set_pool_size` |
+| `PG_Resolve` | `Guardian_Resolve` | **executing** `set_pool_size` |
 
 **This file is where the names are ratified.** `resolve-api.md` §9.3 defers to it, calling the
-`%Guardian_Resolve` in its own examples "illustrative and not ratified here" and instructing Dev C to
+`Guardian_Resolve` in its own examples "illustrative and not ratified here" and instructing Dev C to
 render `audit.role` as an opaque string and never compare it to a literal. That instruction stands
 even now that the value is fixed: Dev C comparing against a literal is what would make a later rename
 a dashboard change. The names here match `resolve-api.md`'s examples so nothing has to be rewritten.
 
-Resources are named `PG_*` while roles are named `%Guardian_*`, which looks inconsistent and is not:
-the `%` prefix is the IRIS convention for a system-supplied role and is what `resolve-api.md`'s
-examples already carry, while a **custom resource must not use `%`** — that prefix is reserved and
-collides with the shipped `%Ens_*` / `%System_*` namespace. Two different naming rules, applied
-correctly, rather than one applied uniformly and wrongly.
+Resources are named `PG_*` and roles `Guardian_*` — **neither takes a `%` prefix.**
+
+CORRECTED 2026-08-18, and the original reasoning was backwards. This paragraph used to argue that
+roles carry `%` because it "is the IRIS convention for a system-supplied role", concluding that two
+different naming rules were being applied correctly. The premise is true and the conclusion does not
+follow: `%` marks a role as **system-supplied**, which is exactly why a *custom* role may not use it.
+IRIS refuses outright:
+
+```
+ERROR #887: Invalid role name '%Guardian_Read'
+```
+
+So the ratified names were unimplementable, and this was found by trying to create them rather than
+by review — the paragraph reads as a considered decision, which is what made it survive ratification.
+The rule is one rule, not two: `%` is reserved for what InterSystems ships, for both resources and
+roles. Custom names take no prefix.
 
 Resources gated with `$SYSTEM.Security.Check("PG_Resolve","USE")` rather than a `$ROLES` string
 match. That is the shape the shipped `%AI.Policy.ConsoleAuth` already uses — read from its

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -142,7 +142,7 @@ renders from one type rather than from a status code.
   "audit": {
     "auditId": "aihub-audit-44812",
     "actor": "guardian_resolve",
-    "role": "%Guardian_Resolve",
+    "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
     "tool": "set_pool_size",
     "recordedAt": "2026-08-18T14:06:43Z",
@@ -609,7 +609,7 @@ that leaves no trace is not reviewable.
 "audit": {
   "auditId": "aihub-audit-44812",
   "actor": "guardian_resolve",
-  "role": "%Guardian_Resolve",
+  "role": "Guardian_Resolve",
   "requestedBy": "presenter@laptop",
   "tool": "set_pool_size",
   "recordedAt": "2026-08-18T14:06:43Z",
@@ -767,9 +767,9 @@ proven path is proven for a different job.
   | | `mcp-tools.md` calls it | appears in this contract as |
   |---|---|---|
   | IRIS **resource** — what is gated | `PG_Resolve` (write), `PG_Read` (read) | not published; internal to the gate |
-  | IRIS **role** — what a caller holds | `%Guardian_Resolve`, `%Guardian_Read` | `audit.role` |
+  | IRIS **role** — what a caller holds | `Guardian_Resolve`, `Guardian_Read` | `audit.role` |
 
-  So `audit.role: "%Guardian_Resolve"` in §11 and "executable by `PG_Resolve`" in the catalogue are
+  So `audit.role: "Guardian_Resolve"` in §11 and "executable by `PG_Resolve`" in the catalogue are
   the same rule stated from two ends, not two names for one thing. A reader grepping for one string
   and finding the other should not "fix" it. The resource is the thing `%CanExecute` tests; the role
   is the thing an audit record can attribute an action to, which is why only the latter is in this
@@ -909,7 +909,7 @@ Response `200`, `X-Resolve-Outcome: previewed`:
   "audit": {
     "auditId": "aihub-audit-44810",
     "actor": "guardian_resolve",
-    "role": "%Guardian_Resolve",
+    "role": "Guardian_Resolve",
     "requestedBy": null,
     "tool": "get_pool_size",
     "recordedAt": "2026-08-18T14:06:12Z",
@@ -985,7 +985,7 @@ Same request as §11.2, from a caller without the write role. Response `200`,
   "audit": {
     "auditId": "aihub-audit-44813",
     "actor": "guardian_readonly",
-    "role": "%Guardian_Resolve",
+    "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
     "tool": "set_pool_size",
     "recordedAt": "2026-08-18T14:07:02Z",
@@ -1038,7 +1038,7 @@ Response `200`, `X-Resolve-Outcome: refused`:
   "audit": {
     "auditId": "aihub-audit-44814",
     "actor": "guardian_resolve",
-    "role": "%Guardian_Resolve",
+    "role": "Guardian_Resolve",
     "requestedBy": null,
     "tool": "set_pool_size",
     "recordedAt": "2026-08-18T14:07:20Z",


### PR DESCRIPTION
A **contract change PR**, per root `CLAUDE.md` §4: its own PR, a `CHANGELOG.md` entry, reviewed by the other developer.

## What changed

Values only, in `mcp-tools.md` and `resolve-api.md` — 14 occurrences:

| Was | Is |
|---|---|
| `%Guardian_Read` | `Guardian_Read` |
| `%Guardian_Resolve` | `Guardian_Resolve` |

No field added, removed or retyped. No schema and no sample affected — neither contract has either yet. `validate.mjs` unchanged and passing (15 accept / 19 reject / 7 capture claims). **Resources are untouched**: `PG_Read` / `PG_Resolve` were always correct.

## Why — the ratified names were unimplementable

```
ERROR #887: Invalid role name '%Guardian_Read'
```

`%` marks a role as **system-supplied**, so a custom role may not use it.

## The part worth reviewing: the reasoning was backwards, not just the values

`mcp-tools.md` §5 argued that roles carry `%` *because* it "is the IRIS convention for a system-supplied role", and concluded:

> Two different naming rules, applied correctly, rather than one applied uniformly and wrongly.

The premise is **true** and it supports the **opposite** conclusion — being the marker for system-supplied roles is exactly what makes it unavailable to ours. It is one rule applied wrongly.

I rewrote the paragraph rather than swapping its values, because a corrected value sitting under intact bad reasoning invites the next person to change it back, with a rationale already written for them.

**This was found by trying to create the roles, not by review.** The passage reads as a considered decision, complete with an explanation for the apparent `PG_*` / `%Guardian_*` inconsistency — which is why it survived ratification by three people. A confident explanation is harder to doubt than a bare value.

## Verified against the running instance

Not inferred from the error text:

```
RES   PG_Read           RES   PG_Resolve
ROLE  Guardian_Read     ROLE  Guardian_Resolve
```

## What I deliberately did NOT change

- **The existing `2026-08-18` CHANGELOG entry keeps the old values in its prose**, with a note pointing at the correction. A changelog records what a contract *said*; silently updating a past entry would erase the fact that the ratified names were unimplementable. The resource-vs-role distinction that entry draws is unaffected and still correct.
- **`resolve-api.md` §9.3's instruction to Dev C** — render `audit.role` as an opaque string and never compare it to a literal — **stays in force**. It is what kept this from being a dashboard change, and that argument holds even now the values are settled.
- **`iris/labdemo/Tools/AuthPolicy.cls`** already records the divergence in a class comment (it hit `#887` and said so, with "the contracts need correcting"). Updating that comment belongs with the code, not in a contracts PR — it is in #92's area and I will follow up there once this lands.

@kskubach — you are the required second reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)