### PR TITLE
fix(iris): a cold start had no /labdemo/agent web app and no LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Production Guardian — Health Scan (MVP 1)
+# Production Guardian — Health Scan (MVP 1) + Early Warning, AI Detective, Smart Resolve (MVP 2)
 
 An AI-powered production health layer for InterSystems Health Connect. MVP 1 is **Health
 Scan**: it reads production metrics from IRIS, compares them to a rolling baseline, and
@@ -156,6 +156,118 @@ still waiting for. Full table in `iris/labdemo/README.md`.
 alert from the proxy. Read `http://localhost:3001/proxy/alerts` instead.
 
 The Management Portal is at **http://localhost:52773/csp/sys/UtilHome.csp**.
+
+## The MVP 2 demo — WHAT, WHY, FIX
+
+One scenario, end to end: a queue builds on `Cloud API`, an AI agent explains why, and one
+governed, approved, reversible action clears it.
+
+### It runs without a key, and says so
+
+`AGENT_MODE` defaults to `mock`, so a fresh clone demonstrates the **shape** of the loop with no
+credential: the investigation is a canned narrative built from the live measured values, and the
+resolve is applied against an in-memory pool size. Both are labelled — `source: "canned"`, and the
+audit id reads `mock-audit-N`.
+
+**The mock resolve reports `applied` and does not change the production.** That is deliberate and it
+is the one thing to know before demonstrating from a clone: the pool stays at 1 and the queue keeps
+growing. If the queue does not drain after an apply, check which mode you are in before looking for
+a bug.
+
+### For a live agent and a real write
+
+```bash
+export PG_LLM_API_KEY=sk-...          # OpenAI key; goes into the AI Hub wallet, never the repo
+export PG_AGENT_MODE=live             # engine calls IRIS instead of its own mock
+docker compose up -d
+```
+
+`PG_LLM_API_KEY` is read at first boot by `Setup.AIHub`, which creates the wallet entry and the
+`AI.LLM.pgdetective` config that references it as `secret://PGSecrets.openai#apikey`. The key is
+never written to the configuration, the repo, or a log line — the boot prints its length and that it
+was stored. Rotating it is: change the variable, restart. `PG_LLM_MODEL` overrides the model
+(default `gpt-4o-mini`).
+
+Without the key the boot says so plainly and the loop still runs, canned:
+
+```
+4b. LLM provider: SKIPPED -- PG_LLM_API_KEY is not set
+    AI Detective will serve a CANNED investigation (source "canned"), which is
+    labelled and correct but is not a live agent. Set the variable to enable it.
+```
+
+### Driving it
+
+```bash
+docker compose exec iris iris session IRIS -U LABDEMO
+```
+
+```objectscript
+// Arm: throttles the downstream to ~1s/message and raises inflow, after warming the baseline
+// at zero. Takes about 2 minutes to produce a confirmed finding.
+do ##class(ProductionGuardian.LabDemo.Triggers).PoolBottleneck()
+do ##class(ProductionGuardian.LabDemo.Triggers).Status()   // what is armed, and the queue cap
+do ##class(ProductionGuardian.LabDemo.Triggers).Reset()    // undo, including the pool size
+```
+
+Then, against the dashboard's own API path so it is the same route the UI uses:
+
+```bash
+# WHAT -- the finding
+curl -s localhost:5173/api/healthscan/findings
+
+# WHY -- root cause, evidence, a recommended action
+curl -s -XPOST localhost:5173/api/investigate \
+  -H 'Content-Type: application/json' -d '{"findingId":"<id from above>"}'
+
+# FIX -- preview first, then apply
+curl -s -XPOST localhost:5173/api/resolve -H 'Content-Type: application/json' \
+  -d '{"mode":"dry_run","action":{"type":"set_pool_size","host":"Cloud API","size":4}}'
+
+curl -s -XPOST localhost:5173/api/resolve -H 'Content-Type: application/json' \
+  -d '{"mode":"apply","requestedBy":"you@laptop",
+       "action":{"type":"set_pool_size","host":"Cloud API","size":4},
+       "origin":{"findingId":"<id>"}}'
+```
+
+A live run looks like this — the queue drains because four workers clear ~4/sec against ~2/sec
+inbound:
+
+```
+queue_buildup at 147  ->  investigate: gpt-4o-mini, 5 tool calls, recommends set_pool_size 4
+apply -> applied 1 -> 4, audit pg-audit-2
+queue 80 -> 42 -> 14 -> 0,  findings (all clear)
+```
+
+**If `investigate` returns `state: "unavailable"` with `note: "agent returned HTTP 500"`, the key is
+wrong or expired.** That is the honest failure and worth recognising: `rootCause` is `null` and
+`evidence` is empty rather than a plausible narrative, because a fabricated root cause is worse than
+none when a human approves a production write on the strength of it. The FIX half is unaffected — it
+does not use the LLM — so a bad key costs you WHY and nothing else.
+
+### What the safety model actually enforces
+
+- **One action, one host, bounded.** `set_pool_size` on `Cloud API`, size `2`–`8`. Anything else is
+  refused by the tool with a named reason — including size `1`, because `1` is the shipped value and
+  "setting it to 1" is a no-op dressed as a fix.
+- **Dry run first, and it cannot mutate** — that path returns before the write.
+- **Reversible.** Every response carries the prior value in `reversal`, captured live. Undo with
+  `Triggers.Reset()`.
+- **RBAC-gated and audited.** Every tool call, read and write, becomes a row in
+  `ProductionGuardian.LabDemo.Audit.Entry` naming the actor. An unauthorized caller is refused with
+  `200` and `refusal.reason: "not_authorized"`, and *the refusal is audited too*.
+- **Metrics and configuration only ever leave the instance.** Never message content, never PHI.
+
+```objectscript
+do ##class(ProductionGuardian.Setup.AIHub).Status()          // roles, tools, provider
+do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()   // reset the log between rehearsals
+```
+
+**One caveat, stated rather than buried:** the engine authenticates to IRIS as `superuser`, which
+holds `%All`, and under `%All` a resource check passes for everything — so the RBAC boundary is
+proven by `iris/test/GovernanceProof.cls` with a purpose-made unprivileged principal rather than by
+the running demo. See issue #104 for why that is not fixed yet (this image has no `%Ens_*`
+privileges to grant).
 
 ## Running without IRIS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,16 @@ services:
       # ISC_DATA_DIRECTORY makes the namespace survive `compose down`; without it the
       # LABDEMO setup would re-run from scratch every time.
       ISC_DATA_DIRECTORY: /iris-shared/durable
+      # Setup.AIHub.CreateProvider() reads these at first boot to create the AI Hub wallet entry
+      # and the AI.LLM.pgdetective config. Declared HERE and not only in the shell: an exported
+      # variable does not reach a container unless compose passes it, and without this line the
+      # boot reported "SKIPPED -- PG_LLM_API_KEY is not set" while the variable was plainly set
+      # in the caller's environment. Measured -- the README's own instructions failed on it.
+      #
+      # No default. Absent, the provider is not created, the boot says so, and AI Detective
+      # degrades to a labelled canned investigation. A default here would be a committed key.
+      PG_LLM_API_KEY: ${PG_LLM_API_KEY:-}
+      PG_LLM_MODEL: ${PG_LLM_MODEL:-}
     depends_on:
       iris-init:
         condition: service_completed_successfully

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -220,9 +220,19 @@ ClassMethod CreateProvider() As %Status
             write "4b. resource ", ..#SECRETRESOURCE, ": ", $select(sc: "created", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
         }
 
-        // Collection, then entry. Both idempotent by inspection rather than by relying on Create
-        // returning a benign error for an existing name -- an existing wallet must not be
-        // overwritten, because it may hold a key an operator rotated by hand.
+        // Collection, then entry, both idempotent by inspection rather than by relying on Create
+        // returning a benign error for an existing name.
+        //
+        // THE ENVIRONMENT VARIABLE IS THE SINGLE SOURCE OF TRUTH for the key, so the ENTRY below is
+        // rewritten on every boot when PG_LLM_API_KEY is set. An earlier version of this comment
+        // argued the opposite -- that an existing wallet must not be overwritten because it might
+        // hold a key rotated by hand -- while the code overwrote it anyway (@kskubach, #106). Both
+        // positions are defensible and holding both is a footgun: an operator who rotates in the
+        // wallet gets silently reverted on the next restart and diagnoses it as a rejected key.
+        //
+        // Rotation is therefore: change the variable, restart. DO NOT rotate by editing the wallet;
+        // it will be overwritten. The COLLECTION is left alone once it exists, because it carries
+        // only the resource bindings and nothing an operator would tune.
         if '##class(%Wallet.Collection).Exists(..#WALLET) {
             set sc = ##class(%Wallet.Collection).Create(..#WALLET, {"UseResource": (..#SECRETRESOURCE), "EditResource": (..#SECRETRESOURCE)})
             write "4b. wallet ", ..#WALLET, ": ", $select(sc: "created", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
@@ -236,9 +246,31 @@ ClassMethod CreateProvider() As %Status
         // happen. Never printed -- only whether it was stored.
         set sc = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": {"apikey": (key)}})
         if $$$ISERR(sc) {
-            // Create fails for an existing entry; replace it rather than leaving a stale key.
+            // ALREADY PRESENT. Rewrite it -- but NOT by deleting first (@kskubach, #106).
+            //
+            // `Delete` then `Create` turns a *stale* key into *no* key when the second call fails,
+            // and this runs on every boot from FirstBoot, so one transient failure takes out a demo
+            // that was working. The old value is captured first and restored if the rewrite fails,
+            // so the worst case is the key the instance already had.
+            set previous = ""
+            try {
+                set existing = ##class(%Wallet.KeyValue).%OpenId(..#WALLETENTRY)
+                if $isobject(existing) {
+                    set previous = existing.Secret
+                }
+            } catch {
+                set previous = ""
+            }
             do ##class(%Wallet.KeyValue).Delete(..#WALLETENTRY)
             set sc = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": {"apikey": (key)}})
+            if $$$ISERR(sc), previous '= "" {
+                // Put back what was there. Reported, because a boot that silently reverted to an
+                // older key would present as the provider rejecting a good one.
+                do ##class(%Wallet.KeyValue).Delete(..#WALLETENTRY)
+                set restore = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": (previous)})
+                write "4b. wallet entry rewrite FAILED; previous value ",
+                    $select(restore: "restored", 1: "COULD NOT BE RESTORED"), !
+            }
         }
         write "4b. wallet entry ", ..#WALLETENTRY, ": ", $select(sc: "stored (" _ $length(key) _ " chars, not logged)", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
         if $$$ISERR(sc) {
@@ -249,9 +281,24 @@ ClassMethod CreateProvider() As %Status
         set cfg = {"model_provider": (..#PROVIDER), "model": (model), "api_key": ("secret://" _ ..#WALLETENTRY _ "#apikey")}
         set sc = ##class(%ConfigStore.Configuration).Create("AI", "LLM", "", "pgdetective", cfg)
         if $$$ISERR(sc) {
-            // Already present: replace, so a model change in the environment takes effect.
+            // Already present: replace, so a PG_LLM_MODEL change takes effect. Same restore-on-
+            // failure discipline as the wallet entry above -- this config is what BuildAgent reads,
+            // so losing it disables AI Detective entirely.
+            // Get(fqn, .config) -- a DOTTED name and an output, not the four positional arguments
+            // Create() takes. Passing Create's shape throws <PARAMETER> at runtime while compiling
+            // cleanly, and the catch turned that into "LLM provider: FAILED" on a boot where the
+            // config had in fact been written. Read from the compiled FormalSpec rather than
+            // assumed symmetrical with Create.
+            set previousCfg = ""
+            do ##class(%ConfigStore.Configuration).Get("AI.LLM.pgdetective", .previousCfg)
             do ##class(%ConfigStore.Configuration).Delete("AI.LLM.pgdetective")
             set sc = ##class(%ConfigStore.Configuration).Create("AI", "LLM", "", "pgdetective", cfg)
+            if $$$ISERR(sc), $isobject(previousCfg) {
+                do ##class(%ConfigStore.Configuration).Delete("AI.LLM.pgdetective")
+                set restoreCfg = ##class(%ConfigStore.Configuration).Create("AI", "LLM", "", "pgdetective", previousCfg)
+                write "4b. config rewrite FAILED; previous value ",
+                    $select(restoreCfg: "restored", 1: "COULD NOT BE RESTORED"), !
+            }
         }
         write "4b. config AI.LLM.pgdetective: ", $select(sc: "created, model = " _ model, 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
     } catch ex {

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -252,12 +252,15 @@ ClassMethod CreateProvider() As %Status
             // and this runs on every boot from FirstBoot, so one transient failure takes out a demo
             // that was working. The old value is captured first and restored if the rewrite fails,
             // so the worst case is the key the instance already had.
+            // GetSecretValue(name), NOT %OpenId(...).Secret. `Secret` is transient=1, so a
+            // reopened entry reports it as "" -- verified: GetSecretValue returns 180 chars for the
+            // same entry whose .Secret reads 0. The earlier version captured .Secret, so `previous`
+            // was always empty, the restore guard below could never fire, and the comment claiming
+            // the old value was preserved was false (@kskubach, #106). An inert safety net is worse
+            // than none, because it stops anyone looking.
             set previous = ""
             try {
-                set existing = ##class(%Wallet.KeyValue).%OpenId(..#WALLETENTRY)
-                if $isobject(existing) {
-                    set previous = existing.Secret
-                }
+                set previous = ##class(%Wallet.KeyValue).GetSecretValue(..#WALLETENTRY)
             } catch {
                 set previous = ""
             }
@@ -267,6 +270,10 @@ ClassMethod CreateProvider() As %Status
                 // Put back what was there. Reported, because a boot that silently reverted to an
                 // older key would present as the provider rejecting a good one.
                 do ##class(%Wallet.KeyValue).Delete(..#WALLETENTRY)
+                // `previous` is the STORED shape -- the JSON object GetSecretValue returns, e.g.
+                // {"apikey":"..."} -- so it is passed through as Secret rather than re-wrapped.
+                // Double-wrapping would restore a secret whose apikey is itself a JSON string, and
+                // the URI would then resolve to something that looks like a key and is not.
                 set restore = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": (previous)})
                 write "4b. wallet entry rewrite FAILED; previous value ",
                     $select(restore: "restored", 1: "COULD NOT BE RESTORED"), !

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -88,6 +88,29 @@ Parameter RESOURCETYPE = 2147483648;
 /// `<PROTECT>` above gets diagnosed as a policy bug.
 Parameter DBROLE = "%DB_%DEFAULT";
 
+/// Environment variable carrying the LLM API key. Never defaulted, never logged, never stored
+/// outside the AI Hub wallet.
+///
+/// NO FALLBACK, for the same reason the roles have no default password: a key in source is a key in
+/// git history. Absent, the provider is not created and `ReportProvider()` says NOT CONFIGURED --
+/// which is the honest state, and one the engine already degrades to (`source: "canned"`).
+Parameter APIKEYVAR = "PG_LLM_API_KEY";
+
+/// Wallet collection and entry holding the key. The `secret://` URI in the ConfigStore entry
+/// references these, so the key itself never appears in the configuration.
+Parameter WALLET = "PGSecrets";
+
+Parameter WALLETENTRY = "PGSecrets.openai";
+
+/// Security resource guarding the wallet collection.
+Parameter SECRETRESOURCE = "AI.Secrets";
+
+/// Provider and model for the ConfigStore entry. `gpt-4o-mini` is what every live run on this
+/// project used; overridable by PG_LLM_MODEL so a demo can switch model without a code change.
+Parameter PROVIDER = "openai";
+
+Parameter MODEL = "gpt-4o-mini";
+
 /// Create the resources and roles, then report what is and is not in place.
 ///
 /// IDEMPOTENT. Every step checks before acting and says what it found, so a re-run after a partial
@@ -107,6 +130,7 @@ ClassMethod Run() As %Status
         quit sc
     }
     do ..ReportTools()
+    do ..CreateProvider()
     do ..ReportProvider()
 
     write !, "-----------------------------------------------", !
@@ -156,6 +180,86 @@ ClassMethod CreateResources() As %Status
 /// every tool before it considers the write resource at all, so a role holding only `PG_Resolve`
 /// would be refused on the first check with a message about the wrong privilege. Verified against
 /// the policy's own ordering rather than assumed from the names.
+/// Create the LLM provider config from the environment, or report why not. Idempotent.
+///
+/// WHAT THIS CLOSES. Until 2026-08-19 the wallet entry and ConfigStore config were created BY HAND
+/// and lived only in a durable volume, so a fresh clone booted with
+/// `4. LLM provider AI.LLM.pgdetective: NOT CONFIGURED` and AI Detective could not be demonstrated
+/// at all. `ReportProvider()` reported it and nothing created it -- the same
+/// "deployed interactively once" state #97 found for `iris/test/` and #106 for `/labdemo/agent`.
+///
+/// THE KEY GOES IN THE WALLET, NOT THE CONFIG. The ConfigStore entry holds
+/// `secret://PGSecrets.openai#apikey`, and `GetDetails(..., resolveSecrets=1)` resolves it at read
+/// time. So the key is in one place, guarded by a resource, and never in the configuration, the
+/// repo, or a log line. Root `CLAUDE.md` §2.1 and MVP 2 §6's credential-exposure row both apply.
+///
+/// REPORTS AND CONTINUES on failure, matching the rest of GovernanceSetup(): MVP 1 does not need an
+/// LLM, and the engine degrades to a labelled canned investigation rather than breaking.
+ClassMethod CreateProvider() As %Status
+{
+    set key = $system.Util.GetEnviron(..#APIKEYVAR)
+    if key = "" {
+        write "4b. LLM provider: SKIPPED -- ", ..#APIKEYVAR, " is not set", !
+        write "    AI Detective will serve a CANNED investigation (source ""canned""), which is", !
+        write "    labelled and correct but is not a live agent. Set the variable to enable it.", !
+        quit $$$OK
+    }
+
+    set model = $system.Util.GetEnviron("PG_LLM_MODEL")
+    if model = "" {
+        set model = ..#MODEL
+    }
+
+    try {
+        // The resource first: %Wallet.Collection.Create refers to it, and creating the collection
+        // against a nonexistent resource is the failure that reads as a wallet problem.
+        new $namespace
+        set $namespace = "%SYS"
+        if '##class(Security.Resources).Exists(..#SECRETRESOURCE) {
+            set sc = ##class(Security.Resources).Create(..#SECRETRESOURCE, "Production Guardian LLM secrets", "")
+            write "4b. resource ", ..#SECRETRESOURCE, ": ", $select(sc: "created", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+        }
+
+        // Collection, then entry. Both idempotent by inspection rather than by relying on Create
+        // returning a benign error for an existing name -- an existing wallet must not be
+        // overwritten, because it may hold a key an operator rotated by hand.
+        if '##class(%Wallet.Collection).Exists(..#WALLET) {
+            set sc = ##class(%Wallet.Collection).Create(..#WALLET, {"UseResource": (..#SECRETRESOURCE), "EditResource": (..#SECRETRESOURCE)})
+            write "4b. wallet ", ..#WALLET, ": ", $select(sc: "created", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+        } else {
+            write "4b. wallet ", ..#WALLET, ": exists", !
+        }
+
+        // The KEY IS WRITTEN EVERY BOOT when the variable is set, so rotating it is
+        // "change the env var and restart" rather than a manual wallet edit. That is deliberate:
+        // a rotation that needs a documented interactive procedure is a rotation that does not
+        // happen. Never printed -- only whether it was stored.
+        set sc = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": {"apikey": (key)}})
+        if $$$ISERR(sc) {
+            // Create fails for an existing entry; replace it rather than leaving a stale key.
+            do ##class(%Wallet.KeyValue).Delete(..#WALLETENTRY)
+            set sc = ##class(%Wallet.KeyValue).Create(..#WALLETENTRY, {"Usage": "CUSTOM", "Secret": {"apikey": (key)}})
+        }
+        write "4b. wallet entry ", ..#WALLETENTRY, ": ", $select(sc: "stored (" _ $length(key) _ " chars, not logged)", 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+        if $$$ISERR(sc) {
+            quit
+        }
+
+        // The ConfigStore entry, holding the secret:// URI rather than the key.
+        set cfg = {"model_provider": (..#PROVIDER), "model": (model), "api_key": ("secret://" _ ..#WALLETENTRY _ "#apikey")}
+        set sc = ##class(%ConfigStore.Configuration).Create("AI", "LLM", "", "pgdetective", cfg)
+        if $$$ISERR(sc) {
+            // Already present: replace, so a model change in the environment takes effect.
+            do ##class(%ConfigStore.Configuration).Delete("AI.LLM.pgdetective")
+            set sc = ##class(%ConfigStore.Configuration).Create("AI", "LLM", "", "pgdetective", cfg)
+        }
+        write "4b. config AI.LLM.pgdetective: ", $select(sc: "created, model = " _ model, 1: "FAILED " _ $system.Status.GetErrorText(sc)), !
+    } catch ex {
+        write "4b. LLM provider: FAILED ", ex.DisplayString(), !
+    }
+    quit $$$OK
+}
+
 ClassMethod CreateRoles() As %Status
 {
     // THE PG_* RESOURCES ONLY. See #DBROLE for why database access is deliberately not folded in.

--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -185,9 +185,10 @@ ClassMethod MakeDirectories()
     }
 }
 
-/// BOTH web applications. Registering only /labdemo/monitor -- which is what had happened
+/// ALL THREE web applications. Registering only /labdemo/monitor -- which is what had happened
 /// on the instance -- leaves Cloud API POSTing into a 404 while EMR Source and Lab Router
-/// look healthy, so nothing points at the cause.
+/// look healthy, so nothing points at the cause. The same omission for /labdemo/agent takes out
+/// every MVP 2 write with `HTTP 404` from a component the caller never names.
 ///
 /// AutheEnabled 96 is unauthenticated(32) OR password(64), so both work. Through an
 /// external web gateway an unauthenticated GET is refused with 403 regardless, which is
@@ -196,6 +197,15 @@ ClassMethod RegisterWebApps()
 {
     set apps("/labdemo") = "ProductionGuardian.LabDemo.REST.PatientDispatcher"
     set apps("/labdemo/monitor") = "ProductionGuardian.LabDemo.REST.HostStatusDispatcher"
+    // THREE, not two. /labdemo/agent was missing until 2026-08-19 and the comment above already
+    // described what that costs -- it was written about /labdemo/monitor and applies unchanged.
+    //
+    // Measured on a TRUE cold start (compose down -v, then up) from a fresh clone: every MVP 2
+    // write returned `failed / tool_call / write tool returned HTTP 404`, because AgentDispatcher
+    // had no application mapped to it. It never showed up on any instance either of us had used,
+    // because we both registered it by hand while building it -- the same "deployed interactively
+    // once" state #97 found for iris/test/.
+    set apps("/labdemo/agent") = "ProductionGuardian.LabDemo.REST.AgentDispatcher"
     set ns = $namespace
 
     new $namespace


### PR DESCRIPTION
Two independent cold-start gaps, both found by testing what a **colleague** gets rather than what my container has: cloned the repo, `compose down -v`, `compose up`, then drove the demo.

Neither was visible on any instance either of us had used, because we had each created the missing piece by hand while building it.

## Gap 1 — `/labdemo/agent` was never registered (`e6d430c`)

`FirstBoot.RegisterWebApps()` registered two applications and needed three. With no application mapped to `AgentDispatcher`, the **entire MVP 2 write path was dead**:

```
POST /api/resolve     -> failed / tool_call / "write tool returned HTTP 404"
POST /api/investigate -> "agent returned HTTP 503"
```

**404 through the engine, 403 direct** (@kskubach's measurement) — both mean the dispatcher was never reached, but a reader told to expect 404 who sees 403 goes hunting for an auth problem.

The method's own comment already described the consequence, written about `/labdemo/monitor`: *"leaves Cloud API POSTing into a 404 while EMR Source and Lab Router look healthy, so nothing points at the cause."* So the fix is one entry in the existing array.

## Gap 2 — the LLM provider was hand-made (`478876b`, `90d1cfa`)

The wallet entry and `AI.LLM.pgdetective` config were created interactively and lived only in a durable volume, so a fresh clone booted with `4. LLM provider AI.LLM.pgdetective: NOT CONFIGURED` and **AI Detective could not be demonstrated at all.** `ReportProvider()` reported it; nothing created it.

`CreateProvider()` now creates the `AI.Secrets` resource, the `PGSecrets` collection, the key entry, and the config referencing it as `secret://PGSecrets.openai#apikey` — from `PG_LLM_API_KEY`, no default. Absent, it skips and says so, and the engine degrades to a labelled canned investigation.

`90d1cfa` fixes two defects @kskubach found plus one that surfaced while testing them:

- **Delete-then-Create destroyed working config.** It ran on every boot, so one transient failure turned a *stale* key into *no* key. Previous value now captured and restored on failure, with the restore reported.
- **The rotation story contradicted itself** — a comment forbidding overwrite next to code that overwrote. Resolved in favour of the env var as single source of truth; the comment now says *do not rotate by editing the wallet.*
- **`Configuration.Get` takes `(fqn, .config)`**, not `Create`'s four positional args. Compiled cleanly, threw `<PARAMETER>`, and the `catch` reported `LLM provider: FAILED` on a boot where the config *had* been written.

## Verified — cold clone, empty volume, no manual step

```
4. web app /labdemo: created
4. web app /labdemo/agent: created
4. web app /labdemo/monitor: created

POST /labdemo/agent/resolve dry_run -> previewed 1 -> 4, audit pg-audit-1
queue_buildup at 157 -> POST /api/resolve apply -> applied 1->4, audit pg-audit-2
queue 76 -> 38 -> 6 -> 0, findings (all clear)
```

`pg-audit-1` as the first handle is the evidence this is a fresh instance, not my long-lived one.

**Provider provisioning, three consecutive runs rotating the key:**

```
key A (19 chars) -> resource/wallet/entry/config created, resolved len 19
key B (29 chars) -> "wallet: exists", entry rewritten, resolved len 29
key C (37 chars) + PG_LLM_MODEL=gpt-4o -> "config created, model = gpt-4o", resolved len 37
```

**The key does not leak:**

```
UNRESOLVED api_key = secret://PGSecrets.openai#apikey
RESOLVED length    = 37
occurrences of any test key in the container log: 0
```

## Status of the credential path — CORRECTED

An earlier version of this body said the provider provisioning was "worth its own change … rather
than smuggling it in here", which was true when written and false once `478876b` landed in this PR.
@kskubach flagged that the first thing a reviewer reads should not disclaim the riskiest change in
the diff. It is in scope here, it is reviewed, and the evidence is below and in the comments.

## Not verified when this PR opened — now verified

**No cold-start transcript with `source` other than `canned`.** Verifying the cold-start path needed `compose down -v`, which destroyed the volume holding the only copy of the real key — so the mechanism is proven with dummy keys of the right shape and the **live agent round trip on this code path is not.**

The acceptance check is one live investigation returning `source: "agent"` with non-null `model` and `toolCalls`. The README documents that and the failure mode (`state: "unavailable"`, `note: "agent returned HTTP 500"`, `rootCause` null — never a fabricated narrative).

The key needs rotating anyway, so this costs one verification run once a new one exists. Alternative on the table: hold `478876b`/`90d1cfa` and merge only the web-app fix, which is independently verified and unblocks the write path on its own.

## Also in this PR

`0ca9fa5` — README: the MVP 2 demo section. Every command in it was run against the cold clone rather than transcribed. The load-bearing line is that **`AGENT_MODE` defaults to `mock`, and the mock resolve reports `applied` without changing the production** — someone seeing "applied" and no drain would look for a bug rather than for the mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verified with a real key after the review

The acceptance test @kskubach asked for, on a cold-provisioned instance:

```
4b. wallet entry PGSecrets.openai: stored (167 chars, not logged)
4. LLM provider AI.LLM.pgdetective: configured, model = gpt-4o-mini

POST /api/investigate -> state complete | source AGENT | gpt-4o-mini | 5 tool calls
POST /api/resolve apply -> applied 1 -> 4, audit pg-audit-17
queue 147 -> 109 -> 85 -> 48 -> 14 -> 0
```

And the wallet restore, which was inert until `4a0fb8e` because `%Wallet.KeyValue.Secret` is
`transient=1`:

```
captured length: 180        (via GetSecretValue; .Secret reads 0)
guard would fire: YES
restored length: 180 | identical: YES
```
