### PR TITLE
feat(dashboard): the WHY and FIX UI — AI Detective and Smart Resolve in the drawer

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { createLiveClient } from './api/liveClient';
 import { createMockClient, type MockClient } from './api/mockClient';
 import { useHealthScan } from './hooks/useHealthScan';
 import { useInvestigation } from './hooks/useInvestigation';
+import { useProjections } from './hooks/useProjections';
 import { pollIntervalMs, usePolling } from './hooks/usePolling';
 import { AppShell } from './components/AppShell';
 import { ConnectionBanner, type ConnectionState } from './components/ConnectionBanner';
@@ -62,6 +63,12 @@ export function App(): JSX.Element {
   );
 
   const { failureCount, pollNow } = usePolling({ onTick, intervalMs });
+
+  /* Early Warning rides the SAME tick as the findings poll rather than its own timer: a projection
+     shown next to a queue depth from a different moment would be two readings pretending to be one,
+     and two independent intervals would drift apart within minutes. Failures are swallowed inside
+     the hook -- a missing forecast must never blank a host card that has real metrics on it. */
+  const projections = useProjections(api, failureCount);
 
   // One shared clock for every relative timestamp on the page.
   useEffect(() => {
@@ -227,6 +234,7 @@ export function App(): JSX.Element {
             Hosts
           </h2>
           <HostGrid
+            projections={projections}
             hosts={hosts}
             findings={findings}
             now={now}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import type { Mode } from './api/HealthScanApi';
 import { createLiveClient } from './api/liveClient';
 import { createMockClient, type MockClient } from './api/mockClient';
 import { useHealthScan } from './hooks/useHealthScan';
+import { useInvestigation } from './hooks/useInvestigation';
 import { pollIntervalMs, usePolling } from './hooks/usePolling';
 import { AppShell } from './components/AppShell';
 import { ConnectionBanner, type ConnectionState } from './components/ConnectionBanner';
@@ -18,6 +19,7 @@ import { SeveritySummary } from './components/SeveritySummary';
 import { HostGrid } from './components/HostGrid';
 import { FindingsList } from './components/FindingsList';
 import { FindingDetail } from './components/FindingDetail';
+import { InvestigationPanel } from './components/InvestigationPanel';
 import { IconRestart } from './components/icons';
 import { formatAge } from './lib/format';
 import { readMode, readScenario, writeMode } from './lib/mode';
@@ -95,6 +97,12 @@ export function App(): JSX.Element {
      somewhere sensible. The row keeps DOM identity across polls thanks to the
      `finding.id` key, so this ref stays valid through a refresh. */
   const returnFocusTo = useRef<string | null>(null);
+
+  /* The MVP 2 request lifecycle, keyed by the selected finding.
+     Keyed rather than global so an investigation cannot outlive the finding it explains: the hook
+     clears itself when `selectedId` changes, which is what stops a previous finding's root cause
+     appearing under a new heading. */
+  const detective = useInvestigation(api, selectedId);
 
   /* Drop the selection once its finding is gone, rather than leaving `selectedId`
      pointing at nothing. Without this the drawer would *reopen by itself* if the
@@ -246,7 +254,25 @@ export function App(): JSX.Element {
       {/* Outside the dimming wrapper: stale data dims the grid, but the drawer the
           operator deliberately opened should stay fully legible. Its numbers carry
           the same "as of" caveat the banner states once. */}
-      <FindingDetail finding={selected} now={now} onClose={closeDetail} />
+      <FindingDetail
+        finding={selected}
+        now={now}
+        onClose={closeDetail}
+        investigation={
+          selected === null ? null : (
+            <InvestigationPanel
+              investigation={detective.investigation}
+              investigating={detective.investigating}
+              error={detective.error}
+              resolve={detective.resolve}
+              resolving={detective.resolving}
+              resolveError={detective.resolveError}
+              onInvestigate={detective.investigate}
+              onResolve={detective.applyAction}
+            />
+          )
+        }
+      />
     </AppShell>
   );
 }

--- a/apps/dashboard/src/api/HealthScanApi.ts
+++ b/apps/dashboard/src/api/HealthScanApi.ts
@@ -12,10 +12,36 @@
  */
 
 import type { FindingView, HostView } from '../types/healthscan';
+import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
 
 export interface HealthScanApi {
   getHosts(signal?: AbortSignal): Promise<HostView[]>;
   getFindings(signal?: AbortSignal): Promise<FindingView[]>;
+
+  /**
+   * AI Detective — POST /api/investigate. Resolves for every outcome including failure: the
+   * contract serves 200 with a labelled state rather than an error, because a blanked panel is
+   * worse on stage than one saying "could not investigate" (investigation-api.md §5).
+   *
+   * So a rejected promise here means the TRANSPORT failed, not that the investigation did.
+   */
+  investigate(findingId: string, signal?: AbortSignal): Promise<InvestigationView>;
+
+  /**
+   * Smart Resolve — POST /api/resolve.
+   *
+   * `mode` is required and has no default on purpose (resolve-api.md §1.1): a missing mode must
+   * not become `apply`, because that turns a caller's omission into a live production write.
+   *
+   * A refusal RESOLVES with `outcome: "refused"` rather than rejecting. It arrives as HTTP 200 and
+   * carries the reason, and treating it as an error would lose that (§5.1).
+   */
+  resolve(
+    mode: ResolveMode,
+    action: ResolveActionView,
+    origin: { findingId: string },
+    signal?: AbortSignal,
+  ): Promise<ResolveView>;
 }
 
 export type Mode = 'demo' | 'live';

--- a/apps/dashboard/src/api/HealthScanApi.ts
+++ b/apps/dashboard/src/api/HealthScanApi.ts
@@ -12,11 +12,25 @@
  */
 
 import type { FindingView, HostView } from '../types/healthscan';
-import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
+import type {
+  HostProjectionView,
+  InvestigationView,
+  ResolveActionView,
+  ResolveMode,
+  ResolveView,
+} from '../types/mvp2';
 
 export interface HealthScanApi {
   getHosts(signal?: AbortSignal): Promise<HostView[]>;
   getFindings(signal?: AbortSignal): Promise<FindingView[]>;
+
+  /**
+   * Early Warning — GET /api/earlywarning. One entry per reported host.
+   *
+   * Empty is a legitimate answer (no host has a projectable metric yet), so this resolves with `[]`
+   * rather than raising, same as the two list endpoints.
+   */
+  getProjections(signal?: AbortSignal): Promise<HostProjectionView[]>;
 
   /**
    * AI Detective — POST /api/investigate. Resolves for every outcome including failure: the

--- a/apps/dashboard/src/api/liveClient.ts
+++ b/apps/dashboard/src/api/liveClient.ts
@@ -8,8 +8,14 @@
  */
 
 import type { HealthScanApi } from './HealthScanApi';
-import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
-import { parseInvestigation, parseResolve } from './mvp2Guards';
+import type {
+  HostProjectionView,
+  InvestigationView,
+  ResolveActionView,
+  ResolveMode,
+  ResolveView,
+} from '../types/mvp2';
+import { parseInvestigation, parseProjections, parseResolve } from './mvp2Guards';
 import { parseFindings, parseHosts } from './guards';
 import type { FindingView, HostView } from '../types/healthscan';
 
@@ -144,6 +150,28 @@ async function postJson(path: string, body: unknown, signal?: AbortSignal): Prom
   }
 }
 
+/** getJson, but for a path that is NOT under the healthscan base. Same error mapping. */
+async function getJsonAbsolute(url: string, signal?: AbortSignal): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(url, { signal, headers: { Accept: 'application/json' } });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') throw cause;
+    throw new HealthScanRequestError('Cannot reach the Health Scan API', null);
+  }
+  // 404 -> empty, matching getJson: an engine build without this endpoint should degrade to "no
+  // projections" rather than break the host grid it is decorating.
+  if (response.status === 404) return [];
+  if (!response.ok) {
+    throw new HealthScanRequestError(`Health Scan API returned ${response.status}`.trim(), response.status);
+  }
+  try {
+    return await response.json();
+  } catch {
+    throw new HealthScanRequestError('Health Scan API returned malformed JSON', response.status);
+  }
+}
+
 export function createLiveClient(): HealthScanApi {
   return {
     async getHosts(signal?: AbortSignal): Promise<HostView[]> {
@@ -152,6 +180,13 @@ export function createLiveClient(): HealthScanApi {
 
     async getFindings(signal?: AbortSignal): Promise<FindingView[]> {
       return parseFindings(await getJson('/findings', signal));
+    },
+
+    async getProjections(signal?: AbortSignal): Promise<HostProjectionView[]> {
+      /* Sibling of /api/healthscan, not a child -- same one-level strip as the POSTs. Uses getJson
+         so an engine that has not warmed up yet yields [] rather than an error banner. */
+      const root = baseUrl().replace(/\/healthscan\/?$/, '');
+      return parseProjections(await getJsonAbsolute(`${root}/earlywarning`, signal));
     },
 
     async investigate(findingId: string, signal?: AbortSignal): Promise<InvestigationView> {

--- a/apps/dashboard/src/api/liveClient.ts
+++ b/apps/dashboard/src/api/liveClient.ts
@@ -8,6 +8,8 @@
  */
 
 import type { HealthScanApi } from './HealthScanApi';
+import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
+import { parseInvestigation, parseResolve } from './mvp2Guards';
 import { parseFindings, parseHosts } from './guards';
 import type { FindingView, HostView } from '../types/healthscan';
 
@@ -82,6 +84,66 @@ async function getJson(path: string, signal?: AbortSignal): Promise<unknown> {
   }
 }
 
+/**
+ * POST for the two MVP 2 endpoints.
+ *
+ * SEPARATE FROM getJson BECAUSE THE 404 MAPPING WOULD BE WRONG HERE. getJson turns 404 into `[]`,
+ * which is a deliberate belt-and-braces for the list endpoints. On a write endpoint a 404 means the
+ * route or the IRIS dispatcher is missing -- exactly the failure that took the whole MVP 2 write
+ * path down until `/labdemo/agent` was registered at boot -- and swallowing it would hide that.
+ *
+ * `baseUrl()` points at `/api/healthscan`, so these strip back one level: the MVP 2 endpoints are
+ * siblings of it (`/api/investigate`, `/api/resolve`), not children.
+ */
+async function postJson(path: string, body: unknown, signal?: AbortSignal): Promise<unknown> {
+  const root = baseUrl().replace(/\/healthscan\/?$/, '');
+  let response: Response;
+  try {
+    response = await fetch(`${root}${path}`, {
+      method: 'POST',
+      signal,
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') throw cause;
+    throw new HealthScanRequestError('Cannot reach the Health Scan API', null);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    /* The engine answers 503 for an endpoint that exists in this build but is not configured on
+       this deployment -- "no agent wired here" -- and that is a different fact from a fault. Named
+       explicitly so the panel can say which, rather than showing a generic failure for a stack
+       that is working as configured. */
+    if (response.status === 503) {
+      throw new HealthScanRequestError(
+        'This deployment has no AI agent configured (the engine answered 503)',
+        503,
+      );
+    }
+    /* A 400 carries a reason worth surfacing verbatim: the engine returns
+       `{"error":"bad request: ..."}` for a malformed action, and that message names the field. */
+    let detail = '';
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed.error === 'string') detail = parsed.error;
+    } catch {
+      detail = '';
+    }
+    throw new HealthScanRequestError(
+      detail.length > 0 ? detail : `Health Scan API returned ${response.status}`.trim(),
+      response.status,
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    throw new HealthScanRequestError('Health Scan API returned malformed JSON', response.status);
+  }
+}
+
 export function createLiveClient(): HealthScanApi {
   return {
     async getHosts(signal?: AbortSignal): Promise<HostView[]> {
@@ -90,6 +152,32 @@ export function createLiveClient(): HealthScanApi {
 
     async getFindings(signal?: AbortSignal): Promise<FindingView[]> {
       return parseFindings(await getJson('/findings', signal));
+    },
+
+    async investigate(findingId: string, signal?: AbortSignal): Promise<InvestigationView> {
+      const parsed = parseInvestigation(await postJson('/investigate', { findingId }, signal));
+      if (parsed === null) {
+        throw new HealthScanRequestError('The investigation response could not be read', null);
+      }
+      return parsed;
+    },
+
+    async resolve(
+      mode: ResolveMode,
+      action: ResolveActionView,
+      origin: { findingId: string },
+      signal?: AbortSignal,
+    ): Promise<ResolveView> {
+      /* `requestedBy` is an advisory label recorded NEXT TO the server-resolved actor, never in
+         place of it (resolve-api.md §8) -- a caller cannot name itself. Sent so the audit row shows
+         which surface asked, which is the only thing the browser can honestly contribute. */
+      const parsed = parseResolve(
+        await postJson('/resolve', { mode, action, origin, requestedBy: 'dashboard' }, signal),
+      );
+      if (parsed === null) {
+        throw new HealthScanRequestError('The resolve response could not be read', null);
+      }
+      return parsed;
     },
   };
 }

--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -13,6 +13,7 @@
 
 import type { HealthScanApi } from './HealthScanApi';
 import { parseFindings, parseHosts } from './guards';
+import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
 import { PROGRESSION, resolveScenario, scenarioById, SCENARIOS } from './scenarios';
 import type { FindingView, HostView, Scenario } from '../types/healthscan';
 
@@ -80,6 +81,11 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
     return pinned ?? scenarioAt(cursor);
   }
 
+  /* Mock write state. Module-scoped per client instance so `restart()` does not reset it -- a
+     presenter stepping the scenario back should not silently un-apply a fix they demonstrated. */
+  let mockPoolSize = 1;
+  let mockAuditSeq = 0;
+
   function noteRead(which: 'hosts' | 'findings'): void {
     if (pinned !== undefined) return;
     served = cursor;
@@ -106,6 +112,154 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
       const { findings } = resolveScenario(serving(), Date.now());
       noteRead('findings');
       return parseFindings(findings);
+    },
+
+    /**
+     * Demo-mode investigation. `source: "canned"`, and that is the load-bearing field.
+     *
+     * The narrative is fixed; the NUMBERS are not -- host and queue depth come from the finding
+     * being explained, so the panel never shows `Cloud API` while the drawer shows another host.
+     * A mock that returned a wholly fixed string would drift the moment the scenario changed.
+     *
+     * It must never be mistaken for a live agent, so `model` and `toolCalls` are null: those are
+     * the two fields the UI uses to say "a real model answered, and it looked things up".
+     */
+    async investigate(findingId: string, signal?: AbortSignal): Promise<InvestigationView> {
+      await delay(SIMULATED_LATENCY_MS * 4, signal);
+      const { findings } = resolveScenario(serving(), Date.now());
+      const parsed = parseFindings(findings);
+      const finding = parsed.find((f) => f.id === findingId) ?? parsed[0];
+      const host = finding?.host ?? 'Cloud API';
+      const queued = finding?.currentValue ?? null;
+
+      return {
+        requestId: `inv-mock-${findingId}`,
+        findingId,
+        state: 'complete',
+        source: 'canned',
+        investigatedAt: new Date().toISOString().slice(0, 19) + 'Z',
+        rootCause:
+          `${host} is throughput-bound. It runs at PoolSize 1 against a downstream that takes ` +
+          `about a second per message, so it clears roughly 1 message/sec while inbound volume ` +
+          `exceeds that. The host itself is healthy — it is outnumbered, not broken.`,
+        evidence: [
+          { label: 'Configured pool size', detail: `${host} PoolSize = 1`, source: 'mcp_tool', tool: 'get_pool_size' },
+          {
+            label: 'Queue depth',
+            detail: queued === null ? 'queue depth not measurable' : `${queued} message(s) queued`,
+            source: 'snapshot',
+            tool: null,
+          },
+          { label: 'Downstream latency', detail: 'average processing time ~1s per message', source: 'mcp_tool', tool: 'get_processing_time' },
+        ],
+        confidence: 0.9,
+        recommendedAction: {
+          action: { type: 'set_pool_size', host, size: 4 },
+          currentValue: 1,
+          bounds: { min: 2, max: 8 },
+          reversible: true,
+          requiresApproval: true,
+          summary: `increase ${host} pool 1 -> 4`,
+        },
+        diagnostics: { model: null, toolCalls: null, durationMs: 240, note: 'demo mode: canned investigation' },
+      };
+    },
+
+    /**
+     * Demo-mode resolve, against an in-memory pool size.
+     *
+     * `audit.source: "mock"` and a `mock-audit-*` handle, so nothing here can be mistaken for a
+     * record of a real production change. It tracks state so apply-then-apply gives
+     * `applied` then `no_change`, matching the real tool -- a mock that returned `applied` twice
+     * would leave the double-click path untested, and a demo will hit it.
+     */
+    async resolve(
+      mode: ResolveMode,
+      action: ResolveActionView,
+      origin: { findingId: string },
+      signal?: AbortSignal,
+    ): Promise<ResolveView> {
+      await delay(SIMULATED_LATENCY_MS * 2, signal);
+      const at = new Date().toISOString().slice(0, 19) + 'Z';
+      mockAuditSeq += 1;
+      const audit = {
+        auditId: `mock-audit-${mockAuditSeq}`,
+        actor: 'demo',
+        role: 'Guardian_Resolve',
+        requestedBy: 'dashboard',
+        tool: mode === 'apply' ? 'set_pool_size' : 'get_pool_size',
+        recordedAt: at,
+        source: 'mock',
+      };
+      const base = {
+        resolveId: `res-mock-${mockAuditSeq}`,
+        requestId: null,
+        mode,
+        action,
+        reversal: { host: action.host, size: mockPoolSize, capturedFrom: 'mock' },
+        failure: null,
+        audit,
+        requestedAt: at,
+        completedAt: at,
+      };
+
+      // Bounds refused with the contract's field names, so the UI's refusal path is exercised in
+      // demo mode rather than only against a live production.
+      if (action.size < 2 || action.size > 8) {
+        return {
+          ...base,
+          outcome: 'refused',
+          before: { poolSize: mockPoolSize },
+          after: null,
+          reversal: null,
+          refusal: {
+            reason: 'out_of_bounds',
+            message: 'size must be an integer between 2 and 8',
+            checkedBy: 'iris',
+            bounds: { min: 2, max: 8 },
+          },
+          confirmation: null,
+        };
+      }
+
+      if (mockPoolSize === action.size) {
+        return {
+          ...base,
+          outcome: 'no_change',
+          before: { poolSize: mockPoolSize },
+          after: { poolSize: mockPoolSize },
+          refusal: null,
+          confirmation: null,
+        };
+      }
+
+      if (mode === 'dry_run') {
+        return {
+          ...base,
+          outcome: 'previewed',
+          before: { poolSize: mockPoolSize },
+          after: { poolSize: action.size },
+          refusal: null,
+          confirmation: null,
+        };
+      }
+
+      const before = mockPoolSize;
+      mockPoolSize = action.size;
+      return {
+        ...base,
+        outcome: 'applied',
+        before: { poolSize: before },
+        after: { poolSize: mockPoolSize },
+        refusal: null,
+        confirmation: {
+          status: 'pending',
+          findingId: origin.findingId,
+          observeVia: 'GET /api/healthscan/findings',
+          expectedWithinSeconds: 120,
+          directEvidence: false,
+        },
+      };
     },
 
     currentScenario: () => pinned ?? scenarioAt(served),

--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -13,7 +13,13 @@
 
 import type { HealthScanApi } from './HealthScanApi';
 import { parseFindings, parseHosts } from './guards';
-import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
+import type {
+  HostProjectionView,
+  InvestigationView,
+  ResolveActionView,
+  ResolveMode,
+  ResolveView,
+} from '../types/mvp2';
 import { PROGRESSION, resolveScenario, scenarioById, SCENARIOS } from './scenarios';
 import type { FindingView, HostView, Scenario } from '../types/healthscan';
 
@@ -112,6 +118,50 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
       const { findings } = resolveScenario(serving(), Date.now());
       noteRead('findings');
       return parseFindings(findings);
+    },
+
+    /**
+     * Demo-mode projections, derived from the scenario's own queue depths.
+     *
+     * A RISING QUEUE GETS A PROJECTION; ANYTHING ELSE GETS A REASON. The slope is not invented --
+     * it is the current depth over the fit span, which is the same arithmetic the engine does. A
+     * fixed slope would show "crosses in 4 minutes" for a host whose queue is empty.
+     */
+    async getProjections(signal?: AbortSignal): Promise<HostProjectionView[]> {
+      await delay(SIMULATED_LATENCY_MS, signal);
+      const { hosts } = resolveScenario(serving(), Date.now());
+      const at = new Date().toISOString().slice(0, 19) + 'Z';
+
+      return parseHosts(hosts).map((host) => {
+        const queued = host.queued;
+        const threshold = 50;
+        const rising = queued !== null && queued > 0 && queued < threshold;
+        return {
+          host: host.host,
+          metric: 'queued',
+          currentValue: queued,
+          measuredAt: at,
+          fitSampleCount: 60,
+          fitSpanSeconds: 295,
+          threshold: { value: threshold, basis: 'absoluteFloor', baselineValue: 0, findingType: 'queue_buildup' },
+          projection: rising
+            ? {
+                kind: 'projection' as const,
+                slope: Number(((queued ?? 0) / 5).toFixed(1)),
+                slopeUnit: 'items/minute',
+                secondsToThreshold: Math.round(((threshold - (queued ?? 0)) / ((queued ?? 1) / 300)) || 0),
+                crossesAt: null,
+              }
+            : null,
+          projectionUnavailable: rising
+            ? null
+            : queued === null
+              ? ('metric_unmeasurable' as const)
+              : queued >= threshold
+                ? ('already_crossed' as const)
+                : ('not_rising' as const),
+        };
+      });
     },
 
     /**

--- a/apps/dashboard/src/api/mvp2Guards.ts
+++ b/apps/dashboard/src/api/mvp2Guards.ts
@@ -1,0 +1,239 @@
+/**
+ * Parsers for the MVP 2 responses — field by field, never a cast.
+ *
+ * Same discipline as `guards.ts`, and for a sharper reason here. `contracts/investigation-api.md`
+ * and `resolve-api.md` have no schema and no `.d.ts`, so nothing generated or tested enforces their
+ * shape on either side. Dev B's engine hit exactly this: a `refusal` object typed by a cast passed
+ * type-checking as `{code, detail}` while the contract said `{reason, message, checkedBy}`, and the
+ * mismatch would have rendered `undefined` in a banner. A cast asserts; reading each field checks.
+ *
+ * TWO RULES SPECIFIC TO THESE SHAPES:
+ *
+ * 1. A MISSING NARRATIVE IS NOT A PARSE FAILURE. `rootCause: null` is a legitimate, meaningful
+ *    response (§4.4) — the engine declining to invent an explanation. So the parser returns an
+ *    investigation with `rootCause: null` rather than rejecting the payload.
+ * 2. AN UNRECOGNISED `reason` IS FORWARDED, NOT DROPPED. §5 tells consumers to render
+ *    `refusal.message` verbatim for any reason they do not know. A narrow union here would swallow a
+ *    new refusal code and show nothing, which is worse than showing an unfamiliar label.
+ */
+
+import type {
+  EvidenceItemView,
+  EvidenceSource,
+  InvestigationSource,
+  InvestigationState,
+  InvestigationView,
+  RecommendedActionView,
+  ResolveActionView,
+  ResolveMode,
+  ResolveOutcome,
+  ResolveView,
+} from '../types/mvp2';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function str(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function nullableStr(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function nullableNum(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function poolShape(value: unknown): { poolSize: number } | null {
+  if (!isRecord(value)) return null;
+  const size = nullableNum(value['poolSize']);
+  return size === null ? null : { poolSize: size };
+}
+
+function parseAction(value: unknown): ResolveActionView | null {
+  if (!isRecord(value)) return null;
+  const host = nullableStr(value['host']);
+  const size = nullableNum(value['size']);
+  // `type` is checked rather than assumed: a future second action type must not render as a pool
+  // change, because the approve button's label and bounds are derived from it.
+  if (value['type'] !== 'set_pool_size' || host === null || size === null) return null;
+  return { type: 'set_pool_size', host, size };
+}
+
+function parseEvidence(value: unknown): EvidenceItemView[] {
+  if (!Array.isArray(value)) return [];
+  const items: EvidenceItemView[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const label = nullableStr(entry['label']);
+    const detail = nullableStr(entry['detail']);
+    if (label === null || detail === null) continue;
+    /* Defaults to `llm`, the least trusted source, when the field is absent or unknown. An
+       unlabelled bullet is an assertion rather than a citation, and showing it as `mcp_tool` would
+       give a model's guess the same standing as a tool reading — in front of an approve button. */
+    const raw = entry['source'];
+    const source: EvidenceSource =
+      raw === 'mcp_tool' || raw === 'snapshot' || raw === 'llm' ? raw : 'llm';
+    items.push({ label, detail, source, tool: nullableStr(entry['tool']) });
+  }
+  return items;
+}
+
+function parseRecommendedAction(value: unknown): RecommendedActionView | null {
+  if (!isRecord(value)) return null;
+  const action = parseAction(value['action']);
+  if (action === null) return null;
+  const rawBounds = value['bounds'];
+  /* Bounds come from the response, never from a constant here. A hardcoded 2..8 in the UI is the
+     stale-copy defect the engine has already been bitten by — and the approve control uses these to
+     decide what it may offer. */
+  const bounds = isRecord(rawBounds)
+    ? { min: nullableNum(rawBounds['min']) ?? action.size, max: nullableNum(rawBounds['max']) ?? action.size }
+    : { min: action.size, max: action.size };
+  return {
+    action,
+    currentValue: nullableNum(value['currentValue']),
+    bounds,
+    reversible: value['reversible'] === true,
+    // DEFAULTS TO TRUE. An action whose approval requirement cannot be read must not render as
+    // auto-appliable; the safe default is "a human must approve this".
+    requiresApproval: value['requiresApproval'] !== false,
+    summary: str(value['summary'], `set pool size to ${action.size}`),
+  };
+}
+
+export function parseInvestigation(payload: unknown): InvestigationView | null {
+  if (!isRecord(payload)) return null;
+
+  const rawState = payload['state'];
+  const state: InvestigationState =
+    rawState === 'complete' || rawState === 'degraded' || rawState === 'unavailable'
+      ? rawState
+      : 'unavailable';
+
+  const rawSource = payload['source'];
+  const source: InvestigationSource =
+    rawSource === 'agent' || rawSource === 'cache' || rawSource === 'canned' || rawSource === 'none'
+      ? rawSource
+      : 'none';
+
+  const diagnostics = isRecord(payload['diagnostics']) ? payload['diagnostics'] : {};
+
+  return {
+    requestId: str(payload['requestId']),
+    findingId: str(payload['findingId']),
+    state,
+    source,
+    investigatedAt: str(payload['investigatedAt']),
+    rootCause: nullableStr(payload['rootCause']),
+    evidence: parseEvidence(payload['evidence']),
+    confidence: nullableNum(payload['confidence']),
+    recommendedAction: parseRecommendedAction(payload['recommendedAction']),
+    diagnostics: {
+      model: nullableStr(diagnostics['model']),
+      toolCalls: nullableNum(diagnostics['toolCalls']),
+      durationMs: nullableNum(diagnostics['durationMs']),
+      note: nullableStr(diagnostics['note']),
+    },
+  };
+}
+
+export function parseResolve(payload: unknown): ResolveView | null {
+  if (!isRecord(payload)) return null;
+
+  const rawOutcome = payload['outcome'];
+  const outcomes: readonly string[] = ['previewed', 'applied', 'no_change', 'refused', 'failed'];
+  /* An unrecognised outcome becomes `failed`, never a success. This is the one response in the app
+     that reports whether a live production changed, and guessing in the optimistic direction is the
+     failure mode that matters. */
+  const outcome: ResolveOutcome =
+    typeof rawOutcome === 'string' && outcomes.includes(rawOutcome)
+      ? (rawOutcome as ResolveOutcome)
+      : 'failed';
+
+  const rawMode = payload['mode'];
+  const mode: ResolveMode = rawMode === 'apply' ? 'apply' : 'dry_run';
+
+  const rawRefusal = payload['refusal'];
+  const refusal = isRecord(rawRefusal)
+    ? {
+        reason: str(rawRefusal['reason'], 'unknown'),
+        message: str(rawRefusal['message'], 'The request was refused.'),
+        checkedBy: str(rawRefusal['checkedBy'], 'iris'),
+        ...(isRecord(rawRefusal['bounds']) &&
+        nullableNum((rawRefusal['bounds'] as Record<string, unknown>)['min']) !== null
+          ? {
+              bounds: {
+                min: nullableNum((rawRefusal['bounds'] as Record<string, unknown>)['min']) ?? 0,
+                max: nullableNum((rawRefusal['bounds'] as Record<string, unknown>)['max']) ?? 0,
+              },
+            }
+          : {}),
+      }
+    : null;
+
+  const rawReversal = payload['reversal'];
+  const reversal =
+    isRecord(rawReversal) && nullableNum(rawReversal['size']) !== null
+      ? {
+          host: str(rawReversal['host']),
+          size: nullableNum(rawReversal['size']) ?? 0,
+          capturedFrom: str(rawReversal['capturedFrom'], 'unknown'),
+        }
+      : null;
+
+  const rawFailure = payload['failure'];
+  const failure = isRecord(rawFailure)
+    ? {
+        stage: str(rawFailure['stage'], 'unknown'),
+        message: str(rawFailure['message']),
+        // FALSE unless explicitly true: "we could not confirm the live state" is the safe reading,
+        // and it drives whether the UI tells the operator to verify by hand.
+        liveStateVerified: rawFailure['liveStateVerified'] === true,
+      }
+    : null;
+
+  const rawConfirmation = payload['confirmation'];
+  const confirmation = isRecord(rawConfirmation)
+    ? {
+        status: str(rawConfirmation['status'], 'unknown'),
+        findingId: nullableStr(rawConfirmation['findingId']),
+        observeVia: str(rawConfirmation['observeVia']),
+        expectedWithinSeconds: nullableNum(rawConfirmation['expectedWithinSeconds']) ?? 0,
+        directEvidence: rawConfirmation['directEvidence'] === true,
+      }
+    : null;
+
+  const rawAudit = payload['audit'];
+  const audit =
+    isRecord(rawAudit) && nullableStr(rawAudit['auditId']) !== null
+      ? {
+          auditId: nullableStr(rawAudit['auditId']),
+          actor: nullableStr(rawAudit['actor']),
+          role: nullableStr(rawAudit['role']),
+          requestedBy: nullableStr(rawAudit['requestedBy']),
+          tool: nullableStr(rawAudit['tool']),
+          recordedAt: nullableStr(rawAudit['recordedAt']),
+          source: nullableStr(rawAudit['source']),
+        }
+      : null;
+
+  return {
+    resolveId: str(payload['resolveId']),
+    requestId: nullableStr(payload['requestId']),
+    mode,
+    outcome,
+    action: parseAction(payload['action']),
+    before: poolShape(payload['before']),
+    after: poolShape(payload['after']),
+    reversal,
+    refusal,
+    failure,
+    confirmation,
+    audit,
+    requestedAt: str(payload['requestedAt']),
+    completedAt: str(payload['completedAt']),
+  };
+}

--- a/apps/dashboard/src/api/mvp2Guards.ts
+++ b/apps/dashboard/src/api/mvp2Guards.ts
@@ -19,6 +19,8 @@
 
 import type {
   EvidenceItemView,
+  HostProjectionView,
+  ProjectionDeclineReason,
   EvidenceSource,
   InvestigationSource,
   InvestigationState,
@@ -236,4 +238,77 @@ export function parseResolve(payload: unknown): ResolveView | null {
     requestedAt: str(payload['requestedAt']),
     completedAt: str(payload['completedAt']),
   };
+}
+
+const DECLINE_REASONS: readonly string[] = [
+  'disabled',
+  'metric_unmeasurable',
+  'warming',
+  'insufficient_samples',
+  'already_crossed',
+  'not_rising',
+  'beyond_horizon',
+];
+
+/**
+ * Early Warning projections.
+ *
+ * `projection` IS ONLY BUILT WHEN IT IS WHOLE. A partially-read projection is the defect this
+ * contract's shape exists to prevent -- a slope with no threshold, or a `secondsToThreshold` the
+ * engine never sent, would render as a forecast nobody made. So a missing or non-numeric `slope`
+ * drops the whole object to null rather than filling in a default.
+ */
+export function parseProjections(payload: unknown): HostProjectionView[] {
+  if (!Array.isArray(payload)) return [];
+  const out: HostProjectionView[] = [];
+
+  for (const entry of payload) {
+    if (!isRecord(entry)) continue;
+    const host = nullableStr(entry['host']);
+    if (host === null) continue;
+
+    const rawThreshold = entry['threshold'];
+    const threshold = isRecord(rawThreshold)
+      ? {
+          value: nullableNum(rawThreshold['value']),
+          basis: str(rawThreshold['basis'], 'unknown'),
+          baselineValue: nullableNum(rawThreshold['baselineValue']),
+          findingType: str(rawThreshold['findingType']),
+        }
+      : null;
+
+    const rawProjection = entry['projection'];
+    let projection: HostProjectionView['projection'] = null;
+    if (isRecord(rawProjection)) {
+      const slope = nullableNum(rawProjection['slope']);
+      if (slope !== null) {
+        projection = {
+          kind: 'projection',
+          slope,
+          slopeUnit: str(rawProjection['slopeUnit'], 'items/minute'),
+          secondsToThreshold: nullableNum(rawProjection['secondsToThreshold']),
+          crossesAt: nullableStr(rawProjection['crossesAt']),
+        };
+      }
+    }
+
+    const rawReason = entry['projectionUnavailable'];
+    const reason =
+      typeof rawReason === 'string' && DECLINE_REASONS.includes(rawReason)
+        ? (rawReason as ProjectionDeclineReason)
+        : null;
+
+    out.push({
+      host,
+      metric: str(entry['metric'], 'queued'),
+      currentValue: nullableNum(entry['currentValue']),
+      measuredAt: str(entry['measuredAt']),
+      fitSampleCount: nullableNum(entry['fitSampleCount']) ?? 0,
+      fitSpanSeconds: nullableNum(entry['fitSpanSeconds']) ?? 0,
+      threshold,
+      projection,
+      projectionUnavailable: reason,
+    });
+  }
+  return out;
 }

--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -6,18 +6,28 @@
  * §1.4 makes it a boundary condition: a forecast presented as a reading is the same defect class as
  * the coerced `lastActivity` in #58, and it is worse here because the number is about the future.
  *
- * IT RENDERS NOTHING WHEN THERE IS NOTHING TO SAY, and that is deliberate rather than lazy. Of the
- * seven decline reasons only three are worth a host card's vertical space:
+ * WHAT IT RENDERS, AND THE ONE CASE THAT CHANGED. Measured on the live stack: a projection exists
+ * for roughly 100 seconds of a queue_buildup run — from the queue starting to rise until it crosses
+ * the threshold. Before that the slope is too flat to fit; after it, `already_crossed`.
  *
- *  - `already_crossed` — the threshold is behind us. That is the state a FINDING covers, and the
- *    card already shows the finding count, so repeating it would be noise.
- *  - `not_rising` / `warming` / `insufficient_samples` / `disabled` / `metric_unmeasurable` —
- *    nothing is projected and nothing is wrong. A row saying "no projection available" on every
- *    healthy host would make the grid unreadable for information the operator does not need.
+ *     q=9    (not_rising)
+ *     q=19   slope=1.5/min  eta=1240s     <- strip appears
+ *     q=49   slope=8.6/min  eta=7s
+ *     q=58   (already_crossed)            <- strip used to vanish here
  *
- * So the strip appears only when a projection exists, or when the reason is one an operator would
- * otherwise mistake for silence: `warming` and `insufficient_samples`, which mean "ask again
- * shortly" rather than "there is nothing coming".
+ * The first version hid `already_crossed` entirely, reasoning that the state is covered by a
+ * FINDING and repeating it would be noise. That reasoning is sound and the consequence was not:
+ * **an operator looking at the grid a minute later saw nothing at all**, and reasonably concluded
+ * Early Warning was not implemented. Reported by the user, who could not find it on screen.
+ *
+ * So `already_crossed` now renders as a spent forecast — "threshold reached, see the finding" —
+ * which is honest about there being no forecast left to make while leaving evidence that the module
+ * exists and was watching. A feature nobody can find is indistinguishable from a missing one.
+ *
+ * Still silent for `not_rising`, `disabled` and `metric_unmeasurable`: those are steady states on a
+ * healthy host, and a row saying "no projection available" on every card would make the grid
+ * unreadable for information nobody needs. `warming` and `insufficient_samples` render because they
+ * mean "ask again shortly" rather than "nothing is coming".
  */
 
 import type { HostProjectionView } from '../types/mvp2';
@@ -26,10 +36,16 @@ export interface EarlyWarningProps {
   projection: HostProjectionView | null;
 }
 
-/** The two reasons worth surfacing: both mean "not yet", not "nothing". */
-const PENDING_REASONS: Record<string, string> = {
+/**
+ * The reasons worth a row, and what each says.
+ *
+ * `already_crossed` is the one that earns its place by NOT being a forecast: it marks the module as
+ * present and watching after the window has closed. The other two mean "ask again shortly".
+ */
+const SHOWN_REASONS: Record<string, string> = {
   warming: 'Baseline still warming — no projection yet',
   insufficient_samples: 'Not enough samples yet for a projection',
+  already_crossed: 'Threshold reached — see the finding below',
 };
 
 /**
@@ -53,12 +69,16 @@ export function EarlyWarning({ projection }: EarlyWarningProps): JSX.Element | n
   const { projection: forecast, projectionUnavailable: reason } = projection;
 
   if (forecast === null) {
-    const pending = reason === null ? null : PENDING_REASONS[reason];
-    if (pending === undefined || pending === null) return null;
+    const shown = reason === null ? undefined : SHOWN_REASONS[reason];
+    if (shown === undefined) return null;
+    /* `already_crossed` reads as spent rather than pending -- it is not waiting for anything, it is
+       reporting that the thing it was watching for has happened. The other two are genuinely
+       "not yet", so they keep the muted pending styling. */
+    const spent = reason === 'already_crossed';
     return (
-      <div className="pg-forecast pg-forecast--pending">
+      <div className={`pg-forecast ${spent ? 'pg-forecast--spent' : 'pg-forecast--pending'}`}>
         <span className="pg-forecast__label">Early warning</span>
-        <span className="pg-forecast__body">{pending}</span>
+        <span className="pg-forecast__body">{shown}</span>
       </div>
     );
   }

--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -1,0 +1,90 @@
+/**
+ * Early Warning — the projection strip on a host card.
+ *
+ * A PROJECTION IS NOT A MEASUREMENT, and this component's whole job is keeping that visible. Every
+ * forecast number is prefixed with `~` and the copy says "projected", because `earlywarning-api.md`
+ * §1.4 makes it a boundary condition: a forecast presented as a reading is the same defect class as
+ * the coerced `lastActivity` in #58, and it is worse here because the number is about the future.
+ *
+ * IT RENDERS NOTHING WHEN THERE IS NOTHING TO SAY, and that is deliberate rather than lazy. Of the
+ * seven decline reasons only three are worth a host card's vertical space:
+ *
+ *  - `already_crossed` — the threshold is behind us. That is the state a FINDING covers, and the
+ *    card already shows the finding count, so repeating it would be noise.
+ *  - `not_rising` / `warming` / `insufficient_samples` / `disabled` / `metric_unmeasurable` —
+ *    nothing is projected and nothing is wrong. A row saying "no projection available" on every
+ *    healthy host would make the grid unreadable for information the operator does not need.
+ *
+ * So the strip appears only when a projection exists, or when the reason is one an operator would
+ * otherwise mistake for silence: `warming` and `insufficient_samples`, which mean "ask again
+ * shortly" rather than "there is nothing coming".
+ */
+
+import type { HostProjectionView } from '../types/mvp2';
+
+export interface EarlyWarningProps {
+  projection: HostProjectionView | null;
+}
+
+/** The two reasons worth surfacing: both mean "not yet", not "nothing". */
+const PENDING_REASONS: Record<string, string> = {
+  warming: 'Baseline still warming — no projection yet',
+  insufficient_samples: 'Not enough samples yet for a projection',
+};
+
+/**
+ * Seconds to a human span, rounded coarsely on purpose.
+ *
+ * A least-squares fit over a five-minute window does not support "crosses in 7 minutes 12 seconds",
+ * and printing that precision would imply a confidence the arithmetic does not have. Minutes below
+ * an hour, hours above it.
+ */
+function horizon(seconds: number): string {
+  if (seconds < 90) return 'under a minute';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `~${minutes} min`;
+  const hours = Math.round(minutes / 6) / 10;
+  return `~${hours} h`;
+}
+
+export function EarlyWarning({ projection }: EarlyWarningProps): JSX.Element | null {
+  if (projection === null) return null;
+
+  const { projection: forecast, projectionUnavailable: reason } = projection;
+
+  if (forecast === null) {
+    const pending = reason === null ? null : PENDING_REASONS[reason];
+    if (pending === undefined || pending === null) return null;
+    return (
+      <div className="pg-forecast pg-forecast--pending">
+        <span className="pg-forecast__label">Early warning</span>
+        <span className="pg-forecast__body">{pending}</span>
+      </div>
+    );
+  }
+
+  /* `secondsToThreshold` is null when the crossing is beyond the projection horizon -- the slope is
+     positive but the threshold is far enough out that naming a time would be false precision. The
+     rate is still worth showing, so the two are rendered independently rather than as one string. */
+  const eta = forecast.secondsToThreshold;
+  const threshold = projection.threshold?.value ?? null;
+
+  return (
+    <div className="pg-forecast">
+      <span className="pg-forecast__label">Early warning</span>
+      <span className="pg-forecast__body">
+        {/* Rising rate first, because it is the measured trend; the crossing time is derived from it
+            and is the softer of the two claims. */}
+        {projection.metric} rising ~{forecast.slope.toFixed(1)}/min
+        {eta !== null && threshold !== null && (
+          <>
+            {' · projected to cross '}
+            <span className="pg-facts__mono">{threshold}</span>
+            {` in ${horizon(eta)}`}
+          </>
+        )}
+        {eta === null && ' · crossing is beyond the projection horizon'}
+      </span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/FindingDetail.tsx
+++ b/apps/dashboard/src/components/FindingDetail.tsx
@@ -6,10 +6,15 @@
  * the visual focus: two large monospaced numerals with the comparison between
  * them. Everything else here is supporting context.
  *
- * Two things this view must not do, both from §1.1: no remediation control (Smart
- * Resolve), and no root-cause narrative or confidence score (AI Detective). It
- * shows what breached and what normal looks like — the operator draws the
- * conclusion.
+ * MVP 2 ADDED BOTH THINGS THIS COMMENT USED TO FORBID. It read: "no remediation
+ * control (Smart Resolve), and no root-cause narrative or confidence score (AI
+ * Detective)" — correct under MVP 1's boundary, and root `CLAUDE.md` §2.1 moved
+ * all three modules in scope. The comparison below is still the visual focus and
+ * still renders without an investigation; the panel is opt-in, behind a button, so
+ * a drawer opened to read a number does not fire an LLM call.
+ *
+ * What has NOT changed is who draws the conclusion on a write: the panel proposes,
+ * an operator approves, and nothing is applied unattended.
  *
  * Accessibility (§7.3): closes on `Esc` and returns focus to the row that opened
  * it, which is why `onClose` is called rather than the row being re-focused here —
@@ -37,6 +42,17 @@ export interface FindingDetailProps {
   finding: FindingView | null;
   now: number;
   onClose: () => void;
+  /**
+   * The MVP 2 panel, passed in rather than built here.
+   *
+   * This component takes no `api` and owns no request state -- §4.1 keeps `fetch` out of
+   * components, and threading a client through the drawer would put the LLM call one prop away from
+   * a purely presentational view. The owner wires `useInvestigation` and hands the rendered panel
+   * down, so the drawer stays renderable in a test with no client at all.
+   *
+   * Absent, the drawer is exactly the MVP 1 view.
+   */
+  investigation?: JSX.Element | null;
 }
 
 /**
@@ -58,7 +74,12 @@ function deltaFormatter(kind: ReturnType<typeof valueKind>): (value: number) => 
   return formatCount;
 }
 
-export function FindingDetail({ finding, now, onClose }: FindingDetailProps): JSX.Element | null {
+export function FindingDetail({
+  finding,
+  now,
+  onClose,
+  investigation = null,
+}: FindingDetailProps): JSX.Element | null {
   /* Esc closes from anywhere, not only from inside the drawer: the operator's
      focus is often still on the row that opened it, since that row deliberately
      keeps focus for the return trip. Bound to the document for that reason. */
@@ -212,6 +233,11 @@ export function FindingDetail({ finding, now, onClose }: FindingDetailProps): JS
             the engine having warmed up.
           </p>
         )}
+
+        {/* LAST in the body, deliberately: the comparison is what the operator came for, and an
+            investigation is what they do next. Reversing them would put a paragraph of narrative
+            above the two numbers this view exists to show. */}
+        {investigation}
       </div>
     </aside>
   );

--- a/apps/dashboard/src/components/HostCard.tsx
+++ b/apps/dashboard/src/components/HostCard.tsx
@@ -10,6 +10,8 @@ import type { HostView } from '../types/healthscan';
 import type { Severity } from '../types/healthscan';
 import { formatCount, formatDuration, formatRate, formatRelative } from '../lib/format';
 import { StatusDot } from './StatusDot';
+import { EarlyWarning } from './EarlyWarning';
+import type { HostProjectionView } from '../types/mvp2';
 
 interface MetricRowProps {
   label: string;
@@ -46,9 +48,22 @@ export interface HostCardProps {
   findingCount: number;
   /** Injected so every card's relative time re-renders on the same tick. */
   now: number;
+  /**
+   * This host's Early Warning projection, or null when there is none.
+   *
+   * Optional so the card renders unchanged without it -- the MVP 1 grid, and any test that does not
+   * care about forecasting, need no new prop.
+   */
+  projection?: HostProjectionView | null;
 }
 
-export function HostCard({ host, worst, findingCount, now }: HostCardProps): JSX.Element {
+export function HostCard({
+  host,
+  worst,
+  findingCount,
+  now,
+  projection = null,
+}: HostCardProps): JSX.Element {
   const severityClass = worst === null ? '' : ` pg-host--${worst}`;
 
   return (
@@ -75,6 +90,11 @@ export function HostCard({ host, worst, findingCount, now }: HostCardProps): JSX
         <MetricRow label="Avg queueing" value={formatDuration(host.avgQueueingTime)} />
         <MetricRow label="Last activity" value={formatRelative(host.lastActivity, now)} />
       </div>
+
+      {/* Between the metrics and the finding count: it is derived FROM the metrics above and is
+          about what has not happened yet, so it reads after the readings and before the count of
+          things already wrong. */}
+      <EarlyWarning projection={projection} />
 
       {findingCount > 0 && (
         <footer className="pg-host__footer">

--- a/apps/dashboard/src/components/HostGrid.tsx
+++ b/apps/dashboard/src/components/HostGrid.tsx
@@ -9,9 +9,18 @@ import type { FindingView, HostView, Severity } from '../types/healthscan';
 import { toSeverity, worstSeverity } from '../lib/severity';
 import { EmptyState } from './EmptyState';
 import { HostCard } from './HostCard';
+import type { HostProjectionView } from '../types/mvp2';
 import { IconProductions } from './icons';
 
 export interface HostGridProps {
+  /**
+   * Early Warning projections, keyed by host inside the grid rather than by the caller.
+   *
+   * Optional and defaulted to empty: the grid renders exactly as it did in MVP 1 without them, so a
+   * deployment whose engine predates /api/earlywarning loses nothing.
+   */
+  projections?: readonly HostProjectionView[];
+
   hosts: readonly HostView[];
   findings: readonly FindingView[];
   now: number;
@@ -74,6 +83,7 @@ export function HostGrid({
   now,
   loading,
   skeletonCount = null,
+  projections = [],
 }: HostGridProps): JSX.Element {
   // Skeletons, not spinners (§7.3), as many as this production last reported, so the
   // layout does not jump when real data lands — whatever production that is.
@@ -100,6 +110,9 @@ export function HostGrid({
   }
 
   const bySeverity = severityByHost(findings);
+  /* Built once per render rather than a find() per card: three hosts today, but the grid is the one
+     component that scales with the production's size. */
+  const byHost = new Map(projections.map((p) => [p.host, p]));
 
   return (
     <div className="pg-grid">
@@ -112,6 +125,7 @@ export function HostGrid({
             worst={summary?.worst ?? null}
             findingCount={summary?.count ?? 0}
             now={now}
+            projection={byHost.get(host.host) ?? null}
           />
         );
       })}

--- a/apps/dashboard/src/components/InvestigationPanel.tsx
+++ b/apps/dashboard/src/components/InvestigationPanel.tsx
@@ -1,0 +1,331 @@
+/**
+ * AI Detective and Smart Resolve, inside the finding drawer.
+ *
+ * WHY IT LIVES IN THE DRAWER rather than in its own view: an investigation explains one finding, and
+ * the numbers it reasons about are the ones already on screen above it. A separate view would make
+ * the operator hold "queue 486, baseline 15" in their head while reading the explanation.
+ *
+ * THE THREE THINGS THIS COMPONENT MUST NOT GET WRONG:
+ *
+ * 1. A CANNED INVESTIGATION MUST NOT LOOK LIVE. `source` is rendered as a visible badge, not hidden
+ *    in diagnostics. Presenting a mock narrative as a real one is the same defect class as showing a
+ *    projection as a measurement, and it is worse here because a human approves a production write
+ *    on the strength of it.
+ * 2. `rootCause: null` IS AN ANSWER, NOT A BLANK. It means the engine declined to invent an
+ *    explanation (investigation-api.md §4.4). Rendered as an explicit statement with the
+ *    diagnostic note, never as an empty panel that reads as still-loading.
+ * 3. EVIDENCE PROVENANCE IS PART OF THE EVIDENCE. `mcp_tool` was read from the live production by a
+ *    governed tool; `snapshot` came from the finding; `llm` is the model asserting something nothing
+ *    measured. Each bullet carries its source, because a reader deciding whether to approve needs
+ *    to know which is which.
+ *
+ * APPROVE IS DELIBERATELY THE SECOND STEP. Preview first, then approve, and the preview's own
+ * response is what populates the before/after the approve button is labelled with — so the operator
+ * approves a change they have already seen the shape of. `resolve-api.md` §1.1 requires the mode to
+ * be explicit for the same reason: nothing about a write should be inferred.
+ */
+
+import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
+import { ABSENT } from '../lib/format';
+
+export interface InvestigationPanelProps {
+  investigation: InvestigationView | null;
+  investigating: boolean;
+  error: string | null;
+  resolve: ResolveView | null;
+  resolving: ResolveMode | null;
+  resolveError: string | null;
+  onInvestigate: () => void;
+  onResolve: (mode: ResolveMode, action: ResolveActionView) => void;
+}
+
+/** §3.2's three sources, as short operator-facing labels. */
+const SOURCE_LABEL: Record<string, string> = {
+  mcp_tool: 'read from IRIS',
+  snapshot: 'from the finding',
+  llm: 'asserted by the model',
+};
+
+/**
+ * The outcome, phrased for an operator rather than echoed as an enum.
+ *
+ * `refused` says the safety model worked -- §5.2 is explicit that `refused` and `failed` must not be
+ * merged in the UI, because one means nothing was written and the other means something was tried.
+ */
+const OUTCOME_LABEL: Record<string, string> = {
+  previewed: 'Preview only — nothing was changed',
+  applied: 'Applied to the live production',
+  no_change: 'Already at this value — nothing to do',
+  refused: 'Refused',
+  failed: 'Failed',
+};
+
+function confidenceText(confidence: number | null): string {
+  if (confidence === null) return ABSENT;
+  /* Shown as a percentage but NOT described as a probability. §3.4 says it is the model's own
+     self-report and is not calibrated, so the label says "self-reported". */
+  return `${Math.round(confidence * 100)}%`;
+}
+
+export function InvestigationPanel({
+  investigation,
+  investigating,
+  error,
+  resolve,
+  resolving,
+  resolveError,
+  onInvestigate,
+  onResolve,
+}: InvestigationPanelProps): JSX.Element {
+  const recommended = investigation?.recommendedAction ?? null;
+  const canned = investigation?.source === 'canned';
+  const unavailable = investigation !== null && investigation.rootCause === null;
+
+  return (
+    <section className="pg-investigate" aria-label="AI Detective and Smart Resolve">
+      <h3 className="pg-investigate__heading">Why is this happening?</h3>
+
+      {investigation === null && !investigating && error === null && (
+        <>
+          <p className="pg-investigate__intro">
+            Ask the AI Detective to look at this finding. It reads live configuration and metrics
+            through governed, audited tools — never message content.
+          </p>
+          <button type="button" className="pg-button pg-button--primary" onClick={onInvestigate}>
+            Investigate
+          </button>
+        </>
+      )}
+
+      {investigating && (
+        <p className="pg-investigate__status" role="status">
+          Investigating… the agent is reading live values from IRIS. This usually takes a few
+          seconds.
+        </p>
+      )}
+
+      {error !== null && (
+        <div className="pg-investigate__error" role="alert">
+          <p>{error}</p>
+          {/* Retry rather than a dead end: the common causes -- a cold agent, a rate limit, a
+              missing provider -- are all transient or configuration, and none is helped by making
+              the operator reopen the drawer. */}
+          <button type="button" className="pg-button" onClick={onInvestigate}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {investigation !== null && (
+        <>
+          <div className="pg-investigate__provenance">
+            {canned ? (
+              /* THE MOST IMPORTANT LABEL IN THIS COMPONENT. Demo mode and a live agent must be
+                 distinguishable at a glance, or a rehearsal teaches the wrong thing. */
+              <span className="pg-tag pg-tag--warn">Canned — demo mode, not a live agent</span>
+            ) : (
+              <span className="pg-tag pg-tag--ok">Live agent</span>
+            )}
+            {investigation.diagnostics.model !== null && (
+              <span className="pg-tag">{investigation.diagnostics.model}</span>
+            )}
+            {investigation.diagnostics.toolCalls !== null && (
+              /* Tool calls are the honest check that evidence was gathered rather than recalled: a
+                 plausible narrative with zero tool calls is a model reasoning from its priors. */
+              <span className="pg-tag">
+                {investigation.diagnostics.toolCalls} tool call
+                {investigation.diagnostics.toolCalls === 1 ? '' : 's'}
+              </span>
+            )}
+            {investigation.confidence !== null && (
+              <span className="pg-tag">
+                {confidenceText(investigation.confidence)} confidence (self-reported)
+              </span>
+            )}
+          </div>
+
+          {unavailable ? (
+            <div className="pg-investigate__unavailable">
+              <p>
+                <strong>No root cause is available.</strong> The engine could not produce an
+                explanation, and it will not invent one.
+              </p>
+              {investigation.diagnostics.note !== null && (
+                <p className="pg-investigate__note">{investigation.diagnostics.note}</p>
+              )}
+              <button type="button" className="pg-button" onClick={onInvestigate}>
+                Try again
+              </button>
+            </div>
+          ) : (
+            <p className="pg-investigate__rootcause">{investigation.rootCause}</p>
+          )}
+
+          {investigation.evidence.length > 0 && (
+            <ul className="pg-evidence">
+              {investigation.evidence.map((item, index) => (
+                <li key={`${item.label}-${index}`} className="pg-evidence__item">
+                  <div className="pg-evidence__head">
+                    <span className="pg-evidence__label">{item.label}</span>
+                    <span className={`pg-evidence__source pg-evidence__source--${item.source}`}>
+                      {SOURCE_LABEL[item.source] ?? item.source}
+                      {item.tool !== null && <span className="pg-facts__mono"> · {item.tool}</span>}
+                    </span>
+                  </div>
+                  <div className="pg-evidence__detail">{item.detail}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {recommended !== null && (
+            <div className="pg-resolve">
+              <h3 className="pg-investigate__heading">Recommended action</h3>
+              <p className="pg-resolve__summary">{recommended.summary}</p>
+
+              <dl className="pg-facts">
+                <div className="pg-facts__row">
+                  <dt>Action</dt>
+                  <dd className="pg-facts__mono">
+                    {recommended.action.type} · {recommended.action.host} ·{' '}
+                    {recommended.action.size}
+                  </dd>
+                </div>
+                <div className="pg-facts__row">
+                  <dt>Allowed range</dt>
+                  <dd className="pg-facts__mono">
+                    {recommended.bounds.min}–{recommended.bounds.max}
+                  </dd>
+                </div>
+                <div className="pg-facts__row">
+                  <dt>Reversible</dt>
+                  <dd>{recommended.reversible ? 'Yes' : 'No'}</dd>
+                </div>
+              </dl>
+
+              <div className="pg-resolve__actions">
+                <button
+                  type="button"
+                  className="pg-button"
+                  disabled={resolving !== null}
+                  onClick={() => onResolve('dry_run', recommended.action)}
+                >
+                  {resolving === 'dry_run' ? 'Previewing…' : 'Preview'}
+                </button>
+                <button
+                  type="button"
+                  className="pg-button pg-button--primary"
+                  disabled={resolving !== null}
+                  onClick={() => onResolve('apply', recommended.action)}
+                >
+                  {resolving === 'apply' ? 'Applying…' : 'Approve and apply'}
+                </button>
+              </div>
+
+              {recommended.requiresApproval && (
+                <p className="pg-resolve__gate">
+                  This writes to the live production. It is applied only when you approve it, it is
+                  bounded to {recommended.bounds.min}–{recommended.bounds.max}, and every call is
+                  audited.
+                </p>
+              )}
+
+              {resolveError !== null && (
+                <div className="pg-investigate__error" role="alert">
+                  <p>{resolveError}</p>
+                  {/* The request may have landed. Saying so is the honest reading of a transport
+                      failure on a write, and it is what resolve-api.md's liveStateVerified: false
+                      says when the engine does answer. */}
+                  <p className="pg-investigate__note">
+                    If this was an approval, check the pool size before retrying — the request may
+                    have reached the production.
+                  </p>
+                </div>
+              )}
+
+              {resolve !== null && (
+                <div
+                  className={`pg-resolve__outcome pg-resolve__outcome--${resolve.outcome}`}
+                  role="status"
+                >
+                  <p className="pg-resolve__outcome-label">
+                    {OUTCOME_LABEL[resolve.outcome] ?? resolve.outcome}
+                  </p>
+
+                  {resolve.before !== null && resolve.after !== null && (
+                    <p className="pg-facts__mono">
+                      pool {resolve.before.poolSize} → {resolve.after.poolSize}
+                      {resolve.mode === 'dry_run' && ' (would be)'}
+                    </p>
+                  )}
+
+                  {resolve.refusal !== null && (
+                    <>
+                      {/* Rendered VERBATIM. §5 tells consumers to do that for any reason they do
+                          not recognise, and the message is the only part guaranteed to explain a
+                          refusal code the UI has never seen. */}
+                      <p className="pg-resolve__refusal">{resolve.refusal.message}</p>
+                      <p className="pg-investigate__note">
+                        Reason <span className="pg-facts__mono">{resolve.refusal.reason}</span>,
+                        checked by{' '}
+                        <span className="pg-facts__mono">{resolve.refusal.checkedBy}</span>. Nothing
+                        was written.
+                      </p>
+                    </>
+                  )}
+
+                  {resolve.failure !== null && (
+                    <p className="pg-resolve__refusal">
+                      {resolve.failure.message}
+                      {!resolve.failure.liveStateVerified && (
+                        <>
+                          {' '}
+                          The live state could not be confirmed — check the pool size before
+                          retrying.
+                        </>
+                      )}
+                    </p>
+                  )}
+
+                  {resolve.reversal !== null && (
+                    <p className="pg-investigate__note">
+                      To undo: set {resolve.reversal.host} back to{' '}
+                      <span className="pg-facts__mono">{resolve.reversal.size}</span> (captured{' '}
+                      {resolve.reversal.capturedFrom}).
+                    </p>
+                  )}
+
+                  {resolve.confirmation !== null && !resolve.confirmation.directEvidence && (
+                    /* The write landed; the CONDITION clearing is a separate observation (§7).
+                       Saying so prevents "applied" being read as "fixed" while the queue drains. */
+                    <p className="pg-investigate__note">
+                      The change is in place. The finding clears on its own once the queue drains —
+                      usually within {resolve.confirmation.expectedWithinSeconds} seconds.
+                    </p>
+                  )}
+
+                  {resolve.audit !== null ? (
+                    <p className="pg-investigate__note">
+                      Audited as{' '}
+                      <span className="pg-facts__mono">{resolve.audit.auditId}</span>
+                      {resolve.audit.actor !== null && <> by {resolve.audit.actor}</>}
+                      {resolve.audit.source === 'mock' && ' (demo mode)'}
+                    </p>
+                  ) : (
+                    resolve.outcome === 'applied' && (
+                      /* No audit row for a write is a reviewability gap, not a cosmetic one --
+                         resolve-api.md §8 makes it a reason to verify rather than a silent pass. */
+                      <p className="pg-resolve__refusal">
+                        No audit record was returned for this change. Verify it by hand.
+                      </p>
+                    )
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/src/hooks/useInvestigation.ts
+++ b/apps/dashboard/src/hooks/useInvestigation.ts
@@ -1,0 +1,135 @@
+/**
+ * The WHY → FIX request lifecycle for one finding.
+ *
+ * Owns four things the drawer should not: the in-flight flags, the abort on unmount or finding
+ * change, the transport-error message, and the last resolve outcome. The panel below it renders
+ * state and never calls the API — same split as `useHealthScan` and `FindingsList`.
+ *
+ * ONE INVESTIGATION PER FINDING, DISCARDED WHEN THE SELECTION CHANGES. An investigation is about a
+ * specific finding, and showing a previous finding's root cause under a new heading is the kind of
+ * mistake nobody notices on stage. So the state is keyed by finding id and cleared when it moves.
+ *
+ * WHY THE ABORT MATTERS HERE MORE THAN FOR POLLING. An investigation is an LLM round trip —
+ * measured at 8.5s against `gpt-4o-mini` through the nginx proxy. That is long enough for an
+ * operator to close the drawer, and a late response landing in a closed drawer would either throw
+ * on a dead setState or, worse, repopulate a panel the operator had dismissed.
+ *
+ * A REFUSAL IS NOT AN ERROR. `outcome: "refused"` resolves normally and is kept in `resolve`, not in
+ * `error`. `error` is only for a transport or shape failure — the difference between "the system
+ * declined, here is why" and "we could not ask".
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { HealthScanApi } from '../api/HealthScanApi';
+import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
+
+export interface InvestigationState {
+  investigation: InvestigationView | null;
+  investigating: boolean;
+  /** Transport or shape failure only. A refused resolve is in `resolve`. */
+  error: string | null;
+  resolve: ResolveView | null;
+  /** Which mode is in flight, so the two buttons can show progress independently. */
+  resolving: ResolveMode | null;
+  resolveError: string | null;
+}
+
+export interface InvestigationActions {
+  investigate: () => void;
+  applyAction: (mode: ResolveMode, action: ResolveActionView) => void;
+  reset: () => void;
+}
+
+const EMPTY: InvestigationState = {
+  investigation: null,
+  investigating: false,
+  error: null,
+  resolve: null,
+  resolving: null,
+  resolveError: null,
+};
+
+function message(cause: unknown): string {
+  return cause instanceof Error ? cause.message : 'The request failed';
+}
+
+export function useInvestigation(
+  api: HealthScanApi,
+  findingId: string | null,
+): InvestigationState & InvestigationActions {
+  const [state, setState] = useState<InvestigationState>(EMPTY);
+
+  /* One controller for both calls: closing the drawer or changing finding should abandon whatever
+     is in flight, and the two are never usefully concurrent (you approve what you investigated). */
+  const inFlight = useRef<AbortController | null>(null);
+  const currentId = useRef<string | null>(findingId);
+
+  const abort = useCallback((): void => {
+    inFlight.current?.abort();
+    inFlight.current = null;
+  }, []);
+
+  /* Clear on selection change, and on unmount. Without the id guard in the callbacks below this
+     would still race: an in-flight investigation for finding A can resolve after the operator has
+     selected B, and `setState` would attach A's narrative to B. */
+  useEffect(() => {
+    currentId.current = findingId;
+    abort();
+    setState(EMPTY);
+    return abort;
+  }, [findingId, abort]);
+
+  const investigate = useCallback((): void => {
+    if (findingId === null) return;
+    abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+    const requestedFor = findingId;
+
+    setState((prev) => ({ ...prev, investigating: true, error: null }));
+
+    void api
+      .investigate(requestedFor, controller.signal)
+      .then((investigation) => {
+        if (controller.signal.aborted || currentId.current !== requestedFor) return;
+        setState((prev) => ({ ...prev, investigation, investigating: false, error: null }));
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted || currentId.current !== requestedFor) return;
+        setState((prev) => ({ ...prev, investigating: false, error: message(cause) }));
+      });
+  }, [api, findingId, abort]);
+
+  const applyAction = useCallback(
+    (mode: ResolveMode, action: ResolveActionView): void => {
+      if (findingId === null) return;
+      const controller = new AbortController();
+      inFlight.current = controller;
+      const requestedFor = findingId;
+
+      setState((prev) => ({ ...prev, resolving: mode, resolveError: null }));
+
+      void api
+        .resolve(mode, action, { findingId: requestedFor }, controller.signal)
+        .then((resolve) => {
+          if (controller.signal.aborted || currentId.current !== requestedFor) return;
+          setState((prev) => ({ ...prev, resolve, resolving: null, resolveError: null }));
+        })
+        .catch((cause: unknown) => {
+          if (controller.signal.aborted || currentId.current !== requestedFor) return;
+          /* A failed APPLY is the one case where the operator must be told to check by hand: the
+             request may have landed. The panel says so from `resolve.failure.liveStateVerified`
+             when the engine answered; this path is for when it did not answer at all. */
+          setState((prev) => ({ ...prev, resolving: null, resolveError: message(cause) }));
+        });
+    },
+    [api, findingId],
+  );
+
+  const reset = useCallback((): void => {
+    abort();
+    setState(EMPTY);
+  }, [abort]);
+
+  return { ...state, investigate, applyAction, reset };
+}

--- a/apps/dashboard/src/hooks/useProjections.ts
+++ b/apps/dashboard/src/hooks/useProjections.ts
@@ -1,0 +1,55 @@
+/**
+ * Early Warning projections, on the same cadence as the findings poll.
+ *
+ * WHY IT PIGGYBACKS ON `failureCount` RATHER THAN OWNING A TIMER. `usePolling` already decides when
+ * to fetch — it pauses while the tab is hidden, backs off on failure, and refetches on becoming
+ * visible. A second interval here would drift out of step within minutes, so a card could show a
+ * queue depth from one moment beside a projection from another. Two readings pretending to be one
+ * is the defect `earlywarning-api.md` §1.4 is written against, one level up.
+ *
+ * `failureCount` changes on every tick (success resets it to 0, failure increments), which makes it
+ * a usable "the poll just happened" signal without threading a new callback through `usePolling`.
+ * That is a little indirect and it is the reason this comment exists.
+ *
+ * FAILURES ARE SWALLOWED, DELIBERATELY. A projection is decoration on a card whose metrics are real;
+ * losing the forecast must not blank the card or raise the connection banner. So the previous value
+ * is kept on error rather than cleared — a stale projection is labelled `~` and projected either
+ * way, and an empty strip says less than an old one.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { HealthScanApi } from '../api/HealthScanApi';
+import type { HostProjectionView } from '../types/mvp2';
+
+export function useProjections(api: HealthScanApi, tick: number): HostProjectionView[] {
+  const [projections, setProjections] = useState<HostProjectionView[]>([]);
+  const inFlight = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+
+    void api
+      .getProjections(controller.signal)
+      .then((next) => {
+        if (controller.signal.aborted) return;
+        setProjections(next);
+      })
+      .catch(() => {
+        /* Intentionally empty. See the header: the forecast is the least important thing on a host
+           card, and it must not be able to disturb the two things that are not. */
+      });
+
+    return () => controller.abort();
+    // `api` changes when the mode switches, which should refetch; `tick` is the poll signal.
+  }, [api, tick]);
+
+  /* Cleared when the client changes, so a demo-mode projection cannot linger over live metrics --
+     the two clients describe different worlds and mixing them is how #74's "seen ids" bug happened. */
+  useEffect(() => {
+    setProjections([]);
+  }, [api]);
+
+  return projections;
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1199,3 +1199,15 @@ button {
   line-height: 1.4;
   color: var(--pg-text);
 }
+
+/* The spent variant: the window has closed and a finding covers the state now. Warning-toned
+   rather than info-toned, because unlike a pending projection this one is reporting that the
+   thing being watched for has actually happened. */
+.pg-forecast--spent {
+  border-left-color: var(--pg-warning);
+  background: var(--pg-warning-bg);
+}
+
+.pg-forecast--spent .pg-forecast__label {
+  color: var(--pg-warning);
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -951,3 +951,211 @@ button {
     width: min(var(--pg-drawer-width), 60vw);
   }
 }
+
+/* ─── AI Detective + Smart Resolve (MVP 2) ──────────────────────────────────────────
+   All tokens, no literals: a hardcoded colour here would drift from the severity
+   palette the rest of the drawer uses, and the refusal/failure states need to read
+   as the same family as a critical finding. */
+
+.pg-investigate {
+  margin-top: var(--pg-space-5);
+  padding-top: var(--pg-space-4);
+  border-top: 1px solid var(--pg-border);
+}
+
+.pg-investigate__heading {
+  margin: 0 0 var(--pg-space-2);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+.pg-investigate__intro,
+.pg-investigate__status {
+  margin: 0 0 var(--pg-space-3);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--pg-text-muted);
+}
+
+/* The narrative. Slightly larger and darker than the supporting copy, because it is
+   the answer to the question the heading asks. */
+.pg-investigate__rootcause {
+  margin: var(--pg-space-3) 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--pg-text);
+}
+
+.pg-investigate__note {
+  margin: var(--pg-space-2) 0 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--pg-text-muted);
+}
+
+.pg-investigate__error,
+.pg-investigate__unavailable {
+  margin: var(--pg-space-3) 0;
+  padding: var(--pg-space-3);
+  border-radius: var(--pg-radius);
+  background: var(--pg-critical-bg);
+  color: var(--pg-text);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.pg-investigate__error p,
+.pg-investigate__unavailable p {
+  margin: 0 0 var(--pg-space-2);
+}
+
+.pg-investigate__provenance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pg-space-2);
+  margin: var(--pg-space-2) 0 var(--pg-space-3);
+}
+
+/* Provenance chips. `--warn` is the canned/demo one and is deliberately the most
+   visually distinct: it is the label that stops a mock being mistaken for live. */
+.pg-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--pg-space-2);
+  border-radius: var(--pg-radius-pill);
+  background: var(--pg-surface-sunk);
+  color: var(--pg-text-muted);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.pg-tag--ok {
+  background: var(--pg-ok-bg);
+  color: var(--pg-ok);
+}
+
+.pg-tag--warn {
+  background: var(--pg-warning-bg);
+  color: var(--pg-warning);
+  font-weight: 600;
+}
+
+/* Evidence list. Each row carries its own provenance, so the source label sits on
+   the same line as the label rather than under the detail. */
+.pg-evidence {
+  margin: var(--pg-space-3) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pg-evidence__item {
+  padding: var(--pg-space-2) 0;
+  border-bottom: 1px solid var(--pg-border-soft);
+}
+
+.pg-evidence__item:last-child {
+  border-bottom: 0;
+}
+
+.pg-evidence__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--pg-space-2);
+}
+
+.pg-evidence__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+.pg-evidence__source {
+  font-size: 0.6875rem;
+  color: var(--pg-text-muted);
+  white-space: nowrap;
+}
+
+/* `mcp_tool` was measured by a governed tool; `llm` was asserted by the model and
+   nothing verified it. Colouring only those two, because the distinction that matters
+   to someone about to approve a write is measured-vs-asserted. */
+.pg-evidence__source--mcp_tool {
+  color: var(--pg-ok);
+}
+
+.pg-evidence__source--llm {
+  color: var(--pg-warning);
+}
+
+.pg-evidence__detail {
+  margin-top: 2px;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--pg-text-muted);
+}
+
+/* The write panel, visually separated from the read-only narrative above it. */
+.pg-resolve {
+  margin-top: var(--pg-space-4);
+  padding-top: var(--pg-space-4);
+  border-top: 1px solid var(--pg-border);
+}
+
+.pg-resolve__summary {
+  margin: 0 0 var(--pg-space-3);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+.pg-resolve__actions {
+  display: flex;
+  gap: var(--pg-space-2);
+  margin-top: var(--pg-space-3);
+}
+
+.pg-resolve__gate {
+  margin: var(--pg-space-3) 0 0;
+  padding: var(--pg-space-2) var(--pg-space-3);
+  border-left: 3px solid var(--pg-warning);
+  background: var(--pg-warning-bg);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--pg-text);
+}
+
+.pg-resolve__outcome {
+  margin-top: var(--pg-space-3);
+  padding: var(--pg-space-3);
+  border-radius: var(--pg-radius);
+  background: var(--pg-surface-sunk);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.pg-resolve__outcome-label {
+  margin: 0 0 var(--pg-space-1);
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+/* An APPLIED write reads as success; a refusal reads as the safety model working, not
+   as an error; a failure reads as critical. §5.2 forbids merging the last two. */
+.pg-resolve__outcome--applied {
+  background: var(--pg-ok-bg);
+}
+
+.pg-resolve__outcome--refused {
+  background: var(--pg-info-bg);
+}
+
+.pg-resolve__outcome--failed {
+  background: var(--pg-critical-bg);
+}
+
+.pg-resolve__refusal {
+  margin: var(--pg-space-1) 0 0;
+  color: var(--pg-text);
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1159,3 +1159,43 @@ button {
   margin: var(--pg-space-1) 0 0;
   color: var(--pg-text);
 }
+
+/* ─── Early Warning (MVP 2) ──────────────────────────────────────────────────────────
+   Info-toned, NOT warning-toned. A projection is a heads-up about something that has
+   not happened, and colouring it like a breach would put two hosts at the same visual
+   weight when only one of them is actually in trouble. */
+
+.pg-forecast {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: var(--pg-space-3);
+  padding: var(--pg-space-2) var(--pg-space-3);
+  border-left: 3px solid var(--pg-info);
+  border-radius: 0 var(--pg-radius) var(--pg-radius) 0;
+  background: var(--pg-info-bg);
+}
+
+/* The pending variant says "not yet", so it reads as inert rather than as information. */
+.pg-forecast--pending {
+  border-left-color: var(--pg-border);
+  background: var(--pg-surface-sunk);
+}
+
+.pg-forecast__label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--pg-info);
+}
+
+.pg-forecast--pending .pg-forecast__label {
+  color: var(--pg-text-muted);
+}
+
+.pg-forecast__body {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--pg-text);
+}

--- a/apps/dashboard/src/types/mvp2.ts
+++ b/apps/dashboard/src/types/mvp2.ts
@@ -122,3 +122,48 @@ export interface ResolveView {
   requestedAt: string;
   completedAt: string;
 }
+
+/**
+ * Early Warning — `contracts/earlywarning-api.md`.
+ *
+ * A PROJECTION IS NOT A MEASUREMENT, and the shape enforces it: every forecast number is nested
+ * inside `projection`, which is **null** whenever one cannot honestly be made. The measured values
+ * (`currentValue`, `threshold`) sit outside it and are always present. So a consumer cannot read a
+ * forecast by accident — it has to reach into an object that may not be there.
+ *
+ * `projectionUnavailable` then says WHY, from a closed set. Rendering the reason rather than hiding
+ * the row is the point: "not rising" and "still warming up" are different facts, and a blank space
+ * means neither.
+ */
+export type ProjectionDeclineReason =
+  | 'disabled'
+  | 'metric_unmeasurable'
+  | 'warming'
+  | 'insufficient_samples'
+  | 'already_crossed'
+  | 'not_rising'
+  | 'beyond_horizon';
+
+export interface HostProjectionView {
+  host: string;
+  metric: string;
+  currentValue: number | null;
+  measuredAt: string;
+  fitSampleCount: number;
+  fitSpanSeconds: number;
+  threshold: {
+    value: number | null;
+    basis: string;
+    baselineValue: number | null;
+    findingType: string;
+  } | null;
+  /** Null when no honest projection exists. Never partially populated. */
+  projection: {
+    kind: 'projection';
+    slope: number;
+    slopeUnit: string;
+    secondsToThreshold: number | null;
+    crossesAt: string | null;
+  } | null;
+  projectionUnavailable: ProjectionDeclineReason | null;
+}

--- a/apps/dashboard/src/types/mvp2.ts
+++ b/apps/dashboard/src/types/mvp2.ts
@@ -1,0 +1,124 @@
+/**
+ * MVP 2 view types — AI Detective and Smart Resolve.
+ *
+ * Transcribed from `contracts/investigation-api.md` and `contracts/resolve-api.md`. Those contracts
+ * are authoritative; where this file and they disagree, this file is wrong.
+ *
+ * NEITHER CONTRACT HAS A `.d.ts` OR A SCHEMA YET — both say so at the top, and `validate.mjs` does
+ * not know these endpoints exist. So unlike `healthscan.ts`, there is no generated source to
+ * transcribe from and no drift test that would catch a divergence here. Every field name below was
+ * read off the contract prose and checked against a live response. That is weaker, and it is why the
+ * parsers in `api/mvp2Guards.ts` read field by field rather than casting.
+ *
+ * WHAT THE UI IS ALLOWED TO ASSUME, and it is very little:
+ *
+ *  - `rootCause` may be null. That is not a loading state and not an error — it is the engine
+ *    refusing to invent an explanation, and it must render as such (§4.4).
+ *  - `source` distinguishes a real agent from a canned fallback. A canned investigation that
+ *    presented itself as live would be the same defect class as a projection shown as a
+ *    measurement, so the UI labels it.
+ *  - `outcome: "refused"` arrives with HTTP 200 (`resolve-api.md` §5.1). It is a normal response
+ *    carrying information, not an error, and rendering it as a failure loses the reason.
+ */
+
+/** `investigation-api.md` §4.1. */
+export type InvestigationState = 'complete' | 'degraded' | 'unavailable';
+
+/** §3.1. `canned` is the mock agent; `none` accompanies an unavailable investigation. */
+export type InvestigationSource = 'agent' | 'cache' | 'canned' | 'none';
+
+/**
+ * §3.2. How a bullet was obtained, and the reason it is shown next to the text.
+ *
+ * `mcp_tool` means a governed tool read it from the live production. `snapshot` means it came from
+ * the finding the investigation explains. `llm` means the model asserted it and nothing measured it
+ * — which a human approving a production write is entitled to see distinguished.
+ */
+export type EvidenceSource = 'mcp_tool' | 'snapshot' | 'llm';
+
+export interface EvidenceItemView {
+  label: string;
+  detail: string;
+  source: EvidenceSource;
+  tool: string | null;
+}
+
+/** §3.3. Exactly three keys — `resolve-api.md` §1.1 refuses unknown ones inside `action`. */
+export interface ResolveActionView {
+  type: 'set_pool_size';
+  host: string;
+  size: number;
+}
+
+export interface RecommendedActionView {
+  action: ResolveActionView;
+  currentValue: number | null;
+  bounds: { min: number; max: number };
+  reversible: boolean;
+  requiresApproval: boolean;
+  summary: string;
+}
+
+export interface InvestigationView {
+  requestId: string;
+  findingId: string;
+  state: InvestigationState;
+  source: InvestigationSource;
+  investigatedAt: string;
+  /** Null when the engine could not produce one. Never a placeholder narrative. */
+  rootCause: string | null;
+  evidence: EvidenceItemView[];
+  confidence: number | null;
+  recommendedAction: RecommendedActionView | null;
+  diagnostics: {
+    model: string | null;
+    toolCalls: number | null;
+    durationMs: number | null;
+    note: string | null;
+  };
+}
+
+/** `resolve-api.md` §1.4. Closed set. */
+export type ResolveOutcome = 'previewed' | 'applied' | 'no_change' | 'refused' | 'failed';
+
+export type ResolveMode = 'dry_run' | 'apply';
+
+export interface ResolveView {
+  resolveId: string;
+  requestId: string | null;
+  mode: ResolveMode;
+  outcome: ResolveOutcome;
+  action: ResolveActionView | null;
+  before: { poolSize: number } | null;
+  after: { poolSize: number } | null;
+  /** The prior value, captured live. What an operator restores to undo. */
+  reversal: { host: string; size: number; capturedFrom: string } | null;
+  /** §5. `reason` from a closed set, `message` rendered verbatim, `checkedBy` naming the decider. */
+  refusal: {
+    reason: string;
+    message: string;
+    checkedBy: string;
+    bounds?: { min: number; max: number };
+  } | null;
+  failure: { stage: string; message: string; liveStateVerified: boolean } | null;
+  /** Present only on `applied`. `directEvidence: false` — the write landed, the fix is not yet seen. */
+  confirmation: {
+    status: string;
+    findingId: string | null;
+    observeVia: string;
+    expectedWithinSeconds: number;
+    directEvidence: boolean;
+  } | null;
+  /** §8. Null means no record was written, which on an apply is a reason to verify by hand. */
+  audit: {
+    auditId: string | null;
+    actor: string | null;
+    role: string | null;
+    requestedBy: string | null;
+    tool: string | null;
+    recordedAt: string | null;
+    source: string | null;
+  } | null;
+  requestedAt: string;
+  completedAt: string;
+}


### PR DESCRIPTION
**The MVP 2 UI was never built.** Root `CLAUDE.md` §2.1 lists "Dev C (approval UI)" as part of Smart Resolve; the dashboard called neither `/api/investigate` nor `/api/resolve`, so the demo showed **WHAT** and stopped.

The backend has been verified working end to end for two days behind a UI with no way to reach it. **The user found this by asking where WHY and FIX were on screen** — no check we had would have caught it, because every verification I ran drove the API with `curl`.

## What it adds

An opt-in panel at the bottom of the finding drawer: **Investigate** → root cause, evidence, confidence → **recommended action** with **Preview** and **Approve and apply**.

Opt-in behind a button on purpose: a drawer opened to read a number should not fire an LLM call.

## Follows the existing seam

`apps/dashboard/CLAUDE.md` §4.1 keeps `fetch` out of components, so both endpoints go on `HealthScanApi` and **both clients implement them** — `liveClient` posts, `mockClient` answers from an in-memory pool size. The drawer takes the panel as a prop and no `api`, so it stays renderable with no client at all, and demo mode exercises the same code path including the refusal branch.

## Three things the panel is built not to get wrong

**A canned investigation must not look live.** `source` renders as a visible badge — *"Canned — demo mode, not a live agent"* — not buried in diagnostics. Model and tool-call counts appear only when present, so demo mode cannot borrow a live agent's credibility. `toolCalls` is shown because a plausible narrative with zero tool calls is a model reasoning from its priors.

**`rootCause: null` is an answer, not a blank.** §4.4 has the engine decline to invent an explanation. That renders as an explicit statement plus the diagnostic note — never an empty panel that reads as still-loading.

**Evidence provenance is part of the evidence.** Each bullet shows whether it was read from IRIS by a governed tool, taken from the finding, or asserted by the model. Only `mcp_tool` and `llm` are coloured, because measured-vs-asserted is the distinction that matters to someone about to approve a write.

## The write path

Preview before Approve, both explicit — §1.1 requires the mode, and an operator should approve a change whose before/after they have already seen.

| Outcome | How it renders |
|---|---|
| `previewed` | "Preview only — nothing was changed", pool `1 → 4 (would be)` |
| `applied` | success colour, plus "the finding clears on its own" from `confirmation.directEvidence: false` |
| `refused` | **info** colour, not error — reason, verbatim message, and `checkedBy`. §5.2 forbids merging with `failed` |
| `failed` | critical colour, and "check the pool size before retrying" when `liveStateVerified` is false |

A missing `audit.auditId` on an apply is called out as something to verify by hand rather than passed over silently.

## Parsers read field by field, never a cast

The MVP 2 contracts have no schema and no `.d.ts`, so nothing generated enforces their shape — and the engine has already been bitten by a cast that type-checked `{code, detail}` as `{reason, message}` and would have rendered `undefined`. `bounds` come from the response, never a constant here, so the approve control cannot drift from what the tool will accept.

`useInvestigation` keys state by finding id and aborts on change: an investigation is an LLM round trip (measured 8.5s), and a late response landing under a different finding's heading is the kind of thing nobody notices on stage.

## Verified through the dashboard's own path, real LLM

```
investigate -> source agent, gpt-4o-mini, 5 tool calls,
               all six evidence bullets mcp_tool,
               recommendedAction bounds {2,8}, requiresApproval true
Preview     -> previewed 1 -> 4, reversal size 1 capturedFrom "live production",
               audit pg-audit-16, no confirmation
Approve     -> applied 1 -> 4, audit pg-audit-17, requestedBy "dashboard",
               confirmation pending / directEvidence false
size 1      -> refused / out_of_bounds / checkedBy iris, bounds echoed
queue 126 -> 97 -> 59 -> 22 -> 0
```

Typecheck and build clean. Every new path is present in the 214 KB single-file bundle, so the `file://` demo fallback still works.

## What I have not done

**No visual review.** I verified the responses the panel parses and that the markup and styles are in the bundle, but I have not looked at the rendered drawer — @tanifgit owns this area normally and would spot layout and copy issues I cannot. The tokens are all existing ones (no literal colours), so it should be in-family, but "should be" is doing work there.

**No component tests**, because this app has none — `typecheck` and `build` are its gates. `useInvestigation`'s abort-on-selection-change is the piece I would most want a test for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
