### PR TITLE
contracts: reversal is a record, not a request; the 1..8 asymmetry withdrawn (#100)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,64 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-20 — `reversal` is a record, not a request; the `1..8` asymmetry withdrawn (Dev A)
+
+Closes #100. **Two files, no field added and none removed that anything emitted.** `resolve-api.md`
+§4 and the field table; `mcp-tools.md` §3.6 and three bound references. `validate.mjs` unchanged and
+passing — neither contract has a sample for it to check, which is the gap the entry above records.
+
+### The contradiction
+
+§4 told the caller *"Dev C can POST it back verbatim to undo"*, with `reversal.action.size` set to the
+shipped pool size — `1`. §3 bounds `action.size` at `2..8`, and §5 lists exactly that as
+`out_of_bounds`.
+
+**So the endpoint handed the caller an undo request and then refused it.** That is internal to one
+document and needed no implementation to be wrong.
+
+### The resolution: reversal is documentation
+
+`1` stays unapprovable, because §3.6's reason is sound — it is the shipped value, so approving it is a
+no-op dressed as a fix that reports success and changes nothing. Widening the bound to make the undo
+POSTable would trade a real safety property for a convenience.
+
+Restoring the pool is an operator action through `Triggers.Reset()`, which is deliberately not
+LLM-callable. **"Reversible" now means the prior value is measured, recorded and restorable** — which
+is true, provable, and what the demo does. A second write path would need its own spec under root
+`CLAUDE.md` §2.
+
+### The contract was the outlier, not the code
+
+Worth recording because it is the reverse of the usual direction and is why this survived a week.
+`reversal` was specified as `{action: {...}, capturedFrom, automatic}`; `Tools.Resolve`, the engine and
+the mock all shipped flat `{host, size, capturedFrom}` and **nothing ever emitted `automatic`**. Four
+components agreed with each other and disagreed with the document.
+
+The shape is now flat, matching them. `action` existed to make a body dispatchable and this body is not
+dispatched. **No consumer loses a field it read or emitted.**
+
+### And `set_pool_size` was never `1..8`
+
+§3.6 ratified `1..8` for the tool against `2..8` for the endpoint, arguing "a tool that refuses `1`
+cannot undo its own first call". The premise was true and the conclusion did not follow — **the third
+time that shape has cost us something here**, after the `%`-prefix paragraph and §5.5's audit claim.
+
+`Tools.Resolve` has shipped `MINSIZE = 2` since the tools landed, and its own comment rejects the
+reversal argument by name: *"Reversal to `1` is `Reset()`'s job, through a path that is not
+LLM-callable."* So the ratified range never described the implementation, and the undo path the wider
+bound existed to serve did not work at either layer. Both are `2..8`.
+
+Also corrected: `capturedFrom` was `"live production"` in `Tools.Resolve` against `"live"` in the
+contract (#111) — a *value* drift in a correctly-shaped field, and the one that argues hardest for
+schemas, since only an `enum` catches it.
+
+### Not in this entry
+
+Both documents' headers still say Dev A has left and name Dev C as a consumer. That is the same stale
+premise root `CLAUDE.md` §3 carried until #113, and it is a separate change — kept out so this entry
+describes one decision.
+
+
 ## 2026-08-20 — MVP 2 shipped; the four contracts carry no machine-readable artefact (Dev B)
 
 **No contract text changed in this entry.** It records a gap that should be visible before anyone

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -25,7 +25,7 @@ silently disagrees with its neighbour is worse than one that is wrong out loud:
 | | `resolve-api.md` | here | Why they differ |
 |---|---|---|---|
 | dry-run | a `mode` on the endpoint | **no flag on the tool** | The endpoint's dry-run calls `get_pool_size` and never invokes the write tool. §3.6 |
-| `size` range | `2..8` | `1..8` | The tool must be able to express the reversal to `1`. §3.6 |
+| `size` range | `2..8` | `2..8` | **Agreed since 2026-08-20 (#100)** — the `1..8` asymmetry was withdrawn. §3.6 |
 | role names | `Guardian_Resolve`, "illustrative, not ratified" | **ratified here** | §5.3 is the naming authority; the values match its examples |
 
 `investigation-api.md` is the other consumer: its `evidence[].tool` values are names from §1, and its
@@ -455,7 +455,7 @@ Set the configured pool size of one host and apply it to the running production.
 | Field | Type | Req | Notes |
 |---|---|---|---|
 | `host` | string | **required** | Must be `Cloud API`. Whitelist of one. |
-| `size` | integer | **required** | `1..8` inclusive — see bounds below. |
+| `size` | integer | **required** | `2..8` inclusive — see bounds below. |
 
 **There is no `dryRun` parameter, deliberately.** This tool always writes. Preview is
 `get_pool_size`, a *read* tool. That is a reconciliation with `resolve-api.md` §2, which guarantees
@@ -509,7 +509,7 @@ partial-apply mode being added without a discriminator.
    would otherwise make this method a silent no-op that reports success, and `CheckProduction()` does
    not catch it because it compares only the production *name*. **A write tool that reports applied
    and applied nothing is the worst failure in this file.**
-3. **Bounds.** `host` must be `Cloud API`; `size` must be an integer in `1..8`. Anything else is an
+3. **Bounds.** `host` must be `Cloud API`; `size` must be an integer in `2..8`. Anything else is an
    error, not a clamp — clamping `40` to `8` would apply a change nobody approved, report it as
    applied, and be indistinguishable in the audit log from someone deliberately choosing `8`.
 4. **Reversibility is returned, not remembered.** `previousSize` and `reversal` are in the response
@@ -522,13 +522,27 @@ partial-apply mode being added without a discriminator.
    copying it here would add an `Ens.Config.Setting` row named `PoolSize` that changes nothing while
    reporting success — #66's failure mode in a new place.
 
-**Why `1..8`, and why the tool's range is wider than the endpoint's.** This is deliberate and the
-asymmetry is the point:
+**Why `2..8` at both layers — the asymmetry was withdrawn on 2026-08-20 (#100).**
 
 | Layer | Range | Why |
 |---|---|---|
 | `POST /api/resolve` (`resolve-api.md` §3) | `2..8` | An operator-facing action. `1` is the shipped value, so approving it is a no-op dressed as a fix. |
-| `set_pool_size` (here) | `1..8` | Must be able to express the **reversal**. `previousSize` is `1`, so a tool that refuses `1` cannot undo its own first call. |
+| `set_pool_size` (here) | `2..8` | Same reason. The tool is LLM-callable, so `1` is the *worst* value to accept: it reports success and changes nothing. |
+
+This section previously ratified `1..8` here against `2..8` at the endpoint, on the grounds that "a
+tool that refuses `1` cannot undo its own first call". **The premise was true and the conclusion did
+not follow**, which is the third time on this contract set that shape has cost us something (see the
+`%`-prefix paragraph and §5.5's audit claim).
+
+Two things it missed. `Tools.Resolve` has shipped `MINSIZE = 2` since the tools landed and its own
+comment rejects the reversal argument by name — *"Reversal to `1` is `Reset()`'s job, through a path
+that is not LLM-callable"* — so the ratified range never described the implementation. And
+`resolve-api.md` §4 promised the caller could POST the reversal body back to undo, while §3 refused
+exactly that body: the undo path the wider bound existed to serve **did not work at either layer**.
+
+`resolve-api.md` §4.1 now records reversal as a *record of the prior value* rather than a request, and
+restoring the pool is an operator action through `Triggers.Reset()`. With no POST-the-reversal path,
+nothing needs `1`, and accepting it in an LLM-callable tool is a liability rather than a capability.
 
 `8` is the shared ceiling, for `resolve-api.md`'s reason: every pool job is a real IRIS process, and
 an unbounded `size` lets one fat-fingered digit — or one hallucinated number — spawn hundreds of jobs
@@ -1032,7 +1046,7 @@ owner does not match its actual one is how a review gets skipped.
 `README.md` in this directory does not yet list this file in its owner table. Adding it belongs to
 the same PR as publishing this file.
 
-**These changes are contract changes, not configuration:** the `1..8` bound on `size`, the
+**These changes are contract changes, not configuration:** the `2..8` bound on `size`, the
 `Cloud API` whitelist, the `PG_Read` / `PG_Resolve` split, the listable-but-not-executable decision
 in §5.3, the `get_recent_errors` allowlist and its catalogue policy, and any widening of what a tool
 may return under §6. Each is written here specifically so that changing it requires review rather

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -125,9 +125,9 @@ renders from one type rather than from a status code.
   "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
   "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
   "reversal": {
-    "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
-    "capturedFrom": "live",
-    "automatic": false
+    "host": "Cloud API",
+    "size": 1,
+    "capturedFrom": "live"
   },
   "refusal": null,
   "failure": null,
@@ -163,7 +163,7 @@ renders from one type rather than from a status code.
 | `action` | object | Echoed **as evaluated**, not as sent. If the request was refused for being out of bounds, this still shows what was asked for. |
 | `before` | object \| null | Live state read immediately before the write. `null` only when nothing could be read (`wrong_production`, `host_not_in_production`, `not_authorized`). |
 | `after` | object \| null | Live state read back **after** the update. `null` for `previewed` and for refusals. **Populated even on `failed`** — see §4. |
-| `reversal` | object \| null | How to undo. `null` unless `outcome` is `applied`. See §4. |
+| `reversal` | object \| null | **A record of the prior value, not a request** — `{host, size, capturedFrom}`. `null` unless `outcome` is `applied`. It is not POSTable: `size` is the shipped value and §3 bounds `action.size` at `2..8`. See §4.1. |
 | `refusal` | object \| null | Non-null **iff** `outcome` is `refused`. See §5. |
 | `failure` | object \| null | Non-null **iff** `outcome` is `failed`. See §5.2. |
 | `confirmation` | object | Always present. `status: "not_applicable"` for everything except `applied`. See §7. |
@@ -317,20 +317,51 @@ calling the tool directly. If the two disagree, IRIS wins and the response repor
 ## 4. Reversibility — capture the actual prior value
 
 `before.poolSize` is read from the **live** `Ens.Config.Item.PoolSize` immediately before the
-write, inside the same call, and returned. `reversal.action` is then a fully formed request body
-naming that measured value:
+write, inside the same call, and returned. `reversal` then records that measured value:
 
 ```json
 "reversal": {
-  "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
-  "capturedFrom": "live",
-  "automatic": false
+  "host": "Cloud API",
+  "size": 1,
+  "capturedFrom": "live"
 }
 ```
 
-Dev C can POST it back verbatim to undo. `capturedFrom` is always `"live"`; the field exists so
-that a future value like `"assumed"` would be visible rather than inferred, and so a mock that
-cannot read the live value has to say so instead of emitting a plausible `1`.
+`capturedFrom` is always `"live"`; the field exists so that a future value like `"assumed"` would be
+visible rather than inferred, and so a mock that cannot read the live value has to say so instead of
+emitting a plausible `1`.
+
+### 4.1 `reversal` is a record, not a request — corrected 2026-08-20 (#100)
+
+**This section previously said "Dev C can POST it back verbatim to undo", and wrapped the value in an
+`action` object plus an `automatic` flag to make that possible. Both were withdrawn, because the
+endpoint would refuse that body.**
+
+`reversal.size` is the *shipped* pool size, which for `Cloud API` is `1` — and §3 bounds `action.size`
+at `2..8`, with §5 listing exactly that as `out_of_bounds`. So the contract handed the caller an undo
+request and then declined it. That is a self-contradiction inside this document, independent of any
+implementation.
+
+**The resolution is that reversal is documentation.** It answers *what was the value before* so an
+operator can restore it, and it is deliberately not a body anything POSTs:
+
+- **`1` must stay unapprovable.** §3.6's reason is sound — `1` is the shipped value, so approving it
+  is a no-op dressed as a fix that would report success, change nothing, and leave an operator
+  believing the problem was addressed. Widening the bound to `1..8` to make the undo POSTable would
+  trade a real safety property for a convenience.
+- **Restoring the pool is an operator action**, through `Triggers.Reset()`, which is deliberately not
+  LLM-callable. "Reversible" means *the prior value is measured, recorded and restorable* — which is
+  true, provable and what the demo actually does.
+- **A second write path is out of scope.** MVP 2 §1.3 puts a generalised action catalogue in later
+  work, and root `CLAUDE.md` §2 now requires a spec before anything beyond the one action is built.
+
+**The shape is now flat, matching what every component already shipped.** `Tools.Resolve`, the engine
+and the mock all emitted `{host, size, capturedFrom}` and nothing ever emitted `automatic` — so here
+the *contract* was the outlier rather than the code, which is the reverse of the usual direction and
+is why it went unnoticed for a week. `action` and `automatic` are removed: an `action` wrapper exists
+to make a body dispatchable, and this body is not dispatched.
+
+**Consumer impact: none.** No component is losing a field it emitted or read.
 
 **Never hardcode the restore value.** This is not a hypothetical — it is a bug that was found and
 fixed in the exact write path this tool wraps. `Triggers.ErrorRate()` points `Cloud API` at a
@@ -973,9 +1004,9 @@ load-bearing parts:
   "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
   "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
   "reversal": {
-    "action": { "type": "set_pool_size", "host": "Cloud API", "size": 1 },
-    "capturedFrom": "live",
-    "automatic": false
+    "host": "Cloud API",
+    "size": 1,
+    "capturedFrom": "live"
   },
   "confirmation": { "status": "pending", "findingId": "f-1042" },
   "audit": { "actor": "guardian_resolve", "auditId": "pg-audit-44812", "source": "live" }


### PR DESCRIPTION
Closes #100. A contract change, so per root `CLAUDE.md` §4: its own PR, a `CHANGELOG.md` entry, and it needs your review.

## The contradiction

`resolve-api.md` §4 told the caller:

> Dev C can POST it back verbatim to undo

with `reversal.action.size` set to the shipped pool size — `1`. §3 bounds `action.size` at `2..8`, and §5 lists exactly that as `out_of_bounds`.

**The endpoint handed the caller an undo request and then refused it.** Internal to one document; no implementation needed to be wrong.

## The resolution — reversal is documentation, not a request

Taking option 1 from the issue, for the reason your #110 entry supplied rather than the one I originally had.

`1` **stays unapprovable**, because §3.6's argument is sound: it is the shipped value, so approving it is a no-op dressed as a fix that reports success, changes nothing, and leaves an operator believing the problem was addressed. Widening the bound to make the undo POSTable would trade a real safety property for a convenience.

Restoring the pool is an operator action through `Triggers.Reset()`, deliberately not LLM-callable. So **"reversible" now means the prior value is measured, recorded and restorable** — true, provable, and what the demo actually does. A second write path would need its own spec under root `CLAUDE.md` §2, which is the accretion your MVP 2 record exists to prevent.

## The contract was the outlier, not the code

This is your observation from #110 and it is what decided the direction. `reversal` was specified as `{action: {...}, capturedFrom, automatic}`. `Tools.Resolve`, the engine and the mock all shipped flat `{host, size, capturedFrom}`, and **nothing ever emitted `automatic`**.

Four components agreed with each other and disagreed with the document — the reverse of the usual direction, and why this survived a week. So the shape is now flat, matching them. `action` existed to make a body dispatchable and this body is not dispatched.

**No consumer loses a field it read or emitted.**

## And `set_pool_size` was never `1..8`

§3.6 ratified `1..8` for the tool against `2..8` for the endpoint, arguing *"a tool that refuses `1` cannot undo its own first call"*. The premise was true and the conclusion did not follow — **the third time that shape has cost us something on this contract set**, after the `%`-prefix paragraph and §5.5's audit claim.

Two things it missed:

- `Tools.Resolve` has shipped `MINSIZE = 2` since the tools landed, and its comment rejects the reversal argument **by name**: *"Reversal to `1` is `Reset()`'s job, through a path that is not LLM-callable."* The ratified range never described the implementation.
- The undo path the wider bound existed to serve **did not work at either layer**.

Both are `2..8`. Four references updated: the reconciliation table, the input table, §3.6's bounds list, and §10's contract-change note.

## What I could not verify

**I could not run `validate.mjs` locally — `ajv` is not installed here — so CI is the check.** No sample or schema is added, so the counts should be unchanged at 15/19/7, which is itself the gap your 2026-08-20 entry records. I would rather say that than imply I ran it.

## Deliberately not in this PR

Both documents' headers still say **Dev A has left** and name **Dev C** as a consumer — the same stale premise root `CLAUDE.md` §3 carried until #113. I kept it out so this PR describes one decision, which is the scope-mixing I asked you to avoid on #106. Happy to take it as a follow-up once #113 lands, so the contracts and the root table agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
