### PR TITLE
docs(iris): first boot never compiles iris/test/, so the acceptance proof is absent

### DIFF
--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -144,13 +144,34 @@ returns PHI, it lands in `Audit.Entry.Result` in plain text.
 |---|---|
 | Read tools return real evidence | met — six tools discovered, live values |
 | `set_pool_size` changes the live pool and is reversible | **dry-run verified only**; `before`/`after`/`reversal` correct, an apply has not been run against a live queue |
-| An unauthorized role is refused | met — observed, `iris/test/GovernanceProof.cls` |
+| An unauthorized role is refused | met — observed, `iris/test/GovernanceProof.cls`. **Compile `test/` first — first boot does not** (see below) |
 | Every call appears in the audit log | met for executions and for authorization denials |
-| RBAC roles and resources exist from a clean boot | met — `Setup.AIHub`, called by `FirstBoot` |
+| RBAC roles and resources exist from a clean boot | met, and **verified from a real boot** rather than inferred: the four security objects were deleted and `docker compose restart iris` recreated them through step 9. `Audit/` compiled on the way through, including its SQL table, so the recursive load picks up a new subdirectory |
 | A principal can actually *use* the roles | needs `%DB_%DEFAULT` **as well**, from the invocation path — the `Guardian_*` roles stay minimal and grant only `PG_*`. Without it you get `<PROTECT>` before any policy is consulted |
 | LLM credential in the vault | **not met on the compose stack** — needs a key, and the current one must be rotated |
 
 ```objectscript
 do ##class(ProductionGuardian.Setup.AIHub).Status()          // what is and is not in place
 do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()   // reset the log between rehearsals
+```
+
+### `iris/test/` is not deployed by first boot — compile it by hand
+
+`docker/iris-firstboot.sh` loads `/pg-src/setup/` and `/pg-src/labdemo/` and **nothing else**, so on a
+fresh instance `Test.GovernanceProof` and `Test.StubPolicy` do not exist and the acceptance proof
+fails with `<CLASS DOES NOT EXIST>`. Found by deleting the security objects, restarting the container,
+and looking for the classes in the boot log rather than in the namespace — they were present, but only
+as leftovers from an earlier manual compile, which is exactly the kind of thing that reads as "it
+works" until someone tries it on a second machine.
+
+Left out of the boot deliberately rather than fixed: `GovernanceProof` **creates and deletes an IRIS
+user**, and auto-compiling that onto every container start widens what the deploy ships for the
+benefit of a fixture. Compile it when you want to run the proof:
+
+```objectscript
+do $system.OBJ.LoadDir("/pg-src/test/", "ck", .errors, 1)
+set pw = ##class(ProductionGuardian.Test.GovernanceProof).Prove()
+// then, in a SEPARATE session, because the login cannot be undone:
+do ##class(ProductionGuardian.Test.GovernanceProof).AsReadOnlyUser(pw)
+do ##class(ProductionGuardian.Test.GovernanceProof).Cleanup()
 ```


### PR DESCRIPTION
Verifying #94's last unverified claim, which turned up a real gap.

#94 said the RBAC boundary is armed from a clean boot. That was true of the *roles* and untested as a *boot* — on my container the resources and roles had only ever taken the "exists" path, because I created them by hand while writing the setup. So I deleted `PG_Read`, `PG_Resolve`, `Guardian_Read` and `Guardian_Resolve`, restarted the container, and read the boot log.

## The clean-boot path works

```
9. MVP 2 governance:
1. resource PG_Read: created
1. resource PG_Resolve: created
2. role Guardian_Read: created with PG_Read:U
2. role Guardian_Resolve: created with PG_Read:U,PG_Resolve:U
3. tools discovered: 6 (expected 6)
4. LLM provider AI.LLM.pgdetective: NOT CONFIGURED
FirstBoot: OK
```

All four **created**, not "exists". Three further things this settles that were previously assumed:

- **`Audit/` compiles through the normal boot**, SQL table included. It is a new subdirectory, and nothing had confirmed `FirstBoot`'s recursive `LoadDir` would pick one up.
- **Compile order does not bite.** `Governance` and `AuditPolicy` compiled *before* `Audit.Entry` despite referencing it, which is fine for runtime `##class()` resolution — worth knowing given the ToolSet compile-order trap documented in `docs/mvp2-aihub-verified-api.md`.
- **Nothing writes audit rows during boot.** I accounted for every row present by timestamp; all three were mine.

Data survived (41,305 → 41,378 patient rows — the generator kept running), the production came back `Running` at pool size 1, and the full observed denial passes on the freshly booted stack:

```
1. logged in as pg_proof_readonly, roles = %DB_%DEFAULT,Guardian_Read
2. GetPoolSize : executed
3. SetPoolSize : denied -- requires PG_Resolve:USE
4. audit row: {"actor":"pg_proof_readonly","disposition":"denied",...}
PASS: read allowed, write refused, refusal audited.
```

## The gap

`docker/iris-firstboot.sh` loads `/pg-src/setup/` and `/pg-src/labdemo/` and **nothing else**. So on a fresh instance `Test.GovernanceProof` and `Test.StubPolicy` do not exist, and the acceptance proof `resolve-api.md` §9.4 asks for fails with `<CLASS DOES NOT EXIST>`.

They were present on my container — as leftovers from an earlier manual compile. **Checking the namespace would have confirmed the wrong thing;** the boot log is what shows they were never loaded. That is the same shape as the defect #94 was about: a state that looks deployed because somebody deployed it by hand once.

## Deliberately not fixed by adding `test/` to the boot

`GovernanceProof` **creates and deletes an IRIS user**. Auto-compiling that onto every container start widens what the deploy ships for a fixture's benefit, and the boot path should stay the smallest thing that produces a working demo.

So this documents the one command that makes it runnable, next to the acceptance table where someone verifying the boundary will actually be looking. Open to being overruled if you'd rather it shipped — it is a one-line change to the script either way.

Doc-only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
