### PR TITLE
fix(iris): bound the scenario queue so the demo cannot take the web server down (#101)

### DIFF
--- a/iris/labdemo/HL7Generator.cls
+++ b/iris/labdemo/HL7Generator.cls
@@ -62,6 +62,33 @@ ClassMethod Run(count As %Integer = 20, delaySecs As %Double = 2) As %Status
 ///
 /// Same pattern as the injected delay in PatientDemographicsOperation: a global read at runtime,
 /// so nothing is edited or recompiled mid-demo, and Triggers.Reset() clears it.
+///
+/// IT ALSO PAUSES ABOVE A QUEUE CAP, and that is a safety valve rather than a demo nicety (#101).
+/// `Cloud API` POSTs to the SAME embedded web server that serves the Management Portal, the
+/// /api/monitor/ endpoints the metrics proxy polls, and the agent dispatcher -- so this generator
+/// is, transitively, a load generator against the instance the whole stack depends on. On
+/// 2026-08-19 a long armed run reached ~2,650 queued and that web server stopped serving
+/// ENTIRELY: connections accepted, nothing answered, for a static file as well as a CSP page. The
+/// Portal, the metrics endpoint and the dispatcher all went down together and it took a
+/// `compose down` to recover.
+///
+/// The cause is not proven (#101 ranks the options; mod_status is not enabled, so worker/keep-alive
+/// exhaustion fits the evidence but is inference). The cap does not depend on the diagnosis being
+/// right: no demo needs a 2,600-message backlog, and the scenario's SHAPE -- a queue building, then
+/// draining once the pool grows -- is unaffected by bounding it. A few hundred messages
+/// demonstrates a bottleneck exactly as well as a few thousand.
+///
+/// PAUSES, DOES NOT STOP. Stopping would end the demo: inflow has to resume once the fix drains
+/// the queue, or the recovery shows a drained queue with no traffic behind it, which looks like the
+/// production died rather than recovered. So above the cap it waits and re-checks, and inflow
+/// returns on its own as soon as the queue falls back under.
+/// The config item whose queue the cap watches. Named here rather than repeated as a literal --
+/// root CLAUDE.md §5 keeps the host list in Production.cls, and a copied name is what went stale
+/// when FHIR Transform was removed. Triggers.#OPERATION is the same value; this class cannot
+/// reference it without a circular dependency, so the two are checked against each other by
+/// Triggers.Status() rather than by being one copy.
+Parameter Target = "Cloud API";
+
 ClassMethod RunContinuous(delaySecs As %Double = 2)
 {
     set sc = ..EnsureDropDir()
@@ -82,6 +109,39 @@ ClassMethod RunContinuous(delaySecs As %Double = 2)
         // argument.
         set override = +$get(^ProductionGuardian.Trigger("RateSecs"), 0)
         hang $select(override > 0: override, 1: delaySecs)
+
+        // QUEUE CAP. Checked after the hang so the first message always goes out -- a cap that
+        // could stall before producing anything would make a misconfigured global look like a dead
+        // generator.
+        //
+        // 0 or unset disables it, because the cap must never be the reason a demo produces no
+        // traffic. Triggers.Reset() clears the global, so the default state is uncapped exactly as
+        // before this change.
+        set cap = +$get(^ProductionGuardian.Trigger("QueueCap"), 0)
+        if cap > 0 {
+            set waited = 0
+            // Ens.Queue.GetCount is the same read Triggers.Status() uses -- the authoritative
+            // depth, not the proxy's copy, because this must hold even with the proxy down.
+            while ##class(Ens.Queue).GetCount(..#Target) >= cap {
+                if waited = 0 {
+                    write "  PAUSED: queue at cap (", cap, "), waiting for it to drain", !
+                }
+                hang 2
+                set waited = waited + 2
+                // A bound on the pause itself, so a permanently stuck queue cannot silence the
+                // generator forever. 300s is far longer than any drain in this scenario (a pool-4
+                // drain of 2,600 messages takes ~20 minutes at the demo's rates; 300s covers every
+                // depth the cap allows) and short enough that a wedged production still ends up
+                // showing traffic rather than an unexplained silence.
+                if waited >= 300 {
+                    write "  RESUMING despite the cap after ", waited, "s -- the queue is not draining", !
+                    quit
+                }
+            }
+            if waited > 0 {
+                write "  resumed after ", waited, "s", !
+            }
+        }
         set i = i + 1
     }
 }

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -350,7 +350,7 @@ ClassMethod SystemAlert(pHost As %String = {..#OPERATION}) As %Status
 /// So the default leaves headroom: 2/sec in against 4/sec out drains ~2/sec, and the backlog the
 /// demo built visibly disappears. Raise pRateSecs to make the drain faster and more dramatic;
 /// lower it toward 0.25 only if you want to demonstrate that a pool of 4 is NOT enough.
-ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Double = 0.5, pWarmSeconds As %Integer = 75) As %Status
+ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Double = 0.5, pWarmSeconds As %Integer = 75, pQueueCap As %Integer = 600) As %Status
 {
     set sc = ..CheckProduction()
     if $$$ISERR(sc) {
@@ -365,6 +365,25 @@ ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Doubl
         // filesystem allows, which takes the instance down instead of demonstrating a queue.
         write "REFUSED  an inflow interval of ", pRateSecs, "s would spin the generator", !
         quit $$$ERROR($$$GeneralError, "pRateSecs must be > 0")
+    }
+    if pQueueCap < 0 {
+        write "REFUSED  a negative queue cap is meaningless; pass 0 to disable the cap", !
+        quit $$$ERROR($$$GeneralError, "pQueueCap must be >= 0")
+    }
+    // 600 by default, and the number is a judgement rather than a measurement: it is comfortably
+    // above the 50-message absolute floor queue_buildup needs and roughly a quarter of the ~2,650
+    // depth at which the embedded web server stopped serving (#101). A queue of 600 at pool 1 is
+    // ~10 minutes of backlog, which is more than any rehearsal needs to show a bottleneck.
+    //
+    // Set BEFORE the throttle goes on, so there is no window where inflow is raised and the cap is
+    // not yet in force.
+    if pQueueCap > 0 {
+        set ^ProductionGuardian.Trigger("QueueCap") = pQueueCap
+    } else {
+        // Explicit 0 means uncapped, and it is worth saying out loud: this is the configuration
+        // that took the stack down, so someone choosing it should see that they chose it.
+        kill ^ProductionGuardian.Trigger("QueueCap")
+        write "  QUEUE CAP DISABLED by request -- inflow will build without bound (#101)", !
     }
 
     // Stash before changing anything, and only if not already stashed -- arming twice must not
@@ -441,6 +460,14 @@ ClassMethod Reset() As %Status
     if $data(^ProductionGuardian.Trigger("DispatcherMs")) {
         kill ^ProductionGuardian.Trigger("DispatcherMs")
         write "  cleared the downstream dispatcher throttle", !
+    }
+    // The cap goes AFTER the inflow rate is restored, deliberately. Cleared first, the generator
+    // would be uncapped for the interval it takes the rate to drop -- brief, but it is the exact
+    // combination (raised inflow, no cap) that #101 was about, so the ordering closes the window
+    // rather than shortening it.
+    if $data(^ProductionGuardian.Trigger("QueueCap")) {
+        kill ^ProductionGuardian.Trigger("QueueCap")
+        write "  cleared the generator queue cap", !
     }
 
     // Pool size back to what it WAS, by the same rule as the port above: restore the stashed
@@ -522,6 +549,11 @@ ClassMethod Status() As %Status
     write "  dispatcher     : ", $select(thr > 0: thr _ "ms per POST  <- downstream throttled", 1: "no throttle"), !
     set rate = +$get(^ProductionGuardian.Trigger("RateSecs"), 0)
     write "  HL7 inflow     : ", $select(rate > 0: rate _ "s per message  <- rate overridden", 1: "generator default"), !
+    // Reported for the same reason as the two above -- invisible otherwise -- and the UNCAPPED
+    // state is the one worth seeing, because that is the configuration #101 was about. So the
+    // absent case says "uncapped" rather than staying quiet.
+    set cap = +$get(^ProductionGuardian.Trigger("QueueCap"), 0)
+    write "  queue cap      : ", $select(cap > 0: cap _ " messages  <- generator pauses above this", 1: "UNCAPPED (#101)"), !
     if $data(^ProductionGuardian.Trigger("PoolWas")) {
         write "  pool stashed   : ", ^ProductionGuardian.Trigger("PoolWas"), "  <- Reset() will restore this", !
     }


### PR DESCRIPTION
Takes option 3 from #101. `iris/**` is your area (@kskubach), so this is a proposal rather than a decision — happy to hand it over if you'd rather own it.

## What it does

The generator **pauses** above a queue cap instead of building without limit. `PoolBottleneck()` sets it (default **600**, `0` disables, negative refused), `Reset()` clears it, `Status()` reports it — including the **uncapped** state, because that is the configuration #101 was about.

## Why option 3 first

Of the four options in #101 this is the only one that protects the demo without depending on the diagnosis being right. `mod_status` isn't enabled, so worker/keep-alive exhaustion fits every piece of evidence but remains inference. A cap doesn't care: **no demo needs a 2,600-message backlog**, and the scenario's shape — a queue building, then draining once the pool grows — is unaffected by bounding it. A few hundred messages demonstrates a bottleneck exactly as well as a few thousand.

I'd still like option 1 (`mod_status` on a localhost path) regardless, because without it the next occurrence is as unprovable as this one.

## Two design points worth reviewing

**It pauses; it does not stop.** Inflow has to resume once the fix drains the queue, or the recovery shows a drained queue with no traffic behind it — which looks like the production *died* rather than recovered. So above the cap it waits and re-checks, and inflow returns on its own. The pause is itself bounded at 300s so a permanently stuck queue cannot silence the generator forever: a wedged production should still show traffic rather than unexplained silence.

**Ordering, in two places, both deliberate:**

- The cap is checked **after** the hang, so the first message always goes out. A cap that could stall before producing anything would make a misconfigured global look like a dead generator.
- In `Reset()` it is cleared **after** the inflow rate. Clearing it first leaves a window with raised inflow and no cap — the exact combination #101 was about. Shortening that window isn't the same as closing it.

## Verified on the live stack, cap 120 for a short test

```
queue 30 -> 58 -> 78 -> 97 -> 122, then PINNED at 118-122 for two minutes
queue_buildup still fires: "Queue depth 123 with no baseline queue"  (120 > the 50 floor)
Status(): "queue cap      : 120 messages  <- generator pauses above this"
SetPoolSize 1->4 through the governed tool (pg-audit-46) -> 88 -> 53 -> 16 -> 0 in 60s
inflow resumed on its own as the depth fell under the cap
Reset() -> "cleared the generator queue cap", pool 1
pQueueCap=0  -> "QUEUE CAP DISABLED by request -- inflow will build without bound (#101)"
pQueueCap=-5 -> refused
```

The pinned-for-two-minutes reading is the one that matters: before this, the same configuration grew monotonically past 2,500.

## The 600 default is a judgement, not a measurement

Stated as such in the code. It sits comfortably above the 50-message absolute floor `queue_buildup` needs, and at roughly a quarter of the depth where the web server stopped serving. At pool 1 that is ~10 minutes of backlog — more than any rehearsal needs. Push back if you want it lower; I'd have no objection to 300.

## One trap worth knowing, recorded in the commit

**A recompile does not affect the running generator**, because `FirstBoot` `job`s it as a background process. I measured 2.5 msg/sec of inflow against a global that said the cap was set, and the pause only took effect after the container restarted. Same class as the #96 recompile drift: code on disk is not code running. I also terminated the wrong process while hunting for the generator's PID (`Routine["HL7"` matched a `CONTROL` process) — harmless, stack stayed healthy, but worth saying rather than quietly not mentioning.

## Not addressed here

Options 1, 2 and 4 from #101 — `mod_status`, the Apache worker/keep-alive settings, and a restart policy for a wedged web server. All three are still worth doing, and 2 touches shared compose/config rather than `iris/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
