### PR TITLE
docs: MVP 2 is shipped — close the scope boundary and record what is not done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Rules that apply to **every developer**. Deep, area-specific instructions live i
 
 ## 1. What this project is
 
-**Production Guardian** is an AI-powered production health and optimization layer for InterSystems Health Connect. Eight modules are planned. **MVP 1 (Health Scan) is shipped; MVP 2 adds Early Warning, AI Detective and Smart Resolve.**
+**Production Guardian** is an AI-powered production health and optimization layer for InterSystems Health Connect. Eight modules are planned. **MVP 1 (Health Scan) and MVP 2 (Early Warning, AI Detective, Smart Resolve) are both shipped.**
 
 Health Scan reads production metrics from the built-in IRIS `/api/monitor/` API, compares them to a rolling baseline, and surfaces findings — dead jobs, hung processes, queue buildup, elevated error rates, slow processing, system alerts. MVP 2 turns one of those findings into a closed loop: **WHAT** (project it forward) → **WHY** (explain it) → **FIX** (apply a governed, approved action and confirm it clears).
 
@@ -23,12 +23,23 @@ Specs: `docs/production-guardian-healthscan-mvp1.docx`, `docs/production-guardia
 
 ## 2. Hard scope boundary
 
-**MVP 1 (Health Scan) is complete and shipped.** We are now building **MVP 2**, which
-deliberately crosses three of the boundaries MVP 1 held. This section is the record of what is
-in and out *now*; the MVP 1 boundary is kept below it because the reasoning still governs the
-five modules that remain out.
+**MVP 1 and MVP 2 are both complete and shipped.** MVP 2 deliberately crossed three of the
+boundaries MVP 1 held. This section is the record of what is in and out *now*; the MVP 1
+boundary is kept below it because the reasoning still governs the five modules that remain out.
 
 Spec: `docs/production-guardian-mvp2.docx`.
+
+**MVP 2 shipped on 2026-08-20**, verified from an empty volume in one `compose up`: Early
+Warning projected the crossing (`eta` tightening 820s -> 23s), `queue_buildup` fired, a live
+`gpt-4o-mini` agent explained it with all evidence read through governed tools, and one approved
+`set_pool_size 1 -> 4` drained the queue to zero. Six audit rows for six tool calls. The
+standing pre-demo check is #108 and `iris/CLAUDE.md`'s acceptance table.
+
+**What shipped is one scenario, not a general capability** — that was the §2.1 bargain and it
+held. `set_pool_size` on `Cloud API` within `2..8` is still the only action, and the five
+modules in §2.2 are still out. **Anything beyond that is MVP 3 scope and needs its own spec
+before it is built**, for the same reason MVP 2 had one: three modules landed because the
+boundary was written down first.
 
 ### 2.1 In scope for MVP 2 — three modules, one scenario
 

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,57 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-20 — MVP 2 shipped; the four contracts carry no machine-readable artefact (Dev B)
+
+**No contract text changed in this entry.** It records a gap that should be visible before anyone
+starts MVP 3, because the honest answer to "are the MVP 2 contracts done" is *the prose is, the
+enforcement is not*.
+
+All four MVP 2 contracts are implemented and verified end to end from an empty volume. Three say
+`Status: published`; `earlywarning-api.md` still says `proposed`. **None of the four has a
+`.schema.json`, a `.d.ts`, or a captured sample**, and each says so in its own text — so
+`validate.mjs` does not know these endpoints exist, and its counts (15 accept / 19 reject / 7
+capture claims) are entirely MVP 1.
+
+### What that costs, measured rather than asserted
+
+Two drifts got through in a week, both in shapes no schema covered:
+
+1. **`refusal` field names.** `Tools.Resolve`, the engine's type and the mock all emitted
+   `{code, detail}` against a contract specifying `{reason, message, checkedBy}` (#99). It
+   type-checked because the parser *cast* rather than read; §5 tells consumers to render
+   `refusal.message` verbatim, so the UI would have shown `undefined`.
+2. **`reversal` shape.** The contract specifies `{action: {...}, capturedFrom, automatic}`; every
+   component ships flat `{host, size, capturedFrom}` and nothing emits `automatic` (#100). The
+   implementation is self-consistent and the *contract* is the outlier — the reverse of the usual
+   direction, and only findable by reading both.
+
+`healthscan-api.md` has had a schema and a drift test since Day 1 and has produced neither class of
+defect. That is the argument, and it is the reason this entry exists rather than a note in a PR.
+
+### The stopgap that exists
+
+`services/detection-engine/test/mvp2-contract-drift.test.ts` greps the contract *prose* for field
+names. It caught nothing retroactively — it was written after both drifts — and its own header says
+it should be **replaced** by schema validation rather than extended. A prose grep is weaker than a
+schema and the risk is that a weak check gets trusted like a strong one.
+
+### Before MVP 3 builds on these
+
+Whoever specs MVP 3 should decide, explicitly, whether the four MVP 2 contracts get schemas and
+captured samples first. Two reasons to do it before rather than after:
+
+- MVP 3's modules (Health Score, Health Summary, Ask Guardian, Performance Coach — §2.2) all
+  *consume* investigation and resolve output. A shape that is only enforced by review is a shape
+  every new consumer re-litigates.
+- `#100` is an open contract self-contradiction: the endpoint hands back `reversal` with `size: 1`
+  and then refuses that exact body, because the bound is `2..8`. It needs a decision either way, and
+  it is cheaper to settle while the four documents are being made machine-readable than afterwards.
+
+Not proposing the work here — this is the record that it is outstanding, so it is a decision rather
+than a discovery.
+
+
 ## 2026-08-19 — audit and RBAC: four corrections from implementing them (Dev A raised, Dev B wrote)
 
 **Two files, no shape change.** `mcp-tools.md` §4/§5/§5.5 and `resolve-api.md` §8. No field added,


### PR DESCRIPTION
Prompted by the user asking whether we are ready for MVP 3. Checking rather than assuming turned up two pieces of repo-state debt. **Docs only — no code, no contract text changed.**

## 1. Root `CLAUDE.md` still said we were mid-build

§1 said MVP 1 was shipped and MVP 2 "adds" three modules; §2 said *"We are now building MVP 2"*. Both now state shipped, with the verification recorded rather than claimed:

```
empty volume -> one `compose up`
Early Warning  eta 820s -> 256s -> 123s -> 60s -> 23s, then queue_buildup fired
WHY            source: agent | gpt-4o-mini | 4 tool calls | all evidence mcp_tool
FIX            dry_run previewed 1->4, apply applied 1->4
               queue 23 -> 0, findings (all clear), 6 audit rows for 6 tool calls
```

The §2.1 bargain is restated because **it held**: one scenario, one action, one host, `2..8`. Three modules landed in the time three modules were planned, and the boundary being written down first is why. Anything beyond it is MVP 3 and needs its own spec.

## 2. The four MVP 2 contracts have no machine-readable artefact

Three say `Status: published`; `earlywarning-api.md` still says `proposed`. **None has a `.schema.json`, a `.d.ts`, or a captured sample** — each says so in its own text — so `validate.mjs` does not know these endpoints exist and its 15/19/7 counts are entirely MVP 1.

Recorded in `contracts/CHANGELOG.md` rather than fixed, with the cost measured instead of asserted. Two shape drifts got through in a week, both in objects no schema covered:

| | What drifted | How it got through |
|---|---|---|
| #99 | `refusal`: `{code, detail}` vs `{reason, message, checkedBy}` | the parser **cast** rather than read, so it type-checked |
| #100 | `reversal`: contract specifies nested `action` + `automatic`; every component ships flat without it | still open — and the endpoint hands back `size: 1` then refuses that exact body |

`healthscan-api.md` has had a schema and a drift test since Day 1 and has produced neither class of defect. That is the argument.

The stopgap that exists — `mvp2-contract-drift.test.ts` — greps the contract *prose*. It caught nothing retroactively (written after both drifts) and its own header says it should be **replaced** by schema validation, not extended. A weak check being trusted like a strong one is the risk.

## Why this matters specifically for MVP 3

Every module in §2.2 — Health Score, Health Summary, Ask Guardian, Performance Coach — **consumes** investigation and resolve output. A shape enforced only by review is one that every new consumer re-litigates, and #100 is a live self-contradiction sitting in the middle of it.

So the recommendation for the MVP 3 conversation is: **decide explicitly whether the four contracts get schemas and captured samples first.** Not proposing the work in this PR — this is the record that it is outstanding, so it is a decision rather than a discovery.

@kskubach — this touches root `CLAUDE.md`, which is shared and PR-reviewed by convention, and `contracts/CHANGELOG.md`. You are also the person the user is about to discuss MVP 3 with, so the second half is written for that conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
