### PR TITLE
docs(iris): the live-agent check belongs in the acceptance table (#108)

### DIFF
--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -148,12 +148,46 @@ returns PHI, it lands in `Audit.Entry.Result` in plain text.
 | Every call appears in the audit log | met for executions and for authorization denials |
 | RBAC roles and resources exist from a clean boot | met, and **verified from a real boot** rather than inferred: the four security objects were deleted and `docker compose restart iris` recreated them through step 9. `Audit/` compiled on the way through, including its SQL table, so the recursive load picks up a new subdirectory |
 | A principal can actually *use* the roles | needs `%DB_%DEFAULT` **as well**, from the invocation path — the `Guardian_*` roles stay minimal and grant only `PG_*`. Without it you get `<PROTECT>` before any policy is consulted |
-| LLM credential in the vault | **not met on the compose stack** — needs a key, and the current one must be rotated |
+| LLM credential in the vault | met — `Setup.AIHub.CreateProvider()` provisions the wallet entry and the `AI.LLM.pgdetective` config from `PG_LLM_API_KEY` at boot (#106), verified on a cold-provisioned instance. **No key, no default:** absent, the boot says `SKIPPED` and AI Detective degrades to a labelled `source: "canned"` |
+| One live investigation returns `source: "agent"` | **standing pre-demo check, not a one-off** — see #108 and below |
 
 ```objectscript
 do ##class(ProductionGuardian.Setup.AIHub).Status()          // what is and is not in place
 do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()   // reset the log between rehearsals
 ```
+
+### Before a demo: prove the agent is live, not canned (#108)
+
+`source: "canned"` builds a plausible narrative **from real measured values**, so a rehearsal looks
+correct while demonstrating nothing about the agent. The three fields that cannot be faked:
+
+```
+POST /api/investigate  ->  state: complete
+                           source: agent        <- NOT "canned"
+                           model: non-null      <- e.g. gpt-4o-mini
+                           toolCalls: > 0       <- evidence was gathered, not guessed
+```
+
+**Run it after any change to the provider path** — `CreateProvider()`, the wallet, the ConfigStore
+entry, `REST.AgentDispatcher`, or the compose variables.
+
+`source: "agent"` is the cheapest assertion that covers the whole chain at once, because it cannot be
+produced unless the compose variable, the provider config, the wallet entry, the web application and
+the agent are *all* correct simultaneously. That matters because three defects in this path were each
+invisible to the check that preceded them, and each failed at a different link:
+
+| Defect | Where it broke | Found in |
+|---|---|---|
+| `/labdemo/agent` never registered — every MVP 2 write `404`d | web application | #106 |
+| `CreateProvider()` never ran — the variable was not passed to the `iris` service | compose | `f4e6561` |
+| the wallet restore was inert — `%Wallet.KeyValue.Secret` is `transient=1` | error path | `4a0fb8e` |
+
+The common gap: **a mechanism that works and a mechanism that is reached are different claims**, and
+only the second is what a demo depends on.
+
+Not automatable in CI — it needs a real API key and costs a metered call, so it is a human check. If
+it is ever scripted it belongs in `tools/` and run on request, for the same reason
+`Test.GovernanceProof` is hand-run rather than compiled at boot.
 
 ### Every row above means "on a boot", so test with `compose down -v`
 


### PR DESCRIPTION
Puts #108's check where @Ari-Glikman proposed it — the acceptance table in `iris/CLAUDE.md`, which is where someone reads "met" and decides whether a demo is safe to run.

## Two rows changed

**`LLM credential in the vault` is now met.** #106 provisions the wallet entry and the `AI.LLM.pgdetective` config from `PG_LLM_API_KEY` at boot, verified on a cold instance. The row said *"not met on the compose stack — needs a key, and the current one must be rotated"*, which was true when I wrote it and stale the moment #106 merged. Recorded with the no-default behaviour, because "absent, the boot says `SKIPPED` and degrades to a labelled `source: canned`" is the part an operator actually needs.

That's the third time one of my own rows in this table has gone stale in the direction of *understating* what works — after the dry-run row corrected in #105 and this one. The table is doing its job, but only because somebody keeps re-reading it against reality.

**A new row for the standing check**, with a section explaining why it's standing rather than a one-off.

## The argument I wanted to preserve

`source: "agent"` is the cheapest assertion that covers the entire chain, because it cannot be produced unless the compose variable, the provider config, the wallet entry, the web application and the agent are **all** correct simultaneously.

That matters because three defects in this path were each invisible to the check that preceded them, and each broke a *different* link:

| Defect | Where it broke | Found in |
|---|---|---|
| `/labdemo/agent` never registered — every MVP 2 write `404`d | web application | #106 |
| `CreateProvider()` never ran — variable not passed to the `iris` service | compose | `f4e6561` |
| the wallet restore was inert — `%Wallet.KeyValue.Secret` is `transient=1` | error path | `4a0fb8e` |

**A mechanism that works and a mechanism that is reached are different claims**, and a demo depends on the second. That sentence is the reason the check exists, so it's in the file rather than only in the issue.

I also kept the reason `canned` is *dangerous* rather than merely limited: it builds a plausible narrative from real measured values, so a rehearsal looks correct while demonstrating nothing about the agent. A degradation that looked broken would be safer.

## Not automatable, and why that's recorded

It needs a real key and costs a metered call, so it can't live in CI and shouldn't. Noted that if it's ever scripted it belongs in `tools/` and run on request — the same reasoning that keeps `Test.GovernanceProof` hand-run rather than compiled at boot (#97).

Docs only, no code. #108 stays open as the standing item; this is where the instruction lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
