### PR TITLE
fix(iris): reversal.capturedFrom was "live production", contract says "live"

### DIFF
--- a/iris/labdemo/Tools/Resolve.cls
+++ b/iris/labdemo/Tools/Resolve.cls
@@ -125,7 +125,19 @@ ClassMethod SetPoolSize(host As %String, size As %Integer, dryRun As %Boolean = 
     // had tuned.
     set before = +item.PoolSize
     set out.before = { "poolSize": (before) }
-    set out.reversal = { "host": (host), "size": (before), "capturedFrom": "live production" }
+    // `capturedFrom` IS "live", NOT "live production". `resolve-api.md` §4 states it is always
+    // `"live"`, and this emitted `"live production"` until 2026-08-20 -- a value drift found by
+    // diffing the two documents field by field for #110, after reading the line several times
+    // without seeing it. An `enum: ["live", "mock"]` in a schema catches this at validation time and
+    // review demonstrably does not, which is the argument that CHANGELOG entry is making.
+    //
+    // THE SHAPE IS STILL WRONG AND IS DELIBERATELY LEFT ALONE. The contract specifies
+    // `{"action": {"type", "host", "size"}, "capturedFrom", "automatic"}` and this is flat with no
+    // `automatic`. Fixing that means deciding what `reversal` is FOR -- #100 is open on exactly
+    // that, because the contract hands the caller a body with `size: 1` and then refuses it against
+    // its own `2..8` bound. Changing the shape before that decision would be guessing at an
+    // interface, so only the value that is wrong under every option is corrected here.
+    set out.reversal = { "host": (host), "size": (before), "capturedFrom": "live" }
 
     if before = size {
         // Not an error and not a refusal: the requested state is already true. A demo will hit


### PR DESCRIPTION
Found while reviewing #110, which lists two divergences in the `reversal` object. There are three, and this fixes the one that is wrong under every option.

## The divergence

| | `resolve-api.md` | `Tools/Resolve.cls:128` (before) |
|---|---|---|
| wrapper | `{"action": {"type", "host", "size"}}` | flat `{"host", "size"}` |
| `automatic` | `false` | absent |
| **`capturedFrom`** | **`"live"`** | **`"live production"`** |

§4 is explicit: *"`capturedFrom` is always `"live"`"*. It is effectively an enum — `"live"` \| `"mock"` — and a consumer branching on it saw a value in neither branch.

## Why only this one

The wrapper and `automatic` require deciding what `reversal` is *for*, and **#100 is open on exactly that**: the contract hands the caller a body carrying `size: 1` and then refuses that body against its own `2..8` bound. Changing the shape of an object whose purpose is under discussion would be guessing at an interface, so the shape is untouched and the comment says so.

## Why it is worth more than one word

I read that line **four times** today — implementing the audit trail, writing #100, and twice reviewing #110 — and only saw it by diffing the two documents field by field.

That makes it a sharper argument for the machine-readable artefacts #110's CHANGELOG entry asks for than either drift it cites. Both of those were **shape** errors, which a TypeScript type or a careful reader can catch. This is a **value** error inside a correctly-shaped object, and essentially only `enum: ["live", "mock"]` in a schema catches it. `healthscan-api.md` has had a schema since Day 1 and has produced neither class of defect — that comparison is the whole case.

It also survived `mvp2-contract-drift.test.ts`, and would have regardless: that test greps contract *prose* for field names, and `capturedFrom` is present in both documents. A prose grep cannot see a wrong value in a right field.

## Verified

```
compile: OK
dry run -> reversal: {"capturedFrom":"live","host":"Cloud API","size":1}
deployment target: 127.0.0.1:52773 matches   (recompiling labdemo re-triggers #96)
```

One-line behaviour change; the rest is the comment explaining what was deliberately *not* fixed, so the next reader does not "finish the job" without seeing #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
