### PR TITLE
feat: demo trigger buttons in the rail, off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,29 @@ Also in MVP 3, and needing no setup: two rail entries under **Production Guardia
 dashboard — **Architecture** (two slides, drawn as SVG from the design tokens) and **Brochure**.
 Both are static documents about the product; no API, no engine, no IRIS.
 
+### Driving it from the dashboard instead of a terminal
+
+The rail can carry buttons for the three scenarios plus **Reset all**, which is usually easier on
+stage than a second window. **Off by default** — the flag is what enables it:
+
+```bash
+export PG_DEMO_TRIGGERS=1
+docker compose up -d
+```
+
+Without it every trigger route answers **404** and the rail looks exactly as it does now. That is
+deliberate rather than tidy: the buttons deliberately break the production, which is the opposite of
+the governed, bounded, audited Smart Resolve write, so nothing in the shipped default can arm a
+fault from a browser. Set it only on a throwaway demo instance.
+
+The trigger's own explanation of what it armed comes back with the response, so the panel shows the
+same text the terminal prints — which findings to expect, and which deliberately will not fire.
+Armed state is read from IRIS on each poll, so driving the terminal at the same time stays correct.
+
+**Reset all** is always available when the flag is on, and it is the same `Triggers.Reset()`
+described above, with the same one caveat: a `system_alert` finding outlives it, because the alert
+sits in the metrics proxy's in-memory buffer where IRIS cannot reach.
+
 ### Before a rehearsal: three things that will bite
 
 - **`AGENT_MODE` defaults to `mock`.** Rebuild or restart the engine without `PG_AGENT_MODE=live`

--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -33,6 +33,7 @@ import {
   IconShield,
   type IconProps,
 } from './icons';
+import { TriggerRail } from './TriggerRail';
 
 /** Which top-level view is on screen. */
 export type View = 'dashboard' | 'brochure' | 'architecture';
@@ -149,6 +150,11 @@ export function AppShell({ headerActions, view, onNavigate, children }: AppShell
             </li>
           ))}
         </ul>
+
+        {/* Renders nothing unless the deployment enables it — see TriggerRail. Placed last in the
+            rail so an audience reads the product's own navigation first and the demo scaffolding
+            after it, and so its absence leaves the rail visually unchanged. */}
+        <TriggerRail />
       </nav>
 
       <header className="pg-header">

--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -1,0 +1,209 @@
+/**
+ * Demo scenario triggers in the nav rail.
+ *
+ * ONLY RENDERS WHEN THE DEPLOYMENT SAYS SO. `GET /api/demo/triggers` reports `enabled` and the
+ * scenario list; when it is off this component returns `null` and the rail looks exactly as it did
+ * before. That is why the endpoint answers 200-with-`enabled: false` rather than 404 — the UI needs
+ * a truthful "no" it can distinguish from a network failure.
+ *
+ * THE SCENARIO LIST COMES FROM THE SERVER, not from a constant here. IRIS owns the `$case` that
+ * decides which names are real, so a list in this file would be a second copy that goes stale into
+ * buttons that 400 — the same failure as every host list this project has duplicated (root
+ * `CLAUDE.md` §6). The consequence is that this component renders whatever it is given, including a
+ * scenario added later with no dashboard change.
+ *
+ * ARMED STATE IS ALSO THE SERVER'S. It is read from the trigger globals in IRIS on every poll, not
+ * tracked locally from button presses, because driving the terminal during a rehearsal is normal and
+ * a button showing state from its own last click would be confidently wrong.
+ *
+ * DELIBERATELY STYLED AS SOMETHING THAT BREAKS THINGS. These sit under their own heading, in a
+ * warning tone, separate from the two navigation buttons above. The rail already distinguishes inert
+ * context from real controls; this adds a third category — real controls that make the production
+ * worse on purpose — and conflating it with "Brochure" would be the wrong affordance entirely.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { IconAlert } from './icons';
+
+/** One scenario, exactly as the server describes it. */
+export interface TriggerScenario {
+  id: string;
+  label: string;
+  detail: string;
+  findings: string;
+}
+
+export interface TriggerState {
+  enabled: boolean;
+  scenarios: TriggerScenario[];
+  armed: Record<string, boolean>;
+}
+
+/** Field-by-field. The endpoint is ours, but a shape check here is what keeps a bad payload from
+    rendering a broken rail rather than no rail. */
+function parseState(raw: unknown): TriggerState {
+  const off: TriggerState = { enabled: false, scenarios: [], armed: {} };
+  if (typeof raw !== 'object' || raw === null) return off;
+  const r = raw as Record<string, unknown>;
+  if (r['enabled'] !== true) return off;
+
+  const scenarios: TriggerScenario[] = [];
+  if (Array.isArray(r['scenarios'])) {
+    for (const entry of r['scenarios']) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e['id'] !== 'string' || e['id'] === '') continue;
+      if (typeof e['label'] !== 'string' || e['label'] === '') continue;
+      scenarios.push({
+        id: e['id'],
+        label: e['label'],
+        detail: typeof e['detail'] === 'string' ? e['detail'] : '',
+        findings: typeof e['findings'] === 'string' ? e['findings'] : '',
+      });
+    }
+  }
+
+  const armed: Record<string, boolean> = {};
+  if (typeof r['armed'] === 'object' && r['armed'] !== null) {
+    for (const [k, v] of Object.entries(r['armed'] as Record<string, unknown>)) {
+      if (typeof v === 'boolean') armed[k] = v;
+    }
+  }
+  return { enabled: true, scenarios, armed };
+}
+
+const BASE = '/api/demo';
+
+/**
+ * Poll cadence for the armed state.
+ *
+ * Slower than the findings poll on purpose: arming is a human action taken seconds apart, not a
+ * metric stream, and this endpoint reaches into IRIS on every call. 5s is responsive enough that a
+ * terminal-driven arm shows up before the presenter has finished explaining it.
+ */
+const STATUS_POLL_MS = 5000;
+
+export function TriggerRail(): JSX.Element | null {
+  const [state, setState] = useState<TriggerState | null>(null);
+  /** The scenario currently being armed, so its own button can show pending without freezing others
+      that are still legitimately clickable. */
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(`${BASE}/triggers`);
+      setState(parseState(await res.json()));
+    } catch {
+      // Silent. A failed status poll must not render an error over the whole rail: the endpoint is
+      // optional by construction, and the connection banner already owns "the engine is unreachable".
+      setState(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const id = setInterval(() => void refresh(), STATUS_POLL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  const post = useCallback(
+    async (path: string, body: unknown, pending: string) => {
+      setBusy(pending);
+      setError(null);
+      setNote(null);
+      try {
+        const res = await fetch(`${BASE}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        });
+        const payload = (await res.json()) as Record<string, unknown>;
+        if (typeof payload['error'] === 'string' && payload['error'] !== '') {
+          setError(payload['error']);
+        } else if (typeof payload['note'] === 'string' && payload['note'] !== '') {
+          // A reset reports what it CANNOT undo. Surfaced rather than dropped: "the alert is still
+          // there" is the question a presenter asks ten seconds later.
+          setNote(payload['note']);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'request failed');
+      } finally {
+        setBusy(null);
+        // Refresh regardless of outcome. A trigger that errored partway may still have armed
+        // something, so the armed state must be re-read rather than assumed unchanged.
+        void refresh();
+      }
+    },
+    [refresh],
+  );
+
+  if (state === null || !state.enabled) return null;
+
+  return (
+    <div className="pg-triggers">
+      <span className="pg-rail__brand pg-rail__brand--triggers">
+        <IconAlert size={14} />
+        Demo triggers
+      </span>
+      <p className="pg-triggers__caption">These break the production on purpose.</p>
+
+      <ul className="pg-rail__list">
+        {state.scenarios.map((s) => {
+          const isArmed = state.armed[s.id] === true;
+          const pending = busy === s.id;
+          return (
+            <li key={s.id}>
+              <button
+                type="button"
+                className={`pg-rail__item pg-rail__item--trigger${
+                  isArmed ? ' pg-rail__item--armed' : ''
+                }`}
+                /* Every button disabled while ANY is pending. Arming two scenarios concurrently
+                   would interleave two sets of setting writes on the same production, and the
+                   trigger class stashes previous values in one global per setting — a concurrent
+                   pair could stash the other's value and make Reset() restore the wrong thing. */
+                disabled={busy !== null}
+                onClick={() => void post('/trigger', { scenario: s.id }, s.id)}
+                title={`${s.detail}\n\nFires: ${s.findings}`}
+              >
+                <span className="pg-rail__trigger-label">
+                  {s.label}
+                  {isArmed && <span className="pg-rail__armed-dot" aria-hidden="true" />}
+                </span>
+                {/* The pending state is words, not a spinner: PoolBottleneck warms a baseline for
+                    75 seconds and a spinner that long reads as a hang. */}
+                {pending && <span className="pg-rail__trigger-state">arming… up to 90s</span>}
+                {isArmed && !pending && <span className="pg-rail__trigger-state">armed</span>}
+              </button>
+            </li>
+          );
+        })}
+        <li>
+          <button
+            type="button"
+            className="pg-rail__item pg-rail__item--trigger pg-rail__item--reset"
+            disabled={busy !== null}
+            onClick={() => void post('/reset', {}, '__reset__')}
+            title="Restore every setting the triggers changed"
+          >
+            <span className="pg-rail__trigger-label">Reset all</span>
+            {busy === '__reset__' && <span className="pg-rail__trigger-state">resetting…</span>}
+          </button>
+        </li>
+      </ul>
+
+      {error !== null && (
+        <p className="pg-triggers__error" role="alert">
+          {error}
+        </p>
+      )}
+      {note !== null && (
+        <p className="pg-triggers__note" role="status">
+          {note}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1486,3 +1486,109 @@ button {
   line-height: 1.5;
   color: var(--pg-text);
 }
+
+/* ── Demo triggers in the rail (opt-in, see TriggerRail.tsx) ─────────────────── */
+
+/* Pushed to the bottom of the rail and separated by a rule, because this is scaffolding
+   rather than product: an audience should read the navigation above it first. `margin-top:
+   auto` works because .pg-rail is already a flex column. */
+.pg-triggers {
+  margin-top: auto;
+  padding-top: var(--pg-space-4);
+  border-top: 1px solid rgb(255 255 255 / 12%);
+}
+
+/* WARNING tone, not brand. These buttons make the production worse on purpose, and the rail
+   already uses brand colours for things that are safe to press. */
+.pg-rail__brand--triggers {
+  display: flex;
+  align-items: center;
+  gap: var(--pg-space-2);
+  color: var(--pg-warning);
+}
+
+.pg-triggers__caption {
+  margin: 0 0 var(--pg-space-2);
+  padding: 0 var(--pg-space-4);
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgb(255 255 255 / 55%);
+}
+
+.pg-rail__item--trigger {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  color: rgb(255 255 255 / 78%);
+  cursor: pointer;
+}
+
+.pg-rail__item--trigger:hover:not(:disabled) {
+  background: var(--pg-navy-700);
+  color: var(--pg-text-invert);
+}
+
+.pg-rail__item--trigger:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: -2px;
+}
+
+/* Disabled while any trigger is in flight. Reduced opacity AND not-allowed, because a rail
+   item that merely stops responding reads as broken. */
+.pg-rail__item--trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pg-rail__trigger-label {
+  display: flex;
+  align-items: center;
+  gap: var(--pg-space-2);
+}
+
+/* Armed is signalled by a dot AND the word "armed" below it — never by colour alone (§7.3). */
+.pg-rail__armed-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--pg-radius-pill);
+  background: var(--pg-warning);
+  flex-shrink: 0;
+}
+
+.pg-rail__item--armed {
+  color: var(--pg-text-invert);
+}
+
+.pg-rail__trigger-state {
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--pg-teal-200);
+}
+
+.pg-rail__item--reset {
+  color: rgb(255 255 255 / 62%);
+  font-style: italic;
+}
+
+.pg-triggers__error,
+.pg-triggers__note {
+  margin: var(--pg-space-2) 0 0;
+  padding: 0 var(--pg-space-4);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.pg-triggers__error {
+  color: var(--pg-warning);
+}
+
+.pg-triggers__note {
+  color: rgb(255 255 255 / 55%);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,17 @@ services:
       # degrades to a labelled canned investigation. A default here would be a committed key.
       PG_LLM_API_KEY: ${PG_LLM_API_KEY:-}
       PG_LLM_MODEL: ${PG_LLM_MODEL:-}
+      # The dashboard's trigger buttons. UNSET BY DEFAULT and that is the safety property, not a
+      # convenience: TriggerDispatcher returns 404 on every route without it, so a `compose up` with
+      # no flag has no way to break the production from a browser. Set it only on a throwaway demo
+      # instance -- the triggers deliberately disable hosts and repoint paths, which is the opposite
+      # of the governed, bounded, audited Smart Resolve write.
+      #
+      # Passed to IRIS *and* to the engine below, because both need it: IRIS to decide whether the
+      # routes exist, the engine to decide whether to advertise them to the UI. Two reads of one
+      # variable rather than the engine trusting a 404, so a misconfigured pair is visible instead
+      # of looking like a network fault.
+      PG_DEMO_TRIGGERS: ${PG_DEMO_TRIGGERS:-}
     depends_on:
       iris-init:
         condition: service_completed_successfully
@@ -247,6 +258,10 @@ services:
       # holds no LLM credential, and turning this to `live` without the provider gives a 503
       # from the dispatcher rather than a broken investigation.
       AGENT_MODE: ${PG_AGENT_MODE:-mock}
+      # Mirrors the iris service's flag -- see there for why it is off by default. The engine only
+      # PROXIES to IRIS's trigger routes; it holds no trigger logic of its own, so with the flag off
+      # it declines before making a request rather than forwarding one that would 404.
+      DEMO_TRIGGERS: ${PG_DEMO_TRIGGERS:-}
       IRIS_BASE_URL: http://iris:52773
       # The ENGINE's IRIS credentials, for the RBAC-gated dispatcher. Same variables as the
       # proxy above, so one override moves both. These authenticate to IRIS; they carry no

--- a/iris/labdemo/REST/TriggerDispatcher.cls
+++ b/iris/labdemo/REST/TriggerDispatcher.cls
@@ -1,0 +1,278 @@
+/// REST bridge to the demo scenario triggers, for the dashboard's trigger buttons.
+///
+/// Three routes, all POST except the first:
+///
+///   GET  /labdemo/trigger/status    what is armed right now
+///   POST /labdemo/trigger/arm       {"scenario": "pool_bottleneck"} -> arms it
+///   POST /labdemo/trigger/reset     undoes everything Triggers.Reset() can undo
+///
+/// THIS IS A SECOND WRITE PATH INTO A LIVE PRODUCTION, and it is deliberately NOT the governed one.
+/// `Tools.Resolve` exists so an AI-recommended change is RBAC-checked, bounded, previewable,
+/// reversible and audited. These triggers are the opposite by design: they BREAK the production on
+/// purpose so there is something for Health Scan to detect. Routing them through the same governance
+/// would be dishonest -- it would make "the AI may only change a pool size within 2..8" and "a demo
+/// operator may disable a host and repoint a path" look like the same class of act.
+///
+/// So the boundary here is a different one, and it is stated rather than implied:
+///
+///   1. **A DEMO-ONLY FLAG.** `PG_DEMO_TRIGGERS` must be set, or every route returns 404 -- not 403.
+///      404 because a disabled demo surface should be indistinguishable from one that was never
+///      deployed; a 403 advertises that there is a way to break this production if you find the
+///      credential. The shipped default is off, so `compose up` with no flag has no arming path.
+///   2. **A FIXED SCENARIO LIST.** The scenario name is looked up in a `$case`, never dispatched
+///      dynamically. `$classmethod("...Triggers", pName)` would turn one JSON field into "call any
+///      class method in this namespace", which is a remote code execution primitive rather than a
+///      demo convenience.
+///   3. **NO PARAMETERS.** Every trigger is invoked with its own defaults. `SlowProcessing(ms)` and
+///      `PoolBottleneck(ms, rate, warm, cap)` all take arguments, and accepting them from the wire
+///      would mean validating four numeric ranges to prevent a caller pinning the instance with
+///      `PoolBottleneck(1, 0.001, 0, 999999)`. The demo does not need the knobs.
+///   4. **RESET IS ALWAYS AVAILABLE** when the flag is on, and takes no scenario name. The one
+///      operation that makes the others safe must not be reachable only via a correct argument.
+///
+/// WHY NOT `%CSP.REST` AUTHENTICATION FOR THIS. The engine already authenticates to
+/// `/labdemo/agent` with a credential from its environment, and the same credential reaches here.
+/// That is sufficient BECAUSE of the flag: without it there is nothing to reach, and with it the
+/// operator has deliberately opted a throwaway demo instance into being breakable. On anything that
+/// is not a throwaway demo instance, do not set the flag.
+///
+/// `Triggers.Reset()` is the compensating control and it is genuinely complete for the three
+/// scenarios exposed here -- each stashes what it replaced and restores it. One caveat inherited
+/// from that class: `system_alert` cannot be reset from IRIS because the alert sits in the proxy's
+/// in-memory buffer, which is why no alert scenario is exposed here.
+Class ProductionGuardian.LabDemo.REST.TriggerDispatcher Extends %CSP.REST
+{
+
+/// The environment variable that must be set for any of this to exist.
+///
+/// Read at REQUEST time rather than cached in a parameter: a compiled-in value would need a
+/// recompile to turn off, and "turn this off now" is the operation most likely to be urgent.
+Parameter FLAGVAR = "PG_DEMO_TRIGGERS";
+
+XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
+{
+<Routes>
+<Route Url="/status" Method="GET" Call="Status"/>
+<Route Url="/arm" Method="POST" Call="Arm"/>
+<Route Url="/reset" Method="POST" Call="Reset"/>
+</Routes>
+}
+
+/// True when the demo surface is enabled. Private.
+ClassMethod Enabled() As %Boolean [ Private ]
+{
+    set v = $system.Util.GetEnviron(..#FLAGVAR)
+    // Any non-empty value except an explicit "0"/"false", so `=1`, `=true` and `=yes` all work --
+    // an operator who set the variable meant to set it, and failing on a spelling is worse than
+    // being liberal here. The DEFAULT is what carries the safety, not the parsing.
+    quit (v '= "") && (v '= "0") && ($zconvert(v, "L") '= "false")
+}
+
+/// Report what is armed. Also the endpoint the UI uses to decide whether to render the buttons.
+ClassMethod Status() As %Status
+{
+    set %response.ContentType = "application/json"
+    if '..Enabled() {
+        quit ..Gone()
+    }
+
+    // The scenario list is published so the UI does not hardcode it. A button that posts a scenario
+    // this class does not know would 400, and the UI having its own copy of the list is how that
+    // happens -- the same stale-copy argument as the host list in root CLAUDE.md §6.
+    set out = { "enabled": true, "scenarios": [], "armed": {} }
+    do out.scenarios.%Push({ "id": "pool_bottleneck", "label": "Pool bottleneck",
+        "detail": "Throttles the downstream and raises inflow. Queue builds behind one worker; the fix is a bigger pool.",
+        "findings": "queue_buildup, growing_queue_wait" })
+    do out.scenarios.%Push({ "id": "missing_folder", "label": "Missing directory",
+        "detail": "Repoints EMR Source at a directory that does not exist. No governed fix -- the recommendation is words.",
+        "findings": "dead_host" })
+    do out.scenarios.%Push({ "id": "closed_port", "label": "Downstream unreachable",
+        "detail": "Points Cloud API at a closed port. The queue is a symptom; a bigger pool would only fail faster.",
+        "findings": "elevated_error_rate, queue_buildup, throughput_drop" })
+
+    // What is actually armed, read from the trigger globals rather than inferred, so the UI can
+    // show state instead of assuming its own button presses are the whole truth. Someone driving
+    // the terminal at the same time is a normal thing to do in a rehearsal.
+    do out.armed.%Set("missing_folder", ''$data(^ProductionGuardian.Trigger("PathWas")), "boolean")
+    do out.armed.%Set("closed_port", ''$data(^ProductionGuardian.Trigger("PortWas")), "boolean")
+    do out.armed.%Set("pool_bottleneck", ''$data(^ProductionGuardian.Trigger("PoolWas")), "boolean")
+
+    write out.%ToJSON()
+    quit $$$OK
+}
+
+/// Arm one named scenario.
+ClassMethod Arm() As %Status
+{
+    set %response.ContentType = "application/json"
+    if '..Enabled() {
+        return ..Gone()
+    }
+    try {
+        set body = ##class(%DynamicObject).%FromJSON(%request.Content)
+        set scenario = body.%Get("scenario", "")
+
+        // THE TRIGGERS WRITE TO THE CURRENT DEVICE, so their progress text lands in the HTTP
+        // response body ahead of the JSON and the caller gets `non-JSON (HTTP 200)` for a call that
+        // actually succeeded. Measured before the fix: the scenario armed, the engine reported a
+        // parse failure, and the two disagreed about whether anything had happened -- the worst
+        // shape for a demo control, because the operator retries an action that already worked.
+        //
+        // CAPTURED RATHER THAN SUPPRESSED, into a temporary file that becomes the current device for
+        // the duration of the call. That text is the clearest explanation of each scenario anyone has
+        // written -- what it arms, which findings to expect, which deliberately will NOT fire -- so
+        // it is returned as `log` for the UI to show. Suppressing it would discard the one thing a
+        // presenter wants on screen.
+        //
+        // A FILE rather than %Device.ReDirectIO: the redirect API dispatches to six labels in a
+        // MAC routine, which this class is not, and a half-working redirect leaks into every
+        // subsequent response on the same process. `use` on a file device is the smaller mechanism
+        // and it restores in the `catch` too, which is what makes a failed trigger safe rather than
+        // silently breaking the next request.
+        set capturePath = "/tmp/pg-trigger-" _ $job _ ".log"
+        set prior = $io
+        set log = ""
+
+        // A FIXED $case, not $classmethod. See the class comment: dynamic dispatch on a wire value
+        // is arbitrary code execution wearing a scenario name.
+        //
+        // PoolBottleneck's defaults are used unchanged, which includes a 75-second baseline warm-up
+        // -- so this call BLOCKS for over a minute. That is why the UI shows a pending state rather
+        // than assuming a quick reply, and why the engine's timeout for this route is generous.
+        //
+        // The unknown-scenario branch is evaluated BEFORE the redirect opens, so a bad name never
+        // creates a temp file. Checked separately for that reason rather than folded into the $case.
+        if '$listfind($listbuild("pool_bottleneck", "missing_folder", "closed_port"), scenario) {
+            set %response.Status = "400 Bad Request"
+            write { "error": ("unknown scenario '" _ scenario _ "'"), "scenario": (scenario) }.%ToJSON()
+            return $$$OK
+        }
+
+        open capturePath:("NRW"):5
+        if '$test {
+            // Could not open the capture file. Run the trigger anyway with output going nowhere
+            // useful rather than refusing to arm: the scenario matters more than its narration.
+            set sc = ..Invoke(scenario)
+        } else {
+            use capturePath
+            set sc = ..Invoke(scenario)
+            use prior
+            close capturePath
+            set log = ..ReadCapture(capturePath)
+        }
+
+        if $$$ISERR(sc) {
+            // 400 rather than 500 for an unknown name: it is the caller's input that is wrong. A
+            // trigger that genuinely failed also lands here, which is imprecise but honest -- the
+            // message carries the difference and the UI renders it.
+            set %response.Status = "400 Bad Request"
+            write { "error": ($system.Status.GetErrorText(sc)), "scenario": (scenario) }.%ToJSON()
+            return $$$OK
+        }
+
+        write { "armed": (scenario), "ok": true, "log": (log) }.%ToJSON()
+        return $$$OK
+    } catch ex {
+        // RESTORE THE DEVICE FIRST, before anything that writes. A leaked redirect would send this
+        // error response -- and every subsequent response on this process -- into a temp file, so
+        // the visible symptom of a failed trigger would be an empty reply to an unrelated request.
+        use prior
+        set %response.Status = "500 Internal Server Error"
+        write { "error": ("arm failed: " _ ex.DisplayString()) }.%ToJSON()
+        return $$$OK
+    }
+}
+
+/// Run one named scenario. Private, and the only place the scenario names map to methods.
+///
+/// Split out of Arm() so the mapping is not tangled with the IO redirect around it -- and so the
+/// name check in Arm() and this $case cannot drift into disagreeing about which names are real.
+ClassMethod Invoke(scenario As %String) As %Status [ Private ]
+{
+    quit $case(scenario,
+        "pool_bottleneck": ##class(ProductionGuardian.LabDemo.Triggers).PoolBottleneck(),
+        "missing_folder":  ##class(ProductionGuardian.LabDemo.Triggers).MissingFolder(),
+        "closed_port":     ##class(ProductionGuardian.LabDemo.Triggers).ErrorRate(),
+        : $$$ERROR($$$GeneralError, "unknown scenario '" _ scenario _ "'"))
+}
+
+/// Read a capture file back as one string and delete it. Private.
+ClassMethod ReadCapture(path As %String) As %String [ Private ]
+{
+    set out = ""
+    set stream = ##class(%Stream.FileCharacter).%New()
+    if $$$ISOK(stream.LinkToFile(path)) {
+        while 'stream.AtEnd {
+            // Bounded: a runaway trigger must not put megabytes into a JSON field. 4000 characters
+            // is far more than any scenario prints and small enough to render in a rail panel.
+            if $length(out) > 4000 {
+                set out = out _ $char(10) _ "... truncated"
+                quit
+            }
+            set out = out _ stream.ReadLine() _ $char(10)
+        }
+    }
+    do ##class(%File).Delete(path)
+    quit out
+}
+
+/// Undo everything the trigger class can undo. Takes no argument, deliberately.
+ClassMethod Reset() As %Status
+{
+    set %response.ContentType = "application/json"
+    if '..Enabled() {
+        return ..Gone()
+    }
+    try {
+        // SAME CAPTURE AS Arm(), for the same reason and it was missed here first: Reset() writes a
+        // long summary of what it restored, so without this the response body is that text followed
+        // by JSON and the caller reports `non-JSON (HTTP 200)` for a reset that worked. Found by
+        // testing both routes rather than assuming the fix generalised -- Arm() was clean and this
+        // was not, in the same commit.
+        set capturePath = "/tmp/pg-trigger-reset-" _ $job _ ".log"
+        set prior = $io
+        set log = ""
+
+        open capturePath:("NRW"):5
+        if '$test {
+            set sc = ##class(ProductionGuardian.LabDemo.Triggers).Reset()
+        } else {
+            use capturePath
+            set sc = ##class(ProductionGuardian.LabDemo.Triggers).Reset()
+            use prior
+            close capturePath
+            set log = ..ReadCapture(capturePath)
+        }
+
+        if $$$ISERR(sc) {
+            set %response.Status = "500 Internal Server Error"
+            write { "error": ($system.Status.GetErrorText(sc)) }.%ToJSON()
+            return $$$OK
+        }
+        // The known-incomplete part of a reset, stated in the response rather than only in a class
+        // comment nobody reading a UI will see: a system_alert finding outlives this because the
+        // alert is buffered in the proxy, a Node process IRIS cannot reach.
+        write { "ok": true, "log": (log),
+            "note": "Findings clear within ~10s. A system_alert finding persists until it ages out of the proxy's buffer." }.%ToJSON()
+        return $$$OK
+    } catch ex {
+        // Device restored before writing, as in Arm().
+        use prior
+        set %response.Status = "500 Internal Server Error"
+        write { "error": ("reset failed: " _ ex.DisplayString()) }.%ToJSON()
+        return $$$OK
+    }
+}
+
+/// 404, for a disabled demo surface. Private.
+///
+/// NOT 403. A 403 says "this exists and you may not use it", which tells a reader of a production
+/// instance that there is a way to break it if they find the right credential. 404 says nothing.
+ClassMethod Gone() As %Status [ Private ]
+{
+    set %response.Status = "404 Not Found"
+    write { "error": "not found" }.%ToJSON()
+    quit $$$OK
+}
+
+}

--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -185,7 +185,7 @@ ClassMethod MakeDirectories()
     }
 }
 
-/// ALL THREE web applications. Registering only /labdemo/monitor -- which is what had happened
+/// ALL FOUR web applications. Registering only /labdemo/monitor -- which is what had happened
 /// on the instance -- leaves Cloud API POSTing into a 404 while EMR Source and Lab Router
 /// look healthy, so nothing points at the cause. The same omission for /labdemo/agent takes out
 /// every MVP 2 write with `HTTP 404` from a component the caller never names.
@@ -206,6 +206,13 @@ ClassMethod RegisterWebApps()
     // because we both registered it by hand while building it -- the same "deployed interactively
     // once" state #97 found for iris/test/.
     set apps("/labdemo/agent") = "ProductionGuardian.LabDemo.REST.AgentDispatcher"
+    // FOUR. The demo trigger surface, registered unconditionally while the DISPATCHER itself
+    // returns 404 on every route unless PG_DEMO_TRIGGERS is set. Registering the application is
+    // not what enables it -- putting the flag check here instead would mean the routes exist or
+    // not depending on the environment at FIRST BOOT, and a named volume makes that state
+    // permanent: an instance booted once without the flag could never gain the routes, and one
+    // booted with it could never lose them. The check belongs at request time.
+    set apps("/labdemo/trigger") = "ProductionGuardian.LabDemo.REST.TriggerDispatcher"
     set ns = $namespace
 
     new $namespace

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -27,6 +27,20 @@ export interface ServerOptions {
   investigate?: (findingId: string) => Promise<unknown>;
   /** Handles `POST /api/resolve`. Same 503-not-404 reasoning. */
   resolve?: (body: unknown) => Promise<unknown>;
+  /**
+   * Demo trigger routes, present even when triggers are DISABLED.
+   *
+   * Unlike `investigate`/`resolve`, these are always wired: `disabledTriggers()` answers
+   * `{enabled: false, scenarios: []}` for the status GET and an error for the writes. So the GET is
+   * a 200 with a truthful "off" rather than a 503, because the UI polls it to decide whether to
+   * render the buttons at all -- and a 503 there would be indistinguishable from the engine being
+   * unhealthy, which is what the connection banner is for.
+   */
+  triggerStatus?: () => Promise<unknown>;
+  /** Handles `POST /api/demo/trigger`. Declines when triggers are off; never 404s. */
+  armTrigger?: (body: unknown) => Promise<unknown>;
+  /** Handles `POST /api/demo/reset`. */
+  resetTriggers?: () => Promise<unknown>;
 }
 
 /**
@@ -44,9 +58,11 @@ const GET_PATHS = new Set([
   '/api/healthscan/findings',
   '/api/healthscan/health',
   '/api/earlywarning',
+  // Under /api/demo/ so the demo surface is one prefix, greppable and removable as a unit.
+  '/api/demo/triggers',
 ]);
 
-const POST_PATHS = new Set(['/api/investigate', '/api/resolve']);
+const POST_PATHS = new Set(['/api/investigate', '/api/resolve', '/api/demo/trigger', '/api/demo/reset']);
 
 /**
  * Origins permitted to POST — the fix for `resolve-api.md` §13.2's confused deputy.
@@ -165,7 +181,16 @@ export function createFindingsServer(options: ServerOptions): Server {
           ? options.investigate === undefined
             ? undefined
             : async (body: unknown) => options.investigate!(readFindingId(body))
-          : options.resolve;
+          : path === '/api/demo/trigger'
+            ? options.armTrigger
+            : path === '/api/demo/reset'
+              ? // Takes no body. Ignoring it rather than validating an empty object: reset is the
+                // operation that recovers from every other one, and it must not be refusable on a
+                // malformed request.
+                options.resetTriggers === undefined
+                ? undefined
+                : async () => options.resetTriggers!()
+              : options.resolve;
 
       if (handler === null) {
         // A POST to a path that exists as a GET route is 405, not 404 -- the endpoint is real, the
@@ -237,6 +262,26 @@ export function createFindingsServer(options: ServerOptions): Server {
           // share its freshness by construction.
           sendJson(res, 200, snapshot.projections, snapshot.state);
           return;
+        case '/api/demo/triggers': {
+          // THE ONE ASYNC GET, because the armed state lives in IRIS and this must report what is
+          // actually armed rather than what the UI last asked for -- someone driving the terminal
+          // during a rehearsal is normal, and a button showing stale state is worse than no button.
+          //
+          // A failure is a 200 with `enabled: false`, not a 5xx: this endpoint answers "should the
+          // trigger buttons exist", and if IRIS cannot be reached the honest answer is "no". A 5xx
+          // would put the connection banner into an error state over an optional demo affordance.
+          if (options.triggerStatus === undefined) {
+            sendJson(res, 200, { enabled: false, scenarios: [], armed: {} }, snapshot.state);
+            return;
+          }
+          options.triggerStatus()
+            .then((payload) => sendJson(res, 200, payload, snapshot.state))
+            .catch((err: unknown) => {
+              log(`trigger status unavailable: ${String(err)}`);
+              sendJson(res, 200, { enabled: false, scenarios: [], armed: {} }, snapshot.state);
+            });
+          return;
+        }
         case '/api/healthscan/health':
           // Not in the contract — operational only, for "is the engine up".
           sendJson(

--- a/services/detection-engine/src/detect/triggers.ts
+++ b/services/detection-engine/src/detect/triggers.ts
@@ -1,0 +1,208 @@
+/**
+ * Proxy to the demo scenario triggers in IRIS, for the dashboard's trigger buttons.
+ *
+ * THE ENGINE HOLDS NO TRIGGER LOGIC. It forwards to `TriggerDispatcher` and returns what came back.
+ * That is the same division as `/api/resolve` (CLAUDE.md §1.1): this service gained orchestration
+ * responsibilities, not authority, and it cannot mutate a production even if a bug here tried to.
+ * Every guard — the demo flag, the fixed scenario list, the absence of parameters — lives in IRIS.
+ *
+ * OFF BY DEFAULT, checked HERE as well as in IRIS. `DEMO_TRIGGERS` gates this module and
+ * `PG_DEMO_TRIGGERS` gates the dispatcher; compose passes one variable to both. The duplication is
+ * deliberate: without it, a disabled instance would be discovered only by forwarding a request and
+ * receiving a 404, which is indistinguishable from IRIS being unreachable or the web application
+ * being unregistered — and that last one has cost this project two defects already (#106 and the
+ * nginx 405s). Declining locally makes "triggers are off" a different observable state from
+ * "something is broken".
+ *
+ * NOT AUDITED, and that is a deliberate asymmetry worth stating rather than leaving to be noticed.
+ * `set_pool_size` writes an `Audit.Entry` row per call because the question "did the AI change a
+ * production setting" must be answerable. A demo trigger is a human deliberately breaking a
+ * throwaway instance, so there is no attribution question to answer — and routing it through the
+ * governed path would make the two look like the same class of act. `Triggers.Status()` reports what
+ * is armed, which is the state that actually matters here.
+ */
+
+/** One scenario the dispatcher will accept, as it describes itself. */
+export interface TriggerScenario {
+  id: string;
+  label: string;
+  detail: string;
+  findings: string;
+}
+
+export interface TriggerStatus {
+  enabled: boolean;
+  scenarios: TriggerScenario[];
+  /** Per-scenario armed state, read from the trigger globals in IRIS. */
+  armed: Record<string, boolean>;
+}
+
+export interface TriggerResult {
+  ok: boolean;
+  /** The scenario armed, or null for a reset. */
+  armed: string | null;
+  /** Present when the dispatcher qualified the outcome — e.g. what a reset cannot undo. */
+  note: string | null;
+  error: string | null;
+}
+
+export interface TriggerDeps {
+  status: () => Promise<TriggerStatus>;
+  arm: (scenario: string) => Promise<TriggerResult>;
+  reset: () => Promise<TriggerResult>;
+}
+
+/**
+ * What the API serves when triggers are off.
+ *
+ * `enabled: false` with an EMPTY scenario list, not a populated one. A UI given the list would be
+ * able to render disabled buttons, which advertises a capability the deployment declined — the same
+ * reasoning as the dispatcher answering 404 rather than 403.
+ */
+export const TRIGGERS_DISABLED: TriggerStatus = { enabled: false, scenarios: [], armed: {} };
+
+/** Field-by-field, never a cast — the dispatcher's reply crosses a process boundary. */
+function parseScenario(raw: unknown): TriggerScenario | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  const id = r['id'];
+  const label = r['label'];
+  if (typeof id !== 'string' || id === '') return null;
+  if (typeof label !== 'string' || label === '') return null;
+  return {
+    id,
+    label,
+    detail: typeof r['detail'] === 'string' ? r['detail'] : '',
+    findings: typeof r['findings'] === 'string' ? r['findings'] : '',
+  };
+}
+
+function parseStatus(raw: unknown): TriggerStatus {
+  if (typeof raw !== 'object' || raw === null) return TRIGGERS_DISABLED;
+  const r = raw as Record<string, unknown>;
+  // `enabled` must be explicitly true. An absent or non-boolean field reads as off, so a garbled
+  // reply cannot switch the buttons on.
+  if (r['enabled'] !== true) return TRIGGERS_DISABLED;
+
+  const scenarios: TriggerScenario[] = [];
+  if (Array.isArray(r['scenarios'])) {
+    for (const entry of r['scenarios']) {
+      const parsed = parseScenario(entry);
+      // Skip a malformed entry rather than rejecting the whole payload: one bad scenario should
+      // not remove the reset button, which is the one that recovers from everything else.
+      if (parsed !== null) scenarios.push(parsed);
+    }
+  }
+
+  const armed: Record<string, boolean> = {};
+  const rawArmed = r['armed'];
+  if (typeof rawArmed === 'object' && rawArmed !== null) {
+    for (const [key, value] of Object.entries(rawArmed as Record<string, unknown>)) {
+      // Only a real boolean. An unparseable value must not read as armed=true, since the UI uses
+      // this to decide whether to show "armed" state on a button.
+      if (typeof value === 'boolean') armed[key] = value;
+    }
+  }
+
+  return { enabled: true, scenarios, armed };
+}
+
+function parseResult(raw: unknown, scenario: string | null): TriggerResult {
+  const base: TriggerResult = { ok: false, armed: null, note: null, error: null };
+  if (typeof raw !== 'object' || raw === null) {
+    return { ...base, error: 'trigger dispatcher returned a non-object' };
+  }
+  const r = raw as Record<string, unknown>;
+  if (typeof r['error'] === 'string' && r['error'] !== '') {
+    return { ...base, error: r['error'] };
+  }
+  return {
+    ok: r['ok'] === true,
+    // From the REQUEST, not the reply. The dispatcher echoes it, but the caller's own value is the
+    // one the UI needs to correlate a response with the button that was pressed — the same reason
+    // `requestedBy` is threaded through resolve.ts rather than read back.
+    armed: scenario,
+    note: typeof r['note'] === 'string' && r['note'] !== '' ? r['note'] : null,
+    error: null,
+  };
+}
+
+/**
+ * Live trigger caller, over HTTP to the dispatcher in IRIS.
+ *
+ * ARM'S TIMEOUT IS LARGE ON PURPOSE. `PoolBottleneck()` warms a baseline at zero for 75 seconds
+ * before it returns, so a conventional 30s timeout would abort a call that was working and leave
+ * the production half-armed with nothing reporting why. Measured: the trigger blocks for ~80s.
+ */
+export function liveTriggers(
+  baseUrl: string,
+  user: string,
+  pass: string,
+  log?: (m: string) => void,
+): TriggerDeps {
+  const auth = `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`;
+
+  async function call(path: string, body: unknown, timeoutMs: number): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}/labdemo/trigger${path}`, {
+        method: body === undefined ? 'GET' : 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: auth },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+        signal: controller.signal,
+      });
+      const text = await res.text();
+      // A 404 here means the dispatcher's own flag is off while ours is on — a MISCONFIGURED PAIR,
+      // which is worth naming rather than reporting as a generic failure. It is the one state the
+      // local check cannot rule out.
+      if (res.status === 404) {
+        throw new Error(
+          'IRIS reports the trigger routes do not exist. DEMO_TRIGGERS is set on the engine but ' +
+            'PG_DEMO_TRIGGERS is not set on the iris service, or /labdemo/trigger is unregistered.',
+        );
+      }
+      try {
+        return JSON.parse(text) as unknown;
+      } catch {
+        throw new Error(`trigger dispatcher returned non-JSON (HTTP ${res.status})`);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        log?.(`trigger call ${path} timed out after ${timeoutMs}ms`);
+        throw new Error(`trigger call timed out after ${timeoutMs}ms`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return {
+    status: async () => parseStatus(await call('/status', undefined, 10_000)),
+    arm: async (scenario) => parseResult(await call('/arm', { scenario }, 150_000), scenario),
+    reset: async () => parseResult(await call('/reset', {}, 60_000), null),
+  };
+}
+
+/**
+ * Disabled triggers, for every deployment that has not opted in.
+ *
+ * A SEPARATE IMPLEMENTATION rather than a flag inside `liveTriggers`, so "the engine declined
+ * locally" and "IRIS declined" cannot be confused, and so there is no code path in which a disabled
+ * engine makes an outbound request. The same reasoning as `mockMissingFolderAgent` being its own
+ * function: a shape that must never occur is best made unreachable.
+ */
+export function disabledTriggers(): TriggerDeps {
+  const declined: TriggerResult = {
+    ok: false,
+    armed: null,
+    note: null,
+    error: 'demo triggers are not enabled on this deployment',
+  };
+  return {
+    status: async () => TRIGGERS_DISABLED,
+    arm: async () => declined,
+    reset: async () => declined,
+  };
+}

--- a/services/detection-engine/src/index.ts
+++ b/services/detection-engine/src/index.ts
@@ -34,6 +34,7 @@ import { liveAgent, mockAgent, liveResolveTool, mockResolveTool } from './detect
 // under the same name compiles as a duplicate-identifier error rather than shadowing -- but had it
 // shadowed, `resolve(serviceRoot, 'thresholds.json')` would have called the write orchestrator.
 import { parseResolveRequest, resolve as runResolve } from './detect/resolve.ts';
+import { disabledTriggers, liveTriggers } from './detect/triggers.ts';
 import { DEFAULT_POLL_INTERVAL_MS, ThresholdStore } from './config/thresholds.ts';
 import { DetectionEngine } from './detect/engine.ts';
 import { HttpProxyClient } from './proxy/client.ts';
@@ -104,6 +105,26 @@ const IRIS_BASE_URL = process.env['IRIS_BASE_URL'] ?? 'http://localhost:52773';
 const IRIS_USER = process.env['IRIS_USER'] ?? 'superuser';
 const IRIS_PASS = process.env['IRIS_PASS'] ?? 'SYS';
 
+/**
+ * Demo scenario triggers for the dashboard's buttons — OFF unless explicitly enabled.
+ *
+ * Gated separately from AGENT_MODE, because they answer a different question. AGENT_MODE selects
+ * where investigations come from; this decides whether a browser may break the production. A demo
+ * with a live agent is normal; a deployment where a button can disable a host is not, so it does not
+ * ride along on `live`.
+ *
+ * `liveTriggers` also requires a live IRIS. With AGENT_MODE=mock there is no reachable dispatcher,
+ * so the flag alone is not enough and both conditions are named here rather than one implying the
+ * other.
+ */
+const DEMO_TRIGGERS = (process.env['DEMO_TRIGGERS'] ?? '').trim();
+const triggersEnabled =
+  DEMO_TRIGGERS !== '' && DEMO_TRIGGERS !== '0' && DEMO_TRIGGERS.toLowerCase() !== 'false';
+const triggers =
+  triggersEnabled && AGENT_MODE === 'live'
+    ? liveTriggers(IRIS_BASE_URL, IRIS_USER, IRIS_PASS, (m: string) => console.error(m))
+    : disabledTriggers();
+
 const agentSource = AGENT_MODE === 'live' ? 'agent' : 'canned';
 const callAgent =
   AGENT_MODE === 'live'
@@ -148,6 +169,22 @@ const server = createFindingsServer({
     // to 400. Validated here rather than inside resolve() so the endpoint answers a bad body
     // without ever reaching the write tool.
     runResolve(parseResolveRequest(body), { callTool, log: (m) => console.error(m) }),
+  triggerStatus: () => triggers.status(),
+  armTrigger: async (body) => {
+    // Read here rather than in triggers.ts so a malformed body is a 400 from the API boundary,
+    // the same division as parseResolveRequest above. The scenario is NOT validated against the
+    // list -- IRIS owns that list and its $case is the authority; duplicating it here is the
+    // stale-copy pattern, and an unknown name comes back as a named 400 from the dispatcher.
+    const scenario =
+      typeof body === 'object' && body !== null
+        ? (body as Record<string, unknown>)['scenario']
+        : undefined;
+    if (typeof scenario !== 'string' || scenario === '') {
+      throw new Error('bad request: scenario must be a non-empty string');
+    }
+    return triggers.arm(scenario);
+  },
+  resetTriggers: () => triggers.reset(),
 });
 
 server.listen(PORT, () => {
@@ -158,7 +195,9 @@ server.listen(PORT, () => {
     `detection-engine listening on :${PORT} (proxy=${PROXY_MODE}` +
       `${PROXY_MODE === 'live' ? ` ${PROXY_BASE_URL}` : ''}` +
       `, agent=${AGENT_MODE}${AGENT_MODE === 'live' ? ` ${IRIS_BASE_URL}` : ''}` +
-      `, poll=${POLL_INTERVAL_MS}ms)`,
+      `, poll=${POLL_INTERVAL_MS}ms` +
+      // Printed because a trigger surface that is silently ON is the thing worth noticing in a log.
+      `${triggersEnabled ? ', demo-triggers=ON' : ''})`,
   );
 });
 


### PR DESCRIPTION
Arm the three demo scenarios and reset them from the dashboard rather than a terminal. Three layers: a new `TriggerDispatcher` in IRIS, a proxy in the engine, a rail panel in the UI.

## Off by default, and that is the safety property

**This is a second write path into a live production and deliberately not the governed one.** `Tools.Resolve` exists so an AI-recommended change is RBAC-checked, bounded, previewable and audited. These triggers are the opposite by design — they break the production on purpose so there is something to detect. Routing them through the same governance would make "the AI may change a pool size within 2..8" and "an operator may disable a host and repoint a path" look like one class of act.

So the boundary is a different one, and it is stated rather than implied:

- **`PG_DEMO_TRIGGERS` must be set or every route returns 404** — not 403. 404 because a disabled demo surface should be indistinguishable from one that was never deployed; a 403 advertises that there is a way to break this production if you find the credential. Verified: all three routes 404 with the flag unset.
- **A fixed `$case`, never `$classmethod`.** Dynamic dispatch on a wire value is arbitrary code execution wearing a scenario name. An unknown name is refused *before* any temp file is created — `{"scenario":"rm -rf"}` → `400 unknown scenario 'rm -rf'`, nothing armed.
- **No parameters.** `PoolBottleneck` takes four, and accepting them from the wire would mean validating four numeric ranges to stop a caller pinning the instance with `PoolBottleneck(1, 0.001, 0, 999999)`.
- **Reset takes no argument and is always available** when the flag is on. The operation that makes the others safe must not require a correct argument to reach.

The flag is read at **request** time and the web application is registered unconditionally. Putting the check in `FirstBoot` would bake it into the named volume: an instance booted once without the flag could never gain the routes, and one booted with it could never lose them.

**The engine holds no trigger logic** — it forwards and returns what came back, the same division as `/api/resolve`. It checks the flag locally *as well*, so "triggers are off" is a distinct observable state from "IRIS is unreachable" or "the web app is unregistered". That last one has cost this project two defects (#106, and the nginx 405s).

Not audited, deliberately: a human breaking a throwaway instance has no attribution question to answer. `Triggers.Status()` reports what is armed, which is the state that matters here.

## The bug only a live test finds

The trigger methods `write` progress text to the current device, so it landed in the HTTP response body ahead of the JSON:

```
ARMED  dead_host  (the MVP 3 missing-folder scenario)
  EMR Source FilePath -> /tmp/labdemo/hl7-in-missing/
  ...
{"armed":"missing_folder","ok":true}
```

The scenario **armed** and the caller reported `non-JSON (HTTP 200)`. The two disagreed about whether anything had happened — the worst shape for a demo control, because the operator retries an action that already worked.

**Captured rather than suppressed**, into a temp file that becomes the current device for the call. That text is the clearest explanation of each scenario anyone has written, so it comes back as `log` for the panel to show.

A file rather than `%Device.ReDirectIO`: I tried the redirect first and it captured nothing, because it dispatches to six labels in a MAC routine which this class is not. The device is restored in the `catch` too — a leaked redirect would send every later response on the process into a dead file, so a failed trigger would break an unrelated request.

**Fixed in `Arm()` and not in `Reset()`, in the same commit.** Arm came back clean while reset still returned `non-JSON (HTTP 200)`. Found by testing both routes rather than assuming the fix generalised.

## UI

The scenario list **and** the armed state both come from the server. A list in the component would be a second copy that goes stale into buttons that 400 (root `CLAUDE.md` §6), and armed state tracked from button presses would be confidently wrong the moment someone drives the terminal — normal during a rehearsal.

Every button disables while any is pending, because the trigger class stashes previous values in one global per setting and a concurrent pair could stash each other's, making `Reset()` restore the wrong thing. Pending is words, not a spinner: `PoolBottleneck` blocks ~80s and a spinner that long reads as a hang. Armed is signalled by a dot **and** the word "armed", never colour alone (§7.3).

Styled in a warning tone under its own heading. The rail already distinguishes inert context from real controls; this is a third category — real controls that make the production worse on purpose — and grouping it with "Brochure" would be the wrong affordance.

## Verified end to end, through nginx on :5173

```
flag off  ->  {"enabled":false,"scenarios":[],"armed":{}}   rail renders nothing
              GET/POST/POST on /labdemo/trigger/* all 404

flag on   ->  three scenarios published by the server
              arm closed_port      -> {"ok":true,"armed":"closed_port"}
              armed state          -> {"closed_port":true, ...}  (read back from IRIS)
              110s later           -> 5 findings: dead_host, elevated_error_rate,
                                      queue wait 1375x, slow_processing 100x, throughput_drop
              reset                -> ok, with its note about what it cannot undo
              temp files left      -> 0

238 engine tests pass · dashboard tsc clean · engine tsc clean · architecture validator green
```

## Also in this branch

`ABC` showing as `unknown` type is **not** fixed here — it is #127, a proxy issue with a different root cause (the `hosttype` label only rides on per-`messagetype` families, so a host that has never processed a message has no type label anywhere). Filed rather than worked around.

Confirmed while investigating: **reading the error log per business component works** — `GetRecentErrors` matches on `ConfigName` and returns classified counts per host (`Cloud API` 354 / `#6059` + `ErrFailureTimeout`, `EMR Source` 2, `Lab Router` 0, and that zero is genuine rather than a failure to read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
