### PR TITLE
fix(iris): the goal must name the two tools that answer WHY, and the window that hides them

### DIFF
--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -415,7 +415,27 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     if $isobject(body.trend) {
         set g = g _ " Trend: " _ body.trend.%ToJSON()
     }
-    set g = g _ " Use the tools to confirm the configuration before concluding."
+    // NAMES THE TWO TOOLS THAT ANSWER *WHY*, because "use the tools" did not get them called
+    // reliably and the finding itself never says why. Measured over three consecutive live runs on
+    // the armed missing-folder scenario, only one produced a `manualRemediation` -- the other two
+    // returned a diagnosis with no fix, having never read the error codes or the setting values.
+    // Honest, and useless: the evidence was one tool call away.
+    //
+    // The failure is asymmetric, which is why this is worth a directive rather than a hope. A
+    // status and a queue depth describe THAT something is wrong; only the error catalogue and the
+    // configuration describe WHAT. A model that stops after the first two has enough to write a
+    // fluent paragraph and nothing to recommend.
+    set g = g _ " Before concluding you MUST call get_recent_errors and get_host_settings on this"
+    set g = g _ " host: the first names the KIND of failure, the second gives the configured values"
+    set g = g _ " a fix would change. A status and a queue depth alone cannot tell you why."
+
+    // The window is stated because the default is 15 minutes and a host in Error logs once on
+    // entering that state and then goes quiet. So the evidence EXPIRES while the condition
+    // persists, and an empty byCode is then indistinguishable from a healthy host -- the same
+    // unmeasurable-is-not-zero trap as §2.1, in the time dimension. 60 is the tool's ceiling.
+    set g = g _ " Call get_recent_errors with sinceMinutes 60, not the default: a host logs its"
+    set g = g _ " error once on entering Error and then stops, so a short window can come back"
+    set g = g _ " empty while the fault is still present. An empty result does not mean healthy."
     quit g
 }
 


### PR DESCRIPTION
`manualRemediation` populated on only **1 of 3** live runs against the armed scenario, and **0 of 4** on a scenario armed 20 minutes earlier. Found by demoing from `main` after #123 rather than by reading anything.

The other runs returned an honest diagnosis with no fix at all — having never read the error codes or the setting values, both one tool call away.

Two causes, neither of them the model being unreasonable.

## 1. The goal said "use the tools" without saying which answer which question

`dead_host` carries a **status**, not a cause. A status and a queue depth describe *that* something is wrong; only the error catalogue and the configuration describe *what*. So a model that stops after the first two has enough to write a fluent paragraph and nothing to recommend.

**The failure is asymmetric**, which is why it needs a directive rather than a hope: stopping early still produces a plausible answer. The goal now names `get_recent_errors` and `get_host_settings` and says what each contributes.

## 2. The evidence expires while the condition persists

A host logs its error once on entering `Error` and then goes quiet. `get_recent_errors` defaults to 15 minutes, so 20 minutes after arming:

```
sinceMinutes 15 -> {"count":0,"byCode":[]}
sinceMinutes 60 -> {"count":9,"byCode":[{"#5021",3,...},{"<Ens>ErrProductionSettingInvalid",6,...}]}
```

Same host, same second, still in `Error`, missing path still configured. **An empty `byCode` is indistinguishable from a healthy host** — §2.1's unmeasurable-is-not-zero trap in the *time* dimension, and the third time this project has been bitten by that shape (#33, #49, #58 were the value dimension).

The goal now asks for 60 — the tool's documented ceiling, unchanged — and states that an empty result does not mean healthy.

## Verified

Five consecutive live runs through nginx on `:5173`, the browser's own path:

```
manual=YES target=yes tools=2   x5
recommendedAction: null          x5
```

5/5 with `manualRemediation` **and** a populated `target` naming the real path, up from 1/3. `recommendedAction` null on all five, so this and `DropUnapplicableAction` are independent and both hold.

A full response:

```
rootCause: "...primarily related to invalid configuration values and missing file paths..."
evidence:  GetRecentErrors  "11 errors in the past 60 minutes, including 4 for missing directory"
           GetHostSettings  "Configured FilePath: /tmp/labdemo/hl7-in-missing/"
manualRemediation.target: {host: "EMR Source", setting: "FilePath",
                           currentValue: "/tmp/labdemo/hl7-in-missing/"}
```

## What this is not

No tool bound changed, no new tool, no widened window — 60 was always the ceiling in `mcp-tools.md` §3.4. The fix is telling the agent which questions its tools answer, which is orchestration and stays on the right side of "we orchestrate, we do not reason."

## For review, @kskubach

Three prompt-and-goal fixes in one day (#122, then `DropUnapplicableAction`, now this) all point the same way: **a prompt is a request, and every behaviour we actually depend on has needed either a deterministic guard or an explicit directive.** Worth deciding whether the standing pre-demo check in `iris/CLAUDE.md` should assert `manualRemediation` non-null on this scenario, the way it already asserts `source: agent` — it would have caught this in one run instead of four.

Also still open from #122: whether a shared argument-coercion helper on the `%AI.Tool` base is the right structural fix for the omitted-optional-argument class of bug. Your area, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
