### PR TITLE
fix(iris): MVP 3 Track A — the scenario with no governed fix, and two defects only a live agent found

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,68 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-23 — `get_host_settings`, and an optional argument does not default (Dev B)
+
+**`mcp-tools.md` only.** No schema change, no sample change — `validate.mjs` stays at 3 samples /
+26 reject. Two edits, one additive and one a correction to a statement that was wrong in a way that
+cost a live investigation.
+
+### 1. §3.4b — `get_host_settings` added
+
+MVP 3's scenario needs the agent to **name** the directory a service cannot read. That value lives
+in exactly two places: the `#5021` log message, and the host's configuration. `get_recent_errors`
+will never return log text — `Ens_Util.Log` on this instance holds 61,772 rows carrying `PatientID`
+in plain text — so without this tool the agent can learn *a path is missing* and never *which path*.
+
+Configuration is what the boundary permits: root `CLAUDE.md` §2.1 is "metrics and configuration only,
+never message content." A setting **value** is configuration by definition — typed by whoever
+deployed the production, not derived from a message.
+
+**An allowlist of nine setting names, not the whole collection.** Returning everything would be one
+`Credentials` row away from handing an external LLM the name of a credential set, and one future
+setting away from something worse, since productions are configured by people and people put
+surprising things in free-text settings. `Credentials` is deliberately absent even though it is only
+an identifier: an agent has no diagnostic use for it that outweighs saying its name out loud. Adding
+a name to the allowlist is a contract change, on purpose — the same reasoning as `set_pool_size`'s
+single whitelisted host and the `#5021` catalogue.
+
+`settingsOnItem` reports the unfiltered count, so "this host has three settings" is distinguishable
+from "the allowlist filtered most of them out". Without it, a host configured entirely through
+refused settings looks identical to one with no configuration at all.
+
+Expected tool count moves **6 → 7**; `Setup.AIHub.Run()` prints it at boot.
+
+### 2. §2 — an optional parameter arrives as `""`, not as its default
+
+The paragraph above it said required-vs-optional is expressed in the ObjectScript signature, which is
+true of the **generated schema** and does not describe what the tool body receives.
+`%AI.ToolMgr.ExecuteTool` passes `""` for a key the model omitted rather than omitting the argument,
+so `sinceMinutes As %Integer = 15` never defaults on the tool path. Measured, same host, same second:
+
+```
+{"host":"EMR Source"}                      -> {"error": "sinceMinutes must be between 1 and 60"}
+{"host":"EMR Source","sinceMinutes":15}    -> 3 errors, #5021 and <Ens>ErrProductionSettingInvalid
+```
+
+A tool declaring an optional parameter and range-checking it therefore **refused every call that
+omitted it**. Live since #106.
+
+**Why it survived that long, and why the fix is in the contract.** The only caller that omits an
+optional parameter is the model. Every hand-written probe, test and demo script passed it explicitly,
+so nothing we ran could see it. And the failure was not an error: blinded to the error codes, the
+agent reasoned from the one value it could still read — `PoolSize 1` — and recommended enlarging the
+pool of a host whose configured directory did not exist. **A tool that refuses is
+indistinguishable, in the narrative, from a tool that found nothing.** That is §2.1's
+unmeasurable-is-not-zero rule arriving through the argument list rather than the return value, which
+is why it belongs next to the schema rule it corrects rather than in a code comment.
+
+The contract now requires the body to restate the default (`if x = "" { set x = default }`) while
+still refusing a value the model sent and got wrong, and asks that samples carry the
+omitted-argument call rather than only the explicit one.
+
+---
+
+
 ## 2026-08-20 — MVP 3's two contract changes, and the first MVP 2 schema (Dev B)
 
 **Two documents changed, one schema and one captured sample added.** `validate.mjs` goes from

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -3,7 +3,7 @@
 **Owner:** Dev B (inherited `iris/**` from Dev A) · **Consumer:** Dev B (agent orchestration), Dev C
 (approval UI, indirectly) · **Runs in:** the `pg-iris` container · **Status:** published
 
-Six tools. Five read, one write. They exist so the **AI Detective** agent can gather evidence about
+**Seven tools since MVP 3. Six read, one write.** They exist so the **AI Detective** agent can gather evidence about
 one condition on one host, and so **Smart Resolve** can apply one bounded action to it. Root
 `CLAUDE.md` §2.1 is the scope boundary; this file is the interface.
 
@@ -72,6 +72,39 @@ is omitted from the generated `required` array; a parameter **without** one is r
 `sinceMinutes As %Integer = 15` is optional *because* it has a default. Do not document a parameter
 as optional and then declare it without a default — the generated schema, not this table, is what
 the agent obeys.
+
+**But the ObjectScript default does not apply on the tool path, and a tool must restate it in the
+body.** `%AI.ToolMgr.ExecuteTool` builds the argument list from the model's JSON and passes `""` for
+a key the model omitted — it does not omit the argument, so `= 15` never fires. A parameter declared
+optional therefore arrives as the empty string, and any range check written against it rejects the
+call. Measured on the same host in the same second:
+
+```
+Invoke("GetRecentErrors", {"host":"EMR Source"})                      -> {"error": "sinceMinutes must be between 1 and 60"}
+Invoke("GetRecentErrors", {"host":"EMR Source", "sinceMinutes": 15})  -> 3 errors, #5021 and <Ens>ErrProductionSettingInvalid
+```
+
+So the signature declares the *schema* and the body must enforce the *default*:
+
+```objectscript
+if sinceMinutes = "" { set sinceMinutes = 15 }   // absence -> default
+if (sinceMinutes < 1) || (sinceMinutes > 60) { ... }   // a wrong value the model SENT is still refused
+```
+
+The two branches are separate on purpose: absence means "use the default", a sent-and-wrong value
+means "refuse and name the range". Collapsing them either way loses one of those.
+
+**Why this is worth a contract paragraph rather than a code comment.** It was live from #106 and
+invisible to every check we had, because the only caller that omits an optional parameter is the
+model — every hand-written probe, test and demo script passed the argument explicitly. It surfaced
+only in a live agent turn, and the failure was not an error: blinded to the error codes, the agent
+reasoned from the one value it could still read (`PoolSize 1`) and recommended enlarging the pool of
+a host whose configured directory did not exist. **A tool that refuses is indistinguishable, in the
+narrative, from a tool that found nothing** — which makes this the same defect class as §2.1's
+unmeasurable-vs-zero, arriving through the argument list instead of the return value.
+
+Any new tool with an optional parameter must do the same, and `contracts/samples/` should carry the
+omitted-argument call rather than only the explicit one.
 
 **Units are seconds**, everywhere a duration appears, matching `healthscan-api.md` Q6. Confirmed
 empirically rather than assumed: `Cloud API` configured at 0.05s latency reports `0.05`.
@@ -477,6 +510,79 @@ settings — never from a log row.
 **The `#5021` entry is the whole reason MVP 3 needs this tool at all**, and it is also why the tool
 alone is insufficient: `count: 8` and that summary tell the agent a path is missing and not *which*
 path. Naming it requires reading configuration, which is a different tool and a different boundary.
+
+### 3.4b `get_host_settings` — read, added in MVP 3
+
+The configured adapter settings for one host, **filtered by an allowlist of setting names**.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `found` | boolean | `false` with an `error` when the host is not in the running production. |
+| `settings` | object | Permitted setting names to their values. Absent names are absent, not null. |
+| `settingsOnItem` | integer | How many settings the item carries **before** filtering. |
+
+Permitted names: `FilePath`, `ArchivePath`, `WorkPath`, `FileSpec`, `PollInterval`, `HTTPServer`,
+`HTTPPort`, `URL`, `TargetConfigNames`, plus `PoolSize` (a property of `Ens.Config.Item`, not a
+settings row — the same value `get_pool_size` publishes, not a second source of truth).
+
+**WHY THIS TOOL EXISTS, and it is a boundary decision rather than a convenience.** MVP 3's scenario
+needs the agent to name a directory a service cannot read. That name lives in exactly two places:
+the `#5021` log message, and the configuration. `get_recent_errors` will never return log text
+(§3.4, §6), so without this tool the agent learns *a path is missing* and never *which path*.
+Configuration is what root `CLAUDE.md` §2.1 permits — a setting value was typed by whoever deployed
+the production, not derived from a message.
+
+**AN ALLOWLIST, NOT THE WHOLE COLLECTION.** Returning every setting is one `Credentials` row away
+from handing an external LLM the name of a credential set, and one future setting away from
+something worse: productions are configured by people, and people put surprising things in free-text
+settings. So the tool names what it returns and refuses the rest by construction — the same
+reasoning as `set_pool_size`'s single whitelisted host.
+
+**`Credentials` is deliberately absent** even though it is only an identifier. It names a stored
+secret, and no diagnosis needs it enough to justify saying its name outside the instance.
+
+**`settingsOnItem` exists so filtering is visible.** Without it, a host configured entirely through
+refused settings looks identical to one with no configuration at all — and "this host has nothing
+set" is a materially different diagnosis from "I am not allowed to see what is set".
+
+```jsonc
+// -> get_host_settings
+{ "host": "EMR Source" }
+```
+
+```jsonc
+// <- the missing-folder scenario, armed
+{
+  "host": "EMR Source",
+  "found": true,
+  "settings": {
+    "FilePath": "/tmp/labdemo/hl7-in-missing/",
+    "FileSpec": "*.hl7",
+    "ArchivePath": "/tmp/labdemo/hl7-archive/",
+    "PollInterval": "2",
+    "TargetConfigNames": "Lab Router",
+    "PoolSize": 1
+  },
+  "settingsOnItem": 6
+}
+```
+
+Combined with `get_recent_errors`, the agent can conclude: *`EMR Source` is in Error; a `#5021` was
+logged, which means a configured path does not exist; its `FilePath` is
+`/tmp/labdemo/hl7-in-missing/`* — a specific diagnosis built entirely from configuration and a
+catalogue, with no log text crossing the boundary.
+
+Measured on `Cloud API`, which carries a `Credentials` setting: `settingsOnItem` reads `4` and
+`settings` returns `3`. The filter is doing something, and the response says so.
 
 ### 3.5 `get_processing_time` — read
 
@@ -954,7 +1060,7 @@ denial happened.
 the same call at `0.0071 s`. Stated because a reader comparing §5.5's promise of a duration against
 a column of zeroes should find the explanation here rather than assume the field is broken.
 
-Every one of the six tools is audited on every call. Not a per-tool setting: it is where the audit
+Every one of the seven tools is audited on every call. Not a per-tool setting: it is where the audit
 hook sits in the execution path (§5.2) — plus the policy's own row for the one case that path
 cannot see.
 

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -289,9 +289,54 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "evidence (array of {label, detail, source, tool} where source is ""mcp_tool"" for a value you read with a tool "
     set p = p _ "or ""snapshot"" for one given to you, and tool is the tool name or null), "
     set p = p _ "confidence (number 0-1, your own judgement), "
-    set p = p _ "recommendedAction ({action: {type, host, size}}) or null. "
-    set p = p _ "The only action type you may recommend is set_pool_size, with size between 2 and 8, "
-    set p = p _ "and host must be the host under investigation. Recommend nothing if no bounded action fits."
+    set p = p _ "recommendedAction ({action: {type, host, size}}) or null, "
+    set p = p _ "manualRemediation ({summary, steps, target}) or null. "
+    // The bounds are READ FROM THE TOOL rather than restated, because a prompt that disagrees with
+    // the guard produces a recommendation the guard then refuses -- which is what happened. The
+    // wording was "host must be the host under investigation", and on the missing-folder scenario the
+    // model dutifully recommended set_pool_size on `EMR Source`; a dry run came back
+    // `not_whitelisted_host`. The safety boundary held perfectly and the recommendation was still
+    // useless, so the UI would have offered an approve button for an action that cannot apply.
+    //
+    // Naming the one host it CAN change is also what makes manualRemediation reachable: told the
+    // action is unavailable here, the model has somewhere else to put a real fix. Told only that the
+    // action exists, it will reach for it.
+    set p = p _ "The only action type you may recommend is set_pool_size, with size between "
+        _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#MINSIZE _ " and "
+        _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#MAXSIZE _ ". "
+    set p = p _ "It can ONLY be applied to '" _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#ALLOWEDHOST
+        _ "', and only when that host is the one under investigation. "
+    set p = p _ "For any other host this action is unavailable and recommending it is an error -- "
+    set p = p _ "it will be refused before it applies. "
+
+    // MVP 3. The two fields are described as MUTUALLY EXCLUSIVE and as differing in AUTHORITY rather
+    // than in format, because that is the distinction the model has to get right: one is a change we
+    // may make, the other is a change only a person may make. A prompt that described them as "a
+    // structured fix or a written fix" would invite both, or the wrong one.
+    set p = p _ "Use recommendedAction ONLY for a bounded action from that list. "
+    set p = p _ "Use manualRemediation when the fix is real but outside what this system may do -- "
+    set p = p _ "for example a directory that must be created on the host, or a setting an operator "
+    set p = p _ "must repoint. Never both, and null for both if nothing can be recommended. "
+    set p = p _ "manualRemediation.summary is one line naming the condition; steps is an ordered array "
+    set p = p _ "of imperative strings, each independently actionable; target is "
+    set p = p _ "{host, setting, currentValue} identifying the CONFIGURATION to change, or null if you "
+    set p = p _ "cannot identify it. "
+
+    // The one thing the model must not be allowed to infer. `appliedBy` is set by the dispatcher, not
+    // read from the reply (investigate.ts does the same), so the prompt does not mention it -- a model
+    // told the field exists could assert "system", and autonomous remediation is what root
+    // CLAUDE.md §2.1 forbids outright. Naming a field only to forbid a value is weaker than not
+    // offering it.
+    set p = p _ "Never claim this system will apply a manual remediation itself; it will not. "
+
+    // Says where the path comes from, because the alternative is the model quoting an error message
+    // it should not have. get_recent_errors returns a catalogue `summary` and never log text, so the
+    // OFFENDING VALUE has to come from get_host_settings -- and a model that does not know that will
+    // either guess a path or ask for the log.
+    set p = p _ "To name a specific path or setting value, read it with get_host_settings. "
+    set p = p _ "get_recent_errors gives you the KIND of failure and never the message text. "
+
+    set p = p _ "Recommend nothing if no bounded action and no manual step fits."
     quit p
 }
 

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -92,6 +92,70 @@ ClassMethod GetPoolSize(host As %String) As %DynamicObject
     quit out
 }
 
+/// Report the configured adapter settings for one interoperability host.
+///
+/// WHY THIS TOOL EXISTS, and it is a data-boundary decision rather than a convenience. MVP 3's
+/// scenario needs the agent to name the directory a service cannot read. That name lives in exactly
+/// two places: the `#5021` log message, and the host's configuration. `GetRecentErrors` will never
+/// return log text -- `Ens_Util.Log` holds 61,772 rows carrying `PatientID` in plain text -- so
+/// without this tool the agent can learn *a path is missing* and never *which path*.
+///
+/// Configuration is what the boundary permits: root `CLAUDE.md` §2.1 is "metrics and configuration
+/// only, never message content". A setting VALUE is configuration by definition; it was typed by
+/// whoever deployed the production, not derived from a message.
+///
+/// AN ALLOWLIST OF SETTING NAMES, NOT EVERY SETTING. Returning the whole collection would be one
+/// `Credentials` row away from handing an external LLM the name of a credential set, and one future
+/// setting away from something worse -- a production is configured by people, and people put
+/// surprising things in free-text settings. So the tool names what it will return and refuses the
+/// rest by construction. Adding a name here is a decision, which is the same reasoning as
+/// `Tools.Resolve`'s single whitelisted host and the `#5021` catalogue.
+///
+/// `Credentials` is deliberately ABSENT even though it is only an identifier: it names a stored
+/// secret, and an agent has no diagnostic use for it that outweighs saying its name out loud.
+ClassMethod GetHostSettings(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "found": false, "settings": {} }
+    set item = ..FindItem(host)
+    if '$isobject(item) {
+        set out.error = "no such config item in " _ ..#PRODUCTION
+        quit out
+    }
+    set out.found = 1
+
+    // The allowlist. Path and target settings, because those are what a misconfiguration diagnosis
+    // needs -- where the host reads from, where it writes to, and where it sends.
+    set allowed = $listbuild(
+        "FilePath",
+        "ArchivePath",
+        "WorkPath",
+        "FileSpec",
+        "PollInterval",
+        "HTTPServer",
+        "HTTPPort",
+        "URL",
+        "TargetConfigNames")
+
+    for i = 1:1:item.Settings.Count() {
+        set setting = item.Settings.GetAt(i)
+        // $listfind, not %INLIST -- the latter is SQL-only and raises #1010 in method code.
+        if $listfind(allowed, setting.Name) > 0 {
+            do out.settings.%Set(setting.Name, setting.Value)
+        }
+    }
+
+    // The POOL SIZE is a property rather than a Settings row, so it is not in the loop above. Added
+    // because a diagnosis about throughput needs it and `get_pool_size` already publishes it -- this
+    // is the same value, not a second source of truth.
+    set out.settings.PoolSize = +item.PoolSize
+
+    // COUNTED, so the agent can tell "this host has three settings" from "the allowlist filtered
+    // most of them out". Without it, a host configured entirely through settings this tool refuses
+    // looks identically bare to one with no configuration at all.
+    set out.settingsOnItem = item.Settings.Count()
+    quit out
+}
+
 /// Report recent error counts for one interoperability host, classified by IRIS error code.
 ///
 /// Returns COUNTS and error CODES only -- never log text. Error text can contain patient data,
@@ -106,6 +170,9 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
         quit { "host": (host), "error": "sinceMinutes must be between 1 and 60", "sanitised": true }
     }
 
+    // `sinceMinutes` echoed under the SAME name as the input. The contract said `windowMinutes` on
+    // output until 2026-08-20 and this said `sinceMinutes`; reconciled in #116 toward one name,
+    // because a different name on each side is a translation step nobody wanted.
     set out = { "host": (host), "sinceMinutes": (sinceMinutes), "count": null, "sanitised": true, "byCode": [] }
 
     // THE PHI BOUNDARY, and this is measured rather than cautious. Ens_Util.Log on this instance
@@ -151,7 +218,10 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
     for {
         set code = $order(codes(code), 1, n)
         quit:code=""
-        do out.byCode.%Push({ "errorCode": (code), "count": (n) })
+        // `summary` lives on the byCode entry because it is keyed by `errorCode` -- a property of
+        // the CODE, not of an occurrence. That is what made the aggregate shape sufficient and the
+        // per-event `errors[]` array unnecessary (@kskubach's correction on #116).
+        do out.byCode.%Push({ "errorCode": (code), "count": (n), "summary": (..ErrorSummary(code)) })
     }
     quit out
 }
@@ -290,6 +360,40 @@ ClassMethod HostStatusRow(host As %String, ByRef row) As %Status [ Private ]
 /// novel error message cannot leak through a gap in a pattern list. A denylist would need to
 /// anticipate every shape PHI can take in a log line, which is not a bet worth taking on a
 /// healthcare system.
+/// The `summary` catalogue — `contracts/mcp-tools.md` §3.4a.
+///
+/// A FIXED STRING LOOKED UP BY `errorCode`, never derived from the log row. That is the whole reason
+/// it is safe to send: `Ens_Util.Log` on this instance holds 61,772 rows carrying `PatientID` in
+/// plain text, and a summary built from the row would carry whatever the row carries. A catalogue
+/// cannot, by construction.
+///
+/// THE ALLOWLIST MUST NOT GAIN AN EXCEPTION FOR `#5021`. The tempting shortcut for MVP 3's scenario
+/// is to return that error's message text, because it contains the missing path and the path is
+/// *usually* harmless. That is the wrong shape twice: an allowlist with one exception is one an
+/// implementer widens, and "usually harmless" is the rare-rather-than-absent pattern that survives
+/// review and then leaks. The agent learns the KIND of fault here and the offending path from
+/// `GetHostSettings` -- configuration, which the boundary permits.
+///
+/// Adding a row is a contract change (§3.4a), deliberately: a code that reaches an agent with a
+/// human-readable meaning is a decision about what the model is told.
+ClassMethod ErrorSummary(code As %String) As %String [ Private ]
+{
+    // Returns "" for anything not listed, which GetRecentErrors emits as JSON null -- §3.4a's
+    // "null when unclassified". An unknown code gets a count and no interpretation, which is honest:
+    // the agent can see something is failing and cannot be told what it means.
+    quit $case(code,
+        "#5021": "a configured directory or file path does not exist",
+        "#6059": "the configured downstream host or port could not be reached",
+        "#5001": "a general IRIS error was raised while handling a message",
+        "<Ens>ErrFailureTimeout": "the host retried and gave up within its failure timeout",
+        "<Ens>ErrConnectionLost": "the connection to the downstream target was lost",
+        "<Ens>ErrHTTPStatus": "the downstream returned an HTTP status the adapter treats as an error",
+        "<Ens>ErrProductionSettingInvalid": "a production setting on this host is not a valid value",
+        "<Ens>ErrTCPTerminatedReadTimeoutExpired": "a TCP read timed out before the downstream replied",
+        "<Ens>ErrGeneral": "the interoperability framework raised a general error",
+        : "")
+}
+
 ClassMethod ClassifyError(text As %String) As %String [ Private ]
 {
     set known = $listbuild(

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -162,10 +162,30 @@ ClassMethod GetHostSettings(host As %String) As %DynamicObject
 /// so this tool classifies rather than quotes.
 ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %DynamicObject
 {
+    // AN OMITTED ARGUMENT IS NOT AN INVALID ONE, and the ObjectScript default above does not cover
+    // this. `%AI.ToolMgr.ExecuteTool` builds the argument list from the model's JSON and passes ""
+    // for a key the model did not send -- so the `= 15` default never applies on the tool path, ""
+    // fails `< 1` below, and the tool refused every call that omitted the parameter. Measured:
+    //
+    //   Invoke("GetRecentErrors", {"host":"EMR Source"})                 -> error, sinceMinutes
+    //   Invoke("GetRecentErrors", {"host":"EMR Source","sinceMinutes":15}) -> 3 errors, #5021
+    //
+    // Same host, same second, opposite answers. This was live from #106 and invisible because every
+    // hand-written check passed the argument -- the only caller that omits it is the model, whose
+    // schema marks it optional. It cost a live investigation: blinded to the error codes, the agent
+    // reasoned from the one number it could still see (PoolSize 1) and recommended enlarging the pool
+    // of a host whose directory did not exist.
+    if sinceMinutes = "" {
+        set sinceMinutes = 15
+    }
+
     // BOUNDED, and the bound is part of the data boundary rather than politeness. A count is not
     // content, but a count of one nearly is: "1 error for patient X in the last 5 seconds" is
     // identifying in a way "40 errors in 15 minutes" is not. 60 minutes is the ceiling because
     // this tool answers questions about a CONDITION, not a message search interface.
+    //
+    // Still rejects a value the model actually sent and got wrong -- `0` and `90` are refusals, and
+    // the refusal names the range. Only absence now means "use the default".
     if (sinceMinutes < 1) || (sinceMinutes > 60) {
         quit { "host": (host), "error": "sinceMinutes must be between 1 and 60", "sanitised": true }
     }

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -47,6 +47,17 @@ Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
 /// reporting nothing armed -- a status method lying by omission (@tanifgit, #66).
 Parameter CLOSEDPORT = 59999;
 
+/// The directory MissingFolder() points EMR Source at — one that does not exist.
+///
+/// Under /tmp/labdemo/ rather than somewhere exotic, so a reader of the boot log sees a path that
+/// looks like the real one with a suffix, not a contrived value. `-missing` rather than a random
+/// name because the point of the scenario is that the *configuration* is wrong, and a plausible
+/// typo is what actually happens on a real deployment.
+///
+/// NOT CREATED, EVER. `FirstBoot.MakeDirectories()` creates the two real drop directories on every
+/// boot; if this one were in that list the scenario would disarm itself. Checked that it is not.
+Parameter MISSINGPATH = "/tmp/labdemo/hl7-in-missing/";
+
 /// dead_host -- absolute, fires within two polls. The demo's headline finding.
 ClassMethod DeadHost() As %Status
 {
@@ -457,6 +468,23 @@ ClassMethod Reset() As %Status
         kill ^ProductionGuardian.Trigger("RateSecs")
         write "  restored the HL7 inflow rate to the generator's own interval", !
     }
+    // The FilePath, restored to what it WAS rather than to a literal -- the same rule as the port
+    // above, and for the same reason: a deployment that legitimately uses a different inbound
+    // directory must not be rewritten by a reset. If nothing was stashed, MissingFolder() never ran
+    // and the path is whatever the environment configured.
+    if $data(^ProductionGuardian.Trigger("PathWas")) {
+        set was = ^ProductionGuardian.Trigger("PathWas")
+        if was '= "" {
+            do ..SetSetting(..#SERVICE, "Adapter", "FilePath", was)
+            write "  ", ..#SERVICE, " FilePath restored to ", was, !
+        } else {
+            // Absent before arming is the shipped state for a setting this class added.
+            do ..RemoveSetting(..#SERVICE, "FilePath")
+            write "  ", ..#SERVICE, " FilePath removed, as it was before arming", !
+        }
+        kill ^ProductionGuardian.Trigger("PathWas")
+    }
+
     if $data(^ProductionGuardian.Trigger("MaxQueued")) {
         kill ^ProductionGuardian.Trigger("MaxQueued")
         write "  removed the generator's queue-depth cap", !
@@ -547,6 +575,15 @@ ClassMethod Status() As %Status
     write "  HL7 inflow     : ", $select(rate > 0: rate _ "s per message  <- rate overridden", 1: "generator default"), !
     // Reported with the live depth beside it, so "capped" and "currently paused" are distinguishable
     // at a glance -- a presenter seeing a flat queue needs to know whether it is held or stuck.
+    // Reported for the same reason as the throttle and the inflow rate: an armed FilePath shows up
+    // as a host in Error with no obvious cause, and Status() exists so nothing armed is invisible.
+    set livePath = ..GetSetting(..#SERVICE, "FilePath")
+    write "  inbound path   : ", $select(livePath = "": "(adapter default)", 1: livePath),
+        $select(livePath = ..#MISSINGPATH: "   <- ARMED, does not exist", 1: ""), !
+    if $data(^ProductionGuardian.Trigger("PathWas")) {
+        write "  path stashed   : ", ^ProductionGuardian.Trigger("PathWas"), "  <- Reset() will restore this", !
+    }
+
     set cap = +$get(^ProductionGuardian.Trigger("MaxQueued"), 0)
     if cap > 0 {
         set depth = ##class(Ens.Queue).GetCount(..#OPERATION)
@@ -734,6 +771,76 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
         quit $$$ERROR($$$GeneralError, "no such config item: " _ pItem _ " (renamed in Production.cls?)")
     }
     quit def.%Save()
+}
+
+/// MVP 3 scenario 2 — the missing folder. A host that cannot read its inbound directory.
+///
+/// WHY THIS SCENARIO EXISTS. Every finding MVP 2 could produce had a governed action behind it, so
+/// nothing exercised the path where the correct answer is **no action at all**. This one is a real
+/// failure — `FirstBoot.cls` records it from the #34/#53 deploy, where the two HL7 drop directories
+/// did not exist and `EMR Source` went straight to Error with `#5021` — and the fix is an operator
+/// creating a directory, which Production Guardian must recommend without offering to do.
+///
+/// ARMED BY REPOINTING THE SETTING, NOT BY DELETING THE DIRECTORY, and the third reason is the one
+/// that decides it:
+///
+///   1. The generator writes into that directory, so deleting it breaks inbound traffic a second way
+///      and the finding stops being about what it claims to be about.
+///   2. `FirstBoot.MakeDirectories()` recreates it on every boot, so an armed demo would disarm
+///      itself on the next restart.
+///   3. **It is not reversible from inside IRIS.** Every toggle in this class stashes what it
+///      replaced and `Reset()` puts it back; a trigger that deleted a filesystem directory could not
+///      honour that contract, because recreating a directory is not the same as never having removed
+///      it — permissions and ownership are lost.
+///
+/// So this is `ErrorRate()`'s stash-and-restore shape with a path instead of a port.
+///
+/// WHICH FINDING FIRES. `dead_host`, because `Error` is already in the engine's `DEAD_STATUSES` —
+/// read from the rule rather than assumed, so MVP 3 needs no new detection rule. `stalled_host`
+/// deliberately does NOT fire: it declines for any host already in `DEAD_STATUSES`, which is the
+/// one-condition-one-finding rule working.
+ClassMethod MissingFolder() As %Status
+{
+    set sc = ..CheckProduction()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    // Stash the REAL path before overwriting it, and only if not already stashed -- arming twice
+    // must not overwrite the saved value with the missing one. Same rule as PortWas and PoolWas,
+    // and the same reason: #66 restored a hardcoded port and destroyed a deployment that
+    // legitimately used a different one.
+    if '$data(^ProductionGuardian.Trigger("PathWas")) {
+        set ^ProductionGuardian.Trigger("PathWas") = ..GetSetting(..#SERVICE, "FilePath")
+    }
+
+    set sc = ..SetSetting(..#SERVICE, "Adapter", "FilePath", ..#MISSINGPATH)
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    // WITHOUT THIS THE SETTING PERSISTS AND NOTHING HAPPENS. SetSetting() saves the production
+    // definition; the RUNNING job keeps the value it started with, so the host stays OK and the
+    // scenario looks broken. Measured: 160 seconds at status OK with the persisted path already
+    // pointing at the missing directory. Every other arming method in this class calls this for the
+    // same reason -- copied the shape rather than rediscovering it a second time.
+    set sc = ..UpdateProduction()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    write "ARMED  dead_host  (the MVP 3 missing-folder scenario)", !
+    write "  ", ..#SERVICE, " FilePath -> ", ..#MISSINGPATH, !
+    write "    stashed the real path; Reset() restores it", !
+    write "  The service polls a directory that does not exist, so every poll fails", !
+    write "    before it can read a message. Expect Error status and #5021 in the log.", !
+    write "  dead_host fires (Error is in DEAD_STATUSES).", !
+    write "  stalled_host will NOT fire -- it declines for a host already in DEAD_STATUSES.", !
+    write "  THERE IS NO GOVERNED FIX. The recommendation is words, for an operator to act on:", !
+    write "    create the directory, or repoint FilePath at one that exists.", !
+    write "  Inbound traffic stops while this is armed -- the generator still writes to the real", !
+    write "    directory, and the service is no longer looking at it.", !
+    quit $$$OK
 }
 
 /// Remove one setting from one config item, if present. Absent is the shipped state for

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -377,7 +377,15 @@ ClassMethod CreateRoles() As %Status
 /// every setup run so the regression is visible at boot rather than in a review.
 ClassMethod ReportTools()
 {
-    set expected = 6
+    // SEVEN since MVP 3, not six. GetHostSettings was added so the agent can name the directory in
+    // the missing-folder scenario from configuration rather than from log text (mcp-tools.md §3.4a).
+    //
+    // This number is moved DELIBERATELY and with the tool list read back, because the guard's whole
+    // value is that an unexpected count is loud: it fired on the first compile of the new tool --
+    // "7 -- EXPECTED 6, INVESTIGATE" -- which is exactly what it is for. Bumping it without reading
+    // the names would defeat it, so the names were checked: six reads plus one write, no helper left
+    // public.
+    set expected = 7
     set found = 0
     for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Resolve" {
         if '##class(%Dictionary.CompiledClass).%ExistsId(class) {


### PR DESCRIPTION
MVP 3 **Track A** — the scenario with no governed fix, end to end. Three commits: the trigger, the read-tool work, and two defects that only a live agent turn could find.

Depends on #118 (merged), which carried `manualRemediation` through the engine and the panel. This is the IRIS half plus the two contract edits.

## What the scenario is

`EMR Source` polls a directory that does not exist. `dead_host` fires because `Error` is already in the engine's `DEAD_STATUSES`, so **no new detection rule** was needed. The fix is an operator creating a directory — there is no governed action, and that is the point: every MVP 2 finding had one, so nothing exercised the path where the correct answer is *no action at all*.

Armed by **repointing the setting, not deleting the directory**, for three reasons — the generator writes into that directory so deleting it breaks inbound a second way; `FirstBoot.MakeDirectories()` recreates it on every boot so an armed demo would disarm itself; and **it is not reversible from inside IRIS**. Every toggle in `Triggers.cls` stashes what it replaced and `Reset()` puts it back. Recreating a directory is not the same as never having removed it — permissions and ownership are lost. So this is `ErrorRate()`'s stash-and-restore shape with a path instead of a port.

## The two defects, both found by running it rather than reading it

### 1. `get_recent_errors` refused every call that omitted `sinceMinutes` — live since #106

`%AI.ToolMgr.ExecuteTool` passes `""` for a key the model did not send. It does **not** omit the argument, so the ObjectScript `= 15` default never fires, `""` fails `< 1`, and the tool returned an error. Same host, same second:

```
{"host":"EMR Source"}                     -> {"error": "sinceMinutes must be between 1 and 60"}
{"host":"EMR Source","sinceMinutes":15}   -> 3 errors, #5021 + <Ens>ErrProductionSettingInvalid
```

**Why it survived four days.** The only caller that omits an optional parameter is the model. Every probe, test and demo script we wrote passed it explicitly, so nothing we ran could see it.

**And the failure was not an error.** Blinded to the error codes, the agent reasoned from the one value it could still read — `PoolSize 1` — and produced this:

> *"The EMR Source host is configured with a pool size of 1, which means it can process only one message at a time…"* → `recommendedAction: set_pool_size`

Fluent, evidence-backed, 0.9 confidence, and about the wrong thing entirely. **A tool that refuses is indistinguishable, in the narrative, from a tool that found nothing.** That is §2.1's unmeasurable-is-not-zero rule arriving through the argument list instead of the return value, which is why the fix is documented in `mcp-tools.md` §2 next to the schema rule it corrects — the paragraph there described the *generated schema* accurately and the *tool body* wrongly.

Absence and a wrong value stay separate branches: `""` → default; `0` and `90` are still refused and the refusal still names the range.

### 2. The prompt recommended an action the tool refuses

The prompt said host *"must be the host under investigation"* and never that `set_pool_size` only accepts `Cloud API`. So the model recommended it on `EMR Source`. A dry run:

```
{"outcome":"refused","refusal":{"reason":"not_whitelisted_host",
 "message":"this tool may only change 'Cloud API'","checkedBy":"iris"}}
```

**The safety boundary held perfectly and the recommendation was still useless.** The UI would have rendered an approve button for an action that cannot apply — a governed system offering a control that does nothing is worse than one offering no control, because a presenter clicks it.

Bounds are now **read from `Tools.Resolve`'s own parameters** (`MINSIZE`/`MAXSIZE`/`ALLOWEDHOST`) rather than restated, since a prompt disagreeing with the guard is exactly what produced this. Naming the one host it *can* change is also what makes `manualRemediation` reachable: told the action is unavailable here, the model has somewhere else to put a real fix. Told only that the action exists, it reaches for it.

## `get_host_settings` — a data-boundary decision, not a convenience

The scenario needs the agent to **name** the missing directory. That value lives in exactly two places: the `#5021` log message, and the configuration. `get_recent_errors` will never return log text — `Ens_Util.Log` holds 61,772 rows carrying `PatientID` in plain text — so without this tool the agent learns *a path is missing* and never *which path*.

Configuration is what the boundary permits (root `CLAUDE.md` §2.1). A setting **value** was typed by whoever deployed the production, not derived from a message.

**An allowlist of nine names, not the whole collection.** Returning everything is one `Credentials` row away from handing an external LLM the name of a credential set, and one future setting away from something worse — productions are configured by people. `Credentials` is deliberately absent even though it is only an identifier. `settingsOnItem` reports the unfiltered count so "this host has three settings" is distinguishable from "the allowlist filtered most of them out". Verified: `Cloud API` returns 3 of 4, `Credentials` filtered.

The tempting shortcut was an exception for `#5021`'s message text, since it contains the path and the path is *usually* harmless. Rejected: an allowlist with one exception is one an implementer widens, and "usually harmless" is the rare-rather-than-absent pattern that survives review and then leaks. So the agent gets the **kind** of fault from the catalogue and the **value** from configuration.

Tool count 6 → 7; `Setup.AIHub.Run()` prints it at boot so an eighth shows up there rather than in review.

## Verified live, after both fixes

Through the engine, which is what the UI calls:

```
POST :3002/api/investigate {"findingId":"f-1058"}
  state: complete   source: agent   model: gpt-4o-mini   toolCalls: 5
  recommendedAction: null
  manualRemediation: {summary, steps[2], target: null, appliedBy: "operator"}
```

And the dispatcher directly, where the agent also called `get_host_settings`:

```
  manualRemediation.target: {host: "EMR Source", setting: "FilePath",
                             currentValue: "/tmp/labdemo/hl7-in-missing/"}
```

`appliedBy` is **set by us, not read from the reply** — a model must not be able to assert `"system"`, so the prompt does not mention the field at all. Naming a field only to forbid a value is weaker than not offering it.

`target: null` on the engine run is legal per the schema and the panel handles it — the model skipped `get_host_settings` that time. Worth knowing it varies run to run.

Boundary checks:

- **All six reads audited**, one row each, `Disposition: executed`.
- The **write tool was never registered** for the investigating agent (`GovernAgent(agent, 0)`), so it could not have called it.
- `stalled_host` correctly declined — it refuses any host already in `DEAD_STATUSES`. One condition, one finding.
- `Reset()` restored `FilePath` to `/tmp/labdemo/hl7-in/`, the real value, not a literal.

Gates:

```
219 tests pass, 0 fail        (Node 22 — Node 20 on PATH cannot strip TS)
tsc --noEmit                  clean
contracts/validate.mjs        3 samples, 15 accept, 26 reject
FirstBoot.LoadClasses         22 classes, "Load finished successfully"
```

## For review

`contracts/` changes need your review before merge, per root `CLAUDE.md` §4 — §3.4b is additive, §2 is a correction. Both have a CHANGELOG entry.

The one thing I would most like a second opinion on: **defect 1 was a live MVP 2 bug for four days and no gate we own could have caught it.** The rule I have written into the contract is "restate the default in the body, and samples must carry the omitted-argument call". If there is a cheaper structural fix — a shared argument-coercion helper on the tool base, say — it belongs in your area and I would rather you designed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
