### PR TITLE
fix(iris): bound the pool-bottleneck backlog so a demo cannot reach 2,650 queued (#101)

### DIFF
--- a/iris/labdemo/HL7Generator.cls
+++ b/iris/labdemo/HL7Generator.cls
@@ -62,6 +62,21 @@ ClassMethod Run(count As %Integer = 20, delaySecs As %Double = 2) As %Status
 ///
 /// Same pattern as the injected delay in PatientDemographicsOperation: a global read at runtime,
 /// so nothing is edited or recompiled mid-demo, and Triggers.Reset() clears it.
+///
+/// RECOMPILING THIS CLASS DOES NOT AFFECT A GENERATOR ALREADY RUNNING, and that distinction cost me
+/// a run to learn. `FirstBoot.StartGenerator()` `job`s this method, and the loop below never returns
+/// -- so the process keeps executing the routine version it loaded at start, and new CODE reaches it
+/// only after the process is restarted. The rate override works on a running generator precisely
+/// because the old code already read that global; the depth cap added for #101 did nothing until the
+/// job was cycled, while the queue sailed past it to 231.
+///
+/// So: a fresh `docker compose up` picks up changes here, and a mid-session recompile needs
+///
+///     do ##class(%SYSTEM.Process).Terminate(pid)   // pid from %SYS.ProcessQuery, Routine LIKE '%HL7Generator%'
+///     do ##class(ProductionGuardian.Setup.FirstBoot).StartGenerator(2)
+///
+/// A global that changes BEHAVIOUR the existing code already reads takes effect within one interval;
+/// a global that only new code reads takes effect never, and looks identical from the outside.
 ClassMethod RunContinuous(delaySecs As %Double = 2)
 {
     set sc = ..EnsureDropDir()
@@ -69,8 +84,48 @@ ClassMethod RunContinuous(delaySecs As %Double = 2)
 
     write "Continuous HL7 generation started (Ctrl-C to stop). Interval: ", delaySecs, "s",!
     write "  Rate is re-read from ^ProductionGuardian.Trigger(""RateSecs"") each message.",!
+    write "  Depth cap re-read from ^ProductionGuardian.Trigger(""MaxQueued"") each message.",!
     set i = 1
+    set paused = 0
     for {
+        // THE DEPTH CAP, checked BEFORE producing rather than after (#101). `PoolBottleneck()` arms
+        // the scenario and exits, so nothing in the trigger can bound the backlog -- the only place
+        // that can is the loop actually producing load. A run left armed reached 2,650 queued and
+        // IRIS's embedded Apache stopped serving on :52773 entirely, taking the portal, the metrics
+        // endpoint the proxy polls and the agent dispatcher with it for ~40 minutes.
+        //
+        // PAUSES, DOES NOT STOP, and that is what keeps the demo's shape. Depth climbs, the
+        // queue_buildup finding fires and stays lit -- the cap is far above the rule's absolute
+        // floor of 50 -- and once Smart Resolve raises the pool the queue drains and inflow resumes
+        // by itself as depth falls back under the cap. A generator that stopped would need
+        // restarting mid-demo, in front of an audience, and the visible drain is the last step of
+        // the whole MVP 2 loop.
+        //
+        // THIS REDUCES EXPOSURE RATHER THAN FIXING THE WEDGE. If worker exhaustion is the
+        // mechanism, a smaller backlog makes it less likely and not impossible. Stated so nobody
+        // reads the cap as a fix and closes #101 on the strength of it.
+        set cap = +$get(^ProductionGuardian.Trigger("MaxQueued"), 0)
+        if cap > 0 {
+            set depth = ..QueueDepth()
+            if (depth '= "") && (depth >= cap) {
+                if 'paused {
+                    // Announced ONCE per pause, not per iteration. A line every interval would bury
+                    // the drain a presenter is watching for under identical messages.
+                    write $zdatetime($ztimestamp, 3, 1), "  PAUSED at ", depth, " queued (cap ", cap, ")", !
+                    set paused = 1
+                }
+                // Re-check on the same cadence as production, so inflow resumes within one interval
+                // of the queue dropping under the cap.
+                set override = +$get(^ProductionGuardian.Trigger("RateSecs"), 0)
+                hang $select(override > 0: override, 1: delaySecs)
+                continue
+            }
+            if paused {
+                write $zdatetime($ztimestamp, 3, 1), "  RESUMED at ", depth, " queued (cap ", cap, ")", !
+                set paused = 0
+            }
+        }
+
         set msg = ..BuildADTA01(i)
         set msgType = "ADT_A01"
         set filename = ..#DropDir _ msgType _ "_" _ $translate($horolog, ",", "_") _ "_" _ i _ ".hl7"
@@ -84,6 +139,34 @@ ClassMethod RunContinuous(delaySecs As %Double = 2)
         hang $select(override > 0: override, 1: delaySecs)
         set i = i + 1
     }
+}
+
+/// Current queue depth for the bottlenecked host, or "" when it cannot be read. Private.
+///
+/// "" AND NOT 0, by the rule this project keeps relearning (#33, #49): an unmeasurable depth is not
+/// a small one. A failed read returning 0 would compare below any cap and let the generator produce
+/// without limit -- which is the exact condition the cap exists to prevent, reached through the cap's
+/// own error path.
+///
+/// Reads `Ens.Queue.GetCount` rather than EnumerateHostStatus: verified signature
+/// `GetCount(pQueueName)`, the queue name is the config item name, and it is one call per message
+/// rather than a result set.
+ClassMethod QueueDepth() As %String [ Private ]
+{
+    // `return`, not `quit`. Inside a TRY block `quit` is the block terminator and cannot carry an
+    // argument -- `#1043: QUIT argument not allowed`, which is a compile error rather than a runtime
+    // one and so failed the whole class. Worth a note because every other method in this area uses
+    // argumentless `quit` to return, and this is the one place that shape is wrong.
+    set depth = ""
+    try {
+        // Triggers.#OPERATION rather than a second copy of "Cloud API" -- that parameter exists so
+        // the name lives in one place (root CLAUDE.md §5), and a stale copied host name is #84.
+        set host = ##class(ProductionGuardian.LabDemo.Triggers).#OPERATION
+        set depth = ##class(Ens.Queue).GetCount(host)
+    } catch ex {
+        set depth = ""
+    }
+    quit depth
 }
 
 /// Build an ADT^A01 (Admit) message.

--- a/iris/labdemo/HL7Generator.cls
+++ b/iris/labdemo/HL7Generator.cls
@@ -104,6 +104,21 @@ ClassMethod RunContinuous(delaySecs As %Double = 2)
         // THIS REDUCES EXPOSURE RATHER THAN FIXING THE WEDGE. If worker exhaustion is the
         // mechanism, a smaller backlog makes it less likely and not impossible. Stated so nobody
         // reads the cap as a fix and closes #101 on the strength of it.
+        //
+        // THE PAUSE IS UNBOUNDED, DELIBERATELY. @Ari-Glikman's parallel implementation (#103) capped
+        // it at 300s and then resumed with a warning, so a permanently stuck queue could not silence
+        // the generator forever -- a demo showing no traffic reads as dead rather than stuck. He
+        // flagged it as a guess and left the call here; declining it, because the argument against is
+        // stronger than the argument for.
+        //
+        // If the queue is genuinely not draining, resuming inflow makes it worse, and unbounded
+        // inflow into a non-draining queue is exactly what wedged the web server in #101. A timed
+        // resume would convert a visible stall into the failure this cap exists to prevent.
+        //
+        // The visibility concern is real and is answered better elsewhere: `Triggers.Status()`
+        // prints the cap beside the live depth and says "PAUSED, inflow held", so "held at the cap"
+        // and "stuck" are distinguishable without putting more messages into a queue that is not
+        // moving. Diagnose with Status(), not by resuming.
         set cap = +$get(^ProductionGuardian.Trigger("MaxQueued"), 0)
         if cap > 0 {
             set depth = ..QueueDepth()

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -350,7 +350,7 @@ ClassMethod SystemAlert(pHost As %String = {..#OPERATION}) As %Status
 /// So the default leaves headroom: 2/sec in against 4/sec out drains ~2/sec, and the backlog the
 /// demo built visibly disappears. Raise pRateSecs to make the drain faster and more dramatic;
 /// lower it toward 0.25 only if you want to demonstrate that a pool of 4 is NOT enough.
-ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Double = 0.5, pWarmSeconds As %Integer = 75) As %Status
+ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Double = 0.5, pWarmSeconds As %Integer = 75, pMaxQueued As %Integer = 400) As %Status
 {
     set sc = ..CheckProduction()
     if $$$ISERR(sc) {
@@ -359,6 +359,16 @@ ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Doubl
     if pDispatcherMs < 1 {
         write "REFUSED  a dispatcher throttle under 1ms induces nothing", !
         quit $$$ERROR($$$GeneralError, "pDispatcherMs must be >= 1")
+    }
+    // THE DEPTH CAP MUST CLEAR THE RULE'S ABSOLUTE FLOOR, or arming this produces no finding at all.
+    // queue_buildup will not fire below 50 queued, so a cap at or under that pauses the generator
+    // before the thing it exists to demonstrate can happen -- an armed scenario that looks armed and
+    // shows nothing. 100 is the lower bound rather than 51 so the depth is unambiguously past the
+    // floor while the finding debounces over its 2 consecutive samples.
+    if pMaxQueued < 100 {
+        write "REFUSED  a cap of ", pMaxQueued, " is too close to the rule's absolute floor (50)", !
+        write "         the generator would pause before queue_buildup could fire", !
+        quit $$$ERROR($$$GeneralError, "pMaxQueued must be >= 100")
     }
     if pRateSecs <= 0 {
         // Guarded rather than trusted: a zero interval spins the generator loop as fast as the
@@ -383,6 +393,9 @@ ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Doubl
     }
     set ^ProductionGuardian.Trigger("DispatcherMs") = pDispatcherMs
     set ^ProductionGuardian.Trigger("RateSecs") = pRateSecs
+    // Read per message by HL7Generator.RunContinuous, which pauses above it. Set with the rest of the
+    // armed state so it cannot outlive the scenario, and cleared by Reset() with everything else.
+    set ^ProductionGuardian.Trigger("MaxQueued") = pMaxQueued
 
     set pool = ..GetPoolSize(..#OPERATION)
     set drainPerSec = 1000 / pDispatcherMs * $select(+pool > 0: +pool, 1: 1)
@@ -393,6 +406,12 @@ ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Doubl
     write "    -> drains ~", $fnumber(drainPerSec, "", 1), "/sec", !
     write "  HL7 inflow every ", pRateSecs, "s -> ~", $fnumber(inflowPerSec, "", 1), "/sec", !
     write "  net ~+", $fnumber(inflowPerSec - drainPerSec, "", 1), "/sec into the queue", !
+    write "  inflow PAUSES at ", pMaxQueued, " queued and resumes as the queue drains (#101)", !
+    // Stated at arming time with the arithmetic, because a presenter needs to know roughly how long
+    // the build-up takes before they are standing in front of it.
+    if (inflowPerSec - drainPerSec) > 0 {
+        write "    ~", $fnumber(pMaxQueued / (inflowPerSec - drainPerSec), "", 0), "s to reach the cap from empty", !
+    }
     write "  Expect queue_buildup once depth clears the absolute floor (50).", !
     write "  dead_host will NOT fire: the host is healthy, just outnumbered.", !
     write "  The fix is more workers, not a restart -- pool ", pool, " -> 4 makes the", !
@@ -437,6 +456,10 @@ ClassMethod Reset() As %Status
     if $data(^ProductionGuardian.Trigger("RateSecs")) {
         kill ^ProductionGuardian.Trigger("RateSecs")
         write "  restored the HL7 inflow rate to the generator's own interval", !
+    }
+    if $data(^ProductionGuardian.Trigger("MaxQueued")) {
+        kill ^ProductionGuardian.Trigger("MaxQueued")
+        write "  removed the generator's queue-depth cap", !
     }
     if $data(^ProductionGuardian.Trigger("DispatcherMs")) {
         kill ^ProductionGuardian.Trigger("DispatcherMs")
@@ -522,6 +545,16 @@ ClassMethod Status() As %Status
     write "  dispatcher     : ", $select(thr > 0: thr _ "ms per POST  <- downstream throttled", 1: "no throttle"), !
     set rate = +$get(^ProductionGuardian.Trigger("RateSecs"), 0)
     write "  HL7 inflow     : ", $select(rate > 0: rate _ "s per message  <- rate overridden", 1: "generator default"), !
+    // Reported with the live depth beside it, so "capped" and "currently paused" are distinguishable
+    // at a glance -- a presenter seeing a flat queue needs to know whether it is held or stuck.
+    set cap = +$get(^ProductionGuardian.Trigger("MaxQueued"), 0)
+    if cap > 0 {
+        set depth = ##class(Ens.Queue).GetCount(..#OPERATION)
+        write "  inflow cap     : ", cap, " queued, now ", depth,
+            $select(depth >= cap: "  <- PAUSED, inflow held", 1: "  <- producing"), !
+    } else {
+        write "  inflow cap     : none  <- the backlog is unbounded (#101)", !
+    }
     if $data(^ProductionGuardian.Trigger("PoolWas")) {
         write "  pool stashed   : ", ^ProductionGuardian.Trigger("PoolWas"), "  <- Reset() will restore this", !
     }


### PR DESCRIPTION
Option 3 from #101. Claimed in a comment there first so we didn't both write it.

## Where the cap goes

`PoolBottleneck()` arms and exits, so nothing in the trigger can bound anything — the enforcement has to live in the loop producing load. `RunContinuous` now reads `^ProductionGuardian.Trigger("MaxQueued")` per message and **pauses** above it. `Reset()` clears it; `Status()` reports it beside the live depth so *capped* and *currently paused* are distinguishable at a glance.

Pausing rather than stopping keeps the demo's shape: depth climbs, `queue_buildup` fires and stays lit, and after Smart Resolve raises the pool the queue drains and inflow resumes by itself. A generator that stopped would need restarting mid-demo.

`PoolBottleneck()` gains `pMaxQueued` (default 400) and **refuses anything under 100** — a cap near the rule's absolute floor of 50 would pause inflow before the finding it exists to demonstrate could fire, which is an armed scenario that shows nothing.

## Verified end to end

Cap 120, 1s dispatcher, 0.5s inflow:

```
queue 0 -> 26 -> 65 -> 95 -> 118 -> 116 -> 121 -> 120     held at the cap
Status: inflow cap : 120 queued, now 120  <- PAUSED, inflow held

live apply via Tools.Governance -> outcome applied, 1 -> 4, auditId pg-audit-2
queue 86 -> 42 -> 8 -> 2 -> 0                             drained
then 6 -> 2                                               inflow resumed
Reset() -> pool restored to 1, cap removed
web server after the run: metrics 200 in 0.12s, portal 200 in 0.007s
```

That live `1 -> 4` is also **Dev A acceptance criterion 2**, which had only ever been dry-run verified. It applied through the governed path, wrote its audit row, and the queue drained visibly — so the criterion is now met rather than asserted.

## Two things this does not do

**It does not fix the wedge.** If worker exhaustion is the mechanism, a smaller backlog makes it less likely and not impossible — a long rehearsal sitting at the cap could still get there. #101's option 1 (`mod_status`) matters more in the long run, because without it the next occurrence is still unprovable. I'd rather that landed separately, with a verified httpd reload, than be bundled here.

**It does not reach a generator already running,** and I only know that because it bit me. `StartGenerator()` `job`s `RunContinuous` and the loop never returns, so the process keeps the routine version it loaded — new *code* arrives only after the job is cycled. I watched the queue sail past the cap to **231** with the new class compiled and was briefly convinced the logic was wrong.

The distinction worth keeping: the *rate* override works on a running generator because the old code already read that global. A global only new code reads takes effect **never**, and looks identical from the outside. Documented on the method with the restart incantation.

## Also worth reporting from this run

I triggered **#96 on myself twice** — recompiling `/pg-src/labdemo/` includes `Production.cls`, which reverts the deployment target. Both times `VerifyDeploymentSettings()` (#98, merged an hour ago) caught it and named the fix:

```
10. HTTPServer DRIFTED: live 'webgateway-webinar' but deployment asked for '127.0.0.1'
10. HTTPPort DRIFTED: live '80' but deployment asked for '52773'
```

The first time I noticed because the queue rose after a `Reset()` instead of draining — which is exactly the misleading symptom #96 describes, and I fell for it for a minute before running the checker. Worth saying out loud: anyone iterating on `iris/labdemo/**` will hit this on every recompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
