### PR TITLE
fix(iris): detect the deployment-setting drift a recompile causes (#96)

### DIFF
--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -95,11 +95,17 @@ ClassMethod Run(pSourceDir As %String = "", pStartGenerator As %Boolean = 1) As 
     // up because an MVP 2 role could not be created is worse than one that comes up and says so.
     do ..GovernanceSetup()
 
+    // LAST, and after StartProduction rather than next to ApplyDeploymentSettings. The point is to
+    // end a boot by confirming what the running production will actually send to -- a check placed
+    // beside the code that applies the setting would only ever agree with it.
+    do ..VerifyDeploymentSettings()
+
     write !, "==================================", !
     write "Done. Verify with:", !
     write "  do ##class(ProductionGuardian.LabDemo.Triggers).Status()", !
     write "  do ##class(ProductionGuardian.Setup.EnableMetrics).Verify()", !
     write "  do ##class(ProductionGuardian.Setup.AIHub).Status()", !
+    write "  do ##class(ProductionGuardian.Setup.FirstBoot).VerifyDeploymentSettings()", !
     quit $$$OK
 }
 
@@ -339,6 +345,96 @@ ClassMethod ApplyDeploymentSettings() As %Status
         write "6b. HTTPPort   -> ", port, !
     }
     quit $$$OK
+}
+
+/// Does the LIVE adapter target still match what the deployment asked for?
+///
+/// WHY THIS IS NEEDED AT ALL: RECOMPILING `Production.cls` REVERTS IT (#96, @Ari-Glikman, found
+/// while verifying #92). `ApplyDeploymentSettings()` writes into the production's stored config;
+/// a recompile regenerates that config from the class's XData and the deployment's values are gone.
+/// Measured: port 52773 before, 80 after `$system.OBJ.Compile(...,"ck-d")`.
+///
+/// A RECOMPILE IS ROUTINE -- `docker compose up --build`, any class edit, a `CompilePackage` while
+/// checking something. Nothing warns, and the failure is silent until the queue grows.
+///
+/// THE SYMPTOM DOES NOT LOOK LIKE THE CAUSE, which is what makes it worth a check rather than a
+/// comment. `Cloud API` goes to Retry and the queue climbs without bound:
+///
+///     ERROR #6059: Unable to open TCP/IP socket to server webgateway-webinar:80
+///
+/// and during MVP 2 that reads as Smart Resolve failing -- `queue_buildup` fires correctly,
+/// `set_pool_size` applies correctly, the pool really becomes 4, and the queue still does not drain,
+/// because nothing is being delivered at all. #96 lost real time to it in that order.
+///
+/// BOTH SETTINGS REVERT, and #96 says only the port does. Corrected here because the wrong version
+/// sends the next reader looking for adapter fallback behaviour that does not exist:
+/// `Production.cls` ships `HTTPServer` as `webgateway-webinar` (line 99), not `127.0.0.1`. So the
+/// hostname in that error is not a red herring and not a fallback -- it is exactly what a recompile
+/// restored. The error message was accurate; the configuration was wrong.
+///
+/// REPORTS, DOES NOT REPAIR. Re-applying silently would hide how often this happens, and a boot that
+/// quietly corrects a drift teaches nobody. `Run()` calls this last so a boot ends by confirming the
+/// target, and the fix is one line, named in the output.
+ClassMethod VerifyDeploymentSettings() As %Status
+{
+    set wantServer = $get(^ProductionGuardian.Setup("HTTPServer"), "")
+    set wantPort = $get(^ProductionGuardian.Setup("HTTPPort"), "")
+    if (wantServer = "") && (wantPort = "") {
+        write "10. deployment target: no globals set, nothing to verify", !
+        quit $$$OK
+    }
+
+    set item = ##class(ProductionGuardian.LabDemo.Triggers).#OPERATION
+    set gotServer = ..LiveSetting(item, "HTTPServer")
+    set gotPort = ..LiveSetting(item, "HTTPPort")
+
+    set drift = 0
+    if (wantServer '= "") && (gotServer '= wantServer) {
+        set drift = 1
+        write "10. HTTPServer DRIFTED: live '", gotServer, "' but deployment asked for '", wantServer, "'", !
+    }
+    if (wantPort '= "") && (gotPort '= wantPort) {
+        set drift = 1
+        write "10. HTTPPort DRIFTED: live '", gotPort, "' but deployment asked for '", wantPort, "'", !
+    }
+    if 'drift {
+        write "10. deployment target: ", gotServer, ":", gotPort, " matches the deployment globals", !
+        quit $$$OK
+    }
+
+    write "    A recompile of Production.cls reverts these to the shipped XData values (#96).", !
+    write "    ", ..#PRODUCTION, " will send to the wrong host and Cloud API will go to Retry", !
+    write "    with a growing queue. Fix with:", !
+    write "      do ##class(ProductionGuardian.Setup.FirstBoot).ApplyDeploymentSettings()", !
+    quit $$$ERROR($$$GeneralError, "deployment settings have drifted from the configured globals")
+}
+
+/// One live adapter setting for a config item, or "" when absent. Private.
+///
+/// Reads the STORED config rather than a running host's adapter, because that is what a recompile
+/// rewrites and therefore what has to be compared. A running host would also answer, but only until
+/// the next restart, which would make this check pass on a production that is about to come back
+/// wrong.
+ClassMethod LiveSetting(pItem As %String, pName As %String) As %String [ Private ]
+{
+    set def = ##class(Ens.Config.Production).%OpenId(..#PRODUCTION)
+    if '$isobject(def) {
+        quit ""
+    }
+    set result = ""
+    for i = 1:1:def.Items.Count() {
+        set item = def.Items.GetAt(i)
+        if item.Name '= pItem {
+            continue
+        }
+        for j = 1:1:item.Settings.Count() {
+            set s = item.Settings.GetAt(j)
+            if (s.Name = pName) && (s.Target = "Adapter") {
+                set result = s.Value
+            }
+        }
+    }
+    quit result
 }
 
 /// Start the production, or report it already running. Refuses to switch a DIFFERENT


### PR DESCRIPTION
Closes #96, with two corrections to the diagnosis that change what the fix should be.

## What this adds

`VerifyDeploymentSettings()` compares the live stored config against `^ProductionGuardian.Setup("HTTPServer"/"HTTPPort")` and names any mismatch with the one-line repair. `Run()` calls it **last**, after `StartProduction`, so a boot ends by confirming what the running production will actually send to — placed beside `ApplyDeploymentSettings()` it would only ever agree with itself.

**It reports rather than repairs.** Re-applying silently would hide how often this happens, and a boot that quietly corrects a drift teaches nobody.

## Correction 1 — both settings revert, not just the port

#96 says `HTTPServer` survives "because `127.0.0.1` happens to be its shipped value too". It isn't: `Production.cls` line 99 ships `webgateway-webinar`. Reproduced:

```
10. HTTPServer DRIFTED: live 'webgateway-webinar' but deployment asked for '127.0.0.1'
10. HTTPPort DRIFTED: live '80' but deployment asked for '52773'
```

This matters more than a detail. It means

```
ERROR #6059: Unable to open TCP/IP socket to server webgateway-webinar:80
```

is **not a red herring and not an adapter fallback** — it is precisely what the recompile restored. The error message was accurate; the configuration was wrong. The red-herring reading is the more damaging one to leave in the record, because it sends the next person looking for fallback behaviour that does not exist instead of at the setting that actually changed.

Your operational conclusion was right either way, and the hostname pointing at the *other* deployment is still exactly why it misleads.

## Correction 2 — option 3 does not work, so this is option 2 alone

Your preference was 2 + 3, with 3 as the one that "removes the trap": drop `HTTPPort` from the XData so absent means set-by-deployment and there is nothing to revert to.

There is. `EnsLib.HTTP.OutboundAdapter` ships `HTTPPort` with an initial expression of `""`:

```
EnsLib.HTTP.OutboundAdapter HTTPPort initial = '""'
```

So a recompile reverts it to **empty** rather than to nothing, and the compose stack still cannot deliver. Option 3 changes what the revert lands on, not whether it happens — and it would also cost `Production.cls` its value as the verified-instance record for no gain.

So this is option 2 on its merits, not as the cheaper half of your preference. I don't think there is a clean option 3 while the deployment target lives in the production config at all; making the adapter read it at runtime would fix it properly and is well outside a bug fix.

## Considered and rejected: a compile-time projection

The obvious "never rely on remembering" fix is a `%Projection.AbstractProjection` on `Production.cls` re-applying the settings after every compile. I didn't, for a reason worth recording: a projection class must be compiled *before* the class referencing it, and `LabDemo.Production` sorts before `Setup.DeploymentProjection`, so `CompilePackage("ProductionGuardian")` would compile Production first and fail on a missing projection — breaking the boot and the CI compile job to fix a setting. Trading a silent drift for a hard compile failure is the wrong direction.

## Verified by reproducing the bug

```
A. check passes clean      -> 10. deployment target: 127.0.0.1:52773 matches
B. recompile Production.cls -> OK
C. check catches it        -> both settings reported, with the fix command
D. ApplyDeploymentSettings -> restored
E. Cloud API               -> Status=OK, queue empty
```

I broke my own stack doing D/E and it recovered fully, which is the same drain you saw.

One thing your issue makes clear that I'd underweighted: this is a **demo-day** failure mode specifically because it mimics Smart Resolve failing. `queue_buildup` fires, `set_pool_size` applies, the pool really becomes 4, and nothing drains. Worth the check on its own for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
