### PR TITLE
contracts: audit and RBAC — four corrections from implementing them (#95)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,83 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-19 — audit and RBAC: four corrections from implementing them (Dev A raised, Dev B wrote)
+
+**Two files, no shape change.** `mcp-tools.md` §4/§5/§5.5 and `resolve-api.md` §8. No field added,
+removed or retyped; `validate.mjs` unchanged and passing. Raised by @kskubach as #95 rather than as a
+PR, because a contract change needs the other developer's review anyway and three of the four touch
+Dev B's area. Every claim below was verified against the running build-126 instance, twice —
+independently by each of us.
+
+### 1. `not_authorized` refusals are not audited by the runtime — and cannot be
+
+`%AI.ToolMgr.ExecuteTool` checks authorization, then executes, then audits. An authorization denial
+throws at the first step, so the audit hook never runs: **0 rows written** with a deny-all policy
+registered.
+
+`mcp-tools.md` §5.5 and `resolve-api.md` §8 both attributed the whole guarantee to the runtime. The
+guarantee is now real but it takes **two mechanisms**: the runtime audits executions, and
+`Tools.AuthPolicy` writes its own row for denials. That distinction is the correction — the previous
+wording made the one security-relevant gap invisible by pointing at the wrong component.
+
+Note which half was broken. A **tool-level** refusal — our `2`–`8` bounds guard — *is* audited,
+because the tool ran. Only the **authorization** denial was not, i.e. exactly the event a security
+review asks about.
+
+### 2. `auditId` implied an AI Hub audit store that does not exist
+
+Example values were `aihub-audit-*`; they are now `pg-audit-*`. `%AI.Policy.ConsoleAudit` — the only
+shipped implementation — writes a coloured box to the current device and returns. There is no
+`%AI.Audit.*` persistent class in the image; verified by enumerating compiled classes. The record is
+`ProductionGuardian.LabDemo.Audit.Entry` and the handle is ours.
+
+The value was always opaque (§9.3 tells Dev C never to compare it to a literal), but the
+*provenance* was not: `aihub-audit-*` claimed a system of record that would not survive someone
+looking for it — the defect this document already names as "inventing an id that resolves to
+nothing".
+
+Also documented: `duration` is integer milliseconds and reads `0` for every read tool, against
+`ExecuteTool`'s own timing of `0.0071 s` for the same call. A reader comparing §5.5's promise to a
+column of zeroes should find the explanation in the contract.
+
+### 3. The role definitions were unusable as specified
+
+`Guardian_Read` / `Guardian_Resolve` grant only `PG_*`, and a principal holding one dies with
+`<PROTECT>` on the tool routine **before any policy is consulted**. Both need `%DB_%DEFAULT:RW` as
+well, granted from the invocation path rather than added to the roles.
+
+`RW` and not `R`: the denial audit row is written **as the refused principal**, so a read-only grant
+produces a denial that cannot be recorded — which would defeat item 1.
+
+And a limitation now stated instead of implied: LABDEMO's database resource is `%DB_%DEFAULT`, the
+*default* resource, so the grant is broad. **The least-privilege story is real at the tool boundary
+and is not a database-isolation story.** A demo showing "AI Detective can look but not act" invites
+the stronger reading, and the stronger reading is false.
+
+### 4. An out-of-bounds argument is a REFUSAL, not a thrown failure
+
+§4's table classified it under *Call failed — thrown `%Status`*. `Tools.Resolve` has returned a
+structured `outcome: "refused"` payload since the tools landed. **The code was right and the
+classification was wrong**, and §4 gains a `Refused` row.
+
+Two reasons it matters beyond tidiness. `resolve-api.md` §5 requires `outcome: "refused"` with
+`refusal.reason: "out_of_bounds"`, and reaching those from a thrown `%Status` would mean parsing
+error *text* into a contract field. And `%LogExecution` receives the tool's *return value*: a throw
+records a status and no payload, so the structured return is why `Audit.Entry.Result` can show what
+was refused and why.
+
+The existing warning — do not invent an error envelope, do not return `{"error": ...}` from a
+successful `%Invoke` — still stands for genuine failures. The line is §5.2's: `refused` means the
+system decided not to act and nothing was written; `failed` means it tried and did not complete.
+
+### What all four have in common
+
+**Each was found by implementing the promise, not by reviewing the text**, and three of the four are
+a correct premise carried to a conclusion it does not support — the same shape as the `%`-prefix
+paragraph corrected the day before. On this contract set the confident, well-argued passage is the
+one to check first: it survives review precisely because it reads as already considered.
+
+
 ## 2026-08-18 — role names corrected: no `%` prefix (Dev B)
 
 **Two files, values only, no shape change.** `mcp-tools.md` and `resolve-api.md`:

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -628,8 +628,29 @@ A caller must be able to tell these apart, and only one of them is an error.
 | Outcome | Shape | Meaning |
 |---|---|---|
 | **Could not measure** | a normal, successful result with `null` in the field | The tool ran. The value does not exist on this instance right now. Not an error. |
-| **Call failed** | thrown `%Status`, surfaced as a tool error | The tool could not do its job: item not found, wrong production, out-of-bounds argument, query failure. |
+| **Call failed** | thrown `%Status`, surfaced as a tool error | The tool could not do its job: query failure, or an argument it cannot interpret at all. |
+| **Refused** | a normal, successful result carrying `outcome: "refused"` and a `refusal` object | The tool ran, understood the request, and declined it: out-of-bounds size, non-whitelisted host, wrong production, host not in the production. **The safety model working, not a fault.** |
 | **Not authorized** | `$$$AICoreToolAccessDenied` from the authorization policy | The tool **did not run at all**. |
+
+**A REFUSAL IS NOT A FAILURE, and the `Refused` row above is new — added 2026-08-19 (#95).**
+
+This table previously classified an "out-of-bounds argument" under *Call failed*, i.e. a thrown
+`%Status`. `Tools.Resolve` has instead returned a structured `outcome: "refused"` payload since the
+six tools landed, and after review (@kskubach) **the code is right and this classification was
+wrong.** Two reasons, both load-bearing rather than stylistic:
+
+1. **`resolve-api.md` §5 requires `outcome: "refused"` with `refusal.reason: "out_of_bounds"`.**
+   From a thrown `%Status` the engine would have to parse error *text* to reach those fields.
+   Text-parsing a refusal into a contract field is fragile in a way a structured return is not.
+2. **It is what makes the audit trail useful.** `%LogExecution` receives the tool's *return value*;
+   a throw records a status and no result payload. So a returned refusal is why `Audit.Entry.Result`
+   can show *what* was refused and *why*, rather than only that something failed. A denial and a
+   bounds refusal stay distinguishable through `Disposition`.
+
+The warning below still stands for genuine failures, and the distinction is exactly the one §5.2 of
+`resolve-api.md` draws: `refused` means the system decided not to act and nothing was written;
+`failed` means it tried and did not complete. Returning `refused` for something that actually broke
+is the defect this warning is about.
 
 **Failure mechanism: `%AI.Tool` provides `%ToolError`, and that is what a tool uses.** Do not invent
 an error envelope and do not return `{"error": ...}` from a successful `%Invoke`. Verified from the
@@ -718,6 +739,34 @@ Three consequences:
 | `PG_Read` | `Guardian_Read` | listing and executing the five read tools; **listing** `set_pool_size` |
 | `PG_Resolve` | `Guardian_Resolve` | **executing** `set_pool_size` |
 
+**BOTH ROLES ALSO NEED A DATABASE PRIVILEGE — `%DB_%DEFAULT:RW` on this image.** Added 2026-08-19
+(#95). The table above is correct and a role built from it alone *cannot be used*: a principal
+holding only `PG_Read:U` logs in successfully and then dies with
+
+```
+<PROTECT> ... |ProductionGuardian.LabDemo.Tools.Governance.1    Access Denied
+```
+
+**before any policy is consulted**, because it cannot read the routine. Verified — the observed
+denial in §5.6 only passes once the probe user also holds `%DB_%DEFAULT`.
+
+`RW`, not `R`, and this is the non-obvious part: the denial audit row is written **as the refused
+principal**, which is what makes it attributable rather than anonymous. A read-only grant produces a
+denial that cannot be recorded, defeating the guarantee in §5.5.
+
+Grant it **from the invocation path** — the web application, or the proof fixture — rather than
+adding it to `Guardian_*`. The roles stay minimal and mean one thing: "may use the Production
+Guardian tools". A role that also carried database access would make "holds `Guardian_Read`" an
+answer to two different questions.
+
+**And the limit of the least-privilege claim, stated rather than implied.** LABDEMO's database
+resource is `%DB_%DEFAULT` (read from `SYS.Database` for its directory), which is the *default*
+resource — so the grant is broad, and a principal permitted to run the tools can reach any database
+sharing it. The least-privilege story MVP 2 §2.2 tells is real at the **tool** boundary:
+`PG_Resolve` genuinely gates `set_pool_size`, with an observed denial to prove it. It is **not** a
+database-isolation story. Worth one sentence because a demo showing "AI Detective can look but not
+act" invites the stronger reading, and the stronger reading is false.
+
 **This file is where the names are ratified.** `resolve-api.md` §9.3 defers to it, calling the
 `Guardian_Resolve` in its own examples "illustrative and not ratified here" and instructing Dev C to
 render `audit.role` as an opaque string and never compare it to a literal. That instruction stands
@@ -783,13 +832,46 @@ protects the endpoint from an unauthenticated caller. Both are required; neither
 
 ### 5.5 Audit
 
-`%LogExecution` receives `status` and `duration`, so **a failed or refused call is audited too**.
-That is the difference between "we log actions" and "we log attempts" — and the second is what makes
-"the AI changed a production setting" reviewable, because the interesting security event is usually
-the one that was blocked.
+**Two mechanisms, not one — and the split is the runtime's, not a choice.** The runtime audits
+*executions*; our authorization policy audits *denials*. Every call is recorded, but by different
+code, and a reader who assumes one mechanism will look for denials in the wrong place.
+
+| Event | Recorded by |
+|---|---|
+| successful read | the runtime, via `%LogExecution` |
+| dry-run of the write tool | the runtime |
+| **tool-level** refusal — our `2`–`8` bounds guard returning `outcome: "refused"` | the runtime (the tool ran) |
+| unknown host | the runtime |
+| **authorization** denial — `%CanExecute` refuses | **`Tools.AuthPolicy`, writing its own row** |
+
+CORRECTED 2026-08-19 (#95, found by implementing it). This section previously read:
+
+> `%LogExecution` receives `status` and `duration`, so **a failed or refused call is audited too**.
+
+The premise is true and the conclusion does not follow. `%AI.ToolMgr.ExecuteTool` checks
+authorization, *then* executes, *then* audits — so an authorization denial throws
+`<%AICore>ToolAccessDenied` at the first step and the audit hook is never reached. Measured with a
+deny-all policy registered: `%LogExecution` not called, **0 rows written**. The one event a security
+review actually asks about was the one going unrecorded, and the wording made it invisible by
+attributing it to the runtime.
+
+The reasoning is still right and is why the gap was worth closing rather than documenting: "we log
+attempts" is the correct goal, and `status`/`duration` in the signature genuinely is suggestive. It
+is just not *sufficient*, because the denial path never reaches that signature. Same shape as the
+`%`-prefix paragraph corrected in the 2026-08-18 role-name entry — a sound premise carried to a
+conclusion it does not support, which is harder to doubt than a bare claim.
+
+**So the guarantee is real but it is ours.** Anything that adds a new deny path must write its own
+audit row, or that refusal leaves no trace. `Tools.AuthPolicy` is the only code that ever learns a
+denial happened.
+
+`duration` is integer milliseconds and reads **0** for every read tool here — `ExecuteTool` timed
+the same call at `0.0071 s`. Stated because a reader comparing §5.5's promise of a duration against
+a column of zeroes should find the explanation here rather than assume the field is broken.
 
 Every one of the six tools is audited on every call. Not a per-tool setting: it is where the audit
-hook sits in the execution path (§5.2).
+hook sits in the execution path (§5.2) — plus the policy's own row for the one case that path
+cannot see.
 
 The audit record must be sufficient to answer *who acted, what changed, when* — the demo's final
 step. For `set_pool_size` that means the caller identity, the tool name, the arguments including

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -140,7 +140,7 @@ renders from one type rather than from a status code.
     "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
   },
   "audit": {
-    "auditId": "aihub-audit-44812",
+    "auditId": "pg-audit-44812",
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
@@ -597,17 +597,37 @@ convincing than a badge.
 **Every call produces exactly one attributable audit event: applies, refusals, and dry-runs
 alike.** `audit` is present in every response.
 
-**This is a property of the runtime, not of our discipline.** `%AI.Policy.Audit`'s
-`%LogExecution(call, metadata, result, duration, status)` is called by the tool-invocation path
-after every execution (§9.4), and it takes `status` and `duration` as parameters — so a refusal, a
-dry-run, and a failure are all first-class auditable events, not just a successful write.
-**"We audit attempts" is a stronger claim than "we audit changes",** and it is the one the
-signature supports: a `status` field only earns its place if non-success is recorded. A preview
-that leaves no trace is not reviewable.
+**It is a property of the runtime for executions, and of OUR authorization policy for denials.**
+Corrected 2026-08-19 (#95). This paragraph previously said "a property of the runtime, not of our
+discipline" — which is true of everything the runtime sees and false of the one event it does not.
+
+`%AI.Policy.Audit`'s `%LogExecution(call, metadata, result, duration, status)` is called after every
+*execution*, and taking `status` and `duration` does make a refusal, a dry-run and a failure
+first-class auditable events. But `%AI.ToolMgr.ExecuteTool` checks authorization *before* executing,
+so an authorization denial throws and never reaches that hook: measured, **0 rows written** with a
+deny-all policy registered. `Tools.AuthPolicy` writes that row itself, which is why §11.3's
+RBAC-denied example can carry a populated `audit` block naming the refused identity.
+
+So "we audit attempts" holds, and it holds because two components cooperate. Anything that adds a
+new deny path must write its own row or the refusal leaves no trace. A preview that leaves no trace
+is not reviewable; a *denial* that leaves none is worse.
+
+**THERE IS NO AI HUB AUDIT STORE.** `auditId` values in this document were written as
+`aihub-audit-*` and are now `pg-audit-*`. `%AI.Policy.ConsoleAudit` — the only shipped
+implementation — writes a coloured box to the current device and returns; there is no `%AI.Audit.*`
+persistent class in the image (verified: `%AI.Policy.Audit` is the abstract base and
+`%AI.Policy.ConsoleAudit` its only concrete subclass, and no `%AI.Audit*` class exists at all). The
+record is `ProductionGuardian.LabDemo.Audit.Entry` and the handle is ours.
+
+The value is opaque either way — §9.3 already tells Dev C to render it as a string and never compare
+it to a literal — but the *provenance* it implied was not. `aihub-audit-*` claims a system of record
+that would not survive someone going to look for it, which is the same defect this document names in
+the mock's own words: "inventing an id that resolves to nothing is worse than admitting there is
+none."
 
 ```json
 "audit": {
-  "auditId": "aihub-audit-44812",
+  "auditId": "pg-audit-44812",
   "actor": "guardian_resolve",
   "role": "Guardian_Resolve",
   "requestedBy": "presenter@laptop",
@@ -619,13 +639,18 @@ that leaves no trace is not reviewable.
 
 | Field | Notes |
 |---|---|
-| `auditId` | Handle for the AI Hub audit entry, so the UI can link to the record MVP 2 §3's last demo step shows. `null` when the record could not be written — and if it could not be written for an `apply`, that is `failed` / `verify`, not a silent success. **Whether an entry is retrievable by this handle is unverified — §13.4.** |
+| `auditId` | Handle into the **Production Guardian** audit trail (`Audit.Entry`), so the UI can link to the record MVP 2 §3's last demo step shows. AI Hub persists nothing itself — see above. `null` when the record could not be written, and if it could not be written for an `apply`, that is `failed` / `verify`, not a silent success. Retrievable: `Audit.Entry.Describe(handle)` returns the block below. |
 | `actor` | **The authenticated IRIS principal, resolved server-side.** The identity the RBAC decision was made about. |
 | `role` | The role that authorized (or, on `not_authorized`, the role that was required). Lets the UI say *what* is missing. |
 | `requestedBy` | The request's advisory label, echoed. Recorded **next to** `actor`, never in place of it. |
 | `tool` | `set_pool_size` on an apply, `get_pool_size` on a dry-run. Which privileged tool was actually invoked, per §2. |
 | `recordedAt` | ISO 8601 UTC. |
 | `source` | `"live"` \| `"mock"`. |
+
+`duration` is not in this block, and where the runtime does report it (`%LogExecution`) it is integer
+milliseconds and reads **0** for every read tool — `ExecuteTool` timed the same call at `0.0071 s`.
+Noted so a reader comparing a duration column of zeroes against §5.5 of `mcp-tools.md` does not
+conclude the field is broken.
 
 **`actor` is not a request field, and a caller cannot name itself.** `requestedBy` is a string a
 browser typed; treating it as identity would make the audit log a record of what the client
@@ -907,7 +932,7 @@ Response `200`, `X-Resolve-Outcome: previewed`:
     "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
   },
   "audit": {
-    "auditId": "aihub-audit-44810",
+    "auditId": "pg-audit-44810",
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": null,
@@ -953,7 +978,7 @@ load-bearing parts:
     "automatic": false
   },
   "confirmation": { "status": "pending", "findingId": "f-1042" },
-  "audit": { "actor": "guardian_resolve", "auditId": "aihub-audit-44812", "source": "live" }
+  "audit": { "actor": "guardian_resolve", "auditId": "pg-audit-44812", "source": "live" }
 }
 ```
 
@@ -983,7 +1008,7 @@ Same request as §11.2, from a caller without the write role. Response `200`,
   "failure": null,
   "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
   "audit": {
-    "auditId": "aihub-audit-44813",
+    "auditId": "pg-audit-44813",
     "actor": "guardian_readonly",
     "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
@@ -1036,7 +1061,7 @@ Response `200`, `X-Resolve-Outcome: refused`:
   "failure": null,
   "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
   "audit": {
-    "auditId": "aihub-audit-44814",
+    "auditId": "pg-audit-44814",
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": null,


### PR DESCRIPTION
Closes #95. A **contract change PR** per root `CLAUDE.md` §4: its own PR, a `CHANGELOG.md` entry, reviewed by the other developer.

@kskubach raised these as an issue rather than a PR because a contract change needs my review anyway and three of the four land in my area. **I verified every claim against the running instance myself before writing the correction** — these are assertions about runtime behaviour, and the last two days have produced three cases where a confident sentence about this runtime turned out to be wrong.

## The four

| | Correction | Verified how |
|---|---|---|
| 1 | `not_authorized` refusals are **not** audited by the runtime — it takes two mechanisms | deny-all policy registered → `%LogExecution` not called, **0 rows** |
| 2 | There is **no AI Hub audit store**; `aihub-audit-*` → `pg-audit-*` | enumerated compiled classes: `%AI.Policy.Audit` (abstract) + `ConsoleAudit` only, no `%AI.Audit*` at all |
| 3 | Both roles need `%DB_%DEFAULT:RW`, or `<PROTECT>` fires before any policy runs | the observed denial only passes once the probe user also holds it |
| 4 | An out-of-bounds argument is a **refusal**, not a thrown failure | `%LogExecution` receives the return value; a throw carries no payload |

## Item 1 is the one that matters

`ExecuteTool` checks authorization → executes → audits. A denial throws at step one, so the audit hook never runs. Both contracts attributed the whole guarantee to the runtime, and **the half that was broken is exactly the half a security review asks about**: a *tool-level* refusal (our `2`–`8` bounds guard) is audited because the tool ran; the *authorization* denial was not.

The guarantee is real now, but it belongs to `Tools.AuthPolicy` rather than to the runtime — so anything that adds a new deny path must write its own row or the refusal leaves no trace. The old wording made that invisible by pointing at the wrong component.

## Where I narrowed your wording

#95 says "every database shares the `%DB_%DEFAULT` resource". I could verify that LABDEMO's does (`SYS.Database` on its directory) and that IRISSYS has `%DB_IRISSYS`, so I wrote the claim I can support: the grant is broad *because LABDEMO uses the default resource*, and the least-privilege story is real at the tool boundary and is not database isolation.

The conclusion is unchanged and the sentence you wanted is there. The premise is now one I tested rather than one I inherited — which is the whole lesson of the other three items.

## On item 4, which was your review note on #92

Agreed, and for both of your reasons. `resolve-api.md` §5 requires `outcome: "refused"` with `refusal.reason: "out_of_bounds"`, and reaching those fields from a thrown `%Status` would mean parsing error *text* into a contract field. And `%LogExecution` receives the tool's **return value**, so the structured return is why `Audit.Entry.Result` can show *what* was refused and why, rather than only that something failed.

§4 gains a `Refused` row. The "do not invent an error envelope" warning stays for genuine failures, with §5.2's line quoted next to it to keep the two apart: `refused` means the system decided not to act and nothing was written; `failed` means it tried and did not complete.

## The pattern, recorded in the CHANGELOG

Each of the four was found by **implementing** the promise, not by reading it. Three of them are a *correct premise carried to a conclusion it does not support* — the same shape as the `%`-prefix paragraph in #93 and the `AgentDispatcher` safety claim in #92. That observation is now written down, because on this contract set the well-argued passage is the one to check first: it survives review precisely by reading as already considered.

## Checks

- `validate.mjs` — unchanged, passing (15 accept / 19 reject / 7 capture claims)
- `services/detection-engine` — **236 tests pass**, including `mvp2-contract-drift.test.ts`, which greps this prose and would have failed if a corrected passage broke a field name it asserts
- No field added, removed or retyped; no schema, no sample, no `.d.ts` affected

You raised all four, so this needs your approval rather than counting as already reviewed. If I have flattened a nuance in item 3, that is the one to push back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
