### PR TITLE
feat(iris): the audit trail AI Hub does not ship, and the seam that applies it

### DIFF
--- a/docs/mvp2-aihub-verified-api.md
+++ b/docs/mvp2-aihub-verified-api.md
@@ -283,15 +283,31 @@ throwaway user with a generated password, logs in as it, and attempts the write:
 PASS: read allowed, write refused, refusal audited.
 ```
 
-**The roles need a database privilege the contracts never mention.** A user holding only
+**A principal needs a database privilege the contracts never mention.** A user holding only
 `PG_Read:U` logged in fine and then died with `<PROTECT> ... Access Denied` on
-`Tools.Governance.1` — before any policy was consulted, because it could not read the routine. Both
-roles therefore carry `%DB_%DEFAULT:RW`, and `RW` rather than `R` because `AuthPolicy` writes the
-denial row *as the refused principal*, which is what makes it attributable.
+`Tools.Governance.1` — before any policy was consulted, because it could not read the routine.
 
-**An honest limitation:** on this image every database shares `%DB_%DEFAULT`, so that grant is
-broad. The least-privilege story is real at the **tool** boundary — `PG_Resolve` genuinely gates
-`set_pool_size` — and is not a database-isolation story. A demo should not imply otherwise.
+**The `Guardian_*` roles deliberately do not grant it.** I first folded `%DB_%DEFAULT:RW` into both
+roles; @Ari-Glikman argued in the #94 review that the role should stay minimal and mean one thing,
+and he is right. The deciding reason is what the grant would *say*: on this image every database
+shares the `%DB_%DEFAULT` resource, so folding it in gives a role whose whole purpose is "may look,
+may not act" the ability to write every database on the instance. A least-privilege boundary that
+hands out broad write to keep a fixture working is not one.
+
+Database access comes from the invocation path instead — the CSP application hosting
+`REST.AgentDispatcher` for the demo, and the throwaway user in `GovernanceProof` for the direct
+session proof (the shipped `%DB_%DEFAULT` role, granted to the *user*). `Setup.AIHub.Run()` prints
+the requirement rather than granting it, because a requirement nobody states is how that `<PROTECT>`
+gets misdiagnosed as a policy bug.
+
+**A guard that could not work, and the reason it is worth recording.** The obvious fix to "the proof
+died before reaching the policy" is to assert inside the unprivileged half that the tool call was
+reached. That is not implementable: with the principal short of database access, `Invoke` dies while
+paging in `Governance.1`, so the process is gone before the result variable is assigned and no line
+after it runs. Verified by stripping the role and re-running. The check therefore lives on the
+**privileged** side — `Prove()` reads the probe user's granted roles back and refuses to hand over a
+password if the database role is missing, since an inconclusive run whose output reads
+`<PROTECT> ... Access Denied` looks exactly like the boundary working.
 
 ## The MCP dev connection
 

--- a/docs/mvp2-aihub-verified-api.md
+++ b/docs/mvp2-aihub-verified-api.md
@@ -129,15 +129,169 @@ execution.
 
 - ~~No LLM provider is configured.~~ **CLOSED** -- see the provider section at the end of this
   file. A real OpenAI call and an agent tool call have both been made from this instance.
-- **What an audit record CONTAINS, and whether it is queryable.** Enforcement is confirmed (see
-  above), but the written record has not been observed, and Dev C needs to display one. This is
-  now the highest-value remaining unknown.
-- **Which policy implementation is active by default.** `%AI.Policy.ConsoleAuth` and
-  `%AI.Policy.ConsoleAudit` exist alongside the abstract bases, so something is wired out of the
-  box -- whether it permits everything until configured is unknown, and "enforced by the runtime"
-  is only a safety property if the configured policy actually denies.
+  **But not on the compose stack** -- see "None of it was on `pg-iris`" below.
+- ~~**What an audit record CONTAINS, and whether it is queryable.**~~ **CLOSED 2026-08-19** -- the
+  answer is that *nothing is written at all*. See "There is no audit store" below.
+- ~~**Which policy implementation is active by default.**~~ **CLOSED 2026-08-19** -- none is. A
+  fresh `%AI.ToolMgr` reports `AuthPolicy: <none>`, `AuditPolicy: <none>`,
+  `DiscoveryPolicy: <none>`. The default permits everything and records nothing.
 - **`@{wallet.*}` substitution** was broken on build 159 per the skill (only `env` and `config`
   registered). Unknown on 126. `%AI.Utils.WalletStore` exists, but existence is not function.
+
+## There is no audit store — the hook fires into nothing
+
+Measured 2026-08-19 on `pg-iris`. `%AI.Policy.Audit` is an abstract base whose one interesting
+method is
+
+```
+%LogExecution(call:%DynamicObject, metadata:%DynamicObject, result:%DynamicObject,
+              duration:%Integer, status:%Status) -> %Status
+```
+
+The only shipped implementation, `%AI.Policy.ConsoleAudit`, writes an ANSI-coloured box to the
+current device and returns. There is no `%AI.Audit.*` persistent class — searched
+`%Dictionary.CompiledClass` for `%AI.*` matching AUDIT or LOG and the only hits are the policy
+classes themselves.
+
+So `mcp-tools.md` §5.5's "every one of the six tools is audited on every call" was true of the
+**hook** and false of the **record**, and MVP 2 §3's final demo step is showing an audit entry.
+`iris/labdemo/Audit/Entry.cls` is the store; `iris/labdemo/Tools/AuditPolicy.cls` is the policy that
+fills it.
+
+### A real `%LogExecution` payload, captured from a live `GetPoolSize("Cloud API")`
+
+```
+call     {"id":"call_id","name":"GetPoolSize","arguments":"{\"host\":\"Cloud API\"}"}
+metadata {}
+result   {"tool_name":"GetPoolSize","result_json":"{...}","display_text":null}
+duration 0
+status   OK
+```
+
+Four things there are not what a reader would assume, and each one changed the implementation:
+
+| Assumption | Reality |
+|---|---|
+| `call.id` identifies the call | it is the **literal string `"call_id"`** on every call — unusable as `auditId` |
+| `call.arguments` is an object | it is a **JSON string**; iterating it yields nothing |
+| `metadata` carries caller identity | it is **empty** `{}` — `actor` has to come from `$username` |
+| `duration` is meaningful | **0** for a call `ExecuteTool` itself timed at `0.0071 s`; it is integer ms |
+
+Tool names are the **ObjectScript method names** — `GetPoolSize`, `SetPoolSize` — not the
+snake_case names in `mcp-tools.md`'s catalogue. Anything joining the two must map.
+
+## A refused call is NOT audited — the contracts overpromise
+
+**This is the most important finding in this file.** `contracts/mcp-tools.md` §5.5 and
+`resolve-api.md` §8 both state that refusals, `not_authorized` explicitly, are audited:
+
+> Every call produces exactly one attributable audit event: applies, refusals, and dry-runs alike.
+
+The runtime cannot deliver that. `ExecuteTool` checks authorization, **then** executes, **then**
+audits — so an authorization denial throws `<%AICore>ToolAccessDenied` at step one and the audit
+hook is never reached. Measured with a deny-all policy registered: `%LogExecution` not called, **0
+rows written**.
+
+The distinction is sharp, and only one half was broken:
+
+| Case | Audited by the runtime? |
+|---|---|
+| successful read | yes |
+| dry-run of the write tool | yes |
+| **tool-level** refusal (our own bounds guard returns `outcome: "refused"`) | yes — the tool ran |
+| unknown host | yes |
+| **authorization** denial (`%CanExecute` refuses) | **no** |
+
+The security-relevant event was the one going unrecorded — an audit log that records only what
+succeeded cannot answer *did anything try to write to the production*.
+
+**Fixed in `iris/labdemo/Tools/AuthPolicy.cls`**, which writes its own `denied` row before
+returning the refusal. It is the only code that ever learns a denial happened, so it is the only
+place the row can come from. That is why `Audit.Entry.Disposition` has two values and two writers.
+
+**Two contract corrections are owed** (`contracts/` is read-only — these are change requests, not
+edits): §5.5 and §8 should say that the *runtime* audits executions and that authorization denials
+are audited by our policy, and `resolve-api.md` §8's `auditId` example `aihub-audit-44812` implies
+an AI Hub audit store that does not exist. The handles are `pg-audit-<n>` — minted by us, because
+inventing AI Hub provenance is the same defect as the mock inventing an id.
+
+## Policies are per-ToolMgr and in memory — not a setting
+
+`SetAuthPolicy` / `SetAuditPolicy` attach the policy to the Rust tool manager identified by that
+object's `%token`:
+
+```objectscript
+Set ..AuditPolicy = policy
+If ..%token '= "" { Do $ZF(-6, $$$IrisLLMLibrary, $$$LLMTOOLMANAGERADDAUDIT, ..%token, policy) }
+```
+
+There is no persisted configuration, so **a first-boot script cannot switch governance on once.**
+Every caller that builds its own `%AI.ToolMgr` — or its own `%AI.Agent`, which builds one — gets an
+ungoverned manager: no authorization check, no audit row, and `SetPoolSize` fully callable against
+the live production. `%AI.Agent.UseToolSet` delegates straight to
+`..ToolManager.RegisterToolSet(className)`, so the natural thing to write is the unsafe thing.
+
+`iris/labdemo/Tools/Governance.cls` is the mitigation: one factory, it cannot return an ungoverned
+manager, and `GovernAgent()` is what Dev B's AI Detective should call instead of `UseToolSet`.
+
+## None of it was on `pg-iris`
+
+Measured 2026-08-19 against the running compose stack, up 2 days:
+
+| | Present |
+|---|---|
+| `PG_Read` / `PG_Resolve` resources | no |
+| `Guardian_Read` / `Guardian_Resolve` roles | no |
+| `AI.Secrets` resource | no |
+| `PGSecrets` wallet collection | no |
+| `AI.LLM.pgdetective` config | no — `ERROR #5809` |
+| `Tools.Read` / `Tools.Resolve` / `Tools.AuthPolicy` compiled | **no** |
+
+Everything the provider section below records as done *was* done — by hand, on the hand-built
+`iris-webinar` instance the MCP dev connection used to point at. None of it reached the container
+the demo runs from, and the tool classes were not even compiled there because the container had
+been up since before #90 landed.
+
+That is the failure `FirstBoot` exists to prevent (#70, #72): a step a person performed on one
+instance is not a step the stack performs. `iris/setup/AIHub.cls` now creates the resources and
+roles idempotently and `FirstBoot` calls it, so a clean `docker compose up` has the boundary armed.
+It deliberately does **not** create the LLM credential — that needs a key, a key does not belong in
+a repository, and this one must be rotated anyway — but it reports the config as missing and prints
+the sequence to create it.
+
+### Observed denial, which is the acceptance criterion
+
+`resolve-api.md` §9.4 and `mcp-tools.md` §5.6(b) both require an *observed* denial rather than a
+passing allow. `iris/test/GovernanceProof.cls` makes it repeatable. It cannot use
+`iris/test/StubPolicy.cls` for this: `$SYSTEM.Security.Check` returns 1 for every resource when the
+caller holds `%All`, and every session that can compile the code holds `%All`. So it creates a real
+throwaway user with a generated password, logs in as it, and attempts the write:
+
+```
+1. logged in as pg_proof_readonly, roles = Guardian_Read
+2. GetPoolSize : executed  <- expected executed
+3. SetPoolSize : denied    <- expected denied
+   error   : ERROR <%AICore>ToolAccessDenied: Tool access denied: Global policy denied:
+             ERROR #5001: 'SetPoolSize' modifies a live production and requires PG_Resolve:USE
+   auditId : pg-audit-6
+4. audit row for the denial:
+   {"auditId":"pg-audit-6","actor":"pg_proof_readonly","role":"Guardian_Read",
+    "tool":"SetPoolSize","recordedAt":"2026-08-19T10:53:43Z","source":"live",
+    "disposition":"denied","denialReason":"'SetPoolSize' modifies a live production
+    and requires PG_Resolve:USE"}
+
+PASS: read allowed, write refused, refusal audited.
+```
+
+**The roles need a database privilege the contracts never mention.** A user holding only
+`PG_Read:U` logged in fine and then died with `<PROTECT> ... Access Denied` on
+`Tools.Governance.1` — before any policy was consulted, because it could not read the routine. Both
+roles therefore carry `%DB_%DEFAULT:RW`, and `RW` rather than `R` because `AuthPolicy` writes the
+denial row *as the refused principal*, which is what makes it attributable.
+
+**An honest limitation:** on this image every database shares `%DB_%DEFAULT`, so that grant is
+broad. The least-privilege story is real at the **tool** boundary — `PG_Resolve` genuinely gates
+`set_pool_size` — and is not a database-isolation story. A demo should not imply otherwise.
 
 ## The MCP dev connection
 

--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -13,6 +13,8 @@ Developer A owns:
 |---|---|
 | `iris/setup/` | One-time ObjectScript setup scripts for the demo namespace |
 | `iris/labdemo/` | LABDEMO production class, HL7 generator, trigger toggles |
+| `iris/labdemo/Tools/` | MVP 2: the six MCP tools, the authorization and audit policies, the governed-manager factory |
+| `iris/labdemo/Audit/` | MVP 2: the persisted audit trail — AI Hub ships no audit store |
 | `services/metrics-proxy/` | Node.js proxy: polls `/api/monitor/metrics` + `/api/monitor/alerts`, exposes per-host JSON |
 
 Do **not** touch `services/detection-engine/`, `apps/dashboard/`, `contracts/` (read only), or any root config shared with other devs without a PR.
@@ -107,3 +109,47 @@ npm run mock
    - **`system_alert` outlives `Reset()`**, because the alert sits in the proxy's in-memory
      buffer on `:3001`, which IRIS cannot reach. Documented in the class and the README.
 4. `/api/monitor/alerts` forwarded as JSON at `/proxy/alerts`.
+
+---
+
+## 7. MVP 2 — the governed MCP tools (read this before touching `Tools/`)
+
+Full measurements are in `docs/mvp2-aihub-verified-api.md`. The four rules that matter here:
+
+**Every public ClassMethod on a `%AI.Tool` subclass becomes an LLM-callable tool.** Verified by
+reading `%AI.Tool.Generator`. A helper left public on `Tools.Resolve` is a second way to mutate a
+live production. Helpers are `[ Private ]`, and `Setup.AIHub.Run()` prints the discovered tool count
+on every boot so a seventh name shows up at boot rather than in review. **Six is the expected
+count.**
+
+**Governance is per-`%AI.ToolMgr` and held in memory — there is no setting.** So never construct a
+`%AI.ToolMgr` or call `%AI.Agent.UseToolSet` directly: both give you an ungoverned manager with no
+authorization check, no audit row, and `SetPoolSize` live. Go through
+`Tools.Governance.ToolManager()` or `Tools.Governance.GovernAgent()`, which cannot return one.
+
+**The runtime does not audit authorization denials.** It checks, then executes, then audits, so a
+denial throws before the audit hook. `Tools.AuthPolicy` writes that row itself. Anything that adds a
+new deny path must go through its `Deny()` helper or the refusal leaves no trace — which is the one
+event a security review actually asks about.
+
+**Tool return values reach an external LLM: metrics and configuration only, never message content
+or PHI** (root `CLAUDE.md` §2.1). `Ens_Util.Log` on this instance holds 61,772 rows carrying
+`PatientID` in plain text, so `GetRecentErrors` extracts an allowlisted error token and never returns
+log text. The audit table *inherits* that guarantee rather than re-enforcing it — if a tool ever
+returns PHI, it lands in `Audit.Entry.Result` in plain text.
+
+### Dev A MVP 2 acceptance
+
+| Criterion | State |
+|---|---|
+| Read tools return real evidence | met — six tools discovered, live values |
+| `set_pool_size` changes the live pool and is reversible | **dry-run verified only**; `before`/`after`/`reversal` correct, an apply has not been run against a live queue |
+| An unauthorized role is refused | met — observed, `iris/test/GovernanceProof.cls` |
+| Every call appears in the audit log | met for executions and for authorization denials |
+| RBAC roles and resources exist from a clean boot | met — `Setup.AIHub`, called by `FirstBoot` |
+| LLM credential in the vault | **not met on the compose stack** — needs a key, and the current one must be rotated |
+
+```objectscript
+do ##class(ProductionGuardian.Setup.AIHub).Status()          // what is and is not in place
+do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()   // reset the log between rehearsals
+```

--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -147,6 +147,7 @@ returns PHI, it lands in `Audit.Entry.Result` in plain text.
 | An unauthorized role is refused | met — observed, `iris/test/GovernanceProof.cls` |
 | Every call appears in the audit log | met for executions and for authorization denials |
 | RBAC roles and resources exist from a clean boot | met — `Setup.AIHub`, called by `FirstBoot` |
+| A principal can actually *use* the roles | needs `%DB_%DEFAULT` **as well**, from the invocation path — the `Guardian_*` roles stay minimal and grant only `PG_*`. Without it you get `<PROTECT>` before any policy is consulted |
 | LLM credential in the vault | **not met on the compose stack** — needs a key, and the current one must be rotated |
 
 ```objectscript

--- a/iris/labdemo/Audit/Entry.cls
+++ b/iris/labdemo/Audit/Entry.cls
@@ -1,0 +1,335 @@
+/// One persisted, queryable record of one MCP tool call.
+///
+/// WHY THIS CLASS EXISTS AT ALL, and it is not a preference. AI Hub ships no audit STORE.
+/// `contracts/mcp-tools.md` §5.6(a) listed "what an audit record actually contains once written,
+/// and whether it is queryable" as unverified; the answer, measured on build 126, is that nothing
+/// is written anywhere:
+///
+///   %AI.ToolMgr.%New().AuditPolicy      ->  <none>
+///   %AI.Policy.ConsoleAudit.%LogExecution -> ANSI-coloured text to the current device
+///
+/// So the only shipped policy prints a box to a terminal and returns. There is no `%AI.Audit.*`
+/// persistent class -- searched `%Dictionary.CompiledClass` for `%AI.*` matching AUDIT or LOG and
+/// the only hits are the policy classes themselves. "Every call is audited" was therefore true of
+/// the HOOK and false of the RECORD, and MVP 2 §3's final demo step is showing an audit entry.
+///
+/// A ROW PER ATTEMPT, not per change. `iris/labdemo/Tools/AuditPolicy.cls` writes the executed
+/// calls and `Tools.AuthPolicy` writes the denied ones -- see `Source` below for why those are two
+/// writers rather than one, and see AuditPolicy's class comment for the measurement that forced it.
+///
+/// THE DATA BOUNDARY IS INHERITED, NOT RE-ENFORCED HERE. `Result` holds the tool's own return
+/// value, and the tools are what guarantee that value carries only metrics and configuration --
+/// `Tools.Read.GetRecentErrors` classifies errors to an allowlisted token precisely so that neither
+/// the model nor this table ever sees log text (root `CLAUDE.md` §2.1, `mcp-tools.md` §6). This
+/// class does not sanitise, and must not be read as a second line of defence: if a tool ever
+/// returns PHI, it lands here in plain text. That is an argument for keeping the guarantee in the
+/// tools, which is where `mcp-tools.md` §5.5 already puts it.
+Class ProductionGuardian.LabDemo.Audit.Entry Extends %Persistent
+{
+
+/// Prefix of the public handle. `resolve-api.md` §8 shows `aihub-audit-44812`, which would claim
+/// this row came out of an AI Hub audit store. It did not -- there is no such store on this build
+/// (see the class comment), and we mint the handle ourselves. Naming it `pg-audit-` says who wrote
+/// it. The contract renders the handle as an opaque string, so the value is free; the provenance it
+/// implies is not, and inventing one is the same defect as inventing an id for the mock resolve
+/// (`resolve-api.md` §8: "inventing an id that resolves to nothing is worse than admitting there is
+/// none"). Recorded as a contract-correction request alongside the `%`-prefixed role names.
+Parameter HANDLEPREFIX = "pg-audit-";
+
+/// UTC, ISO 8601. `recordedAt` in `resolve-api.md` §8.
+Property RecordedAt As %String(MAXLEN = 32) [ Required ];
+
+/// The authenticated IRIS principal, from `$username` at the moment of the call.
+///
+/// `resolve-api.md` §8 is explicit that this is resolved server-side and that a caller cannot name
+/// itself -- `requestedBy` is the advisory label and is recorded NEXT TO this, never instead of it.
+/// Measured: `%LogExecution`'s `metadata` argument arrives as an empty object `{}`, so there is no
+/// identity in the hook payload and `$username` is the only truthful source.
+Property Actor As %String(MAXLEN = 128) [ Required ];
+
+/// `$roles` at the moment of the call, verbatim.
+///
+/// Stored as the raw list rather than "the role that authorized", because which role satisfied the
+/// check is not something the policy is told -- it asks `$SYSTEM.Security.Check` a yes/no question.
+/// Recording the whole set is the honest answer and is what lets a reviewer see that the actor held
+/// `%All` rather than `Guardian_Resolve`, which is the interesting fact about a demo instance.
+Property Roles As %String(MAXLEN = 512);
+
+/// Tool name as the runtime names it -- `GetPoolSize`, `SetPoolSize`.
+///
+/// THE OBJECTSCRIPT METHOD NAME, not the snake_case name in `mcp-tools.md`. Measured from a real
+/// `%LogExecution` payload: `call.name` is `"GetPoolSize"`. The contract's catalogue calls the same
+/// tool `get_pool_size`, so anything joining this column to the contract must map, and
+/// `Tools.AuthPolicy.#WRITETOOL` already depends on the method-name form.
+Property Tool As %String(MAXLEN = 128) [ Required ];
+
+/// The call's arguments as JSON.
+///
+/// `call.arguments` arrives as a JSON STRING, not an object -- measured, and worth stating because
+/// `%GetIterator()` on it fails rather than yielding the arguments. Stored as received.
+Property Arguments As %String(MAXLEN = "");
+
+/// The tool's return value as JSON, or "" when the call never executed.
+///
+/// This is the "what changed" half of *who acted, what changed, when*. For `SetPoolSize` it carries
+/// `before`, `after` and `reversal`, which is what makes a change reviewable and reversible from the
+/// record alone rather than from the operator's memory.
+Property Result As %String(MAXLEN = "");
+
+/// `executed` | `denied`.
+///
+/// TWO VALUES BECAUSE THERE ARE TWO WRITERS, and that is forced by the runtime rather than chosen.
+/// `%AI.ToolMgr.ExecuteTool` checks authorization, then executes, then audits -- so an authorization
+/// denial THROWS `<%AICore>ToolAccessDenied` at step one and the audit hook is never reached.
+/// Measured, with a deny-all policy registered: 0 audit records written, `%LogExecution` never
+/// called. `Tools.AuthPolicy` therefore writes its own `denied` row, because it is the only code
+/// that ever learns a denial happened.
+///
+/// This is why `mcp-tools.md` §5.5 and `resolve-api.md` §8 both overpromise: a tool-level refusal
+/// (our bounds guard returning `outcome: "refused"`) IS audited, because the tool ran; an
+/// authorization refusal is not. The security-relevant one was the one missing.
+Property Disposition As %String(MAXLEN = 16) [ Required ];
+
+/// Populated on `denied` rows: the reason the authorization policy refused.
+///
+/// Names the rule and the missing privilege only. A refusal string crosses the same boundary as any
+/// other tool output (`Tools.AuthPolicy` keeps it free of instance data), and that discipline is
+/// worth preserving in storage too.
+Property DenialReason As %String(MAXLEN = 512);
+
+/// Milliseconds, as the runtime reports them.
+///
+/// MEASURED AS 0 FOR A 7 ms CALL. `%LogExecution` receives `duration` as an integer and
+/// `ExecuteTool`'s own return carries `timing: 0.007099626` seconds for the same call, so anything
+/// under a millisecond -- which every read tool here is -- audits as 0. Recorded rather than
+/// smoothed: `mcp-tools.md` §5.5 lists duration as part of the record, and a reader comparing a
+/// column of zeroes against that sentence should find the explanation here rather than assume the
+/// clock is broken. Null on `denied` rows, which never ran.
+Property DurationMs As %Integer;
+
+/// Error text when the tool executed but returned a failure status; "" otherwise.
+Property StatusText As %String(MAXLEN = 1024);
+
+/// `live` | `mock`. Always `live` from this class -- IRIS is the live path by definition.
+///
+/// Present because `resolve-api.md` §8 makes `source` mandatory and makes `"mock"` mandatory for the
+/// mock resolve. A row written here is a real tool call against the real production; the mock never
+/// reaches IRIS and so never writes one. Stored rather than assumed so a UI reading the table does
+/// not have to know that.
+Property Source As %String(MAXLEN = 8) [ InitialExpression = "live" ];
+
+Index ByRecordedAt On RecordedAt;
+
+Index ByTool On Tool;
+
+/// Write one row and return its public handle, or "" if the write failed.
+///
+/// TAKES THE ALREADY-EXTRACTED FIELDS rather than the raw hook payload, so that the two callers --
+/// the audit policy and the authorization policy -- share the storage and nothing else. They are
+/// recording different events and only one of them has a result.
+///
+/// A FAILED AUDIT WRITE MUST NOT BREAK THE CALL, which is a real decision and not an oversight.
+/// `%LogExecution` runs after the tool has already executed and, for `SetPoolSize`, after the
+/// production has already changed. Returning an error there would report a failure for a change that
+/// did happen -- the worst of both. So this reports "" and the caller records that it could not
+/// write; `resolve-api.md` §8 covers the consequence: `auditId: null`, and for an apply that is
+/// `failed`/`verify` rather than a silent success.
+ClassMethod Record(actor As %String, tool As %String, arguments As %String, result As %String, disposition As %String, durationMs As %Integer = "", statusText As %String = "", denialReason As %String = "") As %String
+{
+    set entry = ..%New()
+    set entry.RecordedAt = ..NowUTC()
+    set entry.Actor = actor
+    set entry.Roles = $roles
+    set entry.Tool = tool
+    set entry.Arguments = arguments
+    set entry.Result = result
+    set entry.Disposition = disposition
+    set entry.DurationMs = durationMs
+    set entry.StatusText = statusText
+    set entry.DenialReason = denialReason
+    set sc = entry.%Save()
+    if $$$ISERR(sc) {
+        quit ""
+    }
+    set handle = ..#HANDLEPREFIX _ entry.%Id()
+    // PROCESS-PRIVATE, and that is what makes it race-free rather than merely convenient. The tool
+    // executes in the caller's own process, so the handle for "the call I just made" is unambiguous
+    // here in a way that "the newest row for this actor and tool" is not -- two investigations
+    // running concurrently would read each other's. Dev B's resolve endpoint needs `audit.auditId`
+    // for the response and this is how it gets it without a query that can be wrong.
+    set ^||ProductionGuardian.Audit("last") = handle
+    quit handle
+}
+
+/// The handle of the most recent row written by THIS process, or "" if none.
+///
+/// The integration seam for `resolve-api.md` §8's `auditId`: invoke the tool, then read this.
+ClassMethod LastHandle() As %String
+{
+    quit $get(^||ProductionGuardian.Audit("last"), "")
+}
+
+/// One row as the `audit` object of `resolve-api.md` §8, or "" if the handle is unknown.
+///
+/// `role` is the recorded role SET rather than a single role -- see `Roles`. The contract instructs
+/// consumers to render it as an opaque string and never compare it to a literal, which is exactly
+/// what makes that honest.
+ClassMethod Describe(handle As %String) As %DynamicObject
+{
+    set id = ..IdFor(handle)
+    if id = "" {
+        quit ""
+    }
+    set entry = ..%OpenId(id)
+    if '$isobject(entry) {
+        quit ""
+    }
+    quit {
+        "auditId": (handle),
+        "actor": (entry.Actor),
+        "role": (entry.Roles),
+        "tool": (entry.Tool),
+        "recordedAt": (entry.RecordedAt),
+        "source": (entry.Source),
+        "disposition": (entry.Disposition),
+        "denialReason": (entry.DenialReason)
+    }
+}
+
+/// The row id inside a handle, or "" when the handle is not one of ours.
+///
+/// Validated rather than trusted: a handle arrives from an HTTP request, and `%OpenId` on arbitrary
+/// text is a way to turn a typo into an unrelated row.
+ClassMethod IdFor(handle As %String) As %String
+{
+    if $extract(handle, 1, $length(..#HANDLEPREFIX)) '= ..#HANDLEPREFIX {
+        quit ""
+    }
+    set id = $extract(handle, $length(..#HANDLEPREFIX) + 1, *)
+    quit $select(id = +id: id, 1: "")
+}
+
+/// The N most recent rows, newest first, as an array of `Describe` objects.
+///
+/// For the read-only audit view MVP 2 §5.4 gives Dev C. Bounded because an unbounded audit query is
+/// a way to time out a dashboard once the table has a demo's worth of read calls in it.
+ClassMethod Recent(limit As %Integer = 20) As %DynamicArray
+{
+    if (limit < 1) || (limit > 200) {
+        set limit = 20
+    }
+    set out = []
+    // Descending by ID rather than by RecordedAt: the id is monotonic per write and RecordedAt has
+    // one-second resolution, so ordering by the timestamp would shuffle calls made in the same
+    // second -- and every read tool here returns in under a millisecond.
+    set sql = "SELECT TOP ? ID FROM ProductionGuardian_LabDemo_Audit.Entry ORDER BY ID DESC"
+    set rs = ##class(%SQL.Statement).%ExecDirect(, sql, limit)
+    if rs.%SQLCODE < 0 {
+        quit out
+    }
+    while rs.%Next() {
+        set desc = ..Describe(..#HANDLEPREFIX _ rs.%Get("ID"))
+        if $isobject(desc) {
+            do out.%Push(desc)
+        }
+    }
+    quit out
+}
+
+/// Delete every row. For resetting between rehearsals, by the same logic as `Triggers.Reset()`.
+///
+/// DELIBERATELY AWKWARD TO REACH, and that is the whole design. Clearing an audit log is the one
+/// operation an audit log exists to make impossible, so this is not on a tool class, is not
+/// LLM-callable (`%AI.ToolMgr.FindTools` only discovers `%AI.Tool` subclasses -- verified), and is not
+/// wired into `FirstBoot`. A boot that silently emptied the audit trail on every container restart
+/// would be worse than no audit trail, because the table would still look authoritative.
+///
+/// It exists because a demo runs several times and `MVP 2 §3`'s last step shows the log -- eleven
+/// rehearsal rows above the one the audience is meant to read is a worse story than a clean log. The
+/// honest framing is that this is a DEMO FIXTURE, not an operations tool; a real deployment would
+/// retain and archive instead, and nothing here should be read as a precedent for that.
+ClassMethod Purge() As %Integer
+{
+    set n = ..AuditCountAll()
+    do ..%KillExtent()
+    kill ^||ProductionGuardian.Audit("last")
+    write "audit log purged: ", n, " row", $select(n = 1: "", 1: "s"), " deleted", !
+    quit n
+}
+
+/// Row count, or "" when the table cannot be read.
+///
+/// "" AND NOT 0, by the same rule as every other unmeasurable value in this area. Caught by running
+/// as an unprivileged principal: `Guardian_Read` cannot SELECT this table, so the count came back as
+/// a confident `0` for a table that had rows in it -- and a caller comparing counts before and after
+/// a call concluded "no audit row was written" when one had been. That is #33 and #49 exactly (an
+/// unmeasurable queue read as a small one; an absent metric deflating a baseline), reproduced in new
+/// code by the person who wrote the comments warning about it.
+ClassMethod AuditCountAll() As %Integer
+{
+    set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT COUNT(*) AS N FROM ProductionGuardian_LabDemo_Audit.Entry")
+    if rs.%SQLCODE < 0 {
+        quit ""
+    }
+    quit $select(rs.%Next(): +rs.%Get("N"), 1: "")
+}
+
+/// ISO 8601 UTC. $ztimestamp is already UTC, unlike $horolog.
+///
+/// NO MANUAL "Z". `$zdatetime(..., 3, 7)` appends one itself -- appending a second produced
+/// `2026-08-19T10:53:43ZZ`, which is not ISO 8601 and which `Date.parse` in the dashboard would
+/// reject. Caught by reading a real row rather than by inspecting the format table.
+ClassMethod NowUTC() As %String [ Private ]
+{
+    quit $zdatetime($ztimestamp, 3, 7)
+}
+
+Storage Default
+{
+<Data name="EntryDefaultData">
+<Value name="1">
+<Value>%%CLASSNAME</Value>
+</Value>
+<Value name="2">
+<Value>RecordedAt</Value>
+</Value>
+<Value name="3">
+<Value>Actor</Value>
+</Value>
+<Value name="4">
+<Value>Roles</Value>
+</Value>
+<Value name="5">
+<Value>Tool</Value>
+</Value>
+<Value name="6">
+<Value>Arguments</Value>
+</Value>
+<Value name="7">
+<Value>Result</Value>
+</Value>
+<Value name="8">
+<Value>Disposition</Value>
+</Value>
+<Value name="9">
+<Value>DenialReason</Value>
+</Value>
+<Value name="10">
+<Value>DurationMs</Value>
+</Value>
+<Value name="11">
+<Value>StatusText</Value>
+</Value>
+<Value name="12">
+<Value>Source</Value>
+</Value>
+</Data>
+<DataLocation>^PG.Audit.EntryD</DataLocation>
+<DefaultData>EntryDefaultData</DefaultData>
+<IdLocation>^PG.Audit.EntryD</IdLocation>
+<IndexLocation>^PG.Audit.EntryI</IndexLocation>
+<StreamLocation>^PG.Audit.EntryS</StreamLocation>
+<Type>%Storage.Persistent</Type>
+}
+
+}

--- a/iris/labdemo/Tools/AuditPolicy.cls
+++ b/iris/labdemo/Tools/AuditPolicy.cls
@@ -1,0 +1,88 @@
+/// Audit policy for the Production Guardian MCP tools — persists what the runtime only announces.
+///
+/// WHAT THE RUNTIME ACTUALLY GIVES US, measured on build 126 rather than read from documentation.
+/// `%AI.Policy.Audit.%LogExecution(call, metadata, result, duration, status)` is called by
+/// `%AI.ToolMgr.ExecuteTool` after a tool runs. A real payload, captured from a live
+/// `GetPoolSize("Cloud API")`:
+///
+///     call     {"id":"call_id","name":"GetPoolSize","arguments":"{\"host\":\"Cloud API\"}"}
+///     metadata {}
+///     result   {"tool_name":"GetPoolSize","result_json":"{...}","display_text":null}
+///     duration 0
+///     status   OK
+///
+/// Four things in that payload are not what `contracts/mcp-tools.md` §5.5 assumes, and each one
+/// changes the implementation:
+///
+///   1. `call.id` is the LITERAL STRING "call_id" -- a placeholder, not an identifier. It is
+///      identical on every call, so it cannot be the `auditId` that `resolve-api.md` §8 promises.
+///      The handle is minted by `Audit.Entry` instead.
+///   2. `call.arguments` is a JSON STRING, not an object. Iterating it yields nothing.
+///   3. `metadata` is EMPTY. There is no caller identity in the payload, so `actor` comes from
+///      `$username` -- which is also the only value a caller cannot forge.
+///   4. `duration` is 0 for a call `ExecuteTool` itself timed at 0.0071 s. It is integer
+///      milliseconds and every read tool here returns faster than that.
+///
+/// AND THE ONE THAT MATTERS MOST: this hook never runs for an authorization denial.
+/// `ExecuteTool` checks the authorization policy, then executes, then audits, and a denial THROWS
+/// `<%AICore>ToolAccessDenied` at the first step. Measured with a deny-all policy registered:
+/// `%LogExecution` was not called and 0 rows were written. So `mcp-tools.md` §5.5's "a failed or
+/// refused call is audited too" is true of a TOOL-LEVEL refusal -- our bounds guard returning
+/// `outcome: "refused"` is audited, because the tool ran -- and false of `not_authorized`, which is
+/// the one a security review asks about. `Tools.AuthPolicy` closes that half by recording its own
+/// denials; see its class comment. Neither class can do it alone and the split is the runtime's,
+/// not ours.
+///
+/// NEVER FAILS THE CALL. Every path returns $$$OK. By the time this runs the tool has executed and,
+/// for `SetPoolSize`, the production has already changed -- so an error here would report failure
+/// for a change that happened. An unwritable audit surfaces as `auditId: null`
+/// (`resolve-api.md` §8), not as a fabricated success and not as a %Status nobody can act on.
+Class ProductionGuardian.LabDemo.Tools.AuditPolicy Extends %AI.Policy.Audit
+{
+
+/// Record one executed tool call.
+Method %LogExecution(call As %DynamicObject, metadata As %DynamicObject, result As %DynamicObject, duration As %Integer, status As %Status) As %Status
+{
+    // WRAPPED WHOLE. A <PROPERTY DOES NOT EXIST> in here would propagate out of ExecuteTool and
+    // turn a successful pool change into an exception at the caller -- the audit reporting a failure
+    // for a change that already landed. The tool has already run; nothing this method does may
+    // change that outcome.
+    try {
+        set name = ""
+        set args = ""
+        if $isobject(call) {
+            set name = call.%Get("name", "")
+            // A STRING, not an object (measured -- see the class comment). Stored as received rather
+            // than parsed and re-serialised, so the record shows exactly what the runtime passed.
+            set args = call.%Get("arguments", "")
+        }
+
+        // `result_json` is where the tool's own return value lives; `display_text` was null on every
+        // payload observed. Fall back to the whole object rather than to "" so an unexpected shape
+        // still leaves evidence instead of an empty column.
+        set payload = ""
+        if $isobject(result) {
+            set payload = result.%Get("result_json", "")
+            if payload = "" {
+                set payload = result.%ToJSON()
+            }
+        }
+
+        set errText = ""
+        if $$$ISERR(status) {
+            set errText = $system.Status.GetErrorText(status)
+        }
+
+        do ##class(ProductionGuardian.LabDemo.Audit.Entry).Record(
+            $username, name, args, payload, "executed", duration, errText)
+    } catch ex {
+        // Deliberately swallowed, and this is the one place in the area where that is right. There is
+        // no device to write to -- an agent invoked over HTTP has no terminal -- and the alternative
+        // is failing a completed call. The absence of a row IS the signal: `resolve-api.md` §8 makes
+        // a missing `auditId` on an apply a `failed`/`verify` outcome rather than a silent success,
+        // so a caller that needs the guarantee still gets one.
+    }
+    quit $$$OK
+}
+
+}

--- a/iris/labdemo/Tools/AuthPolicy.cls
+++ b/iris/labdemo/Tools/AuthPolicy.cls
@@ -53,6 +53,19 @@
 /// -- the `%` prefix is reserved for system roles. The created roles are `Guardian_Read` and
 /// `Guardian_Resolve`, unprefixed, and the contracts need correcting. Recorded here because the
 /// contracts are ratified and a silent divergence is worse than a noted one.
+///
+/// THIS CLASS ALSO WRITES THE AUDIT ROW FOR A DENIAL, which looks like a layering violation and is
+/// not. `%AI.ToolMgr.ExecuteTool` checks authorization, then executes, then calls the AUDIT policy --
+/// so a denial throws `<%AICore>ToolAccessDenied` at step one and the audit hook is never reached.
+/// Measured on build 126 with a deny-all policy registered: `%LogExecution` not called, 0 rows
+/// written. `contracts/mcp-tools.md` §5.5 and `resolve-api.md` §8 both promise that refusals --
+/// `not_authorized` explicitly -- are audited, and the runtime cannot deliver it: a tool-level
+/// refusal is audited because the tool ran, but an authorization refusal is not.
+///
+/// So this class is the only code that ever learns a denial happened, which makes it the only place
+/// the row can be written from. An audit log that records only what succeeded cannot answer "did
+/// anything try to write to the production", and that is the question a healthcare operations review
+/// actually asks. Recording here is what makes `Audit.Entry.Disposition` have two values.
 Class ProductionGuardian.LabDemo.Tools.AuthPolicy Extends %AI.Policy.Authorization
 {
 
@@ -93,13 +106,13 @@ Method %CanExecute(tool As %String, call As %DynamicObject, metadata As %Dynamic
     if name = "" {
         // FAIL CLOSED. A call we cannot identify is not a call we can authorise, and defaulting to
         // allow here would reintroduce the permissive default in a subtler form.
-        quit $$$ERROR($$$GeneralError, "tool call carried no name, so it cannot be authorised")
+        quit ..Deny(name, "tool call carried no name, so it cannot be authorised")
     }
 
     // Every tool needs PG_Read. Checked first so an unprivileged caller gets one clear answer
     // rather than a different one per tool.
     if '..HasResource(..#READRESOURCE) {
-        quit $$$ERROR($$$GeneralError, "'" _ name _ "' requires " _ ..#READRESOURCE _ ":USE")
+        quit ..Deny(name, "'" _ name _ "' requires " _ ..#READRESOURCE _ ":USE")
     }
 
     // The mutating tool needs the privileged resource ON TOP of PG_Read.
@@ -111,11 +124,32 @@ Method %CanExecute(tool As %String, call As %DynamicObject, metadata As %Dynamic
             // One line: a $$$ macro cannot span lines -- MPP5612 "Referenced macro missing right
             // paren". Building the message first keeps it readable without breaking the macro.
             set why = "'" _ name _ "' modifies a live production and requires " _ ..#WRITERESOURCE _ ":USE"
-            quit $$$ERROR($$$GeneralError, why)
+            quit ..Deny(name, why)
         }
     }
 
     quit $$$OK
+}
+
+/// Record the denial, then return it as the refusal. Private.
+///
+/// EVERY DENY PATH GOES THROUGH HERE, which is the point: an audit row that is written by three
+/// separate branches is one a fourth branch will forget. See the class comment for why the row is
+/// written here rather than by the audit policy -- the audit hook never runs for a denial.
+///
+/// The audit write CANNOT change the decision. A denial that failed to record is still a denial;
+/// returning $$$OK because the log was full would trade an unrecorded refusal for an unauthorised
+/// execution, which is the wrong direction. So the write is wrapped and its result ignored, and the
+/// refusal is returned either way.
+Method Deny(name As %String, why As %String) As %Status [ Private ]
+{
+    try {
+        do ##class(ProductionGuardian.LabDemo.Audit.Entry).Record(
+            $username, name, "", "", "denied", , , why)
+    } catch ex {
+        // See above: the decision stands regardless.
+    }
+    quit $$$ERROR($$$GeneralError, why)
 }
 
 /// True when the current user holds USE on a resource. Private.

--- a/iris/labdemo/Tools/Governance.cls
+++ b/iris/labdemo/Tools/Governance.cls
@@ -1,0 +1,167 @@
+/// The one way to obtain a governed tool manager — because governance is per-instance, not global.
+///
+/// THE FINDING THIS CLASS EXISTS FOR, and it invalidates the obvious reading of
+/// `contracts/mcp-tools.md` §5.6(b). "Register ours with `%AI.ToolMgr.SetAuthPolicy(policy)`" sounds
+/// like a one-time instance configuration. It is not. Read from the shipped `SetAuditPolicy` body:
+///
+///     Set ..AuditPolicy = policy
+///     If ..%token '= "" { Do $ZF(-6, $$$IrisLLMLibrary, $$$LLMTOOLMANAGERADDAUDIT, ..%token, policy) }
+///
+/// The policy is attached to the Rust tool manager identified by THIS OBJECT'S `%token`. It is
+/// in-memory and per-`%AI.ToolMgr`. Measured: a freshly constructed manager reports
+/// `AuthPolicy: <none>`, `AuditPolicy: <none>`, `DiscoveryPolicy: <none>`. So there is no persisted
+/// setting, nothing a first-boot script can switch on once, and no default that denies.
+///
+/// WHY THAT IS A SAFETY PROBLEM RATHER THAN AN INCONVENIENCE. Every caller that builds its own
+/// `%AI.ToolMgr` -- or its own `%AI.Agent`, which builds one -- gets an UNGOVERNED one: no
+/// authorization check, no audit row, and `SetPoolSize` fully callable against the live production.
+/// Forgetting two lines is not a visible mistake; it produces a manager that works perfectly and
+/// silently mutates a production without a trace. `iris/setup/AIHub.cls` can create the roles and
+/// resources at boot, but it cannot pre-register a policy onto a manager that does not exist yet.
+///
+/// So the mitigation is structural: there is one factory, it is the only documented way in, and it
+/// cannot hand back an ungoverned manager. Dev B's AI Detective orchestration calls `Govern()` on
+/// its agent rather than assembling policies itself -- that keeps the RBAC and audit story in
+/// `iris/**` where root `CLAUDE.md` §3 puts it, and means a change to the policy model does not need
+/// a matching change in the detection engine.
+///
+/// NOT A `%AI.Tool` SUBCLASS, deliberately. `%AI.ToolMgr.FindTools` filters on
+/// `$$issubclassof(className, "%AI.Tool")` -- verified by reading it -- so nothing here can become a
+/// seventh LLM-callable tool no matter how many public methods it grows.
+Class ProductionGuardian.LabDemo.Tools.Governance
+{
+
+/// The read-tool class. Registered for every caller.
+Parameter READTOOLS = "ProductionGuardian.LabDemo.Tools.Read";
+
+/// The write-tool class, in its own class so the RBAC requirement does not leak onto the reads.
+Parameter WRITETOOLS = "ProductionGuardian.LabDemo.Tools.Resolve";
+
+/// A tool manager with both policies registered and both tool sets loaded.
+///
+/// POLICIES BEFORE TOOL SETS. Registration order is not documented, and the ordering that has been
+/// exercised is this one -- a manager that registered tools first and policies second has never been
+/// observed here, so it is not what this returns. Cheap to keep; expensive to guess wrong about.
+///
+/// `pIncludeWrite = 0` yields a manager that cannot reach `SetPoolSize` at all, for a caller that
+/// only gathers evidence. That is defence in depth rather than the boundary: the boundary is
+/// `AuthPolicy`, which refuses `SetPoolSize` without `PG_Resolve` even when the tool IS registered.
+/// Both matter -- §5.3's demo needs the write tool VISIBLE and refused, which is the default.
+ClassMethod ToolManager(pIncludeWrite As %Boolean = 1, Output pStatus As %Status) As %AI.ToolMgr
+{
+    set pStatus = $$$OK
+    set mgr = ##class(%AI.ToolMgr).%New()
+    if '$isobject(mgr) {
+        set pStatus = $$$ERROR($$$GeneralError, "could not create a %AI.ToolMgr")
+        quit $$$NULLOREF
+    }
+
+    set pStatus = ..Attach(mgr)
+    if $$$ISERR(pStatus) {
+        // NO UNGOVERNED MANAGER LEAVES THIS METHOD. Returning the manager with a warning would put a
+        // fully functional, unaudited `SetPoolSize` in a caller's hands, and the caller most likely
+        // to ignore a status is the one that most needs the policy.
+        quit $$$NULLOREF
+    }
+
+    set pStatus = mgr.RegisterToolSet(..#READTOOLS)
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    if pIncludeWrite {
+        set pStatus = mgr.RegisterToolSet(..#WRITETOOLS)
+        if $$$ISERR(pStatus) {
+            quit $$$NULLOREF
+        }
+    }
+    quit mgr
+}
+
+/// Attach our authorization and audit policies to an existing tool manager.
+///
+/// The seam for `%AI.Agent`: an agent builds its own manager and exposes it as `.ToolManager`, so
+/// governing an agent means governing that object rather than replacing it.
+ClassMethod Attach(pManager As %AI.ToolMgr) As %Status
+{
+    if '$isobject(pManager) {
+        quit $$$ERROR($$$GeneralError, "no tool manager to govern")
+    }
+    set sc = pManager.SetAuthPolicy(##class(ProductionGuardian.LabDemo.Tools.AuthPolicy).%New())
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    quit pManager.SetAuditPolicy(##class(ProductionGuardian.LabDemo.Tools.AuditPolicy).%New())
+}
+
+/// Govern an agent's tool manager and register the tool sets on it.
+///
+/// FOR DEV B's AI DETECTIVE. `%AI.Agent.UseToolSet(className)` delegates to
+/// `..ToolManager.RegisterToolSet(className)`, so an agent that calls `UseToolSet` directly gets the
+/// tools with NO policies attached -- which is exactly the ungoverned manager described in the class
+/// comment, and it is the natural thing to write. Call this instead of `UseToolSet`.
+///
+/// Call it AFTER `%Init()`: `%Init` runs `%LoadToolSets()`, and an agent whose TOOLSETS parameter
+/// names our classes will have registered them on an ungoverned manager by then. Attaching
+/// afterwards still governs every subsequent execution, because the policy is consulted per call
+/// rather than per registration.
+ClassMethod GovernAgent(pAgent As %AI.Agent, pIncludeWrite As %Boolean = 1) As %Status
+{
+    if '$isobject(pAgent) {
+        quit $$$ERROR($$$GeneralError, "no agent to govern")
+    }
+    if '$isobject(pAgent.ToolManager) {
+        // %Init() builds it. An agent handed over before initialisation cannot be governed, and
+        // saying so is better than attaching to nothing and reporting success.
+        quit $$$ERROR($$$GeneralError, "agent has no ToolManager yet -- call %Init() first")
+    }
+    set sc = ..Attach(pAgent.ToolManager)
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    set sc = pAgent.ToolManager.RegisterToolSet(..#READTOOLS)
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    if pIncludeWrite {
+        set sc = pAgent.ToolManager.RegisterToolSet(..#WRITETOOLS)
+    }
+    quit sc
+}
+
+/// Execute one tool through a governed manager and report the audit handle alongside the result.
+///
+/// THE CONVENIENCE THAT KEEPS THE TWO FACTS TOGETHER. `resolve-api.md` §8 requires `audit.auditId`
+/// in every response, and the handle is only knowable after the call. A caller that builds a manager,
+/// executes, and then forgets to read the handle produces a response claiming an audit entry it
+/// cannot point at.
+///
+/// `outcome` here is the TRANSPORT outcome, not the tool's. A tool that refuses on its own bounds
+/// returns `executed` with a refusal inside `result` -- because it ran. Only an authorization denial
+/// yields `denied`, and that distinction is the whole subject of `AuthPolicy`'s class comment.
+ClassMethod Invoke(pTool As %String, pArguments As %DynamicObject) As %DynamicObject
+{
+    set out = { "tool": (pTool), "outcome": null, "result": null, "auditId": null, "error": null }
+    set mgr = ..ToolManager(1, .sc)
+    if $$$ISERR(sc) {
+        set out.outcome = "unavailable"
+        set out.error = $system.Status.GetErrorText(sc)
+        quit out
+    }
+    try {
+        set res = mgr.ExecuteTool(pTool, pArguments)
+        set out.outcome = "executed"
+        set out.result = res
+    } catch ex {
+        // `<%AICore>ToolAccessDenied` arrives here, and ONLY as an exception -- there is no status
+        // return for a denial. The audit row was written by AuthPolicy before the throw, so the
+        // handle below is populated for a denial too, which is what makes §11.3's RBAC-denied
+        // example possible.
+        set out.outcome = "denied"
+        set out.error = ex.DisplayString()
+    }
+    set handle = ##class(ProductionGuardian.LabDemo.Audit.Entry).LastHandle()
+    set out.auditId = $select(handle '= "": handle, 1: "")
+    quit out
+}
+
+}

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -58,29 +58,35 @@ Parameter WRITEROLE = "Guardian_Resolve";
 /// to read, so an existing resource of the right kind is the only honest source.
 Parameter RESOURCETYPE = 2147483648;
 
-/// Database privilege both roles need on top of the PG_* resources.
+/// The shipped role carrying database access, which a caller ALSO needs — and which these roles
+/// deliberately do not include.
 ///
-/// NOT OPTIONAL, AND NOT OBVIOUS. `PG_Read:U` lets the policy say yes; it does not let a principal
-/// run the code that asks. Measured: a real user holding only `Guardian_Read` logged in successfully
-/// (`roles = Guardian_Read`) and then died with
+/// A PRINCIPAL NEEDS TWO THINGS, and only one of them is ours. `PG_Read:U` lets the policy say yes;
+/// it does not let a principal run the code that asks. Measured: a real user holding only
+/// `Guardian_Read` logged in successfully and then died with
 ///
 ///     <PROTECT> ... |ProductionGuardian.LabDemo.Tools.Governance.1    Access Denied
 ///
-/// before any policy was consulted -- it could not read the routine. Neither `mcp-tools.md` nor
+/// before any policy was consulted — it could not read the routine. Neither `mcp-tools.md` nor
 /// `resolve-api.md` mentions a database privilege, so a reader implementing the roles from the
-/// contracts alone produces roles that cannot be used.
+/// contracts alone produces roles that appear correct and cannot be used.
 ///
-/// RW RATHER THAN R, and the reason is the audit trail. `Tools.AuthPolicy` writes the `denied` row as
-/// the REFUSED principal -- that is what makes the row attributable to them -- so a read-only
-/// principal must be able to write one row to the audit table. A role with `:R` produces a denial
-/// that cannot be recorded, which is the hole this whole audit design exists to close.
+/// THESE ROLES STILL DO NOT GRANT IT, and that is @Ari-Glikman's call from the #94 review rather than
+/// mine — I had folded `%DB_%DEFAULT:RW` into both roles and he argued the role should stay minimal
+/// and mean one thing. He is right, and the deciding reason is what the grant would say: on this image
+/// every database shares the `%DB_%DEFAULT` resource, so folding it in gives a role whose entire
+/// purpose is "may look, may not act" the ability to write every database on the instance. A
+/// least-privilege boundary that hands out broad write to keep a fixture working is not one.
 ///
-/// THE HONEST LIMITATION. On this image every database shares the `%DB_%DEFAULT` resource (read from
-/// `SYS.Database` for the labdemo directory), so this grant is broad: a principal who may run the
-/// tools may also reach other databases. The least-privilege story MVP 2 §2.2 tells is real at the
-/// TOOL boundary -- `PG_Resolve` genuinely gates `set_pool_size` -- and is NOT a database isolation
-/// story. Stating that here rather than letting a demo imply otherwise.
-Parameter DBRESOURCE = "%DB_%DEFAULT:RW";
+/// SO WHERE DOES IT COME FROM? The invocation path, which is the layer that actually knows. In the
+/// demo that is the CSP application hosting `REST.AgentDispatcher` — a web application authenticates
+/// the caller and can carry application roles — and for the direct-session proof it is
+/// `Test.GovernanceProof`, which grants this role to its throwaway user. Named here rather than in
+/// both places so there is one spelling of it.
+///
+/// Reported by `Run()` rather than granted, because a requirement nobody states is how the
+/// `<PROTECT>` above gets diagnosed as a policy bug.
+Parameter DBROLE = "%DB_%DEFAULT";
 
 /// Create the resources and roles, then report what is and is not in place.
 ///
@@ -104,6 +110,10 @@ ClassMethod Run() As %Status
     do ..ReportProvider()
 
     write !, "-----------------------------------------------", !
+    write "These roles grant the PG_* resources and nothing else. A principal", !
+    write "ALSO needs database access or it dies with <PROTECT> before any", !
+    write "policy is consulted -- grant ", ..#DBROLE, " alongside, from the", !
+    write "invocation path (the CSP application, or the proof fixture).", !
     write "Policies are NOT registered by this call -- they cannot be.", !
     write "%AI.ToolMgr holds them in memory, per instance. Obtain a governed", !
     write "manager with:", !
@@ -148,12 +158,13 @@ ClassMethod CreateResources() As %Status
 /// the policy's own ordering rather than assumed from the names.
 ClassMethod CreateRoles() As %Status
 {
+    // THE PG_* RESOURCES ONLY. See #DBROLE for why database access is deliberately not folded in.
     set roles(..#READROLE) = $listbuild(
         "Production Guardian: evidence gathering, no mutation",
-        ..#DBRESOURCE _ "," _ ..#READRESOURCE _ ":U")
+        ..#READRESOURCE _ ":U")
     set roles(..#WRITEROLE) = $listbuild(
         "Production Guardian: may apply the governed pool-size action",
-        ..#DBRESOURCE _ "," _ ..#READRESOURCE _ ":U," _ ..#WRITERESOURCE _ ":U")
+        ..#READRESOURCE _ ":U," _ ..#WRITERESOURCE _ ":U")
 
     new $namespace
     set $namespace = "%SYS"

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -1,0 +1,301 @@
+/// The MVP 2 governance setup, as one idempotent call.
+///
+///   do ##class(ProductionGuardian.Setup.AIHub).Run()
+///
+/// WHY THIS EXISTS, and it is the same reason `FirstBoot` exists. Measured on the running compose
+/// stack (`pg-iris`, up 2 days) on 2026-08-19, every piece of MVP 2's security model was ABSENT:
+///
+///   PG_Read resource            0
+///   PG_Resolve resource         0
+///   Guardian_Read role          0
+///   Guardian_Resolve role       0
+///   AI.Secrets resource         0
+///   PGSecrets wallet            0
+///   AI.LLM.pgdetective config   ERROR #5809 -- not found
+///
+/// `docs/mvp2-aihub-verified-api.md` records all of that as done, and it WAS done -- by hand, on the
+/// hand-built `iris-webinar` instance the MCP dev connection used to point at. None of it reached the
+/// container the demo actually runs from. That is exactly the failure `FirstBoot` was written for
+/// (#70, #72): a step performed by a person on one instance is not a step the stack performs.
+///
+/// SO THE TOOLS WERE NOT GOVERNED. `Tools.AuthPolicy` checks `$SYSTEM.Security.Check("PG_Resolve")`,
+/// and a resource that does not exist cannot be held -- but the policy was never registered either
+/// (see `Tools.Governance`), so nothing consulted it. On a clean `docker compose up`, `SetPoolSize`
+/// was callable against the live production by anything that could reach the MCP endpoint, with no
+/// authorization check and no audit row. Every guard inside `Tools.Resolve` still applied; those are
+/// the tool defending itself, not an authorization boundary.
+///
+/// WHAT THIS CLASS DELIBERATELY DOES NOT DO. It does not create the LLM credential. That needs an
+/// API key, a key does not belong in a repository (root `CLAUDE.md` §6, MVP 2 §6 "Credential
+/// exposure"), and the current one must be rotated regardless -- it was pasted into a chat transcript
+/// to reach me. `Status()` REPORTS whether the provider config resolves and prints the exact
+/// sequence to create it, so the missing piece is visible rather than discovered during a rehearsal.
+Class ProductionGuardian.Setup.AIHub
+{
+
+/// Resource required to see or call any Production Guardian tool. Matches
+/// `Tools.AuthPolicy.#READRESOURCE` -- and deliberately NOT imported from it, by the same rule that
+/// keeps `Tools.Read.#PRODUCTION` a separate literal: a setup script that silently followed a rename
+/// in the policy would create a resource for a boundary nobody reviewed.
+Parameter READRESOURCE = "PG_Read";
+
+/// Resource required to EXECUTE the one mutating tool.
+Parameter WRITERESOURCE = "PG_Resolve";
+
+/// Role granted to a caller that may gather evidence but not act. `mcp-tools.md` and
+/// `resolve-api.md` write these `%Guardian_Read` / `%Guardian_Resolve`; IRIS refuses a leading `%`
+/// with `ERROR #887: Invalid role name` because that prefix is reserved for system roles. The
+/// unprefixed names are what can exist, and PR #93 is the contract correction.
+Parameter READROLE = "Guardian_Read";
+
+/// Role granted to a caller that may apply the governed action.
+Parameter WRITEROLE = "Guardian_Resolve";
+
+/// Application-defined resource type.
+///
+/// 2147483648 (0x80000000), read off the FSB_* resources this image already ships rather than picked
+/// from a constant list -- the property is typed `Security.Datatype.ResourceType` with no VALUELIST
+/// to read, so an existing resource of the right kind is the only honest source.
+Parameter RESOURCETYPE = 2147483648;
+
+/// Database privilege both roles need on top of the PG_* resources.
+///
+/// NOT OPTIONAL, AND NOT OBVIOUS. `PG_Read:U` lets the policy say yes; it does not let a principal
+/// run the code that asks. Measured: a real user holding only `Guardian_Read` logged in successfully
+/// (`roles = Guardian_Read`) and then died with
+///
+///     <PROTECT> ... |ProductionGuardian.LabDemo.Tools.Governance.1    Access Denied
+///
+/// before any policy was consulted -- it could not read the routine. Neither `mcp-tools.md` nor
+/// `resolve-api.md` mentions a database privilege, so a reader implementing the roles from the
+/// contracts alone produces roles that cannot be used.
+///
+/// RW RATHER THAN R, and the reason is the audit trail. `Tools.AuthPolicy` writes the `denied` row as
+/// the REFUSED principal -- that is what makes the row attributable to them -- so a read-only
+/// principal must be able to write one row to the audit table. A role with `:R` produces a denial
+/// that cannot be recorded, which is the hole this whole audit design exists to close.
+///
+/// THE HONEST LIMITATION. On this image every database shares the `%DB_%DEFAULT` resource (read from
+/// `SYS.Database` for the labdemo directory), so this grant is broad: a principal who may run the
+/// tools may also reach other databases. The least-privilege story MVP 2 §2.2 tells is real at the
+/// TOOL boundary -- `PG_Resolve` genuinely gates `set_pool_size` -- and is NOT a database isolation
+/// story. Stating that here rather than letting a demo imply otherwise.
+Parameter DBRESOURCE = "%DB_%DEFAULT:RW";
+
+/// Create the resources and roles, then report what is and is not in place.
+///
+/// IDEMPOTENT. Every step checks before acting and says what it found, so a re-run after a partial
+/// failure is safe -- which matters because compose restarts containers and this is called from
+/// `FirstBoot`.
+ClassMethod Run() As %Status
+{
+    write "ProductionGuardian MVP 2 AI Hub governance setup", !
+    write "===============================================", !, !
+
+    set sc = ..CreateResources()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    set sc = ..CreateRoles()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    do ..ReportTools()
+    do ..ReportProvider()
+
+    write !, "-----------------------------------------------", !
+    write "Policies are NOT registered by this call -- they cannot be.", !
+    write "%AI.ToolMgr holds them in memory, per instance. Obtain a governed", !
+    write "manager with:", !
+    write "  set mgr = ##class(ProductionGuardian.LabDemo.Tools.Governance).ToolManager()", !
+    quit $$$OK
+}
+
+/// The two IRIS resources the authorization policy checks.
+ClassMethod CreateResources() As %Status
+{
+    set res(..#READRESOURCE) = "Production Guardian: list and call MCP read tools"
+    set res(..#WRITERESOURCE) = "Production Guardian: execute set_pool_size on a live production"
+
+    new $namespace
+    set $namespace = "%SYS"
+    set name = ""
+    for {
+        set name = $order(res(name), 1, desc)
+        quit:name=""
+        if ##class(Security.Resources).Exists(name) {
+            write "1. resource ", name, ": exists", !
+            continue
+        }
+        // PUBLIC PERMISSION IS EMPTY, which is the whole point of the resource. A public permission
+        // of "U" would grant USE to everyone and make the policy's check pass for every caller --
+        // a boundary that exists, is consulted, and never refuses. That is the shape of defect
+        // `Tools.AuthPolicy` was written to remove, reintroduced one argument later.
+        set sc = ##class(Security.Resources).Create(name, desc, "", ..#RESOURCETYPE)
+        write "1. resource ", name, ": ", $select(sc: "created", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+        if $$$ISERR(sc) {
+            quit
+        }
+    }
+    quit $select($data(sc): sc, 1: $$$OK)
+}
+
+/// The two roles. `Guardian_Resolve` holds BOTH resources.
+///
+/// It is not enough for the write role to hold `PG_Resolve`: `%CanExecute` requires `PG_Read` on
+/// every tool before it considers the write resource at all, so a role holding only `PG_Resolve`
+/// would be refused on the first check with a message about the wrong privilege. Verified against
+/// the policy's own ordering rather than assumed from the names.
+ClassMethod CreateRoles() As %Status
+{
+    set roles(..#READROLE) = $listbuild(
+        "Production Guardian: evidence gathering, no mutation",
+        ..#DBRESOURCE _ "," _ ..#READRESOURCE _ ":U")
+    set roles(..#WRITEROLE) = $listbuild(
+        "Production Guardian: may apply the governed pool-size action",
+        ..#DBRESOURCE _ "," _ ..#READRESOURCE _ ":U," _ ..#WRITERESOURCE _ ":U")
+
+    new $namespace
+    set $namespace = "%SYS"
+    set name = ""
+    for {
+        set name = $order(roles(name), 1, spec)
+        quit:name=""
+        set desc = $list(spec, 1)
+        set resources = $list(spec, 2)
+        if ##class(Security.Roles).Exists(name) {
+            do ##class(Security.Roles).Get(name, .props)
+            set current = $get(props("Resources"))
+            if current = resources {
+                write "2. role ", name, ": exists, resources = ", current, !
+                continue
+            }
+            // CONVERGED, NOT LEFT ALONE -- and the difference from #66 is ownership. #66's lesson was
+            // that restoring a HARDCODED value destroyed a port an operator had legitimately chosen.
+            // These two roles are ours: the names are namespaced to this product, their entire
+            // purpose is defined by this class, and a `Guardian_Read` holding the wrong resources is
+            // not a tuned deployment, it is a stale one. The failure it causes is also silent -- the
+            // policy refuses, the dashboard shows a disabled button, and the cause looks like a
+            // policy bug -- so leaving it and printing a note would be the worse outcome.
+            //
+            // The old value is printed before the new one so the change is reviewable rather than
+            // merely done. That is the part #66 was actually missing.
+            kill mod
+            set mod("Resources") = resources
+            set sc = ##class(Security.Roles).Modify(name, .mod)
+            write "2. role ", name, ": ", $select(sc: "updated", 1: "UPDATE FAILED " _ $system.Status.GetErrorText(sc)), !
+            write "   was: ", current, !
+            write "   now: ", resources, !
+            if $$$ISERR(sc) {
+                quit
+            }
+            continue
+        }
+        set sc = ##class(Security.Roles).Create(name, desc, resources, "")
+        write "2. role ", name, ": ", $select(sc: "created with " _ resources, 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+        if $$$ISERR(sc) {
+            quit
+        }
+    }
+    quit $select($data(sc): sc, 1: $$$OK)
+}
+
+/// How many tools the runtime actually discovers, and their names.
+///
+/// SIX, AND THE COUNT IS THE TEST. `Tools.Read` and `Tools.Resolve` both warn that every public
+/// ClassMethod becomes an LLM-callable tool, so a seventh name here means a helper was left public
+/// -- and for `Tools.Resolve` a seventh name is a second way to mutate a live production. Printed on
+/// every setup run so the regression is visible at boot rather than in a review.
+ClassMethod ReportTools()
+{
+    set expected = 6
+    set found = 0
+    for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Resolve" {
+        if '##class(%Dictionary.CompiledClass).%ExistsId(class) {
+            write "3. tools ", class, ": NOT COMPILED", !
+            continue
+        }
+        try {
+            set inst = $classmethod(class, "%New")
+            set cat = inst.%Discover()
+            set names = ""
+            if $isobject(cat.tools) {
+                set it = cat.tools.%GetIterator()
+                while it.%GetNext(.k, .t) {
+                    set found = found + 1
+                    set names = names _ $select(names = "": "", 1: ", ") _ t.name
+                }
+            }
+            write "3. tools ", $piece(class, ".", *), ": ", names, !
+        } catch ex {
+            write "3. tools ", class, ": DISCOVERY FAILED ", ex.DisplayString(), !
+        }
+    }
+    write "3. tools discovered: ", found, $select(found = expected: " (expected " _ expected _ ")", 1: " -- EXPECTED " _ expected _ ", INVESTIGATE"), !
+}
+
+/// Does an LLM provider configuration resolve? Reported, never created.
+ClassMethod ReportProvider(pName As %String = "pgdetective")
+{
+    set id = "AI.LLM." _ pName
+    try {
+        set sc = ##class(%ConfigStore.Configuration).GetDetails(id, .d, 0, 0)
+        if $$$ISERR(sc) {
+            write "4. LLM provider ", id, ": NOT CONFIGURED", !
+            write "   AI Detective cannot run until it is. It needs an API key, so it is not", !
+            write "   created here -- a key in a repository is the credential-exposure risk", !
+            // ASCII in terminal output. The comments in this area use a section sign freely and that
+            // is fine in a source file, but IRIS wrote it to the terminal as a replacement character
+            // -- and #81 was five raw 0x97 bytes doing the same kind of damage.
+            write "   MVP 2 section 6 lists. Create it with the wallet pattern in", !
+            write "   docs/mvp2-aihub-verified-api.md (""The LLM provider is configured"").", !
+            quit
+        }
+        write "4. LLM provider ", id, ": configured, model = ", $select($isobject($get(d)): d.%Get("model", "?"), 1: "?"), !
+    } catch ex {
+        write "4. LLM provider ", id, ": CHECK FAILED ", ex.DisplayString(), !
+    }
+}
+
+/// Report everything without changing anything.
+ClassMethod Status()
+{
+    write "MVP 2 governance status", !
+    write "-----------------------", !
+    // The security check runs in its own method so `new $namespace` unwinds before the audit count,
+    // which must read the LABDEMO table rather than %SYS.
+    do ..ReportSecurity()
+    set n = ..AuditCount()
+    write "  audit rows: ", $select(n = "": "UNREADABLE from this principal", 1: n), !
+    do ..ReportProvider()
+}
+
+/// Resources and roles as they actually stand. Private -- switches namespace.
+ClassMethod ReportSecurity() [ Private ]
+{
+    new $namespace
+    set $namespace = "%SYS"
+    for name = ..#READRESOURCE, ..#WRITERESOURCE {
+        write "  resource ", name, ": ", $select(##class(Security.Resources).Exists(name): "yes", 1: "MISSING"), !
+    }
+    for name = ..#READROLE, ..#WRITEROLE {
+        if '##class(Security.Roles).Exists(name) {
+            write "  role ", name, ": MISSING", !
+            continue
+        }
+        do ##class(Security.Roles).Get(name, .props)
+        write "  role ", name, ": ", $get(props("Resources")), !
+    }
+}
+
+/// How many audit rows exist, or "" when the table cannot be read.
+///
+/// Delegates rather than keeping a second copy of the query -- two copies of a count is the #84
+/// stale-copy pattern in miniature. See `Audit.Entry.AuditCountAll` for why an unreadable table is
+/// "" and not 0.
+ClassMethod AuditCount() As %Integer
+{
+    quit ##class(ProductionGuardian.LabDemo.Audit.Entry).AuditCountAll()
+}
+
+}

--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -88,11 +88,41 @@ ClassMethod Run(pSourceDir As %String = "", pStartGenerator As %Boolean = 1) As 
         do ..StartGenerator()
     }
 
+    // MVP 2 governance, and it runs on every boot for the same reason the rest of this class does:
+    // measured on the running compose stack, none of the resources or roles existed, because they
+    // had only ever been created by hand on a different instance. A failure here does NOT fail the
+    // boot -- MVP 1's Health Scan does not depend on the MCP tools, and a stack that refuses to come
+    // up because an MVP 2 role could not be created is worse than one that comes up and says so.
+    do ..GovernanceSetup()
+
     write !, "==================================", !
     write "Done. Verify with:", !
     write "  do ##class(ProductionGuardian.LabDemo.Triggers).Status()", !
     write "  do ##class(ProductionGuardian.Setup.EnableMetrics).Verify()", !
+    write "  do ##class(ProductionGuardian.Setup.AIHub).Status()", !
     quit $$$OK
+}
+
+/// The MVP 2 resources, roles and tool check. Delegates rather than restating.
+///
+/// Guarded by a class existence check so this file still runs on a checkout that predates
+/// `AIHub.cls` -- the load step compiles from a mounted source directory, and a missing class there
+/// should read as "not deployed yet" rather than abort a boot with <CLASS DOES NOT EXIST>.
+ClassMethod GovernanceSetup()
+{
+    write "9. MVP 2 governance:", !
+    if '##class(%Dictionary.CompiledClass).%ExistsId("ProductionGuardian.Setup.AIHub") {
+        write "   AIHub.cls not compiled -- skipped", !
+        quit
+    }
+    try {
+        set sc = ##class(ProductionGuardian.Setup.AIHub).Run()
+        if $$$ISERR(sc) {
+            write "   FAILED: ", $system.Status.GetErrorText(sc), !
+        }
+    } catch ex {
+        write "   FAILED: ", ex.DisplayString(), !
+    }
 }
 
 /// Refuse unless this namespace is interop-enabled. IsEnsembleNamespace is the real test

--- a/iris/test/GovernanceProof.cls
+++ b/iris/test/GovernanceProof.cls
@@ -42,7 +42,29 @@ ClassMethod Prove() As %String
         write "could not create ", ..#PROBEUSER, ": ", $system.Status.GetErrorText(sc), !
         quit ""
     }
-    write "1. probe user ", ..#PROBEUSER, ": ready, holds Guardian_Read only", !
+    // The roles must be right before the user is created, or the proof measures a stale boundary.
+    // Converging them here rather than assuming AIHub.Run() was called makes the fixture
+    // self-sufficient -- @Ari-Glikman's run failed because the roles on his instance predated the
+    // definition this class expects, which is a fixture problem rather than his.
+    do ##class(ProductionGuardian.Setup.AIHub).CreateResources()
+    do ##class(ProductionGuardian.Setup.AIHub).CreateRoles()
+
+    // PRECONDITION, CHECKED ON THIS SIDE because the other side cannot check it -- see the comment in
+    // AsReadOnlyUser. A principal without the database role dies with <PROTECT> before any policy is
+    // consulted, and that output reads like the boundary working. Refusing here is what stops an
+    // inconclusive run from being reported as a pass.
+    set granted = ..ProbeUserRoles()
+    if '..HasRole(granted, ##class(ProductionGuardian.Setup.AIHub).#DBROLE) {
+        write "   probe user roles are '", granted, "' -- missing ",
+            ##class(ProductionGuardian.Setup.AIHub).#DBROLE, !
+        write "   Refusing to continue: without it the proof dies at <PROTECT> before the", !
+        write "   tool policy is reached, and that looks like a successful denial.", !
+        quit ""
+    }
+    write "1. probe user ", ..#PROBEUSER, ": ready, holds ", granted, !
+    write "   (", ##class(ProductionGuardian.Setup.AIHub).#READROLE, " grants ",
+        ##class(ProductionGuardian.Setup.AIHub).#READRESOURCE, ":U and NOT ",
+        ##class(ProductionGuardian.Setup.AIHub).#WRITERESOURCE, ")", !
 
     // The privileged calls, through the governed manager. Both must be audited.
     set before = ##class(ProductionGuardian.Setup.AIHub).AuditCount()
@@ -76,12 +98,28 @@ ClassMethod AsReadOnlyUser(pPassword As %String) As %Status
     }
     write "1. logged in as ", $username, ", roles = ", $roles, !
 
-    // A read must still work: the demo's point is that AI Detective can LOOK without acting.
+    // A read must still work: the demo's point is that AI Detective can LOOK without acting. A
+    // failed read ABORTS rather than continuing to a "denied" that would prove nothing.
+    //
+    // THIS GUARD DOES NOT CATCH THE CASE @Ari-Glikman HIT, and I checked rather than assumed it did.
+    // With the principal short of database access, `Invoke` dies at
+    // `<PROTECT> ... Governance.1  Access Denied` while paging in the routine -- the process is gone
+    // before `r1` is ever assigned, so nothing below this line runs. His option 2, "assert the tool
+    // call was reached", is not implementable from inside the unprivileged half for that reason.
+    //
+    // So the real protection is the PRIVILEGED side: `Prove()` verifies the probe user holds the
+    // database role before it hands over a password, and refuses otherwise. This guard stays because
+    // it still catches the failures that DO return -- a misconfigured resource, a tool error, a policy
+    // that refuses the read -- and those are the ones that would otherwise reach a meaningless PASS.
     set r1 = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("GetPoolSize", {"host": "Cloud API"})
     write "2. GetPoolSize : ", r1.outcome, "  <- expected executed", !
     if r1.outcome '= "executed" {
-        write "   UNEXPECTED: a Guardian_Read holder must be able to read.", !
+        write "   *** ABORTING: a ", ##class(ProductionGuardian.Setup.AIHub).#READROLE, " holder must be able to read.", !
         write "   error: ", r1.error, !
+        write "   If this is <PROTECT>/Access Denied, the principal is short of database", !
+        write "   access and the TOOL POLICY WAS NEVER REACHED -- so a refusal below would", !
+        write "   prove nothing. Grant ", ##class(ProductionGuardian.Setup.AIHub).#DBROLE, " to the user.", !
+        quit $$$ERROR($$$GeneralError, "read failed before the policy was reached -- proof inconclusive")
     }
 
     // And the write must be refused.
@@ -132,7 +170,13 @@ ClassMethod CreateProbeUser(pPassword As %String) As %Status [ Private ]
     // and `ProductionGuardian.Setup.AIHub` does not exist in %SYS -- reading it after the switch
     // throws <CLASS DOES NOT EXIST> from a line that looks like a compile-time constant. Cost
     // one run to find; worth a comment so it is not reintroduced.
-    set role = ##class(ProductionGuardian.Setup.AIHub).#READROLE
+    //
+    // TWO ROLES, and the second one is not ours. `Guardian_Read` grants `PG_Read:U` and deliberately
+    // nothing else (see `Setup.AIHub.#DBROLE`), so the probe user needs the shipped `%DB_%DEFAULT`
+    // role as well or it cannot read the routine implementing the tool. Granting it to the USER
+    // rather than to `Guardian_Read` is @Ari-Glikman's #94 review call: the role stays minimal and
+    // means one thing, and the fixture carries its own plumbing instead of widening a boundary.
+    set role = ##class(ProductionGuardian.Setup.AIHub).#READROLE _ "," _ ##class(ProductionGuardian.Setup.AIHub).#DBROLE
 
     new $namespace
     set $namespace = "%SYS"
@@ -155,6 +199,37 @@ ClassMethod CreateProbeUser(pPassword As %String) As %Status [ Private ]
         ,
         0,
         1)
+}
+
+/// The probe user's granted roles, as IRIS records them. "" if the user is absent.
+ClassMethod ProbeUserRoles() As %String [ Private ]
+{
+    new $namespace
+    set $namespace = "%SYS"
+    if '##class(Security.Users).Exists(..#PROBEUSER) {
+        quit ""
+    }
+    do ##class(Security.Users).Get(..#PROBEUSER, .props)
+    quit $get(props("Roles"))
+}
+
+/// Is `role` one of the comma-separated `list`? Private.
+///
+/// EXACT ELEMENT MATCH, not `[`. A substring test would accept `Guardian_ReadOnly` as
+/// `Guardian_Read`, and would also match `%DB_%DEFAULT` inside a hypothetical `%DB_%DEFAULTX` --
+/// the same class of bug as the quoted-label match in `Tools.Read.ScrapeGauge`.
+ClassMethod HasRole(list As %String, role As %String) As %Boolean [ Private ]
+{
+    // Explicit result variable: a bare `quit` breaks the FOR and leaves the loop index pointing at
+    // whatever was examined last, matched or not -- the mistake `Tools.Read.FindItem` documents.
+    set found = 0
+    for i = 1:1:$length(list, ",") {
+        if $zstrip($piece(list, ",", i), "<>W") = role {
+            set found = 1
+            quit
+        }
+    }
+    quit found
 }
 
 /// A random password. Not stored, not derived from anything guessable.

--- a/iris/test/GovernanceProof.cls
+++ b/iris/test/GovernanceProof.cls
@@ -1,0 +1,173 @@
+/// Proof that the MVP 2 governance boundary refuses — run against a live instance.
+///
+/// `contracts/resolve-api.md` §9.4 and `mcp-tools.md` §5.6(b) both make the acceptance criterion **an
+/// observed denial**, not a passing allow: "a policy never seen to deny is not known to be enforcing
+/// anything." This class is how that observation is made repeatable instead of remembered.
+///
+/// WHY A REAL USER AND NOT `StubPolicy`. `iris/test/StubPolicy.cls` injects a resource set, which
+/// proves the policy's LOGIC branches correctly but cannot prove the boundary holds, because
+/// `$SYSTEM.Security.Check` returns 1 for every resource -- including resources that do not exist --
+/// when the caller holds `%All`. Every session that can compile this code holds `%All`. So the only
+/// way to see a genuine refusal is to become a principal that genuinely lacks the privilege, and
+/// that means a real user, a real login, and a real `PG_Resolve` resource to not hold.
+///
+/// TWO PROCESSES, NECESSARILY. `$SYSTEM.Security.Login` cannot be undone -- there is no way back to
+/// `%All` without that account's password -- so the login must happen in a process that is about to
+/// end. `Prove()` therefore does the privileged half (create the user, run the allowed calls) and
+/// `AsReadOnlyUser()` is meant to be the LAST thing a throwaway session does. `Cleanup()` removes the
+/// user afterwards from a fresh privileged session.
+///
+/// THE PASSWORD IS GENERATED, NEVER STORED. It is created, used within the same call chain, and
+/// discarded with the user. Nothing here is a credential the repository knows -- root `CLAUDE.md` §6
+/// and MVP 2 §6's credential-exposure row both apply to a test fixture exactly as much as to the LLM
+/// key, and a default test password in source is how one ends up on a demo instance permanently.
+Class ProductionGuardian.Test.GovernanceProof
+{
+
+/// The throwaway principal. Named so it is obviously not a demo account.
+Parameter PROBEUSER = "pg_proof_readonly";
+
+/// Create the read-only principal, then report what a privileged caller can do.
+///
+/// Returns the generated password so the caller can hand it to the second session. Printed, because
+/// it is worthless the moment `Cleanup()` runs and the alternative is a fixture nobody can drive.
+ClassMethod Prove() As %String
+{
+    write "MVP 2 governance proof -- privileged half", !
+    write "========================================", !, !
+
+    set pass = ..MakePassword()
+    set sc = ..CreateProbeUser(pass)
+    if $$$ISERR(sc) {
+        write "could not create ", ..#PROBEUSER, ": ", $system.Status.GetErrorText(sc), !
+        quit ""
+    }
+    write "1. probe user ", ..#PROBEUSER, ": ready, holds Guardian_Read only", !
+
+    // The privileged calls, through the governed manager. Both must be audited.
+    set before = ##class(ProductionGuardian.Setup.AIHub).AuditCount()
+    set r1 = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("GetPoolSize", {"host": "Cloud API"})
+    write "2. GetPoolSize as ", $username, ": ", r1.outcome, ", auditId = ", r1.auditId, !
+    set r2 = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("SetPoolSize", {"host": "Cloud API", "size": 4, "dryRun": 1})
+    write "3. SetPoolSize dry-run as ", $username, ": ", r2.outcome, ", auditId = ", r2.auditId, !
+    set after = ##class(ProductionGuardian.Setup.AIHub).AuditCount()
+    write "4. audit rows written by those two calls: ", (after - before), " (expected 2)", !
+
+    write !, "Now run, in a SEPARATE session (the login cannot be undone):", !
+    write "  do ##class(ProductionGuardian.Test.GovernanceProof).AsReadOnlyUser(""", pass, """)", !
+    write "Then, from a privileged session:", !
+    write "  do ##class(ProductionGuardian.Test.GovernanceProof).Cleanup()", !
+    quit pass
+}
+
+/// Become the read-only principal and attempt the write. THE LAST THING A SESSION SHOULD DO.
+///
+/// EXPECTS A REFUSAL. A success here is not a passing test -- it means the boundary is not there,
+/// and the message says so rather than leaving a reader to interpret an outcome string.
+ClassMethod AsReadOnlyUser(pPassword As %String) As %Status
+{
+    write "MVP 2 governance proof -- unprivileged half", !
+    write "==========================================", !, !
+
+    set sc = $system.Security.Login(..#PROBEUSER, pPassword)
+    if 'sc {
+        write "login as ", ..#PROBEUSER, " FAILED -- cannot prove anything", !
+        quit $$$ERROR($$$GeneralError, "login failed")
+    }
+    write "1. logged in as ", $username, ", roles = ", $roles, !
+
+    // A read must still work: the demo's point is that AI Detective can LOOK without acting.
+    set r1 = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("GetPoolSize", {"host": "Cloud API"})
+    write "2. GetPoolSize : ", r1.outcome, "  <- expected executed", !
+    if r1.outcome '= "executed" {
+        write "   UNEXPECTED: a Guardian_Read holder must be able to read.", !
+        write "   error: ", r1.error, !
+    }
+
+    // And the write must be refused.
+    set r2 = ##class(ProductionGuardian.LabDemo.Tools.Governance).Invoke("SetPoolSize", {"host": "Cloud API", "size": 4, "dryRun": 1})
+    write "3. SetPoolSize : ", r2.outcome, "  <- expected denied", !
+    write "   error   : ", r2.error, !
+    write "   auditId : ", r2.auditId, !
+    if r2.outcome '= "denied" {
+        write "   *** THE BOUNDARY DID NOT HOLD. A caller without PG_Resolve applied a", !
+        write "   *** production change. This is the failure resolve-api.md 9.4 exists to catch.", !
+        quit $$$ERROR($$$GeneralError, "write tool was not refused")
+    }
+
+    // The denial must be IN THE LOG. The runtime cannot audit it -- ExecuteTool throws before the
+    // audit hook -- so this is what proves Tools.AuthPolicy wrote the row itself.
+    set desc = ##class(ProductionGuardian.LabDemo.Audit.Entry).Describe(r2.auditId)
+    if '$isobject(desc) {
+        write "4. audit row for the denial: MISSING -- the refusal left no trace", !
+        quit $$$ERROR($$$GeneralError, "denial was not audited")
+    }
+    write "4. audit row for the denial: ", desc.%ToJSON(), !
+    write !, "PASS: read allowed, write refused, refusal audited.", !
+    quit $$$OK
+}
+
+/// Remove the probe user. Safe to call when it does not exist.
+ClassMethod Cleanup() As %Status
+{
+    new $namespace
+    set $namespace = "%SYS"
+    if '##class(Security.Users).Exists(..#PROBEUSER) {
+        write "probe user ", ..#PROBEUSER, ": already gone", !
+        quit $$$OK
+    }
+    set sc = ##class(Security.Users).Delete(..#PROBEUSER)
+    write "probe user ", ..#PROBEUSER, ": ", $select(sc: "deleted", 1: "DELETE FAILED " _ $system.Status.GetErrorText(sc)), !
+    quit sc
+}
+
+/// Create the probe user holding Guardian_Read and nothing else.
+///
+/// `ChangePassword` MUST be 0. A fresh account defaults to "must change password on next login" and
+/// IRIS then refuses authentication until it has been changed interactively -- #73 spent real time on
+/// exactly that flag, from the other direction.
+ClassMethod CreateProbeUser(pPassword As %String) As %Status [ Private ]
+{
+    // RESOLVED BEFORE THE NAMESPACE SWITCH. `##class(...).#READROLE` is a runtime class reference,
+    // and `ProductionGuardian.Setup.AIHub` does not exist in %SYS -- reading it after the switch
+    // throws <CLASS DOES NOT EXIST> from a line that looks like a compile-time constant. Cost
+    // one run to find; worth a comment so it is not reintroduced.
+    set role = ##class(ProductionGuardian.Setup.AIHub).#READROLE
+
+    new $namespace
+    set $namespace = "%SYS"
+    if ##class(Security.Users).Exists(..#PROBEUSER) {
+        // Reset the password rather than reuse an unknown one: a leftover user from an interrupted
+        // run has a password this process cannot know.
+        kill props
+        set props("Password") = pPassword
+        set props("ChangePassword") = 0
+        set props("Roles") = role
+        quit ##class(Security.Users).Modify(..#PROBEUSER, .props)
+    }
+    quit ##class(Security.Users).Create(
+        ..#PROBEUSER,
+        role,
+        pPassword,
+        "Production Guardian governance proof (throwaway)",
+        "LABDEMO",
+        ,
+        ,
+        0,
+        1)
+}
+
+/// A random password. Not stored, not derived from anything guessable.
+ClassMethod MakePassword() As %String [ Private ]
+{
+    set out = "Pg"
+    for i = 1:1:18 {
+        // Letters and digits only: the point is a value nobody has to escape through a session
+        // heredoc, not maximum entropy for an account that exists for one minute.
+        set n = $random(62)
+        set out = out _ $case(n < 26, 1: $char(65 + n), : $select(n < 52: $char(97 + n - 26), 1: $char(48 + n - 52)))
+    }
+    quit out
+}
+
+}


### PR DESCRIPTION
Dev A's MVP 2 tasks 4 and 5 (doc §5.2): audit for tool calls, RBAC roles and resources. Everything here was **measured on build 126**, and three measurements changed the design.

## AI Hub ships no audit store

`%AI.Policy.ConsoleAudit` writes an ANSI-coloured box to the current device and returns. There is no `%AI.Audit.*` persistent class in the image — searched `%Dictionary.CompiledClass` for `%AI.*` matching AUDIT or LOG; the only hits are the policy classes themselves.

So `mcp-tools.md` §5.5's "every one of the six tools is audited on every call" was true of the **hook** and false of the **record** — and MVP 2 §3's final demo step is showing an audit entry. `Audit/Entry.cls` is the store, `Tools/AuditPolicy.cls` fills it.

This also closes `mcp-tools.md` §5.6(a) and (b), which were the two open unknowns. (b)'s answer: **no** policy is registered by default — a fresh `%AI.ToolMgr` reports `AuthPolicy: <none>`, `AuditPolicy: <none>`, `DiscoveryPolicy: <none>`.

### The real `%LogExecution` payload

```
call     {"id":"call_id","name":"GetPoolSize","arguments":"{\"host\":\"Cloud API\"}"}
metadata {}
result   {"tool_name":"GetPoolSize","result_json":"{...}","display_text":null}
duration 0
status   OK
```

| Assumption | Reality |
|---|---|
| `call.id` identifies the call | it is the **literal string `"call_id"`** every time — unusable as `auditId` |
| `call.arguments` is an object | it is a **JSON string** |
| `metadata` carries identity | **empty** — `actor` must come from `$username`, which is also the only unforgeable source |
| `duration` is meaningful | **0** for a call `ExecuteTool` timed at `0.0071 s` |

## A refused call is not audited

`ExecuteTool` checks authorization → executes → audits. So an authorization denial throws `<%AICore>ToolAccessDenied` at step one and the hook never runs. Measured with a deny-all policy: **0 rows**.

| Case | Audited by the runtime? |
|---|---|
| successful read | yes |
| dry-run of the write tool | yes |
| **tool-level** refusal (the `2..8` bounds guard) | yes — the tool ran |
| **authorization** denial | **no** |

The security-relevant half was the missing one. `AuthPolicy` now writes its own `denied` row — it is the only code that ever learns a denial happened, which is why `Disposition` has two values and two writers.

## Governance is per-ToolMgr and in memory

`SetAuthPolicy` attaches the policy to the Rust manager identified by *that object's* `%token`. There is no persisted setting, so a first-boot script cannot switch governance on once, and **every caller that builds its own `%AI.ToolMgr` — or its own `%AI.Agent`, which builds one — gets an ungoverned manager**: no check, no audit, `SetPoolSize` live against the production.

`%AI.Agent.UseToolSet` delegates straight to `..ToolManager.RegisterToolSet`, so the natural thing to write is the unsafe thing, and it works perfectly. `Tools/Governance.cls` is one factory that cannot return an ungoverned manager.

**This is already load-bearing:** it is the fix for the finding I raised on #92, where `AgentDispatcher.Resolve()` builds a bare manager. I measured that path succeeding for a principal without `PG_Resolve`, with 0 audit rows.

## None of it was on the compose stack

Measured on `pg-iris`, up 2 days:

| | Present |
|---|---|
| `PG_Read` / `PG_Resolve` | no |
| `Guardian_Read` / `Guardian_Resolve` | no |
| `AI.Secrets`, `PGSecrets` wallet, `AI.LLM.pgdetective` | no |
| `Tools.Read` / `Tools.Resolve` / `Tools.AuthPolicy` compiled | **no** |

It had all been done by hand on the hand-built `iris-webinar` instance. That is exactly the failure `FirstBoot` exists to prevent (#70, #72), so `Setup/AIHub.cls` creates the resources and roles idempotently and `FirstBoot` calls it.

It **deliberately does not create the LLM credential**: that needs a key, a key does not belong in a repository, and this one must be rotated anyway since it reached me through a chat transcript. It reports the config missing and prints the sequence instead.

### The roles need a database privilege no contract mentions

A user holding only `PG_Read:U` logs in fine and then dies with

```
<PROTECT> ... |ProductionGuardian.LabDemo.Tools.Governance.1    Access Denied
```

*before any policy is consulted* — it cannot read the routine. Both roles carry `%DB_%DEFAULT:RW`, and `RW` rather than `R` because the denial row is written **as the refused principal**, which is what makes it attributable.

**Honest limitation, recorded in the class:** every database on this image shares `%DB_%DEFAULT`, so that grant is broad. The least-privilege story is real at the **tool** boundary — `PG_Resolve` genuinely gates `set_pool_size` — and is **not** database isolation. A demo should not imply otherwise.

## Observed denial — the acceptance criterion

`resolve-api.md` §9.4 requires an *observed* denial, not a passing allow. `StubPolicy` cannot provide one: `$SYSTEM.Security.Check` returns 1 for every resource when the caller holds `%All`, and every session that can compile the code holds `%All`. So `test/GovernanceProof.cls` creates a real throwaway user with a generated password (never stored), logs in as it, and measures:

```
1. logged in as pg_proof_readonly, roles = Guardian_Read
2. GetPoolSize : executed  <- expected executed
3. SetPoolSize : denied    <- expected denied
   error : 'SetPoolSize' modifies a live production and requires PG_Resolve:USE
4. audit row: {"actor":"pg_proof_readonly","role":"Guardian_Read","tool":"SetPoolSize",
               "disposition":"denied",...}

PASS: read allowed, write refused, refusal audited.
```

## Verification

- `labdemo`, `setup`, `test` all compile clean
- `AIHub.Run()` idempotent across two runs; `FirstBoot.GovernanceSetup()` exercised
- six tools discovered (the count is the test — a seventh public method on `Tools.Resolve` is a second way to mutate a production)
- **production untouched:** still Running, Cloud API pool size **1**. Only dry-runs were ever applied.
- probe user, probe classes and probe globals all removed afterwards

One bug in my own code found this way and fixed: the row counter returned a confident `0` for a table an unprivileged principal cannot read — #33 and #49's "unmeasurable read as zero", reproduced by the person writing the comments warning about it. It returns `""` now.

## Not in this PR

**Two contract corrections are owed**, and `contracts/` is read-only:

1. §5.5 and `resolve-api.md` §8 promise that `not_authorized` refusals are runtime-audited. They cannot be.
2. `resolve-api.md` §8's `auditId: "aihub-audit-44812"` implies an AI Hub audit store that does not exist. Handles are `pg-audit-<n>`, minted by us — inventing AI Hub provenance is the same defect as the mock inventing an id.

Also still open: **a live apply (1 → 4) has not been run** — that needs a built-up queue and belongs with rehearsal. And AI Detective cannot run until the LLM credential exists on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
