### PR TITLE
contracts: MVP 3's two changes, and the first schema for an MVP 2 contract

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,100 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-20 — MVP 3's two contract changes, and the first MVP 2 schema (Dev B)
+
+**Two documents changed, one schema and one captured sample added.** `validate.mjs` goes from
+2 samples / 19 reject to **3 samples / 26 reject**. Reviewed by Dev A before merge, per §4.
+
+### 1. `investigation-api.md` §3.3a — `manualRemediation`
+
+MVP 3's scenario is a finding with **no governed action**: a service polls a directory that does not
+exist, and the fix is an operator changing a setting. §3.1 already allows `recommendedAction: null`,
+so the *absence* of a fix was expressible; a recommendation **in words** was not, and §3.3 is right
+that `recommendedAction` must stay a structured object.
+
+So this is an additive nullable sibling, and the reason it is a separate field rather than a flag is
+worth stating plainly: the two carry different **authority**.
+
+- `recommendedAction` — *there is a fix and the system may apply it, with approval*
+- `manualRemediation` — *there is a fix and the system may not apply it at all*
+
+Two shapes make the wrong UI **unrepresentable**: there is no `action` object to send, so a consumer
+cannot render an approve control for it. One shape with an `applyable: false` flag makes the wrong UI
+a forgotten `if`, and the thing being designed out is an approve button next to a recommendation the
+system cannot carry out — which a human would click.
+
+`appliedBy` is enumerated with `operator` as its only member, so autonomous remediation becomes a
+contract change rather than a code change.
+
+### 2. `mcp-tools.md` §3.4 — `get_recent_errors` reconciled with the implementation
+
+This table specified a response the tool has never emitted, and the shapes differed **in kind**:
+
+| | contract, before | `Tools/Read.cls` |
+|---|---|---|
+| window echo | `windowMinutes` | `sinceMinutes` |
+| array | `errors[]` of `{occurredAt, errorCode, sourceClass, summary}` | `byCode[]` of `{errorCode, count}` |
+| `truncated`, `limit` | specified | absent |
+
+**The implementation's shape is kept and the contract corrected to it, except `summary`.** Aggregation
+is what the one consumer needs — *what kind of thing is going wrong and how often* — and per-event
+rows invite an agent to reason about individual occurrences, which is exactly the reasoning the data
+boundary cannot support: the row it would want to quote is the one that may carry PHI. `limit` and
+`truncated` bounded a list that no longer exists.
+
+`summary` is added rather than dropped, because MVP 3 needs it, and §3.4a gives it a **catalogue**
+keyed by `errorCode` — `#5021` → *"a configured directory or file path does not exist"*. A fixed
+string cannot carry payload content by construction, which is why it is safe to send.
+
+§3.4a also refuses the shortcut it invites: **the allowlist must not gain an exception for `#5021`**
+so the agent can read the missing path out of the message. An allowlist with one exception is one an
+implementer widens, and "the path is usually harmless" is the rare-rather-than-absent pattern that
+survives review and then leaks. The path comes from configuration; the catalogue supplies the kind.
+
+`occurredAt` and `sourceClass` are dropped, not deferred — neither is emitted, neither is needed, and
+`occurredAt` on an aggregate is meaningless. A field specified and unimplemented for a month is a
+claim the document should stop making.
+
+### 3. `investigation.schema.json` — the first machine-readable MVP 2 contract
+
+The 2026-08-20 entry above recorded that all four MVP 2 contracts were prose-only and that five
+field-level divergences had reached `main` in shapes nothing validated. This closes that for the one
+document MVP 3 edits.
+
+`samples/investigation-response.json` is **captured from a live run** — `source: "agent"`,
+`gpt-4o-mini`, 5 tool calls, five `mcp_tool` evidence bullets — with only the ids and timestamp
+pinned so the fixture does not move. Same rule as the MVP 1 samples: a hand-written sample proves the
+schema accepts what its author imagined; a captured one proves it accepts what the system emits.
+
+**Seven negative cases, each a real defect or a safety property**, because a schema that accepts
+everything would pass the positive case too:
+
+```
+rejects: manualRemediation carrying an action object -- a UI could render Approve for it
+rejects: appliedBy 'system' -- autonomous remediation, which root CLAUDE.md §2.1 forbids
+rejects: target carrying a message-content key -- the data boundary in schema form
+rejects: steps: [] -- a manual remediation with no steps says nothing
+rejects: evidence source 'tool' instead of 'mcp_tool' -- the enum that keeps provenance honest
+rejects: action with a fourth key -- resolve-api.md §1.1 refuses unknown keys inside action
+rejects: action.type 'restart_host' -- one action type, enumerated so a second is a decision
+```
+
+The first three are the ones that could not be caught by a TypeScript type: they are **values and
+extra keys**, not shapes. That is the lesson from `capturedFrom: "live production"` (#111), which
+sat in a correctly-typed string field and survived four readings of the line.
+
+### Deliberately not done
+
+`earlywarning-api.md` and `resolve-api.md` get no schema here. **MVP 3 does not touch them**, and
+retrofitting two documents nothing is about to edit would be scope this change does not need. They
+remain prose-only and that remains a known gap — recorded in the 2026-08-20 entry above rather than
+silently carried.
+
+`earlywarning-api.md` also still reads `Status: proposed` while its endpoint is shipped and consumed
+by the merged dashboard. Left alone for the same reason, and flagged so it is a decision.
+
+
 ## 2026-08-20 — `reversal` is a record, not a request; the `1..8` asymmetry withdrawn (Dev A)
 
 Closes #100. **Two files, no field added and none removed that anything emitted.** `resolve-api.md`

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -390,6 +390,67 @@ spelling, same types — and §1.1 **refuses unknown keys inside `action`** (`ma
 
 `additionalProperties: false` at both levels.
 
+### 3.3a `manualRemediation` — a fix that is not ours to apply
+
+**MVP 3.** `recommendedAction` above stays exactly as specified: a structured object whose `action`
+travels verbatim to `POST /api/resolve`. This is a **separate, additive, nullable sibling** for the
+case where the agent knows the fix and the system may not perform it.
+
+```json
+{
+  "recommendedAction": null,
+  "manualRemediation": {
+    "summary": "EMR Source polls a directory that does not exist",
+    "steps": [
+      "Create the directory /tmp/labdemo/hl7-in/ on the IRIS host, or",
+      "point EMR Source's FilePath setting at an existing directory"
+    ],
+    "target": { "host": "EMR Source", "setting": "FilePath", "currentValue": "/tmp/labdemo/hl7-in-missing/" },
+    "appliedBy": "operator"
+  }
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `summary` | string | One line naming the condition. Rendered as-is; not a button label — there is no button. |
+| `steps` | array of string | Ordered, imperative, each independently actionable. Rendered as a list, verbatim. |
+| `target` | object \| null | What to change, **configuration only**: `{ host, setting, currentValue }`. `null` when the agent could not identify it. |
+| `appliedBy` | string | Enumerated. **`operator` is the only member.** Present so a second value is a contract change rather than a code change. |
+| `steps[]` | — | **Never contains message content or PHI** — same boundary as everything else that leaves the instance (§6 of `mcp-tools.md`). |
+
+`additionalProperties: false`.
+
+**WHY A SEPARATE FIELD RATHER THAN LOOSENING `recommendedAction`.** §3.3 is right that a recommended
+action is a structured object and never prose — that is what makes it safe to hand to a write
+endpoint. Adding a `prose` variant, or an `applyable: false` flag, would put two things with
+different **authority** into one shape:
+
+- `recommendedAction` means *"there is a fix and the system may apply it, with your approval"*
+- `manualRemediation` means *"there is a fix and the system may not apply it at all"*
+
+Two shapes make the wrong UI **unrepresentable**: a consumer cannot render an approve control for a
+`manualRemediation`, because there is no `action` object to send. One shape with a boolean makes the
+wrong UI a forgotten `if`. The failure mode being designed out is an approve button appearing next
+to a recommendation the system cannot carry out — the single worst thing this endpoint could cause,
+because a human would click it.
+
+**BOTH MAY BE NULL, AND THAT IS STILL A VALID INVESTIGATION.** §3.1 already allows
+`recommendedAction: null` on a `complete` investigation. `manualRemediation: null` alongside it means
+the agent explained the condition and recommended nothing — which stays legal and must render as
+*no recommended action* rather than as an error.
+
+**THEY ARE MUTUALLY EXCLUSIVE IN PRACTICE AND NOT ENFORCED HERE.** Nothing in this contract forbids
+both being non-null; a future condition might legitimately have a bounded action *and* a manual
+follow-up. A consumer that receives both must render both, and must not treat `manualRemediation` as
+a reason to suppress the approve control for a genuine `recommendedAction`.
+
+**ACCEPTANCE IS THE ABSENCE OF A CONTROL, WHICH IS WHY IT NEEDS AN EXPLICIT CHECK.** *"With a
+`manualRemediation` finding open, the drawer shows the summary and steps and NO Preview or Approve
+button."* A missing negative is invisible: every check can pass while the control is wrongly present,
+because nothing asserts what should not be there. Stated here rather than left to the UI, because
+this contract is where the authority distinction lives.
+
 **Dev C must not build a translation layer.** Take `recommendedAction.action` and send it as
 `action`; take `currentValue` and send it as `precondition.poolSize`. Any reshaping between the two
 endpoints is the prose-parsing failure with extra steps, which is `resolve-api.md` §1.2's stated

--- a/contracts/investigation.schema.json
+++ b/contracts/investigation.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://production-guardian/contracts/investigation.schema.json",
+  "title": "Production Guardian — AI Detective API",
+  "description": "Schema for POST /api/investigate. Owner: Dev B. See investigation-api.md. Added 2026-08-20 with MVP 3's manualRemediation, because five field-level divergences had already reached main in shapes nothing validated.",
+
+  "definitions": {
+    "ResolveAction": {
+      "description": "Exactly three keys. resolve-api.md §1.1 refuses unknown keys inside action, so additionalProperties: false here is the same rule stated where a validator can enforce it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "host", "size"],
+      "properties": {
+        "type": { "const": "set_pool_size" },
+        "host": { "type": "string", "minLength": 1 },
+        "size": { "type": "integer" }
+      }
+    },
+
+    "RecommendedAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "currentValue",
+        "bounds",
+        "reversible",
+        "requiresApproval",
+        "summary"
+      ],
+      "properties": {
+        "action": { "$ref": "#/definitions/ResolveAction" },
+        "currentValue": { "type": ["integer", "null"] },
+        "bounds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min", "max"],
+          "properties": {
+            "min": { "type": "integer" },
+            "max": { "type": "integer" }
+          }
+        },
+        "reversible": { "type": "boolean" },
+        "requiresApproval": { "type": "boolean" },
+        "summary": { "type": "string" }
+      }
+    },
+
+    "ManualRemediation": {
+      "description": "MVP 3, §3.3a. A fix the system may NOT apply. Deliberately has no `action` object: a consumer cannot render an approve control for it, which makes the wrong UI unrepresentable rather than merely discouraged.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "steps", "target", "appliedBy"],
+      "properties": {
+        "summary": { "type": "string", "minLength": 1 },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "target": {
+          "description": "Configuration only. Never message content -- see mcp-tools.md §6.",
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "required": ["host", "setting", "currentValue"],
+          "properties": {
+            "host": { "type": "string", "minLength": 1 },
+            "setting": { "type": "string", "minLength": 1 },
+            "currentValue": { "type": ["string", "null"] }
+          }
+        },
+        "appliedBy": {
+          "description": "Enumerated so a second value is a contract change rather than a code change.",
+          "enum": ["operator"]
+        }
+      }
+    },
+
+    "EvidenceItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "detail", "source", "tool"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "detail": { "type": "string", "minLength": 1 },
+        "source": {
+          "description": "§3.2. `llm` means the model asserted it and nothing measured it -- the distinction a human approving a write is entitled to see.",
+          "enum": ["mcp_tool", "snapshot", "llm"]
+        },
+        "tool": { "type": ["string", "null"] }
+      }
+    },
+
+    "InvestigationResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requestId",
+        "findingId",
+        "state",
+        "source",
+        "investigatedAt",
+        "rootCause",
+        "evidence",
+        "confidence",
+        "recommendedAction",
+        "diagnostics"
+      ],
+      "properties": {
+        "requestId": { "type": "string", "minLength": 1 },
+        "findingId": { "type": "string", "minLength": 1 },
+        "state": { "enum": ["complete", "degraded", "unavailable"] },
+        "source": {
+          "description": "`canned` is the mock agent. Enumerated because a canned investigation presenting itself as live is the same defect class as a projection shown as a measurement.",
+          "enum": ["agent", "cache", "canned", "none"]
+        },
+        "investigatedAt": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+        },
+        "rootCause": {
+          "description": "NULL IS A LEGITIMATE ANSWER (§4.4) -- the engine declining to invent an explanation. Not a loading state and not an error.",
+          "type": ["string", "null"]
+        },
+        "evidence": { "type": "array", "items": { "$ref": "#/definitions/EvidenceItem" } },
+        "confidence": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "recommendedAction": {
+          "oneOf": [{ "$ref": "#/definitions/RecommendedAction" }, { "type": "null" }]
+        },
+        "manualRemediation": {
+          "description": "MVP 3, optional and additive. Absent on an MVP 2 response; null when the agent recommended nothing manual.",
+          "oneOf": [{ "$ref": "#/definitions/ManualRemediation" }, { "type": "null" }]
+        },
+        "diagnostics": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["model", "toolCalls", "durationMs", "note"],
+          "properties": {
+            "model": { "type": ["string", "null"] },
+            "toolCalls": { "type": ["integer", "null"] },
+            "durationMs": { "type": ["integer", "null"] },
+            "note": { "type": ["string", "null"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -283,28 +283,82 @@ Recent error events for one host, **sanitised**. Read §6 before implementing th
 | Field | Type | Req | Notes |
 |---|---|---|---|
 | `host` | string | **required** | Config item name. |
-| `sinceMinutes` | integer | optional, default `15` | Window, 1..60. |
-| `limit` | integer | optional, default `20` | Max events returned, 1..50. |
+| `sinceMinutes` | integer | optional, default `15` | Window, 1..60. Bounded rather than open — see §6. |
 
 **Output**
 
 | Field | Type | Notes |
 |---|---|---|
 | `host` | string | Echoed. |
-| `windowMinutes` | integer | The window actually applied. |
-| `count` | integer \| null | Events in the window. `null` when the log could not be read. |
-| `errors` | array | At most `limit` entries, newest first. |
-| `truncated` | boolean | `true` when `count > limit`. |
+| `sinceMinutes` | integer | The window actually applied. **Echoes the input name** — see the reconciliation note below. |
+| `count` | integer \| null | Events in the window. `null` when the log could not be read, **never `0`**. |
+| `byCode` | array | One entry per distinct `errorCode`, with a count and a catalogue summary. |
 | `sanitised` | boolean | Always `true`. Present so its absence is conspicuous. |
 
-Each entry:
+Each `byCode` entry:
 
 | Field | Type | Notes |
 |---|---|---|
-| `occurredAt` | string | ISO 8601 UTC. |
-| `errorCode` | string | The IRIS error token only — `<Ens>ErrFailureTimeout`, `#6059`, or `unclassified`. |
-| `sourceClass` | string | Class name from the log row. A class name, never an instance value. |
-| `summary` | string \| null | A **catalogue** string keyed by `errorCode`. `null` when unclassified. |
+| `errorCode` | string | The IRIS error token only — `<Ens>ErrFailureTimeout`, `#6059`, `#5021`, or `unclassified`. |
+| `count` | integer | Occurrences of this code in the window. |
+| `summary` | string \| null | A **catalogue** string keyed by `errorCode`, from the table in §3.4a. `null` when unclassified. |
+
+**RECONCILED WITH THE IMPLEMENTATION 2026-08-20, and the contract moved further than the code.** This
+table specified something the tool has never emitted, and the two shapes differed in kind rather than
+by a field (@kskubach, MVP 3 spec §2.4; @Ari-Glikman, #112 review):
+
+| | this table, before | `Tools/Read.cls` |
+|---|---|---|
+| window echo | `windowMinutes` | `sinceMinutes` |
+| array | `errors[]` of per-event rows | `byCode[]` of `{errorCode, count}` |
+| `truncated` | specified | absent |
+| `limit` input | specified | not a parameter |
+| `occurredAt`, `sourceClass` | specified | absent |
+
+**The implementation's shape is kept and the contract corrected to it, except for `summary`.** Three
+reasons, in ascending order of weight:
+
+1. **`sinceMinutes` on both sides.** A different name on input and output is a translation step for no
+   gain, and the divergence proves nobody wanted it. One name.
+2. **Aggregation beats per-event rows for the consumer that exists.** The agent asks *"what kind of
+   thing is going wrong and how often"*, and `byCode` answers exactly that. Per-event rows with
+   timestamps invite an agent to reason about individual occurrences, which is the reasoning the data
+   boundary cannot support — the row it would want to quote is the one that may carry PHI.
+3. **`limit` and `truncated` were solving a problem aggregation removes.** They exist to bound a list
+   of events; there are at most a handful of distinct codes, so there is nothing to truncate. Removing
+   them removes two fields nothing emitted and nothing needed.
+
+**`summary` is the one thing the contract was right about, and it is added rather than dropped.** MVP
+3's missing-folder scenario needs the agent to learn *what kind of failure* `#5021` is without reading
+log text — see §3.4a. It is a property of a code, so it lives on a `byCode` entry naturally, which is
+where the original `errors[]` shape had nowhere to put it.
+
+**`occurredAt` and `sourceClass` are dropped, not deferred.** Neither is emitted, neither is needed by
+the one consumer, and `occurredAt` on an aggregate is meaningless. A field specified and unimplemented
+for a month is a claim the document should stop making.
+
+### 3.4a The `summary` catalogue — configuration knowledge, not log text
+
+`summary` is a **fixed string looked up by `errorCode`**. It is not derived from the log row, so it
+cannot carry payload-derived content by construction — which is the whole reason it is safe to send
+and the reason it is a catalogue rather than a message excerpt.
+
+| `errorCode` | `summary` |
+|---|---|
+| `#5021` | `a configured directory or file path does not exist` |
+| `#6059` | `the configured downstream host or port could not be reached` |
+| `<Ens>ErrFailureTimeout` | `the host retried and gave up within its failure timeout` |
+| `unclassified` | `null` |
+
+**THE ALLOWLIST MUST NOT GAIN AN EXCEPTION FOR `#5021`.** The obvious shortcut for MVP 3 is to return
+`#5021`'s message text, because it contains the missing path and the path is *usually* harmless. That
+is the wrong shape twice over: an allowlist with one exception is an allowlist an implementer widens,
+and "usually harmless" is the rare-rather-than-absent pattern that survives review and then leaks.
+The path is obtained instead from the host's configured settings — configuration, which §6 permits —
+and this catalogue supplies the *kind* of failure.
+
+**Adding a row is a contract change**, deliberately. A code that reaches an agent with a
+human-readable meaning is a decision about what the model is told, not an implementation detail.
 
 **Wraps** `Ens.Util.Log` filtered to error and alert types for the host, plus a count of
 `Ens.MessageHeader` rows at `Status = 8` (Error) — the same `MSGSTATUSERROR = 8` that
@@ -375,37 +429,54 @@ Raw rows in `Ens_Util.Log` (what the tool reads, and what it must not publish):
 
 ```jsonc
 // -> get_recent_errors
-{ "host": "Cloud API", "sinceMinutes": 15, "limit": 20 }
+{ "host": "Cloud API", "sinceMinutes": 15 }
 ```
 
 ```jsonc
 // <- what the agent, and therefore the external LLM, sees
 {
   "host": "Cloud API",
-  "windowMinutes": 15,
+  "sinceMinutes": 15,
   "count": 42,
-  "truncated": true,
   "sanitised": true,
-  "errors": [
+  "byCode": [
     {
-      "occurredAt": "2026-08-18T07:46:29.533Z",
       "errorCode": "<Ens>ErrFailureTimeout",
-      "sourceClass": "ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation",
-      "summary": "The host did not complete a message within its FailureTimeout."
+      "count": 27,
+      "summary": "the host retried and gave up within its failure timeout"
     },
     {
-      "occurredAt": "2026-08-18T07:46:29.533Z",
       "errorCode": "#6059",
-      "sourceClass": "ProductionGuardian.LabDemo.Operation.PatientDemographicsOperation",
-      "summary": "Could not open a TCP/IP socket to the configured target."
+      "count": 15,
+      "summary": "the configured downstream host or port could not be reached"
     }
   ]
 }
 ```
 
-Note what did **not** survive: the `127.0.0.1:59999` target, the timeout value, and every character
-of the original text. `summary` is written by us, indexed by code. The two entries share a timestamp
-because the raw rows do — that is a real property of `Ens.Util.Log`, not a formatting artefact.
+And the MVP 3 scenario, where the host is a service that cannot read its inbound directory:
+
+```jsonc
+// <- get_recent_errors for EMR Source
+{
+  "host": "EMR Source",
+  "sinceMinutes": 15,
+  "count": 8,
+  "sanitised": true,
+  "byCode": [
+    { "errorCode": "#5021", "count": 8, "summary": "a configured directory or file path does not exist" }
+  ]
+}
+```
+
+Note what did **not** survive: the `127.0.0.1:59999` target, the timeout value, the missing path, and
+every character of the original text. `summary` is written by us and indexed by code (§3.4a), so the
+agent learns the KIND of failure from this tool and the offending path from the host's configured
+settings — never from a log row.
+
+**The `#5021` entry is the whole reason MVP 3 needs this tool at all**, and it is also why the tool
+alone is insufficient: `count: 8` and that summary tell the agent a path is missing and not *which*
+path. Naming it requires reading configuration, which is a different tool and a different boundary.
 
 ### 3.5 `get_processing_time` — read
 

--- a/contracts/samples/investigation-response.json
+++ b/contracts/samples/investigation-response.json
@@ -1,0 +1,62 @@
+{
+  "requestId": "inv-queue_buildup:Cloud API-1755691200000",
+  "findingId": "f-1042",
+  "state": "complete",
+  "source": "agent",
+  "investigatedAt": "2026-08-20T10:00:00Z",
+  "rootCause": "The Cloud API host has a configured pool size of 1, which means it can only process one message at a time. With a current queue depth of 67 and an average queueing time of over 35 seconds, the host is unable to keep up with incoming messages, leading to a significant backlog.",
+  "evidence": [
+    {
+      "label": "Host Status",
+      "detail": "The host is OK and enabled.",
+      "source": "mcp_tool",
+      "tool": "GetHostStatus"
+    },
+    {
+      "label": "Pool Size",
+      "detail": "Configured pool size is 1.",
+      "source": "mcp_tool",
+      "tool": "GetPoolSize"
+    },
+    {
+      "label": "Average Processing Time",
+      "detail": "Average processing time is 1.01 seconds.",
+      "source": "mcp_tool",
+      "tool": "GetProcessingTime"
+    },
+    {
+      "label": "Average Queueing Time",
+      "detail": "Average queueing time is 35.35 seconds.",
+      "source": "mcp_tool",
+      "tool": "GetProcessingTime"
+    },
+    {
+      "label": "Current Queue Depth",
+      "detail": "Current queue depth is 67.",
+      "source": "mcp_tool",
+      "tool": "GetQueueDepth"
+    }
+  ],
+  "confidence": 0.9,
+  "recommendedAction": {
+    "action": {
+      "type": "set_pool_size",
+      "host": "Cloud API",
+      "size": 2
+    },
+    "currentValue": null,
+    "bounds": {
+      "min": 2,
+      "max": 8
+    },
+    "reversible": true,
+    "requiresApproval": true,
+    "summary": "increase Cloud API pool ? -> 2"
+  },
+  "diagnostics": {
+    "model": "gpt-4o-mini",
+    "toolCalls": 5,
+    "durationMs": 8472,
+    "note": null
+  }
+}

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -30,11 +30,80 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const SCHEMA_ID = 'https://production-guardian/contracts/healthscan.schema.json';
 const PROXY_SCHEMA_ID = 'https://production-guardian/contracts/proxy.schema.json';
+const INVESTIGATION_SCHEMA_ID = 'https://production-guardian/contracts/investigation.schema.json';
 
 /** Each sample is validated against ONE named definition, never "either". */
 const CASES = [
   { file: 'samples/hosts-response.json', definition: 'HostsResponse' },
   { file: 'samples/findings-response.json', definition: 'FindingsResponse' },
+];
+
+/**
+ * The MVP 2/3 investigation shape, validated against its own schema.
+ *
+ * `samples/investigation-response.json` is CAPTURED from a live run against a real LLM
+ * (`source: "agent"`, gpt-4o-mini, 5 tool calls) with only the ids and timestamp pinned so the
+ * fixture does not move. Same rule as the MVP 1 samples: a hand-written sample proves the schema
+ * accepts what its author imagined, and a captured one proves it accepts what the system emits.
+ */
+const INVESTIGATION_CASES = [
+  { file: 'samples/investigation-response.json', definition: 'InvestigationResponse' },
+];
+
+/**
+ * Investigation cases that must FAIL, and each one is a defect that actually reached `main` or a
+ * safety property the schema exists to hold.
+ *
+ * The first two are the reason `manualRemediation` is a separate shape rather than a flag: a
+ * consumer must not be able to receive something that looks approvable when it is not.
+ */
+const INVESTIGATION_MUST_REJECT = [
+  {
+    name: 'manualRemediation carrying an action object — a UI could render Approve for it',
+    definition: 'ManualRemediation',
+    data: {
+      summary: 'EMR Source polls a directory that does not exist',
+      steps: ['create the directory'],
+      target: null,
+      appliedBy: 'operator',
+      action: { type: 'set_pool_size', host: 'EMR Source', size: 4 },
+    },
+  },
+  {
+    name: "appliedBy 'system' — autonomous remediation, which root CLAUDE.md §2.1 forbids",
+    definition: 'ManualRemediation',
+    data: { summary: 'x', steps: ['y'], target: null, appliedBy: 'system' },
+  },
+  {
+    name: 'target carrying a message-content key — the data boundary in schema form',
+    definition: 'ManualRemediation',
+    data: {
+      summary: 'x',
+      steps: ['y'],
+      appliedBy: 'operator',
+      target: { host: 'EMR Source', setting: 'FilePath', currentValue: '/x', messageBody: 'PID|...' },
+    },
+  },
+  {
+    name: 'steps: [] — a manual remediation with no steps says nothing',
+    definition: 'ManualRemediation',
+    data: { summary: 'x', steps: [], target: null, appliedBy: 'operator' },
+  },
+  {
+    name: "evidence source 'tool' instead of 'mcp_tool' — the enum that keeps provenance honest",
+    definition: 'EvidenceItem',
+    data: { label: 'a', detail: 'b', source: 'tool', tool: null },
+  },
+  {
+    name: 'action with a fourth key — resolve-api.md §1.1 refuses unknown keys inside action',
+    definition: 'ResolveAction',
+    data: { type: 'set_pool_size', host: 'Cloud API', size: 4, force: true },
+  },
+  {
+    name: "action.type 'restart_host' — one action type in MVP 2, enumerated so a second is a decision",
+    definition: 'ResolveAction',
+    data: { type: 'restart_host', host: 'Cloud API', size: 4 },
+  },
 ];
 
 /**
@@ -498,6 +567,7 @@ const ajv = new Ajv({ strict: false, allErrors: true });
 addFormats(ajv);
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'healthscan.schema.json'), 'utf8')));
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'proxy.schema.json'), 'utf8')));
+ajv.addSchema(JSON.parse(readFileSync(join(here, 'investigation.schema.json'), 'utf8')));
 
 const validatorFor = (definition) => {
   const validate = ajv.getSchema(`${SCHEMA_ID}#/definitions/${definition}`);
@@ -508,6 +578,12 @@ const validatorFor = (definition) => {
 const proxyValidatorFor = (definition) => {
   const validate = ajv.getSchema(`${PROXY_SCHEMA_ID}#/definitions/${definition}`);
   if (validate === undefined) throw new Error(`no such proxy definition: ${definition}`);
+  return validate;
+};
+
+const investigationValidatorFor = (definition) => {
+  const validate = ajv.getSchema(`${INVESTIGATION_SCHEMA_ID}#/definitions/${definition}`);
+  if (validate === undefined) throw new Error(`no such investigation definition: ${definition}`);
   return validate;
 };
 
@@ -530,6 +606,18 @@ for (const { name, definition, data } of MUST_ACCEPT) {
   const ok = validate(data);
   report(ok, `accepts: ${name}`);
   if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+}
+
+for (const { file, definition } of INVESTIGATION_CASES) {
+  const validate = investigationValidatorFor(definition);
+  const data = JSON.parse(readFileSync(join(here, file), 'utf8'));
+  report(validate(data), `${file} validates as ${definition}`);
+  if (validate.errors) console.log(JSON.stringify(validate.errors, null, 2));
+}
+
+for (const { name, definition, data } of INVESTIGATION_MUST_REJECT) {
+  const validate = investigationValidatorFor(definition);
+  report(!validate(data), `rejects: ${name}`);
 }
 
 for (const { name, definition, data } of MUST_REJECT) {
@@ -556,8 +644,8 @@ for (const { name, re } of CAPTURE_CLAIMS) {
 
 console.log(
   failures === 0
-    ? `\nall checks passed (${CASES.length} samples, ${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length} accept, `
-      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length} reject, ${CAPTURE_CLAIMS.length} capture claims)`
+    ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length} samples, ${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length} accept, `
+      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length} reject, ${CAPTURE_CLAIMS.length} capture claims)`
     : `\n${failures} check(s) failed`,
 );
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
**Contract change PR — needs @kskubach's review before merge**, per root `CLAUDE.md` §4. Two documents, one schema, one captured sample. **No code changed**, and the matching `Tools/Read.cls` work is Dev A's area and deliberately not here.

`validate.mjs`: **2 samples / 19 reject → 3 samples / 26 reject.**

## 1. `investigation-api.md` §3.3a — `manualRemediation`

MVP 3's scenario is a finding with **no governed action**. §3.1 already allows `recommendedAction: null`, so the *absence* of a fix was expressible; a recommendation **in words** was not, and §3.3 is right that `recommendedAction` must stay a structured object.

An additive nullable sibling, not a flag — because the two carry different **authority**:

| | |
|---|---|
| `recommendedAction` | *there is a fix and the system may apply it, with approval* |
| `manualRemediation` | *there is a fix and the system may not apply it at all* |

Two shapes make the wrong UI **unrepresentable**: there is no `action` object to send, so a consumer *cannot* render an approve control. One shape with `applyable: false` makes the wrong UI a forgotten `if` — and the thing being designed out is an approve button beside a recommendation the system cannot carry out, which a human would click.

`appliedBy` is enumerated with `operator` as its only member, so autonomous remediation becomes a contract change rather than a code change.

## 2. `mcp-tools.md` §3.4 — `get_recent_errors` reconciled with what ships

You found this in the MVP 3 spec; I verified it and it is a four-point divergence, differing **in kind** rather than by a field:

| | contract, before | `Tools/Read.cls` |
|---|---|---|
| window echo | `windowMinutes` | `sinceMinutes` |
| array | `errors[]` of `{occurredAt, errorCode, sourceClass, summary}` | `byCode[]` of `{errorCode, count}` |
| `truncated`, `limit` | specified | absent |

**The implementation's shape is kept and the contract corrected to it, except `summary`.** Aggregation is what the one consumer needs — *what kind of thing is going wrong and how often*. Per-event rows invite an agent to reason about individual occurrences, and that is the reasoning the data boundary cannot support: the row it would want to quote is the one that may carry PHI. `limit` and `truncated` bounded a list that no longer exists.

`summary` is added because MVP 3 needs it, with a **catalogue** in new §3.4a keyed by `errorCode` — `#5021` → *"a configured directory or file path does not exist"*. A fixed string cannot carry payload content by construction.

§3.4a also writes down the refusal your spec argued for: **the allowlist must not gain an exception for `#5021`** so the agent can read the path out of the message. One exception is an allowlist an implementer widens, and *"the path is usually harmless"* is the rare-rather-than-absent pattern.

`occurredAt` and `sourceClass` are **dropped, not deferred** — neither emitted, neither needed, and `occurredAt` on an aggregate is meaningless. A field specified and unimplemented for a month is a claim the document should stop making. Say if you would rather keep them for a future per-event tool.

## 3. `investigation.schema.json` — the first machine-readable MVP 2 contract

The sample is **captured from a live run**: `source: "agent"`, `gpt-4o-mini`, 5 tool calls, five `mcp_tool` evidence bullets, ids and timestamp pinned so the fixture does not move. A hand-written sample proves the schema accepts what its author imagined; a captured one proves it accepts what the system emits.

**Seven negative cases**, each a real defect or a safety property:

```
rejects: manualRemediation carrying an action object -- a UI could render Approve for it
rejects: appliedBy 'system' -- autonomous remediation, which root CLAUDE.md §2.1 forbids
rejects: target carrying a message-content key -- the data boundary in schema form
rejects: steps: [] -- a manual remediation with no steps says nothing
rejects: evidence source 'tool' instead of 'mcp_tool' -- the enum that keeps provenance honest
rejects: action with a fourth key -- resolve-api.md §1.1 refuses unknown keys inside action
rejects: action.type 'restart_host' -- one action type, enumerated so a second is a decision
```

**The first three cannot be caught by a TypeScript type** — they are values and extra keys, not shapes. That is your `capturedFrom: "live production"` lesson (#111) turned into enforcement: it sat in a correctly-typed string field and survived four readings of the line.

## Deliberately not in this PR

**`earlywarning-api.md` and `resolve-api.md` get no schema.** MVP 3 does not touch them, and retrofitting two documents nothing is about to edit is scope this change does not need. They stay prose-only and that stays recorded rather than silently carried.

`earlywarning-api.md` also still reads `Status: proposed` while its endpoint is shipped and consumed by the merged dashboard — your point from the #110 review. Flagged, not fixed, so it stays a decision rather than becoming a drive-by.

**`Tools/Read.cls` needs the matching change** — `sinceMinutes` echoed, `summary` per code from §3.4a's catalogue. That is `iris/**`, so it is yours; this PR makes the contract the thing to implement against rather than changing code in your area.

236 engine tests pass, dashboard typechecks, `validate.mjs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
