### PR TITLE
fix: both MVP 3 halves in one stack — brochure build context, and a prompt that is not a constraint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Build-context exclusions for the REPO ROOT context.
+#
+# WHY THIS FILE EXISTS AT THE ROOT. Docker reads `.dockerignore` from the build context
+# directory, nowhere else. The dashboard's context moved from `./apps/dashboard` to `.` for
+# MVP 3 Track B (see docker-compose.yml), which silently stopped
+# `apps/dashboard/.dockerignore` from applying — and the first symptom was not "the image is
+# large" but a hard failure:
+#
+#   invalid file request apps/dashboard/node_modules/.bin/baseline-browser-mapping
+#
+# a dangling symlink inside a locally-installed node_modules that was never meant to be sent
+# to the daemon. The per-app file is kept so a `docker build ./apps/dashboard` still behaves,
+# but this one is what the compose build obeys.
+
+# Dependencies — reinstalled inside the image by `npm ci`, never copied in.
+**/node_modules
+
+# Build output. Copying a host-built dist/ in would let a stale bundle ship behind a
+# green image build, which is the whole reason the Dockerfile builds it itself.
+**/dist
+
+# Secrets. Root CLAUDE.md §5 forbids committing these; excluding them here means an
+# untracked local .env cannot reach a layer either.
+**/.env
+**/.env.*
+!**/.env.example
+.claude/settings.local.json
+
+# Repo metadata and history — large, and no build step reads it.
+.git
+.github
+
+# Everything under docs/ EXCEPT the one asset the bundle imports. Brochure.png is
+# `COPY`-ed explicitly by apps/dashboard/Dockerfile; the deck, the MVP .docx files and the
+# concept demo are source material (root CLAUDE.md §3) with no place in a build layer.
+docs/*
+!docs/Brochure.png
+
+# Other services' trees. Each has its own build context; none is read by the dashboard
+# build, and sending them makes every dashboard rebuild wait on unrelated file churn.
+iris
+services
+tools
+contracts
+
+**/*.log
+**/*.mp4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,8 @@ already exists for MVP 2's scenario to build on.
 | Path | Owner |
 |---|---|
 | `iris/**`, `services/metrics-proxy/**` | Dev A |
-| `services/detection-engine/**`, `apps/dashboard/**`, `docs/demo/**` | Dev B |
+| `services/detection-engine/**` | Dev B |
+| `apps/dashboard/**`, `docs/demo/**` | **Dev A from 2026-08-20** (MVP 3 Track B) — was Dev B |
 | `contracts/**` | see §4 — **nobody edits without a PR** |
 | `tools/**`, root config, `.github/**` | shared, PR + review |
 | `docs/*` source material (brochure, deck, MVP docx, demo html) | read-only |

--- a/README.md
+++ b/README.md
@@ -245,6 +245,72 @@ wrong or expired.** That is the honest failure and worth recognising: `rootCause
 none when a human approves a production write on the strength of it. The FIX half is unaffected — it
 does not use the LLM — so a bad key costs you WHY and nothing else.
 
+### MVP 3 — the same loop where the answer is *no action at all*
+
+MVP 2's scenario always ended in a governed fix, so nothing exercised the case where the correct
+answer is **words for an operator**. This is that case, and it is the same three URLs.
+
+```objectscript
+// Arm: repoints EMR Source at a directory that does not exist. Takes ~20s to reach Error.
+do ##class(ProductionGuardian.LabDemo.Triggers).MissingFolder()
+do ##class(ProductionGuardian.LabDemo.Triggers).Status()   // reports the armed path
+do ##class(ProductionGuardian.LabDemo.Triggers).Reset()    // restores the real path
+```
+
+```bash
+curl -s localhost:5173/api/healthscan/findings          # dead_host on EMR Source
+curl -s -XPOST localhost:5173/api/investigate \
+  -H 'Content-Type: application/json' -d '{"findingId":"<the dead_host id>"}'
+```
+
+A live run:
+
+```
+source: agent   model: gpt-4o-mini   toolCalls: 4
+recommendedAction: null                    <- there is no governed fix, and it says so
+manualRemediation:
+  summary: "Configured directory path does not exist."
+  steps:   Check if the directory /tmp/labdemo/hl7-in-missing/ exists.
+           Create the directory /tmp/labdemo/hl7-in-missing/ if it is missing.
+  target:  {host: "EMR Source", setting: "FilePath",
+            currentValue: "/tmp/labdemo/hl7-in-missing/"}
+  appliedBy: "operator"
+```
+
+**`recommendedAction: null` with `manualRemediation` populated is the whole point** — the drawer
+shows the fix in words and renders **no approve control**, because there is no `action` object to
+send. That negative is the acceptance criterion, not a missing feature.
+
+Two details that are easy to misread:
+
+- **The path comes from `get_host_settings`, never from the log.** `get_recent_errors` returns a
+  fixed catalogue string keyed by error code (`#5021` → "a configured directory or file path does
+  not exist") and never message text, because `Ens_Util.Log` carries `PatientID` in plain text. So
+  the agent learns the *kind* of fault from the catalogue and the *value* from configuration —
+  which the data boundary permits.
+- **`appliedBy` is set by us, not read from the model.** The prompt never mentions the field, so a
+  model cannot assert `"system"`.
+
+Also in MVP 3, and needing no setup: two rail entries under **Production Guardian** in the
+dashboard — **Architecture** (two slides, drawn as SVG from the design tokens) and **Brochure**.
+Both are static documents about the product; no API, no engine, no IRIS.
+
+### Before a rehearsal: three things that will bite
+
+- **`AGENT_MODE` defaults to `mock`.** Rebuild or restart the engine without `PG_AGENT_MODE=live`
+  in the environment and `investigate` quietly serves `source: "canned"` — a plausible narrative
+  built from real measured values, which looks correct and demonstrates nothing about the agent.
+  Check `source` is `agent` and `toolCalls` is non-zero. That is the standing #108 check and it
+  earns its keep: it caught exactly this regression during MVP 3.
+- **Restarting the `iris` container reverts an armed trigger.** Recompiling `Production.cls` resets
+  its settings, so `FilePath` and `PoolSize` go back to the shipped values and the scenario
+  disarms itself. Re-arm after any restart; `Status()` shows what is actually live.
+- **A live agent is not deterministic.** The model occasionally proposes `set_pool_size` on a host
+  the tool does not accept. `AgentDispatcher.DropUnapplicableAction()` removes such a
+  recommendation before it reaches the UI, reading the permitted host from the tool itself — so the
+  drawer never offers an approve button for an action that would be refused. The prompt asks; this
+  enforces.
+
 ### What the safety model actually enforces
 
 - **One action, one host, bounded.** `set_pool_size` on `Cloud API`, size `2`–`8`. Anything else is

--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -1,6 +1,21 @@
-# CLAUDE.md — Health Scan Dashboard (**Developer C**)
+# CLAUDE.md — Production Guardian Dashboard (**Dev A**, MVP 3)
 
 Scoped to `apps/dashboard/`. The root `CLAUDE.md` carries the shared rules — scope boundary, ownership, ports — and applies here too. `CONTRIBUTING.md` at the repo root explains the working agreements in full.
+
+> **This file is MVP 1 era and parts of it are now false.** It is corrected only where it would
+> actively mislead; the rest is left for whoever next works here at length, because a rewrite by
+> someone who did not build MVP 2's UI would be worse than a stale document with its staleness marked.
+>
+> - **Ownership.** Written for Developer C, who left on 2026-08-20. `apps/dashboard/**` passed to Dev B,
+>   and to Dev A on 2026-08-20 for MVP 3 Track B — see root `CLAUDE.md` §3, which is the authority.
+> - **§1.1's scope table is superseded.** It forbids root-cause narratives, confidence scores,
+>   forecasts and any "apply remediation" flow. **MVP 2 shipped all four** — `InvestigationPanel.tsx`,
+>   `EarlyWarning.tsx` and the Smart Resolve approve control are on `main`. Root `CLAUDE.md` §2 is the
+>   live boundary; that table describes MVP 1's, which §2.3 keeps as a record.
+> - **§3's file tree lists `public/favicon.svg`.** There is no `public/` directory.
+>
+> Everything else — the stack rules, the token system, the defensive-rendering rules, the
+> accessibility bar, the mock-first discipline — still holds and was followed for MVP 3 Track B.
 
 ---
 

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -8,14 +8,23 @@
 # artefact the file:// fallback is verified against (CLAUDE.md §6), so the container
 # and the fallback cannot drift apart.
 
+# BUILD CONTEXT IS THE REPO ROOT, not this directory — see docker-compose.yml's dashboard
+# service. `BrochureView.tsx` imports ../../../../docs/Brochure.png so the 1.7 MB asset has one
+# copy in git; that import cannot resolve from a context rooted here. Every COPY below is
+# therefore repo-relative, and the source tree is reproduced at the same depth so the relative
+# import resolves inside the image exactly as it does on a host.
 FROM node:22-alpine AS build
-WORKDIR /app
+WORKDIR /repo/apps/dashboard
 
 # package files first so `npm ci` is cached independently of source edits.
-COPY package.json package-lock.json ./
+COPY apps/dashboard/package.json apps/dashboard/package-lock.json ./
 RUN npm ci
 
-COPY . .
+COPY apps/dashboard/ ./
+
+# Only the one asset the bundle imports, not all of docs/ — that directory holds the deck, the
+# MVP docx files and the concept demo, none of which belong in a build layer.
+COPY docs/Brochure.png /repo/docs/Brochure.png
 
 # `npm run build` runs `tsc --noEmit` first, so a type error fails the image build
 # rather than producing one that serves a stale bundle.
@@ -40,8 +49,8 @@ ENV HEALTHSCAN_UPSTREAM=detection-engine:3002
 ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1
 ENV NGINX_ENVSUBST_FILTER="HEALTHSCAN_UPSTREAM|NGINX_LOCAL_RESOLVERS"
 
-COPY nginx.conf.template /etc/nginx/templates/default.conf.template
-COPY --from=build /app/dist/index.html /usr/share/nginx/html/index.html
+COPY apps/dashboard/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build /repo/apps/dashboard/dist/index.html /usr/share/nginx/html/index.html
 
 EXPOSE 80
 

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -14,7 +14,9 @@ import { useHealthScan } from './hooks/useHealthScan';
 import { useInvestigation } from './hooks/useInvestigation';
 import { useProjections } from './hooks/useProjections';
 import { pollIntervalMs, usePolling } from './hooks/usePolling';
-import { AppShell } from './components/AppShell';
+import { AppShell, type View } from './components/AppShell';
+import { ArchitectureView } from './components/ArchitectureView';
+import { BrochureView } from './components/BrochureView';
 import { ConnectionBanner, type ConnectionState } from './components/ConnectionBanner';
 import { SeveritySummary } from './components/SeveritySummary';
 import { HostGrid } from './components/HostGrid';
@@ -35,6 +37,14 @@ export function App(): JSX.Element {
   const [mode, setMode] = useState<Mode>(() => readMode());
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
+
+  /* Which top-level view is on screen (MVP 3).
+     NOT in the URL, unlike `mode`. `mode` is shareable because it changes what the
+     data means; which slide a presenter is looking at is transient, and putting it in
+     the URL would make the back button walk through the deck. Polling is left running
+     across views on purpose -- pausing it would have the dashboard show a stale
+     "updated 4m ago" the moment the presenter came back from the brochure. */
+  const [view, setView] = useState<View>('dashboard');
 
   const intervalMs = useMemo(() => pollIntervalMs(), []);
 
@@ -215,8 +225,20 @@ export function App(): JSX.Element {
   // a stale number as current.
   const contentClass = connectionState === 'ok' ? '' : 'pg-stale';
 
+  /* The two MVP 3 views are static documents about the product, not readings from it,
+     so the connection banner, the severity row and the drawer are all irrelevant to
+     them -- and a "cannot reach the API" banner over a brochure would be actively
+     confusing. They return early rather than being wrapped in the dashboard's chrome. */
+  if (view !== 'dashboard') {
+    return (
+      <AppShell headerActions={headerActions} view={view} onNavigate={setView}>
+        {view === 'brochure' ? <BrochureView /> : <ArchitectureView />}
+      </AppShell>
+    );
+  }
+
   return (
-    <AppShell headerActions={headerActions}>
+    <AppShell headerActions={headerActions} view={view} onNavigate={setView}>
       <ConnectionBanner
         state={connectionState}
         error={error}

--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -6,11 +6,24 @@
  * are inert by design and must *look* inert: rendered as plain spans, not
  * buttons or links, so nothing is clickable-and-broken and nothing lands in the
  * keyboard tab order.
+ *
+ * MVP 3 adds a SECOND, SEPARATELY LABELLED group for the two views that are ours
+ * — Brochure and Architecture. They are real `<button>`s, in the tab order, and
+ * they sit under their own heading rather than joining the list above.
+ *
+ * That separation is the point rather than decoration. The rail's top group is a
+ * deliberate fiction: six of its seven items do nothing. Dropping two working
+ * controls into it would make the fiction ambiguous — an operator would have no
+ * way to tell which of the nine items respond, and the existing design goes out
+ * of its way to ensure "inert" is legible. Ours are grouped, headed, and styled
+ * as controls; theirs stay flat text.
  */
 
 import type { ReactNode } from 'react';
 import {
   IconAlert,
+  IconArchitecture,
+  IconBrochure,
   IconDashboard,
   IconHome,
   IconJobs,
@@ -21,15 +34,19 @@ import {
   type IconProps,
 } from './icons';
 
+/** Which top-level view is on screen. */
+export type View = 'dashboard' | 'brochure' | 'architecture';
+
 interface RailItem {
   label: string;
   Icon: (props: IconProps) => JSX.Element;
-  active?: boolean;
+  /** Set on the one Health Connect item that represents this product. */
+  standsFor?: View;
 }
 
 const RAIL: readonly RailItem[] = [
   { label: 'Home', Icon: IconHome },
-  { label: 'Dashboard', Icon: IconDashboard, active: true },
+  { label: 'Dashboard', Icon: IconDashboard, standsFor: 'dashboard' },
   { label: 'Productions', Icon: IconProductions },
   { label: 'Alerts', Icon: IconAlert },
   { label: 'Messages', Icon: IconMessages },
@@ -37,13 +54,26 @@ const RAIL: readonly RailItem[] = [
   { label: 'Settings', Icon: IconSettings },
 ];
 
+const OURS: readonly { label: string; view: View; Icon: (props: IconProps) => JSX.Element }[] = [
+  { label: 'Architecture', view: 'architecture', Icon: IconArchitecture },
+  { label: 'Brochure', view: 'brochure', Icon: IconBrochure },
+];
+
+const MODULE_LABEL: Record<View, string> = {
+  dashboard: 'Health Scan',
+  brochure: 'Brochure',
+  architecture: 'Architecture',
+};
+
 export interface AppShellProps {
   /** Header right side — mode pill, last-updated, toggle. */
   headerActions: ReactNode;
+  view: View;
+  onNavigate: (view: View) => void;
   children: ReactNode;
 }
 
-export function AppShell({ headerActions, children }: AppShellProps): JSX.Element {
+export function AppShell({ headerActions, view, onNavigate, children }: AppShellProps): JSX.Element {
   return (
     <div className="pg-shell">
       <nav className="pg-rail" aria-label="Health Connect">
@@ -51,17 +81,45 @@ export function AppShell({ headerActions, children }: AppShellProps): JSX.Elemen
         <ul className="pg-rail__list">
           {RAIL.map((item) => (
             <li key={item.label}>
-              {item.active === true ? (
-                <span className="pg-rail__item pg-rail__item--active" aria-current="page">
+              {/* `aria-current` follows the actual view: on Brochure or Architecture,
+                  Dashboard is no longer the current page and must stop claiming to be. */}
+              {item.standsFor === 'dashboard' ? (
+                <button
+                  type="button"
+                  className={`pg-rail__item pg-rail__item--action${
+                    view === 'dashboard' ? ' pg-rail__item--active' : ''
+                  }`}
+                  aria-current={view === 'dashboard' ? 'page' : undefined}
+                  onClick={() => onNavigate('dashboard')}
+                >
                   <item.Icon size={17} />
                   {item.label}
-                </span>
+                </button>
               ) : (
                 <span className="pg-rail__item pg-rail__item--inert">
                   <item.Icon size={17} />
                   {item.label}
                 </span>
               )}
+            </li>
+          ))}
+        </ul>
+
+        <span className="pg-rail__brand pg-rail__brand--ours">Production Guardian</span>
+        <ul className="pg-rail__list">
+          {OURS.map((item) => (
+            <li key={item.view}>
+              <button
+                type="button"
+                className={`pg-rail__item pg-rail__item--action${
+                  view === item.view ? ' pg-rail__item--active' : ''
+                }`}
+                aria-current={view === item.view ? 'page' : undefined}
+                onClick={() => onNavigate(item.view)}
+              >
+                <item.Icon size={17} />
+                {item.label}
+              </button>
             </li>
           ))}
         </ul>
@@ -74,7 +132,10 @@ export function AppShell({ headerActions, children }: AppShellProps): JSX.Elemen
         <h1 className="pg-header__title">
           Production Guardian
           <span className="pg-header__divider">—</span>
-          <span className="pg-header__module">Health Scan</span>
+          {/* Follows the view. Leaving it at "Health Scan" while the brochure is on
+              screen would caption the wrong thing, and the header is the only place
+              on the page that names where you are. */}
+          <span className="pg-header__module">{MODULE_LABEL[view]}</span>
         </h1>
         <div className="pg-header__actions">{headerActions}</div>
       </header>

--- a/apps/dashboard/src/components/ArchitectureView.tsx
+++ b/apps/dashboard/src/components/ArchitectureView.tsx
@@ -52,11 +52,32 @@ function Node({
   );
 }
 
-function Flow({ d, label, dashed = false }: { d: string; label?: string; dashed?: boolean }): JSX.Element {
+/**
+ * An arrow, optionally labelled.
+ *
+ * `lx`/`ly` are REQUIRED when `label` is passed, and the type enforces it rather than defaulting
+ * to a corner. An SVG `<text>` with no `x`/`y` renders at the origin — so the first version of
+ * this component drew all eight labels stacked on top of each other in the top-left of the
+ * viewBox, which reads as a rendering fault rather than as a missing attribute. The types below
+ * make that unrepresentable: a label without a position will not compile.
+ *
+ * Positions are given per call site rather than derived from `d`, because the midpoint of an
+ * L-shaped path is usually the corner — the one place a label is guaranteed to sit on the line.
+ */
+type FlowProps = { d: string; dashed?: boolean } & (
+  | { label: string; lx: number; ly: number }
+  | { label?: undefined; lx?: undefined; ly?: undefined }
+);
+
+function Flow({ d, label, lx, ly, dashed = false }: FlowProps): JSX.Element {
   return (
     <g className={`pg-arch__flow${dashed ? ' pg-arch__flow--dashed' : ''}`}>
       <path d={d} markerEnd="url(#pg-arrow)" />
-      {label !== undefined && <text className="pg-arch__flow-label">{label}</text>}
+      {label !== undefined && (
+        <text className="pg-arch__flow-label" x={lx} y={ly}>
+          {label}
+        </text>
+      )}
     </g>
   );
 }
@@ -78,7 +99,7 @@ function Overview(): JSX.Element {
         <text x="106" y="46">IRIS container</text>
       </g>
       <Node x={32} y={64} w={148} title="LABDEMO" sub="the production" tone="brand" />
-      <Node x={32} y={132} w={148} title="AI Hub" sub="agent · 6 MCP tools" tone="accent" />
+      <Node x={32} y={132} w={148} title="AI Hub" sub="agent · governed MCP tools" tone="accent" />
       <Node x={32} y={200} w={148} title="RBAC · audit" sub="policies, one write tool" />
       <Node x={32} y={264} w={148} title="/api/monitor" sub="built-in metrics" />
 
@@ -88,13 +109,15 @@ function Overview(): JSX.Element {
 
       <Node x={452} y={160} w={148} h={60} title="Dashboard" sub="what the operator sees" tone="accent" />
 
-      <Flow d="M180 290 H248 V100" label="metrics" />
+      {/* Labels sit just above the horizontal leg of each path, left-anchored from its start,
+          so they read along the line rather than crossing a node. */}
+      <Flow d="M180 290 H248 V100" label="metrics" lx={186} ly={284} />
       <Flow d="M316 116 V160" />
       <Flow d="M316 212 V264" />
-      <Flow d="M384 190 H452" label="findings" />
+      <Flow d="M384 190 H452" label="findings" lx={390} ly={184} />
       {/* Dashed: the engine reaches back into IRIS only for WHY and FIX, and only
           through the governed tool path. A solid line would imply a data feed. */}
-      <Flow d="M248 186 H196 V158" label="investigate · resolve" dashed />
+      <Flow d="M248 186 H196 V158" label="investigate · resolve" lx={196} ly={180} dashed />
 
       <text className="pg-arch__note" x="452" y="248">Five compose services.</text>
       <text className="pg-arch__note" x="452" y="264">Ports and names live in</text>
@@ -122,19 +145,21 @@ function Investigation(): JSX.Element {
       </g>
       <Node x={336} y={64} w={168} title="Agent" sub="goal, iteration cap" tone="brand" />
       <Node x={336} y={136} w={168} title="Authorization policy" sub="checked per call" />
-      <Node x={336} y={200} w={168} title="Read tools ×5" sub="metrics · config only" />
+      <Node x={336} y={200} w={168} title="Read tools" sub="metrics · config only" />
       <Node x={336} y={264} w={168} title="set_pool_size" sub="the one write" tone="accent" />
 
       <Node x={552} y={64} w={72} h={44} title="LLM" sub="external" />
       <Node x={552} y={200} w={72} h={44} title="Audit" sub="every call" tone="brand" />
 
       <Flow d="M136 176 H168" />
-      <Flow d="M288 176 H336 V108" label="finding + snapshot" />
-      <Flow d="M504 86 H552" label="reason" dashed />
+      <Flow d="M288 176 H336 V108" label="finding + snapshot" lx={288} ly={170} />
+      <Flow d="M504 86 H552" label="reason" lx={506} ly={80} dashed />
       <Flow d="M420 116 V136" />
-      <Flow d="M420 188 V200" label="evidence" />
+      {/* The two vertical labels are offset to the RIGHT of their arrow rather than centred on
+          it, since a centred label on a 12px vertical run would sit on the line itself. */}
+      <Flow d="M420 188 V200" label="evidence" lx={426} ly={197} />
       <Flow d="M504 222 H552" />
-      <Flow d="M420 252 V264" label="after approval" />
+      <Flow d="M420 252 V264" label="after approval" lx={426} ly={261} />
 
       <text className="pg-arch__note" x="16" y="240">The policy is asked before every</text>
       <text className="pg-arch__note" x="16" y="256">call, and the audit row is written</text>
@@ -173,7 +198,7 @@ export function ArchitectureView(): JSX.Element {
 
       <p className="pg-view__caption">
         {slide === 'overview'
-          ? 'MVP 1 detects. MVP 2 adds WHAT, WHY and FIX on one scenario — the agent, its tools, its RBAC and its audit all run inside the same IRIS instance as the production.'
+          ? 'MVP 1 detects. MVP 2 adds WHAT, WHY and FIX on one scenario, and MVP 3 adds the case where the honest answer is words for an operator rather than a button — the agent, its tools, its RBAC and its audit all run inside the same IRIS instance as the production.'
           : 'Authorization is checked before execution and the audit row is written either way, so a refused attempt is as visible as an applied one.'}
       </p>
     </section>

--- a/apps/dashboard/src/components/ArchitectureView.tsx
+++ b/apps/dashboard/src/components/ArchitectureView.tsx
@@ -1,0 +1,181 @@
+/**
+ * Architecture — two slides, for showing an audience what sits behind the demo.
+ *
+ * SVG COMPONENTS RATHER THAN EXPORTED IMAGES, deliberately. The architecture has
+ * changed four times this month; an exported PNG is a second copy of the topology
+ * that goes stale silently, which is #84's whole subject. Drawn from tokens, so a
+ * brand change moves the diagram with the rest of the UI.
+ *
+ * DELIBERATELY SPARSE. Ports, service names and tool names already live in
+ * `docker-compose.yml`, root `CLAUDE.md` §5 and `contracts/mcp-tools.md`. Anything
+ * restated here is a copy that can disagree with them, so the diagram carries
+ * structure and the caption points at the authority.
+ */
+
+import { useState } from 'react';
+
+type Slide = 'overview' | 'investigation';
+
+const SLIDES: readonly { id: Slide; label: string }[] = [
+  { id: 'overview', label: '1 · The pieces' },
+  { id: 'investigation', label: '2 · One investigation' },
+];
+
+/** Box + label, sized in the 640×360 viewBox both slides share. */
+function Node({
+  x,
+  y,
+  w = 132,
+  h = 52,
+  title,
+  sub,
+  tone = 'plain',
+}: {
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  title: string;
+  sub?: string;
+  tone?: 'plain' | 'brand' | 'accent';
+}): JSX.Element {
+  return (
+    <g className={`pg-arch__node pg-arch__node--${tone}`}>
+      <rect x={x} y={y} width={w} height={h} rx="6" />
+      <text x={x + w / 2} y={sub === undefined ? y + h / 2 + 4 : y + h / 2 - 3}>{title}</text>
+      {sub !== undefined && (
+        <text className="pg-arch__sub" x={x + w / 2} y={y + h / 2 + 13}>
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function Flow({ d, label, dashed = false }: { d: string; label?: string; dashed?: boolean }): JSX.Element {
+  return (
+    <g className={`pg-arch__flow${dashed ? ' pg-arch__flow--dashed' : ''}`}>
+      <path d={d} markerEnd="url(#pg-arrow)" />
+      {label !== undefined && <text className="pg-arch__flow-label">{label}</text>}
+    </g>
+  );
+}
+
+function Overview(): JSX.Element {
+  return (
+    <svg className="pg-arch__svg" viewBox="0 0 640 360" role="img"
+      aria-label="Five services: IRIS with AI Hub, the metrics proxy, the detection engine, and the dashboard.">
+      <defs>
+        <marker id="pg-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+          <path d="M0 0 L10 5 L0 10 z" />
+        </marker>
+      </defs>
+
+      {/* The IRIS container holds both the production and AI Hub -- the single most
+          load-bearing fact on this slide, so it is drawn as containment. */}
+      <g className="pg-arch__group">
+        <rect x="16" y="24" width="180" height="300" rx="8" />
+        <text x="106" y="46">IRIS container</text>
+      </g>
+      <Node x={32} y={64} w={148} title="LABDEMO" sub="the production" tone="brand" />
+      <Node x={32} y={132} w={148} title="AI Hub" sub="agent · 6 MCP tools" tone="accent" />
+      <Node x={32} y={200} w={148} title="RBAC · audit" sub="policies, one write tool" />
+      <Node x={32} y={264} w={148} title="/api/monitor" sub="built-in metrics" />
+
+      <Node x={248} y={64} w={136} title="Metrics proxy" sub="polls, aggregates" />
+      <Node x={248} y={160} w={136} title="Detection engine" sub="baseline · rules · agent" tone="brand" />
+      <Node x={248} y={264} w={136} title="Findings API" sub="/api/*" />
+
+      <Node x={452} y={160} w={148} h={60} title="Dashboard" sub="what the operator sees" tone="accent" />
+
+      <Flow d="M180 290 H248 V100" label="metrics" />
+      <Flow d="M316 116 V160" />
+      <Flow d="M316 212 V264" />
+      <Flow d="M384 190 H452" label="findings" />
+      {/* Dashed: the engine reaches back into IRIS only for WHY and FIX, and only
+          through the governed tool path. A solid line would imply a data feed. */}
+      <Flow d="M248 186 H196 V158" label="investigate · resolve" dashed />
+
+      <text className="pg-arch__note" x="452" y="248">Five compose services.</text>
+      <text className="pg-arch__note" x="452" y="264">Ports and names live in</text>
+      <text className="pg-arch__note" x="452" y="280">docker-compose.yml.</text>
+    </svg>
+  );
+}
+
+function Investigation(): JSX.Element {
+  return (
+    <svg className="pg-arch__svg" viewBox="0 0 640 360" role="img"
+      aria-label="One investigation: the engine asks the agent, the agent reads evidence through governed tools, an external model reasons, and a human approves the one write.">
+      <defs>
+        <marker id="pg-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+          <path d="M0 0 L10 5 L0 10 z" />
+        </marker>
+      </defs>
+
+      <Node x={16} y={150} w={120} title="Operator" sub="clicks Investigate" tone="accent" />
+      <Node x={168} y={150} w={120} title="Engine" sub="orchestrates" />
+
+      <g className="pg-arch__group">
+        <rect x={320} y={24} width={200} height={300} rx="8" />
+        <text x={420} y={46}>IRIS · AI Hub</text>
+      </g>
+      <Node x={336} y={64} w={168} title="Agent" sub="goal, iteration cap" tone="brand" />
+      <Node x={336} y={136} w={168} title="Authorization policy" sub="checked per call" />
+      <Node x={336} y={200} w={168} title="Read tools ×5" sub="metrics · config only" />
+      <Node x={336} y={264} w={168} title="set_pool_size" sub="the one write" tone="accent" />
+
+      <Node x={552} y={64} w={72} h={44} title="LLM" sub="external" />
+      <Node x={552} y={200} w={72} h={44} title="Audit" sub="every call" tone="brand" />
+
+      <Flow d="M136 176 H168" />
+      <Flow d="M288 176 H336 V108" label="finding + snapshot" />
+      <Flow d="M504 86 H552" label="reason" dashed />
+      <Flow d="M420 116 V136" />
+      <Flow d="M420 188 V200" label="evidence" />
+      <Flow d="M504 222 H552" />
+      <Flow d="M420 252 V264" label="after approval" />
+
+      <text className="pg-arch__note" x="16" y="240">The policy is asked before every</text>
+      <text className="pg-arch__note" x="16" y="256">call, and the audit row is written</text>
+      <text className="pg-arch__note" x="16" y="272">whether the call ran or was refused.</text>
+      <text className="pg-arch__note" x="16" y="296">No message content leaves the</text>
+      <text className="pg-arch__note" x="16" y="312">instance — metrics and config only.</text>
+    </svg>
+  );
+}
+
+export function ArchitectureView(): JSX.Element {
+  const [slide, setSlide] = useState<Slide>('overview');
+
+  return (
+    <section className="pg-view" aria-labelledby="pg-arch-heading">
+      <div className="pg-view__head">
+        <h2 id="pg-arch-heading" className="pg-view__title">
+          Architecture
+        </h2>
+        <div className="pg-toggle" role="group" aria-label="Architecture slide">
+          {SLIDES.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              className={`pg-toggle__option${slide === s.id ? ' pg-toggle__option--active' : ''}`}
+              onClick={() => setSlide(s.id)}
+              aria-pressed={slide === s.id}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="pg-arch">{slide === 'overview' ? <Overview /> : <Investigation />}</div>
+
+      <p className="pg-view__caption">
+        {slide === 'overview'
+          ? 'MVP 1 detects. MVP 2 adds WHAT, WHY and FIX on one scenario — the agent, its tools, its RBAC and its audit all run inside the same IRIS instance as the production.'
+          : 'Authorization is checked before execution and the audit row is written either way, so a refused attempt is as visible as an applied one.'}
+      </p>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/BrochureView.tsx
+++ b/apps/dashboard/src/components/BrochureView.tsx
@@ -1,0 +1,67 @@
+/**
+ * The product brochure, for showing an audience what the product claims.
+ *
+ * IMPORTED RATHER THAN SERVED, and that reverses what the MVP 3 spec §3.1
+ * recommended. The spec said serve it as a static asset so 1.7 MB never lands in
+ * the bundle. That is the right instinct and the wrong call for this deployment,
+ * established by reading it rather than assuming:
+ *
+ *   - `docker-compose.yml` builds this image with `context: ./apps/dashboard`, so
+ *     `docs/Brochure.png` is outside the build context and cannot be copied in.
+ *   - `Dockerfile`'s runtime stage copies `dist/index.html` and nothing else — by
+ *     design, "the output is one HTML file plus an nginx config". A `public/` asset
+ *     would be built into `dist/` and then not shipped, so the served dashboard
+ *     would 404 it.
+ *   - `vite-plugin-singlefile` exists so `dist/index.html` opens from `file://`
+ *     (CLAUDE.md §6). A separate asset breaks that promise too.
+ *
+ * So serving it would mean committing a duplicate 1.7 MB binary AND changing the
+ * Dockerfile AND weakening the single-file fallback. Importing it keeps one copy,
+ * one artefact, and both delivery paths working. The cost is bundle size, measured
+ * and recorded in the PR rather than guessed at.
+ *
+ * The asset still lives in `docs/` — read-only source material (root `CLAUDE.md`
+ * §3) — and is referenced across the directory boundary rather than copied, so
+ * there is no second file to go stale.
+ */
+
+import { useState } from 'react';
+import brochureUrl from '../../../../docs/Brochure.png';
+
+export function BrochureView(): JSX.Element {
+  const [failed, setFailed] = useState(false);
+
+  return (
+    <section className="pg-view" aria-labelledby="pg-brochure-heading">
+      <div className="pg-view__head">
+        <h2 id="pg-brochure-heading" className="pg-view__title">
+          Brochure
+        </h2>
+      </div>
+
+      {failed ? (
+        /* Degrade visibly, never blank (§7.3). The image is inlined, so this should
+           be unreachable — which is exactly why it says where the original is
+           rather than just apologising. */
+        <p className="pg-view__caption">
+          The brochure image could not be loaded. The original is{' '}
+          <code>docs/Brochure.png</code> in the repository.
+        </p>
+      ) : (
+        <div className="pg-brochure">
+          <img
+            src={brochureUrl}
+            alt="Production Guardian brochure: the eight planned modules and the product positioning."
+            onError={() => setFailed(true)}
+          />
+        </div>
+      )}
+
+      <p className="pg-view__caption">
+        Marketing material, not a specification. Where it and the shipped product
+        disagree, the product and the contracts in <code>contracts/</code> are right —
+        five of the eight modules shown here are not built.
+      </p>
+    </section>
+  );
+}

--- a/apps/dashboard/src/components/icons.tsx
+++ b/apps/dashboard/src/components/icons.tsx
@@ -247,3 +247,27 @@ export const IconSettings: PathIcon = (props) =>
     </>,
     props,
   );
+
+/* ── Production Guardian views (MVP 3) ────────────────────────────────────── */
+
+/** Open book — the brochure. Distinct from IconMessages' single sheet. */
+export const IconBrochure: PathIcon = (props) =>
+  svg(
+    <>
+      <path d="M12 6.5v13" />
+      <path d="M12 6.5C10.5 5 8.4 4.5 5 4.5v13c3.4 0 5.5.5 7 2 1.5-1.5 3.6-2 7-2v-13c-3.4 0-5.5.5-7 2Z" />
+    </>,
+    props,
+  );
+
+/** Three linked nodes — the architecture. Reads as a topology at 17px. */
+export const IconArchitecture: PathIcon = (props) =>
+  svg(
+    <>
+      <rect x="9" y="3.5" width="6" height="5" rx="1.2" />
+      <rect x="3" y="15.5" width="6" height="5" rx="1.2" />
+      <rect x="15" y="15.5" width="6" height="5" rx="1.2" />
+      <path d="M12 8.5v3.5M12 12H6v3.5M12 12h6v3.5" />
+    </>,
+    props,
+  );

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1264,20 +1264,6 @@ button {
 .pg-view__title {
   margin: 0;
   font-size: 17px;
-/* ─── Manual remediation (MVP 3) ─────────────────────────────────────────────────────
-   Visually distinct from the resolve panel on purpose. The two say different things
-   about authority -- one has an approve button, one cannot -- and making them look the
-   same would invite an operator to look for a control that is not there. */
-
-.pg-manual {
-  margin-top: var(--pg-space-4);
-  padding-top: var(--pg-space-4);
-  border-top: 1px solid var(--pg-border);
-}
-
-.pg-manual__summary {
-  margin: 0 0 var(--pg-space-3);
-  font-size: 0.875rem;
   font-weight: 600;
   color: var(--pg-text);
 }
@@ -1403,6 +1389,26 @@ button {
     flex-direction: column;
     align-items: flex-start;
   }
+}
+
+/* ─── Manual remediation (MVP 3) ─────────────────────────────────────────────────────
+   Visually distinct from the resolve panel on purpose. The two say different things
+   about authority -- one has an approve button, one cannot -- and making them look the
+   same would invite an operator to look for a control that is not there. */
+
+.pg-manual {
+  margin-top: var(--pg-space-4);
+  padding-top: var(--pg-space-4);
+  border-top: 1px solid var(--pg-border);
+}
+
+.pg-manual__summary {
+  margin: 0 0 var(--pg-space-3);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
 .pg-manual__steps {
   margin: 0 0 var(--pg-space-3);
   padding-left: var(--pg-space-5);

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1211,3 +1211,182 @@ button {
 .pg-forecast--spent .pg-forecast__label {
   color: var(--pg-warning);
 }
+
+/* ── MVP 3: brochure and architecture views ───────────────────────────────── */
+
+/* A real control in the rail. Reset the button chrome so it sits flush with the
+   inert spans above it -- the difference an operator should see is hover and
+   focus, not a mismatched box. */
+.pg-rail__item--action {
+  width: 100%;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-size: 13.5px;
+  text-align: left;
+  color: rgb(255 255 255 / 78%);
+  cursor: pointer;
+}
+
+.pg-rail__item--action:hover {
+  background: var(--pg-navy-700);
+  color: var(--pg-text-invert);
+}
+
+.pg-rail__item--action:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: -2px;
+}
+
+/* Our group heading sits below the Health Connect list, so it needs the space the
+   first one gets from the rail's own padding. */
+.pg-rail__brand--ours {
+  margin-top: var(--pg-space-5);
+}
+
+/* Shared frame for both document views. */
+.pg-view {
+  background: var(--pg-surface);
+  border: 1px solid var(--pg-border);
+  border-radius: var(--pg-radius-lg);
+  box-shadow: var(--pg-shadow-card);
+  padding: var(--pg-space-5);
+}
+
+.pg-view__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pg-space-4);
+  margin-bottom: var(--pg-space-4);
+}
+
+.pg-view__title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+.pg-view__caption {
+  margin: var(--pg-space-4) 0 0;
+  max-width: 78ch;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--pg-text-muted);
+}
+
+.pg-brochure {
+  background: var(--pg-surface-sunk);
+  border-radius: var(--pg-radius);
+  padding: var(--pg-space-3);
+  text-align: center;
+}
+
+/* Bounded by viewport height as well as width: the brochure is a tall page, and a
+   projector at 1024×768 would otherwise show only its masthead. */
+.pg-brochure img {
+  max-width: 100%;
+  max-height: 68vh;
+  object-fit: contain;
+  border-radius: var(--pg-radius);
+}
+
+.pg-arch {
+  background: var(--pg-surface-sunk);
+  border-radius: var(--pg-radius);
+  padding: var(--pg-space-4);
+}
+
+.pg-arch__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 64vh;
+}
+
+/* Containment boxes -- the IRIS container, AI Hub. Dashed so they read as a
+   boundary rather than as another component. */
+.pg-arch__group rect {
+  fill: none;
+  stroke: var(--pg-border);
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+}
+
+.pg-arch__group text {
+  fill: var(--pg-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-anchor: middle;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pg-arch__node rect {
+  fill: var(--pg-surface);
+  stroke: var(--pg-border);
+  stroke-width: 1.5;
+}
+
+.pg-arch__node text {
+  fill: var(--pg-text);
+  font-size: 12.5px;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.pg-arch__node .pg-arch__sub {
+  fill: var(--pg-text-muted);
+  font-size: 10.5px;
+  font-weight: 400;
+}
+
+/* Two tones only, and both are brand rather than severity. Severity colours are
+   reserved for severity (§7.1) -- a teal box here must not read as "healthy". */
+.pg-arch__node--brand rect {
+  fill: var(--pg-navy-800);
+  stroke: var(--pg-navy-900);
+}
+
+.pg-arch__node--brand text {
+  fill: var(--pg-text-invert);
+}
+
+.pg-arch__node--brand .pg-arch__sub {
+  fill: var(--pg-teal-200);
+}
+
+.pg-arch__node--accent rect {
+  fill: var(--pg-ok-bg);
+  stroke: var(--pg-teal-500);
+}
+
+.pg-arch__flow path {
+  fill: none;
+  stroke: var(--pg-navy-600);
+  stroke-width: 1.6;
+}
+
+.pg-arch__flow--dashed path {
+  stroke-dasharray: 4 3;
+}
+
+.pg-arch__flow marker path,
+.pg-arch__svg marker path {
+  fill: var(--pg-navy-600);
+  stroke: none;
+}
+
+.pg-arch__flow-label,
+.pg-arch__note {
+  fill: var(--pg-text-muted);
+  font-size: 10.5px;
+}
+
+@media (max-width: 1100px) {
+  .pg-view__head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,68 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-23 — `get_host_settings`, and an optional argument does not default (Dev B)
+
+**`mcp-tools.md` only.** No schema change, no sample change — `validate.mjs` stays at 3 samples /
+26 reject. Two edits, one additive and one a correction to a statement that was wrong in a way that
+cost a live investigation.
+
+### 1. §3.4b — `get_host_settings` added
+
+MVP 3's scenario needs the agent to **name** the directory a service cannot read. That value lives
+in exactly two places: the `#5021` log message, and the host's configuration. `get_recent_errors`
+will never return log text — `Ens_Util.Log` on this instance holds 61,772 rows carrying `PatientID`
+in plain text — so without this tool the agent can learn *a path is missing* and never *which path*.
+
+Configuration is what the boundary permits: root `CLAUDE.md` §2.1 is "metrics and configuration only,
+never message content." A setting **value** is configuration by definition — typed by whoever
+deployed the production, not derived from a message.
+
+**An allowlist of nine setting names, not the whole collection.** Returning everything would be one
+`Credentials` row away from handing an external LLM the name of a credential set, and one future
+setting away from something worse, since productions are configured by people and people put
+surprising things in free-text settings. `Credentials` is deliberately absent even though it is only
+an identifier: an agent has no diagnostic use for it that outweighs saying its name out loud. Adding
+a name to the allowlist is a contract change, on purpose — the same reasoning as `set_pool_size`'s
+single whitelisted host and the `#5021` catalogue.
+
+`settingsOnItem` reports the unfiltered count, so "this host has three settings" is distinguishable
+from "the allowlist filtered most of them out". Without it, a host configured entirely through
+refused settings looks identical to one with no configuration at all.
+
+Expected tool count moves **6 → 7**; `Setup.AIHub.Run()` prints it at boot.
+
+### 2. §2 — an optional parameter arrives as `""`, not as its default
+
+The paragraph above it said required-vs-optional is expressed in the ObjectScript signature, which is
+true of the **generated schema** and does not describe what the tool body receives.
+`%AI.ToolMgr.ExecuteTool` passes `""` for a key the model omitted rather than omitting the argument,
+so `sinceMinutes As %Integer = 15` never defaults on the tool path. Measured, same host, same second:
+
+```
+{"host":"EMR Source"}                      -> {"error": "sinceMinutes must be between 1 and 60"}
+{"host":"EMR Source","sinceMinutes":15}    -> 3 errors, #5021 and <Ens>ErrProductionSettingInvalid
+```
+
+A tool declaring an optional parameter and range-checking it therefore **refused every call that
+omitted it**. Live since #106.
+
+**Why it survived that long, and why the fix is in the contract.** The only caller that omits an
+optional parameter is the model. Every hand-written probe, test and demo script passed it explicitly,
+so nothing we ran could see it. And the failure was not an error: blinded to the error codes, the
+agent reasoned from the one value it could still read — `PoolSize 1` — and recommended enlarging the
+pool of a host whose configured directory did not exist. **A tool that refuses is
+indistinguishable, in the narrative, from a tool that found nothing.** That is §2.1's
+unmeasurable-is-not-zero rule arriving through the argument list rather than the return value, which
+is why it belongs next to the schema rule it corrects rather than in a code comment.
+
+The contract now requires the body to restate the default (`if x = "" { set x = default }`) while
+still refusing a value the model sent and got wrong, and asks that samples carry the
+omitted-argument call rather than only the explicit one.
+
+---
+
+
 ## 2026-08-20 — MVP 3's two contract changes, and the first MVP 2 schema (Dev B)
 
 **Two documents changed, one schema and one captured sample added.** `validate.mjs` goes from

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -3,7 +3,7 @@
 **Owner:** Dev B (inherited `iris/**` from Dev A) · **Consumer:** Dev B (agent orchestration), Dev C
 (approval UI, indirectly) · **Runs in:** the `pg-iris` container · **Status:** published
 
-Six tools. Five read, one write. They exist so the **AI Detective** agent can gather evidence about
+**Seven tools since MVP 3. Six read, one write.** They exist so the **AI Detective** agent can gather evidence about
 one condition on one host, and so **Smart Resolve** can apply one bounded action to it. Root
 `CLAUDE.md` §2.1 is the scope boundary; this file is the interface.
 
@@ -72,6 +72,39 @@ is omitted from the generated `required` array; a parameter **without** one is r
 `sinceMinutes As %Integer = 15` is optional *because* it has a default. Do not document a parameter
 as optional and then declare it without a default — the generated schema, not this table, is what
 the agent obeys.
+
+**But the ObjectScript default does not apply on the tool path, and a tool must restate it in the
+body.** `%AI.ToolMgr.ExecuteTool` builds the argument list from the model's JSON and passes `""` for
+a key the model omitted — it does not omit the argument, so `= 15` never fires. A parameter declared
+optional therefore arrives as the empty string, and any range check written against it rejects the
+call. Measured on the same host in the same second:
+
+```
+Invoke("GetRecentErrors", {"host":"EMR Source"})                      -> {"error": "sinceMinutes must be between 1 and 60"}
+Invoke("GetRecentErrors", {"host":"EMR Source", "sinceMinutes": 15})  -> 3 errors, #5021 and <Ens>ErrProductionSettingInvalid
+```
+
+So the signature declares the *schema* and the body must enforce the *default*:
+
+```objectscript
+if sinceMinutes = "" { set sinceMinutes = 15 }   // absence -> default
+if (sinceMinutes < 1) || (sinceMinutes > 60) { ... }   // a wrong value the model SENT is still refused
+```
+
+The two branches are separate on purpose: absence means "use the default", a sent-and-wrong value
+means "refuse and name the range". Collapsing them either way loses one of those.
+
+**Why this is worth a contract paragraph rather than a code comment.** It was live from #106 and
+invisible to every check we had, because the only caller that omits an optional parameter is the
+model — every hand-written probe, test and demo script passed the argument explicitly. It surfaced
+only in a live agent turn, and the failure was not an error: blinded to the error codes, the agent
+reasoned from the one value it could still read (`PoolSize 1`) and recommended enlarging the pool of
+a host whose configured directory did not exist. **A tool that refuses is indistinguishable, in the
+narrative, from a tool that found nothing** — which makes this the same defect class as §2.1's
+unmeasurable-vs-zero, arriving through the argument list instead of the return value.
+
+Any new tool with an optional parameter must do the same, and `contracts/samples/` should carry the
+omitted-argument call rather than only the explicit one.
 
 **Units are seconds**, everywhere a duration appears, matching `healthscan-api.md` Q6. Confirmed
 empirically rather than assumed: `Cloud API` configured at 0.05s latency reports `0.05`.
@@ -477,6 +510,79 @@ settings — never from a log row.
 **The `#5021` entry is the whole reason MVP 3 needs this tool at all**, and it is also why the tool
 alone is insufficient: `count: 8` and that summary tell the agent a path is missing and not *which*
 path. Naming it requires reading configuration, which is a different tool and a different boundary.
+
+### 3.4b `get_host_settings` — read, added in MVP 3
+
+The configured adapter settings for one host, **filtered by an allowlist of setting names**.
+
+**Input**
+
+| Field | Type | Req | Notes |
+|---|---|---|---|
+| `host` | string | **required** | Config item name. |
+
+**Output**
+
+| Field | Type | Notes |
+|---|---|---|
+| `host` | string | Echoed. |
+| `found` | boolean | `false` with an `error` when the host is not in the running production. |
+| `settings` | object | Permitted setting names to their values. Absent names are absent, not null. |
+| `settingsOnItem` | integer | How many settings the item carries **before** filtering. |
+
+Permitted names: `FilePath`, `ArchivePath`, `WorkPath`, `FileSpec`, `PollInterval`, `HTTPServer`,
+`HTTPPort`, `URL`, `TargetConfigNames`, plus `PoolSize` (a property of `Ens.Config.Item`, not a
+settings row — the same value `get_pool_size` publishes, not a second source of truth).
+
+**WHY THIS TOOL EXISTS, and it is a boundary decision rather than a convenience.** MVP 3's scenario
+needs the agent to name a directory a service cannot read. That name lives in exactly two places:
+the `#5021` log message, and the configuration. `get_recent_errors` will never return log text
+(§3.4, §6), so without this tool the agent learns *a path is missing* and never *which path*.
+Configuration is what root `CLAUDE.md` §2.1 permits — a setting value was typed by whoever deployed
+the production, not derived from a message.
+
+**AN ALLOWLIST, NOT THE WHOLE COLLECTION.** Returning every setting is one `Credentials` row away
+from handing an external LLM the name of a credential set, and one future setting away from
+something worse: productions are configured by people, and people put surprising things in free-text
+settings. So the tool names what it returns and refuses the rest by construction — the same
+reasoning as `set_pool_size`'s single whitelisted host.
+
+**`Credentials` is deliberately absent** even though it is only an identifier. It names a stored
+secret, and no diagnosis needs it enough to justify saying its name outside the instance.
+
+**`settingsOnItem` exists so filtering is visible.** Without it, a host configured entirely through
+refused settings looks identical to one with no configuration at all — and "this host has nothing
+set" is a materially different diagnosis from "I am not allowed to see what is set".
+
+```jsonc
+// -> get_host_settings
+{ "host": "EMR Source" }
+```
+
+```jsonc
+// <- the missing-folder scenario, armed
+{
+  "host": "EMR Source",
+  "found": true,
+  "settings": {
+    "FilePath": "/tmp/labdemo/hl7-in-missing/",
+    "FileSpec": "*.hl7",
+    "ArchivePath": "/tmp/labdemo/hl7-archive/",
+    "PollInterval": "2",
+    "TargetConfigNames": "Lab Router",
+    "PoolSize": 1
+  },
+  "settingsOnItem": 6
+}
+```
+
+Combined with `get_recent_errors`, the agent can conclude: *`EMR Source` is in Error; a `#5021` was
+logged, which means a configured path does not exist; its `FilePath` is
+`/tmp/labdemo/hl7-in-missing/`* — a specific diagnosis built entirely from configuration and a
+catalogue, with no log text crossing the boundary.
+
+Measured on `Cloud API`, which carries a `Credentials` setting: `settingsOnItem` reads `4` and
+`settings` returns `3`. The filter is doing something, and the response says so.
 
 ### 3.5 `get_processing_time` — read
 
@@ -954,7 +1060,7 @@ denial happened.
 the same call at `0.0071 s`. Stated because a reader comparing §5.5's promise of a duration against
 a column of zeroes should find the explanation here rather than assume the field is broken.
 
-Every one of the six tools is audited on every call. Not a per-tool setting: it is where the audit
+Every one of the seven tools is audited on every call. Not a per-tool setting: it is where the audit
 hook sits in the execution path (§5.2) — plus the policy's own row for the one case that path
 cannot see.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,11 +262,24 @@ services:
         condition: service_healthy
 
   # ─── 5. dashboard ───────────────────────────────────────────────────────────────────
-  # Dev C's service (#79). Multi-stage: node builds the same single-file bundle the
-  # `file://` fallback is verified against, nginx serves it and proxies /api/healthscan.
+  # Multi-stage: node builds the same single-file bundle the `file://` fallback is verified
+  # against, nginx serves it and proxies /api/healthscan.
+  #
+  # CONTEXT IS THE REPO ROOT, not ./apps/dashboard, since MVP 3 Track B. `BrochureView.tsx`
+  # imports `../../../../docs/Brochure.png` so the 1.7 MB asset has exactly one copy in git
+  # and no Dockerfile change is needed to ship it (#120). That import cannot resolve from a
+  # context rooted at the app directory:
+  #
+  #   Could not resolve "../../../../docs/Brochure.png" from "src/components/BrochureView.tsx"
+  #
+  # A host `npm run build` succeeds regardless, because the host has the whole repo. So this
+  # was green locally and red in `compose up` -- the same "works and is reached are different
+  # claims" gap as iris/CLAUDE.md's three provider defects, arriving through the build context.
+  # The `dockerfile:` path must now be repo-relative for the same reason.
   dashboard:
     build:
-      context: ./apps/dashboard
+      context: .
+      dockerfile: apps/dashboard/Dockerfile
     container_name: pg-dashboard
     ports:
       # 5173:80 -- the container listens on 80, not 8080. Keeping 5173 on the host so the

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -289,9 +289,54 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "evidence (array of {label, detail, source, tool} where source is ""mcp_tool"" for a value you read with a tool "
     set p = p _ "or ""snapshot"" for one given to you, and tool is the tool name or null), "
     set p = p _ "confidence (number 0-1, your own judgement), "
-    set p = p _ "recommendedAction ({action: {type, host, size}}) or null. "
-    set p = p _ "The only action type you may recommend is set_pool_size, with size between 2 and 8, "
-    set p = p _ "and host must be the host under investigation. Recommend nothing if no bounded action fits."
+    set p = p _ "recommendedAction ({action: {type, host, size}}) or null, "
+    set p = p _ "manualRemediation ({summary, steps, target}) or null. "
+    // The bounds are READ FROM THE TOOL rather than restated, because a prompt that disagrees with
+    // the guard produces a recommendation the guard then refuses -- which is what happened. The
+    // wording was "host must be the host under investigation", and on the missing-folder scenario the
+    // model dutifully recommended set_pool_size on `EMR Source`; a dry run came back
+    // `not_whitelisted_host`. The safety boundary held perfectly and the recommendation was still
+    // useless, so the UI would have offered an approve button for an action that cannot apply.
+    //
+    // Naming the one host it CAN change is also what makes manualRemediation reachable: told the
+    // action is unavailable here, the model has somewhere else to put a real fix. Told only that the
+    // action exists, it will reach for it.
+    set p = p _ "The only action type you may recommend is set_pool_size, with size between "
+        _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#MINSIZE _ " and "
+        _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#MAXSIZE _ ". "
+    set p = p _ "It can ONLY be applied to '" _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#ALLOWEDHOST
+        _ "', and only when that host is the one under investigation. "
+    set p = p _ "For any other host this action is unavailable and recommending it is an error -- "
+    set p = p _ "it will be refused before it applies. "
+
+    // MVP 3. The two fields are described as MUTUALLY EXCLUSIVE and as differing in AUTHORITY rather
+    // than in format, because that is the distinction the model has to get right: one is a change we
+    // may make, the other is a change only a person may make. A prompt that described them as "a
+    // structured fix or a written fix" would invite both, or the wrong one.
+    set p = p _ "Use recommendedAction ONLY for a bounded action from that list. "
+    set p = p _ "Use manualRemediation when the fix is real but outside what this system may do -- "
+    set p = p _ "for example a directory that must be created on the host, or a setting an operator "
+    set p = p _ "must repoint. Never both, and null for both if nothing can be recommended. "
+    set p = p _ "manualRemediation.summary is one line naming the condition; steps is an ordered array "
+    set p = p _ "of imperative strings, each independently actionable; target is "
+    set p = p _ "{host, setting, currentValue} identifying the CONFIGURATION to change, or null if you "
+    set p = p _ "cannot identify it. "
+
+    // The one thing the model must not be allowed to infer. `appliedBy` is set by the dispatcher, not
+    // read from the reply (investigate.ts does the same), so the prompt does not mention it -- a model
+    // told the field exists could assert "system", and autonomous remediation is what root
+    // CLAUDE.md §2.1 forbids outright. Naming a field only to forbid a value is weaker than not
+    // offering it.
+    set p = p _ "Never claim this system will apply a manual remediation itself; it will not. "
+
+    // Says where the path comes from, because the alternative is the model quoting an error message
+    // it should not have. get_recent_errors returns a catalogue `summary` and never log text, so the
+    // OFFENDING VALUE has to come from get_host_settings -- and a model that does not know that will
+    // either guess a path or ask for the log.
+    set p = p _ "To name a specific path or setting value, read it with get_host_settings. "
+    set p = p _ "get_recent_errors gives you the KIND of failure and never the message text. "
+
+    set p = p _ "Recommend nothing if no bounded action and no manual step fits."
     quit p
 }
 

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -105,11 +105,68 @@ ClassMethod Investigate() As %Status
         set stats = session.GetStats()
         set parsed.toolCalls = $select($isobject(stats): stats."total_tool_calls", 1: "")
 
+        do ..DropUnapplicableAction(parsed)
+
         write parsed.%ToJSON()
         return $$$OK
     } catch ex {
         return ..Fail(500, "investigation failed: " _ ex.DisplayString())
     }
+}
+
+/// Drop a `recommendedAction` the write tool would refuse anyway. Private.
+///
+/// WHY A DETERMINISTIC GUARD RATHER THAN A BETTER PROMPT. The prompt already states the bound --
+/// `set_pool_size` applies only to the whitelisted host, and never both fields -- and the model
+/// obeys it **most** of the time. Measured over four consecutive live runs on the same finding,
+/// same prompt, same model:
+///
+///   action=set_pool_size on EMR Source   manual=yes     <- both, and the action is unapplicable
+///   action=set_pool_size on EMR Source   manual=yes
+///   action=set_pool_size on EMR Source   manual=null    <- worst: the only fix offered cannot apply
+///   action=null                          manual=yes     <- correct
+///
+/// One in four. **A prompt is a request, not a constraint**, and a demo cannot run on a 25% gate.
+/// This is the same lesson as the ungoverned write in #92 from the other direction: there, a guard
+/// was documented and absent; here, a guard was *asked for* and probabilistic. Neither is a guard.
+///
+/// So the bound is enforced where it is checkable. `Tools.Resolve` would refuse the call regardless
+/// -- that boundary always held and is what makes this safe rather than merely tidy. What it could
+/// not prevent is the **recommendation** reaching a UI that then renders an approve button for an
+/// action guaranteed to fail. An operator clicking it learns nothing except that the product is
+/// broken.
+///
+/// DROPPED, NOT REWRITTEN. This method never invents a `manualRemediation` to replace what it
+/// removes, and never edits the narrative: `rootCause` and `evidence` are the model's and stay
+/// verbatim. If the model offered only an unapplicable action, the honest result is a diagnosis
+/// with no fix -- which §3.1 has always allowed and which is exactly what MVP 3's scenario is
+/// about. Substituting our own words here would make the dispatcher a second author.
+ClassMethod DropUnapplicableAction(parsed As %DynamicObject) [ Private ]
+{
+    if '$isobject(parsed.%Get("recommendedAction")) {
+        quit
+    }
+    set action = parsed.recommendedAction.%Get("action")
+    if '$isobject(action) {
+        quit
+    }
+
+    // Read the bound from the tool, not from a literal -- the whole defect being fixed is a second
+    // copy of a rule disagreeing with the rule.
+    set host = action.%Get("host", "")
+    if host = ##class(ProductionGuardian.LabDemo.Tools.Resolve).#ALLOWEDHOST {
+        quit
+    }
+
+    set parsed.recommendedAction = ""
+    // Built before the literal: a concatenation inside a %DynamicObject constructor is #1021
+    // "Expected right bracket". Only a parenthesised single expression is accepted there.
+    set detail = "set_pool_size applies only to '" _ ##class(ProductionGuardian.LabDemo.Tools.Resolve).#ALLOWEDHOST _ "'"
+    // Recorded on the response rather than only in the log, because "the model recommended
+    // something we dropped" is information the engine and a reviewer both want, and a silent
+    // filter is indistinguishable from a model that behaved. The engine ignores unknown keys.
+    set parsed.droppedAction = { "type": (action.%Get("type", "")), "host": (host),
+        "reason": "not_whitelisted_host", "detail": (detail) }
 }
 
 /// Invoke the governed write tool. Every guard is the tool's, not this class's.

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -92,6 +92,70 @@ ClassMethod GetPoolSize(host As %String) As %DynamicObject
     quit out
 }
 
+/// Report the configured adapter settings for one interoperability host.
+///
+/// WHY THIS TOOL EXISTS, and it is a data-boundary decision rather than a convenience. MVP 3's
+/// scenario needs the agent to name the directory a service cannot read. That name lives in exactly
+/// two places: the `#5021` log message, and the host's configuration. `GetRecentErrors` will never
+/// return log text -- `Ens_Util.Log` holds 61,772 rows carrying `PatientID` in plain text -- so
+/// without this tool the agent can learn *a path is missing* and never *which path*.
+///
+/// Configuration is what the boundary permits: root `CLAUDE.md` §2.1 is "metrics and configuration
+/// only, never message content". A setting VALUE is configuration by definition; it was typed by
+/// whoever deployed the production, not derived from a message.
+///
+/// AN ALLOWLIST OF SETTING NAMES, NOT EVERY SETTING. Returning the whole collection would be one
+/// `Credentials` row away from handing an external LLM the name of a credential set, and one future
+/// setting away from something worse -- a production is configured by people, and people put
+/// surprising things in free-text settings. So the tool names what it will return and refuses the
+/// rest by construction. Adding a name here is a decision, which is the same reasoning as
+/// `Tools.Resolve`'s single whitelisted host and the `#5021` catalogue.
+///
+/// `Credentials` is deliberately ABSENT even though it is only an identifier: it names a stored
+/// secret, and an agent has no diagnostic use for it that outweighs saying its name out loud.
+ClassMethod GetHostSettings(host As %String) As %DynamicObject
+{
+    set out = { "host": (host), "found": false, "settings": {} }
+    set item = ..FindItem(host)
+    if '$isobject(item) {
+        set out.error = "no such config item in " _ ..#PRODUCTION
+        quit out
+    }
+    set out.found = 1
+
+    // The allowlist. Path and target settings, because those are what a misconfiguration diagnosis
+    // needs -- where the host reads from, where it writes to, and where it sends.
+    set allowed = $listbuild(
+        "FilePath",
+        "ArchivePath",
+        "WorkPath",
+        "FileSpec",
+        "PollInterval",
+        "HTTPServer",
+        "HTTPPort",
+        "URL",
+        "TargetConfigNames")
+
+    for i = 1:1:item.Settings.Count() {
+        set setting = item.Settings.GetAt(i)
+        // $listfind, not %INLIST -- the latter is SQL-only and raises #1010 in method code.
+        if $listfind(allowed, setting.Name) > 0 {
+            do out.settings.%Set(setting.Name, setting.Value)
+        }
+    }
+
+    // The POOL SIZE is a property rather than a Settings row, so it is not in the loop above. Added
+    // because a diagnosis about throughput needs it and `get_pool_size` already publishes it -- this
+    // is the same value, not a second source of truth.
+    set out.settings.PoolSize = +item.PoolSize
+
+    // COUNTED, so the agent can tell "this host has three settings" from "the allowlist filtered
+    // most of them out". Without it, a host configured entirely through settings this tool refuses
+    // looks identically bare to one with no configuration at all.
+    set out.settingsOnItem = item.Settings.Count()
+    quit out
+}
+
 /// Report recent error counts for one interoperability host, classified by IRIS error code.
 ///
 /// Returns COUNTS and error CODES only -- never log text. Error text can contain patient data,
@@ -106,6 +170,9 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
         quit { "host": (host), "error": "sinceMinutes must be between 1 and 60", "sanitised": true }
     }
 
+    // `sinceMinutes` echoed under the SAME name as the input. The contract said `windowMinutes` on
+    // output until 2026-08-20 and this said `sinceMinutes`; reconciled in #116 toward one name,
+    // because a different name on each side is a translation step nobody wanted.
     set out = { "host": (host), "sinceMinutes": (sinceMinutes), "count": null, "sanitised": true, "byCode": [] }
 
     // THE PHI BOUNDARY, and this is measured rather than cautious. Ens_Util.Log on this instance
@@ -151,7 +218,10 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
     for {
         set code = $order(codes(code), 1, n)
         quit:code=""
-        do out.byCode.%Push({ "errorCode": (code), "count": (n) })
+        // `summary` lives on the byCode entry because it is keyed by `errorCode` -- a property of
+        // the CODE, not of an occurrence. That is what made the aggregate shape sufficient and the
+        // per-event `errors[]` array unnecessary (@kskubach's correction on #116).
+        do out.byCode.%Push({ "errorCode": (code), "count": (n), "summary": (..ErrorSummary(code)) })
     }
     quit out
 }
@@ -290,6 +360,40 @@ ClassMethod HostStatusRow(host As %String, ByRef row) As %Status [ Private ]
 /// novel error message cannot leak through a gap in a pattern list. A denylist would need to
 /// anticipate every shape PHI can take in a log line, which is not a bet worth taking on a
 /// healthcare system.
+/// The `summary` catalogue — `contracts/mcp-tools.md` §3.4a.
+///
+/// A FIXED STRING LOOKED UP BY `errorCode`, never derived from the log row. That is the whole reason
+/// it is safe to send: `Ens_Util.Log` on this instance holds 61,772 rows carrying `PatientID` in
+/// plain text, and a summary built from the row would carry whatever the row carries. A catalogue
+/// cannot, by construction.
+///
+/// THE ALLOWLIST MUST NOT GAIN AN EXCEPTION FOR `#5021`. The tempting shortcut for MVP 3's scenario
+/// is to return that error's message text, because it contains the missing path and the path is
+/// *usually* harmless. That is the wrong shape twice: an allowlist with one exception is one an
+/// implementer widens, and "usually harmless" is the rare-rather-than-absent pattern that survives
+/// review and then leaks. The agent learns the KIND of fault here and the offending path from
+/// `GetHostSettings` -- configuration, which the boundary permits.
+///
+/// Adding a row is a contract change (§3.4a), deliberately: a code that reaches an agent with a
+/// human-readable meaning is a decision about what the model is told.
+ClassMethod ErrorSummary(code As %String) As %String [ Private ]
+{
+    // Returns "" for anything not listed, which GetRecentErrors emits as JSON null -- §3.4a's
+    // "null when unclassified". An unknown code gets a count and no interpretation, which is honest:
+    // the agent can see something is failing and cannot be told what it means.
+    quit $case(code,
+        "#5021": "a configured directory or file path does not exist",
+        "#6059": "the configured downstream host or port could not be reached",
+        "#5001": "a general IRIS error was raised while handling a message",
+        "<Ens>ErrFailureTimeout": "the host retried and gave up within its failure timeout",
+        "<Ens>ErrConnectionLost": "the connection to the downstream target was lost",
+        "<Ens>ErrHTTPStatus": "the downstream returned an HTTP status the adapter treats as an error",
+        "<Ens>ErrProductionSettingInvalid": "a production setting on this host is not a valid value",
+        "<Ens>ErrTCPTerminatedReadTimeoutExpired": "a TCP read timed out before the downstream replied",
+        "<Ens>ErrGeneral": "the interoperability framework raised a general error",
+        : "")
+}
+
 ClassMethod ClassifyError(text As %String) As %String [ Private ]
 {
     set known = $listbuild(

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -162,10 +162,30 @@ ClassMethod GetHostSettings(host As %String) As %DynamicObject
 /// so this tool classifies rather than quotes.
 ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %DynamicObject
 {
+    // AN OMITTED ARGUMENT IS NOT AN INVALID ONE, and the ObjectScript default above does not cover
+    // this. `%AI.ToolMgr.ExecuteTool` builds the argument list from the model's JSON and passes ""
+    // for a key the model did not send -- so the `= 15` default never applies on the tool path, ""
+    // fails `< 1` below, and the tool refused every call that omitted the parameter. Measured:
+    //
+    //   Invoke("GetRecentErrors", {"host":"EMR Source"})                 -> error, sinceMinutes
+    //   Invoke("GetRecentErrors", {"host":"EMR Source","sinceMinutes":15}) -> 3 errors, #5021
+    //
+    // Same host, same second, opposite answers. This was live from #106 and invisible because every
+    // hand-written check passed the argument -- the only caller that omits it is the model, whose
+    // schema marks it optional. It cost a live investigation: blinded to the error codes, the agent
+    // reasoned from the one number it could still see (PoolSize 1) and recommended enlarging the pool
+    // of a host whose directory did not exist.
+    if sinceMinutes = "" {
+        set sinceMinutes = 15
+    }
+
     // BOUNDED, and the bound is part of the data boundary rather than politeness. A count is not
     // content, but a count of one nearly is: "1 error for patient X in the last 5 seconds" is
     // identifying in a way "40 errors in 15 minutes" is not. 60 minutes is the ceiling because
     // this tool answers questions about a CONDITION, not a message search interface.
+    //
+    // Still rejects a value the model actually sent and got wrong -- `0` and `90` are refusals, and
+    // the refusal names the range. Only absence now means "use the default".
     if (sinceMinutes < 1) || (sinceMinutes > 60) {
         quit { "host": (host), "error": "sinceMinutes must be between 1 and 60", "sanitised": true }
     }

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -47,6 +47,17 @@ Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
 /// reporting nothing armed -- a status method lying by omission (@tanifgit, #66).
 Parameter CLOSEDPORT = 59999;
 
+/// The directory MissingFolder() points EMR Source at — one that does not exist.
+///
+/// Under /tmp/labdemo/ rather than somewhere exotic, so a reader of the boot log sees a path that
+/// looks like the real one with a suffix, not a contrived value. `-missing` rather than a random
+/// name because the point of the scenario is that the *configuration* is wrong, and a plausible
+/// typo is what actually happens on a real deployment.
+///
+/// NOT CREATED, EVER. `FirstBoot.MakeDirectories()` creates the two real drop directories on every
+/// boot; if this one were in that list the scenario would disarm itself. Checked that it is not.
+Parameter MISSINGPATH = "/tmp/labdemo/hl7-in-missing/";
+
 /// dead_host -- absolute, fires within two polls. The demo's headline finding.
 ClassMethod DeadHost() As %Status
 {
@@ -457,6 +468,23 @@ ClassMethod Reset() As %Status
         kill ^ProductionGuardian.Trigger("RateSecs")
         write "  restored the HL7 inflow rate to the generator's own interval", !
     }
+    // The FilePath, restored to what it WAS rather than to a literal -- the same rule as the port
+    // above, and for the same reason: a deployment that legitimately uses a different inbound
+    // directory must not be rewritten by a reset. If nothing was stashed, MissingFolder() never ran
+    // and the path is whatever the environment configured.
+    if $data(^ProductionGuardian.Trigger("PathWas")) {
+        set was = ^ProductionGuardian.Trigger("PathWas")
+        if was '= "" {
+            do ..SetSetting(..#SERVICE, "Adapter", "FilePath", was)
+            write "  ", ..#SERVICE, " FilePath restored to ", was, !
+        } else {
+            // Absent before arming is the shipped state for a setting this class added.
+            do ..RemoveSetting(..#SERVICE, "FilePath")
+            write "  ", ..#SERVICE, " FilePath removed, as it was before arming", !
+        }
+        kill ^ProductionGuardian.Trigger("PathWas")
+    }
+
     if $data(^ProductionGuardian.Trigger("MaxQueued")) {
         kill ^ProductionGuardian.Trigger("MaxQueued")
         write "  removed the generator's queue-depth cap", !
@@ -547,6 +575,15 @@ ClassMethod Status() As %Status
     write "  HL7 inflow     : ", $select(rate > 0: rate _ "s per message  <- rate overridden", 1: "generator default"), !
     // Reported with the live depth beside it, so "capped" and "currently paused" are distinguishable
     // at a glance -- a presenter seeing a flat queue needs to know whether it is held or stuck.
+    // Reported for the same reason as the throttle and the inflow rate: an armed FilePath shows up
+    // as a host in Error with no obvious cause, and Status() exists so nothing armed is invisible.
+    set livePath = ..GetSetting(..#SERVICE, "FilePath")
+    write "  inbound path   : ", $select(livePath = "": "(adapter default)", 1: livePath),
+        $select(livePath = ..#MISSINGPATH: "   <- ARMED, does not exist", 1: ""), !
+    if $data(^ProductionGuardian.Trigger("PathWas")) {
+        write "  path stashed   : ", ^ProductionGuardian.Trigger("PathWas"), "  <- Reset() will restore this", !
+    }
+
     set cap = +$get(^ProductionGuardian.Trigger("MaxQueued"), 0)
     if cap > 0 {
         set depth = ##class(Ens.Queue).GetCount(..#OPERATION)
@@ -734,6 +771,76 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
         quit $$$ERROR($$$GeneralError, "no such config item: " _ pItem _ " (renamed in Production.cls?)")
     }
     quit def.%Save()
+}
+
+/// MVP 3 scenario 2 — the missing folder. A host that cannot read its inbound directory.
+///
+/// WHY THIS SCENARIO EXISTS. Every finding MVP 2 could produce had a governed action behind it, so
+/// nothing exercised the path where the correct answer is **no action at all**. This one is a real
+/// failure — `FirstBoot.cls` records it from the #34/#53 deploy, where the two HL7 drop directories
+/// did not exist and `EMR Source` went straight to Error with `#5021` — and the fix is an operator
+/// creating a directory, which Production Guardian must recommend without offering to do.
+///
+/// ARMED BY REPOINTING THE SETTING, NOT BY DELETING THE DIRECTORY, and the third reason is the one
+/// that decides it:
+///
+///   1. The generator writes into that directory, so deleting it breaks inbound traffic a second way
+///      and the finding stops being about what it claims to be about.
+///   2. `FirstBoot.MakeDirectories()` recreates it on every boot, so an armed demo would disarm
+///      itself on the next restart.
+///   3. **It is not reversible from inside IRIS.** Every toggle in this class stashes what it
+///      replaced and `Reset()` puts it back; a trigger that deleted a filesystem directory could not
+///      honour that contract, because recreating a directory is not the same as never having removed
+///      it — permissions and ownership are lost.
+///
+/// So this is `ErrorRate()`'s stash-and-restore shape with a path instead of a port.
+///
+/// WHICH FINDING FIRES. `dead_host`, because `Error` is already in the engine's `DEAD_STATUSES` —
+/// read from the rule rather than assumed, so MVP 3 needs no new detection rule. `stalled_host`
+/// deliberately does NOT fire: it declines for any host already in `DEAD_STATUSES`, which is the
+/// one-condition-one-finding rule working.
+ClassMethod MissingFolder() As %Status
+{
+    set sc = ..CheckProduction()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    // Stash the REAL path before overwriting it, and only if not already stashed -- arming twice
+    // must not overwrite the saved value with the missing one. Same rule as PortWas and PoolWas,
+    // and the same reason: #66 restored a hardcoded port and destroyed a deployment that
+    // legitimately used a different one.
+    if '$data(^ProductionGuardian.Trigger("PathWas")) {
+        set ^ProductionGuardian.Trigger("PathWas") = ..GetSetting(..#SERVICE, "FilePath")
+    }
+
+    set sc = ..SetSetting(..#SERVICE, "Adapter", "FilePath", ..#MISSINGPATH)
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    // WITHOUT THIS THE SETTING PERSISTS AND NOTHING HAPPENS. SetSetting() saves the production
+    // definition; the RUNNING job keeps the value it started with, so the host stays OK and the
+    // scenario looks broken. Measured: 160 seconds at status OK with the persisted path already
+    // pointing at the missing directory. Every other arming method in this class calls this for the
+    // same reason -- copied the shape rather than rediscovering it a second time.
+    set sc = ..UpdateProduction()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+
+    write "ARMED  dead_host  (the MVP 3 missing-folder scenario)", !
+    write "  ", ..#SERVICE, " FilePath -> ", ..#MISSINGPATH, !
+    write "    stashed the real path; Reset() restores it", !
+    write "  The service polls a directory that does not exist, so every poll fails", !
+    write "    before it can read a message. Expect Error status and #5021 in the log.", !
+    write "  dead_host fires (Error is in DEAD_STATUSES).", !
+    write "  stalled_host will NOT fire -- it declines for a host already in DEAD_STATUSES.", !
+    write "  THERE IS NO GOVERNED FIX. The recommendation is words, for an operator to act on:", !
+    write "    create the directory, or repoint FilePath at one that exists.", !
+    write "  Inbound traffic stops while this is armed -- the generator still writes to the real", !
+    write "    directory, and the service is no longer looking at it.", !
+    quit $$$OK
 }
 
 /// Remove one setting from one config item, if present. Absent is the shipped state for

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -377,7 +377,15 @@ ClassMethod CreateRoles() As %Status
 /// every setup run so the regression is visible at boot rather than in a review.
 ClassMethod ReportTools()
 {
-    set expected = 6
+    // SEVEN since MVP 3, not six. GetHostSettings was added so the agent can name the directory in
+    // the missing-folder scenario from configuration rather than from log text (mcp-tools.md §3.4a).
+    //
+    // This number is moved DELIBERATELY and with the tool list read back, because the guard's whole
+    // value is that an unexpected count is loud: it fired on the first compile of the new tool --
+    // "7 -- EXPECTED 6, INVESTIGATE" -- which is exactly what it is for. Bumping it without reading
+    // the names would defeat it, so the names were checked: six reads plus one write, no helper left
+    // public.
+    set expected = 7
     set found = 0
     for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Resolve" {
         if '##class(%Dictionary.CompiledClass).%ExistsId(class) {


### PR DESCRIPTION
Merges `main` into Dev A's Track B (#120) and Track A (#122) so **both MVP 3 halves run in one stack**, and fixes three things that only appear when you actually try to demo it.

Supersedes #120's branch — its commits are here unchanged apart from the ownership row. #120 can be closed in favour of this, or I can rebase this onto it, whichever you prefer.

## 1. The `app.css` conflict was not a conflict

#118 and #120 both appended to the same tail region. Both blocks kept — Track B's rail/view styles and `manualRemediation`'s. No competing definitions.

## 2. The brochure import breaks the container build (a real defect in #120)

```
Could not resolve "../../../../docs/Brochure.png" from "src/components/BrochureView.tsx"
```

The irony is exact, and it is worth stating because the reasoning in `BrochureView.tsx` is otherwise right: **that comment cites `context: ./apps/dashboard` as the reason not to *serve* the asset — and importing it across the same boundary fails for the same reason.** A host `npm run build` succeeds regardless, because the host has the whole repo. So this was green locally and red in `compose up`: the same "works and is reached are different claims" gap as `iris/CLAUDE.md`'s three provider defects, arriving through the build context.

Fixed by moving the context to the repo root, making the `COPY` paths repo-relative, and reproducing the tree at the same depth so the relative import resolves in the image exactly as on a host. Only `docs/Brochure.png` is copied, not all of `docs/`.

That required a **root `.dockerignore`**, and the first symptom was not a fat image but a hard failure:

```
invalid file request apps/dashboard/node_modules/.bin/baseline-browser-mapping
```

Docker reads `.dockerignore` from the context directory only, so `apps/dashboard/.dockerignore` silently stopped applying and a dangling symlink in a local `node_modules` got sent to the daemon. The per-app file is kept so a direct `docker build ./apps/dashboard` still behaves.

**I had built the serve-it-instead version and it was wrong** — #121 carried three files to defeat a guarantee that was deliberate. Closed. Your `10.8×` measurement is what decided it.

## 3. A prompt is a request, not a constraint

This is the one I would most like you to look at.

#122 tells the model `set_pool_size` applies only to the whitelisted host and never alongside `manualRemediation`. It obeys **most** of the time. Four consecutive live runs, same finding, same prompt, same model:

```
action=set_pool_size on EMR Source   manual=yes
action=set_pool_size on EMR Source   manual=yes
action=set_pool_size on EMR Source   manual=null   <- worst: the only fix offered cannot apply
action=null                          manual=yes    <- correct
```

**One in four.** `Tools.Resolve` refuses the call regardless — that boundary always held, and it is what makes this safe rather than merely tidy. What it could not prevent is the *recommendation* reaching a UI that then renders an approve button for an action guaranteed to fail with `not_whitelisted_host`. An operator clicking it learns only that the product is broken.

**This is #92's lesson from the other direction.** There a guard was *documented* and absent; here a guard was *asked for* and probabilistic. Neither is a guard.

So `AgentDispatcher.DropUnapplicableAction()` enforces the bound where it is checkable, reading `ALLOWEDHOST` from `Tools.Resolve` rather than a literal — a second copy of a rule disagreeing with the rule is the whole defect. **Dropped, not rewritten:** no `manualRemediation` is invented to replace what is removed, and `rootCause`/`evidence` stay the model's verbatim. A diagnosis with no fix is what §3.1 allows and what `InvestigationPanel` already renders explicitly. Substituting our own words would make the dispatcher a second author. `droppedAction` is recorded on the response rather than only logged, because a silent filter is indistinguishable from a model that behaved.

After: **5 of 5 runs correct.**

## 4. Ownership row restored to what MVP 3 §5 resolved

#120 moved `apps/dashboard/**` to Dev A. That contradicts §5 — *"the whole directory goes to Dev B, not split by file"* — and would have made #118's merge (an hour earlier, `InvestigationPanel.tsx`, Track A's panel state) a boundary violation, along with all of MVP 2's UI. Track B is your contribution to the directory under §3's PR rule, which does not move the row. Your staleness note in `apps/dashboard/CLAUDE.md` is kept in full; only the owner changed.

## Verified end to end, live

Through **nginx on `:5173`** — the exact path the browser takes, not the engine directly:

```
POST /api/investigate {"findingId":"f-1008"}
  source: agent   model: gpt-4o-mini   toolCalls: 4
  recommendedAction: null
  manualRemediation: "Configured directory path does not exist."
    - Check if the directory /tmp/labdemo/hl7-in-missing/ exists.
    - Create the directory /tmp/labdemo/hl7-in-missing/ if it is missing.
  target: {host: "EMR Source", setting: "FilePath",
           currentValue: "/tmp/labdemo/hl7-in-missing/"}
```

The path came from `get_host_settings` — configuration — never from log text.

```
container serves          2,526,633 bytes, both halves present
tsc --noEmit              clean
npm run build             ok, single-file promise intact (no non-data src/href)
engine                    219 tests pass, 0 fail
FirstBoot.LoadClasses     22 classes, load finished successfully
AIHub.Status()            7 tools, provider configured, gpt-4o-mini
```

## Two things I hit that are worth knowing before a rehearsal

- **`docker compose restart iris` reverts an armed `FilePath`.** Same recompile-reverts-settings behaviour already recorded for `PoolSize` — re-arm after any restart. Caught it because `Status()` reports the live path, which is exactly what that reporting is for.
- **`AGENT_MODE` defaults to `mock`**, so a rebuilt engine silently serves `source: "canned"`. The default is right and the README documents it; I just rebuilt without re-exporting `PG_AGENT_MODE=live`. It is the #108 check catching a real regression, which is the argument for keeping that check human and standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
