### PR TITLE
feat(dashboard): a Management Portal link, and labels that stop sitting on boxes

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -12,3 +12,13 @@ VITE_HEALTHSCAN_TARGET=http://localhost:3002
 # upstream interval trades against either the IRIS scrape rate or the engine's debounce.
 # Do not read the two upstream intervals from here; they have both moved once already.
 VITE_POLL_INTERVAL_MS=2000
+
+# The Management Portal link in the header. ABSOLUTE, unlike the API base above, because the
+# portal is a different service on a different port and nothing proxies it — the browser has to
+# be told where IRIS is. Defaults to the interop production page on localhost:52773, which is
+# what `docker compose up` publishes; set this when IRIS is elsewhere.
+#
+# The path is `/csp/healthshare/labdemo/...` rather than `/csp/labdemo/...` because this is IRIS
+# for Health, where EnableNamespace creates the HealthShare-prefixed application. Verified 200
+# against the running instance; `/csp/labdemo/EnsPortal.ProductionConfig.zen` returns 404.
+VITE_IRIS_PORTAL_URL=http://localhost:52773/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,9 +6,10 @@
   "description": "Health Scan dashboard — MVP 1 operator frontend for Production Guardian",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && node tools/validate-architecture.mjs && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "validate:architecture": "node tools/validate-architecture.mjs",
     "validate:fixtures": "node tools/validate-fixtures.mjs && node tools/validate-fixture-claims.mjs",
     "validate:fixtures:strict": "node tools/validate-fixtures.mjs --strict && node tools/validate-fixture-claims.mjs --strict"
   },

--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -37,6 +37,32 @@ import {
 /** Which top-level view is on screen. */
 export type View = 'dashboard' | 'brochure' | 'architecture';
 
+/**
+ * The IRIS Management Portal, for jumping from a finding to the production that produced it.
+ *
+ * DEFAULTS TO THE INTEROP PRODUCTION PAGE, not the portal home. An operator following a finding
+ * wants the host list, and `EnsPortal.ProductionConfig.zen` is one click from every host's settings
+ * — where `/csp/sys/UtilHome.csp` is three. Both verified 200 on the EAP image; the interop path is
+ * under `/csp/healthshare/labdemo` because this is IRIS for Health, where `EnableNamespace` creates
+ * the HealthShare-prefixed application rather than a bare `/csp/labdemo`.
+ *
+ * ABSOLUTE AND CONFIGURABLE, unlike the API base, and the two differ for a real reason. The API is
+ * reached through nginx on the dashboard's own origin, so a relative path is correct and keeps the
+ * bundle environment-independent. The portal is a *different service on a different port* that
+ * nothing proxies, so the browser must be told where it is. `VITE_IRIS_PORTAL_URL` overrides it for
+ * a deployment where IRIS is not on localhost:52773.
+ *
+ * The port is not read from `docker-compose.yml`'s `PG_IRIS_WEB_PORT`: the bundle is built before
+ * compose runs and the browser is on the host, so the build cannot know the mapping. A wrong
+ * default is visible and one variable away from fixed, which is the honest trade.
+ */
+const DEFAULT_PORTAL_URL = 'http://localhost:52773/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen';
+
+function portalUrl(): string {
+  const configured = import.meta.env.VITE_IRIS_PORTAL_URL;
+  return configured !== undefined && configured !== '' ? configured : DEFAULT_PORTAL_URL;
+}
+
 interface RailItem {
   label: string;
   Icon: (props: IconProps) => JSX.Element;
@@ -137,7 +163,24 @@ export function AppShell({ headerActions, view, onNavigate, children }: AppShell
               on the page that names where you are. */}
           <span className="pg-header__module">{MODULE_LABEL[view]}</span>
         </h1>
-        <div className="pg-header__actions">{headerActions}</div>
+        <div className="pg-header__actions">
+          {headerActions}
+          {/* A real link, not a button with an onClick: it navigates to another application, so it
+              must be middle-clickable and copyable like any other link. `rel="noreferrer"` alongside
+              `noopener` because the portal is a different origin. */}
+          <a
+            className="pg-header__portal"
+            href={portalUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Open the IRIS Management Portal's production page in a new tab"
+          >
+            <IconProductions size={14} />
+            Management Portal
+            {/* Marks the new-tab behaviour for screen readers, since the icon cannot. */}
+            <span className="pg-visually-hidden"> (opens in a new tab)</span>
+          </a>
+        </div>
       </header>
 
       <main className="pg-content">{children}</main>

--- a/apps/dashboard/src/components/ArchitectureView.tsx
+++ b/apps/dashboard/src/components/ArchitectureView.tsx
@@ -110,14 +110,22 @@ function Overview(): JSX.Element {
       <Node x={452} y={160} w={148} h={60} title="Dashboard" sub="what the operator sees" tone="accent" />
 
       {/* Labels sit just above the horizontal leg of each path, left-anchored from its start,
-          so they read along the line rather than crossing a node. */}
+          so they read along the line rather than crossing a node. Positions are checked against
+          every node box by test/architecture.test.ts -- a label placed by eye collided with
+          "Detection engine" and shipped that way (@Ari-Glikman). */}
       <Flow d="M180 290 H248 V100" label="metrics" lx={186} ly={284} />
       <Flow d="M316 116 V160" />
       <Flow d="M316 212 V264" />
       <Flow d="M384 190 H452" label="findings" lx={390} ly={184} />
       {/* Dashed: the engine reaches back into IRIS only for WHY and FIX, and only
-          through the governed tool path. A solid line would imply a data feed. */}
-      <Flow d="M248 186 H196 V158" label="investigate · resolve" lx={196} ly={180} dashed />
+          through the governed tool path. A solid line would imply a data feed.
+
+          ly=148 rather than 180: at 180 this label is 124px wide starting at x=196, so it ran
+          straight through the Detection engine box (248..384). Moved above the row into the gap
+          between the AI Hub and Metrics proxy bands, where it still reads as belonging to the
+          dashed arrow beneath it. Shortening the text was the alternative and is worse -- the two
+          verbs ARE the MVP 2 loop, and "WHY · FIX" needs the caption to decode it. */}
+      <Flow d="M248 186 H196 V158" label="investigate · resolve" lx={196} ly={148} dashed />
 
       <text className="pg-arch__note" x="452" y="248">Five compose services.</text>
       <text className="pg-arch__note" x="452" y="264">Ports and names live in</text>
@@ -152,7 +160,10 @@ function Investigation(): JSX.Element {
       <Node x={552} y={200} w={72} h={44} title="Audit" sub="every call" tone="brand" />
 
       <Flow d="M136 176 H168" />
-      <Flow d="M288 176 H336 V108" label="finding + snapshot" lx={288} ly={170} />
+      {/* ly=130, not 170: at 170 this 106px label starting at x=288 overlapped the Authorization
+          policy box (336..504). Sits above it instead, still alongside the vertical leg it
+          describes. */}
+      <Flow d="M288 176 H336 V108" label="finding + snapshot" lx={292} ly={130} />
       <Flow d="M504 86 H552" label="reason" lx={506} ly={80} dashed />
       <Flow d="M420 116 V136" />
       {/* The two vertical labels are offset to the RIGHT of their arrow rather than centred on

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -159,6 +159,43 @@ button {
   margin-left: auto;
 }
 
+/* Link out to the IRIS Management Portal.
+   Styled as a secondary control rather than a primary one: it leaves the product, so it
+   must be findable without competing with the mode toggle beside it. `flex-shrink: 0`
+   because the header is a flex row and at 1024px the label would otherwise be the thing
+   that wraps. */
+.pg-header__portal {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pg-space-2);
+  flex-shrink: 0;
+  padding: var(--pg-space-2) var(--pg-space-3);
+  border: 1px solid var(--pg-border);
+  border-radius: var(--pg-radius-pill);
+  background: var(--pg-surface);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--pg-text);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.pg-header__portal:hover {
+  border-color: var(--pg-teal-500);
+  color: var(--pg-ok);
+}
+
+.pg-header__portal:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: 2px;
+}
+
+/* Inherits the text colour so the icon follows the hover state with the label. */
+.pg-header__portal svg {
+  flex-shrink: 0;
+  stroke: currentColor;
+}
+
 .pg-header__meta {
   font-size: 12.5px;
   color: var(--pg-text-muted);

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -5,6 +5,7 @@
 interface ImportMetaEnv {
   readonly VITE_HEALTHSCAN_BASE_URL?: string;
   readonly VITE_POLL_INTERVAL_MS?: string;
+  readonly VITE_IRIS_PORTAL_URL?: string;
 }
 
 interface ImportMeta {

--- a/apps/dashboard/tools/validate-architecture.mjs
+++ b/apps/dashboard/tools/validate-architecture.mjs
@@ -1,0 +1,141 @@
+/**
+ * Check that no Architecture-slide label overlaps a node box.
+ *
+ * WHY THIS EXISTS. Two labels shipped sitting on top of node boxes — "investigate · resolve" across
+ * "Detection engine", and "finding + snapshot" across "Authorization policy" — reported by
+ * @Ari-Glikman as "there is things on top of other things". Both were positioned by eye by me, in
+ * the same change that fixed the labels rendering at the origin. The type system was made to require
+ * a position; nothing checked that the position was any *good*.
+ *
+ * So this is the third iteration of the same lesson on one component: a label with no coordinates is
+ * a compile error, and a label with bad coordinates is now a build error too.
+ *
+ * PARSES THE JSX RATHER THAN IMPORTING THE COMPONENT, deliberately. The alternative — exporting a
+ * layout table the component renders from — creates a second source of truth that can agree with
+ * the test while disagreeing with the markup. The rendered attributes are what an audience sees, so
+ * those are what get checked. The cost is a regex over source, which is why the patterns below are
+ * anchored tightly and the script fails loudly if it finds nothing to check.
+ *
+ * Run by `npm run validate:architecture`, and by `npm run build` so a bad position cannot ship.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const src = readFileSync(resolve(root, 'src/components/ArchitectureView.tsx'), 'utf8');
+
+/*
+ * Character width for the 10.5px label face, and the ascent above the baseline.
+ *
+ * DELIBERATELY GENEROUS. 5.9px/char is wider than the average glyph in this family, and an
+ * over-estimate is the safe direction: it can report a clash that is visually a near-miss, but it
+ * cannot miss a real overlap. `text-anchor` is `start` for these labels (the CSS sets no anchor on
+ * `.pg-arch__flow-label`), so the box grows rightward from `lx`.
+ */
+const CHAR_WIDTH = 5.9;
+const ASCENT = 8;
+const DESCENT = 2;
+
+/** Every <Node .../> in one slide function, as a box. */
+function nodesIn(body) {
+  const out = [];
+  const re = /<Node\s+x=\{(-?\d+)\}\s+y=\{(-?\d+)\}(?:\s+w=\{(\d+)\})?(?:\s+h=\{(\d+)\})?[^/]*title="([^"]*)"/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const [, x, y, w, h, title] = m;
+    // Defaults mirror the component's own: w = 132, h = 52.
+    out.push({
+      title,
+      x0: Number(x),
+      y0: Number(y),
+      x1: Number(x) + Number(w ?? 132),
+      y1: Number(y) + Number(h ?? 52),
+    });
+  }
+  return out;
+}
+
+/** Every labelled <Flow .../> in one slide function, as a box. */
+function labelsIn(body) {
+  const out = [];
+  const re = /<Flow\s+d="[^"]*"\s+label="([^"]*)"\s+lx=\{(-?\d+)\}\s+ly=\{(-?\d+)\}/g;
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    const [, label, lx, ly] = m;
+    out.push({
+      label,
+      x0: Number(lx),
+      y0: Number(ly) - ASCENT,
+      x1: Number(lx) + label.length * CHAR_WIDTH,
+      y1: Number(ly) + DESCENT,
+    });
+  }
+  return out;
+}
+
+/** The body of one slide function, so labels are only checked against their own slide's nodes. */
+function slideBody(name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  // To the next top-level `function ` / `export function `, which is where the next slide begins.
+  const rest = src.slice(start + 1);
+  const end = rest.search(/\n(?:export )?function /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+function overlaps(a, b) {
+  return !(a.x1 <= b.x0 || b.x1 <= a.x0 || a.y1 <= b.y0 || b.y1 <= a.y0);
+}
+
+const SLIDES = ['Overview', 'Investigation'];
+const problems = [];
+let checked = 0;
+
+for (const slide of SLIDES) {
+  const body = slideBody(slide);
+  if (body === null) {
+    problems.push(`slide function ${slide}() not found — has this component been restructured?`);
+    continue;
+  }
+  const nodes = nodesIn(body);
+  const labels = labelsIn(body);
+
+  // A silent pass because the regexes stopped matching would be worse than a failure, so the
+  // structure itself is asserted.
+  if (nodes.length === 0) problems.push(`${slide}: parsed no <Node> boxes`);
+  if (labels.length === 0) problems.push(`${slide}: parsed no labelled <Flow> arrows`);
+
+  for (const label of labels) {
+    checked += 1;
+    for (const node of nodes) {
+      if (overlaps(label, node)) {
+        problems.push(
+          `${slide}: label "${label.label}" (x ${label.x0.toFixed(0)}–${label.x1.toFixed(0)}, ` +
+            `y ${label.y0}–${label.y1}) overlaps node "${node.title}" ` +
+            `(x ${node.x0}–${node.x1}, y ${node.y0}–${node.y1})`,
+        );
+      }
+    }
+    // Also outside the shared viewBox is a defect, and cheap to catch here.
+    if (label.x0 < 0 || label.y0 < 0 || label.x1 > 640 || label.y1 > 360) {
+      problems.push(
+        `${slide}: label "${label.label}" falls outside the 640×360 viewBox ` +
+          `(x ${label.x0.toFixed(0)}–${label.x1.toFixed(0)}, y ${label.y0}–${label.y1})`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error('architecture layout: FAILED');
+  for (const p of problems) console.error(`  ${p}`);
+  console.error(
+    '\nMove the label into clear space rather than shortening it — the labels name the flows and ' +
+      'are load-bearing for the slide.',
+  );
+  process.exit(1);
+}
+
+console.log(`architecture layout: ok (${checked} labels, no overlaps, all within the viewBox)`);


### PR DESCRIPTION
Two items from demo feedback.

## 1. Management Portal link in the header

Points at the interop **production page**, not the portal home: an operator following a finding wants the host list, and `EnsPortal.ProductionConfig.zen` is one click from every host's settings where `/csp/sys/UtilHome.csp` is three.

The path is `/csp/healthshare/labdemo/...` rather than `/csp/labdemo/...` — this is IRIS for Health, where `EnableNamespace` creates the HealthShare-prefixed application. Established by listing `Security.Applications` rather than guessed; `/csp/labdemo/EnsPortal.ProductionConfig.zen` returns **404**, the healthshare path returns **200**.

**Absolute and configurable, unlike the API base**, and the two differ for a real reason: the API is reached through nginx on the dashboard's own origin, so a relative path keeps the bundle environment-independent. The portal is a different service on a different port that nothing proxies, so the browser must be told where it is. `VITE_IRIS_PORTAL_URL` overrides it. The port is deliberately *not* derived from `PG_IRIS_WEB_PORT` — the bundle is built before compose runs and the browser is on the host, so the build cannot know the mapping.

A real `<a>`, not a button with an `onClick`, so it is middle-clickable and copyable.

## 2. Two architecture labels sat on top of node boxes

Reported as "there is things on top of other things like resolve on top of detection engine". Computed rather than eyeballed:

```
"investigate · resolve"  x 196–320, y 172–182  overlaps "Detection engine"     x 248–384, y 160–212
"finding + snapshot"     x 288–394, y 162–172  overlaps "Authorization policy"  x 336–504, y 136–188
```

Both were positioned by me in the change that fixed these same labels rendering at the origin. Moved into clear space above their rows (`ly` 180→148 and 170→130) rather than shortened — the two verbs *are* the MVP 2 loop.

**Third iteration of one lesson on one component.** A label with no coordinates became a compile error last time; a label with *bad* coordinates was still shippable. `tools/validate-architecture.mjs` now checks every label box against every node box plus the viewBox bounds, and runs as part of `npm run build`. Verified it fails on the reported geometry, naming both boxes:

```
architecture layout: FAILED
  Overview: label "investigate · resolve" (x 196–320, y 172–182) overlaps node "Detection engine" (x 248–384, y 160–212)
```

It **parses the JSX** rather than importing a layout table: a table the component renders from is a second source of truth that can agree with the test while disagreeing with the markup. Character width is over-estimated at 5.9px so it can report a near-miss but cannot miss a real overlap, and it fails loudly if the regexes match nothing rather than passing silently.

## Verified

```
served bundle       lx:196,ly:148 and lx:292,ly:130
portal href         200
architecture        7 labels, no overlaps, all within viewBox
engine tests        238 pass, 0 fail
tsc --noEmit        clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
