### PR TITLE
fix: pool_bottleneck returned nginx's HTML error page, not JSON

### DIFF
--- a/apps/dashboard/nginx.conf.template
+++ b/apps/dashboard/nginx.conf.template
@@ -52,6 +52,46 @@ server {
     # so a per-endpoint list here would be a second copy of its routing table. That is the #84
     # stale-copy pattern, and it is what caused this bug: the block was written when
     # /api/healthscan/* was the only route family and never revisited when MVP 2 added three more.
+    # THE ONE PER-PREFIX EXCEPTION, and it exists because a timeout is a property of the ROUTE
+    # rather than of the routing table. The block below deliberately refuses to enumerate endpoints
+    # -- see its comment -- and that argument still holds for everything a 35s read timeout suits.
+    # It does not suit arming a demo scenario.
+    #
+    # `PoolBottleneck()` warms a baseline at zero for 75 seconds before it returns, so the whole
+    # call blocks for ~80s. Against `proxy_read_timeout 35s` nginx gave up first and answered its own
+    # HTML gateway-timeout page, which the browser then tried to parse:
+    #
+    #     Unexpected token '<', "<html> <h"... is not valid JSON
+    #
+    # The trigger had armed correctly. So the visible failure was a JSON parse error on a control
+    # that worked -- the same disagree-about-what-happened shape as the captured `write` output in
+    # TriggerDispatcher, arriving one layer further out. Reported by @Ari-Glikman; my own curl tests
+    # only exercised the two FAST scenarios and never went through nginx for the slow one.
+    #
+    # 180s, matching the engine's own 150s arm timeout with headroom, so the engine is still the
+    # component that reports a genuine hang. Raising the shared 35s instead would have undone the
+    # reasoning below, where 35s exists precisely so the engine's 30s investigate timeout fires
+    # first.
+    #
+    # Scoped to /api/demo/ so only the trigger routes get it. The status GET is fast and does not
+    # need it, but it lives under the same prefix and a long read timeout costs nothing on a request
+    # that returns immediately.
+    location /api/demo/ {
+        resolver ${NGINX_LOCAL_RESOLVERS} valid=10s ipv6=off;
+        set $demo_upstream "http://${HEALTHSCAN_UPSTREAM}";
+        proxy_pass $demo_upstream$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 180s;
+        # Also the SEND timeout: nginx's default is 60s and arming sends a tiny body, so this is
+        # belt-and-braces rather than load-bearing -- but a 60s send timeout on a 180s read timeout
+        # is the kind of mismatch that produces an unexplainable failure at the 60 second mark.
+        proxy_send_timeout 180s;
+        add_header Cache-Control "no-store" always;
+    }
+
     location /api/ {
         # RESOLVE AT REQUEST TIME, NOT AT CONFIG LOAD. A literal hostname in proxy_pass is
         # resolved when nginx reads its config, so this container refused to start at all

--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -94,7 +94,11 @@ export function TriggerRail(): JSX.Element | null {
   const refresh = useCallback(async () => {
     try {
       const res = await fetch(`${BASE}/triggers`);
-      setState(parseState(await res.json()));
+      // Same text-then-parse as the writes below. Here the catch already swallows it, so this is
+      // about the FAILURE MODE rather than the message: a thrown SyntaxError and a truthful
+      // "triggers are off" both hide the rail, and the second is what an HTML error page means.
+      const raw = await res.text();
+      setState(parseState(JSON.parse(raw)));
     } catch {
       // Silent. A failed status poll must not render an error over the whole rail: the endpoint is
       // optional by construction, and the connection banner already owns "the engine is unreachable".
@@ -119,7 +123,36 @@ export function TriggerRail(): JSX.Element | null {
           headers: { 'Content-Type': 'application/json' },
           ...(body === undefined ? {} : { body: JSON.stringify(body) }),
         });
-        const payload = (await res.json()) as Record<string, unknown>;
+
+        /*
+         * READ AS TEXT, THEN PARSE, so a non-JSON response becomes a sentence rather than a
+         * `SyntaxError` shown to the operator. `res.json()` threw
+         *
+         *     Unexpected token '<', "<html> <h"... is not valid JSON
+         *
+         * when nginx timed out and returned its own HTML error page (@Ari-Glikman). The nginx read
+         * timeout is fixed separately -- but a proxy, a load balancer or an auth gateway returning
+         * HTML is a permanent possibility, not a bug to be fixed once, and a parse error names the
+         * wrong layer entirely: it reads as "the dashboard is broken" when the request never
+         * reached the engine.
+         *
+         * The status code carries the meaning here, so it is reported instead of the body.
+         */
+        const raw = await res.text();
+        let payload: Record<string, unknown>;
+        try {
+          payload = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+          // 504/502 specifically, because for a long arm that is the likely one and "still running"
+          // is materially different advice from "it failed".
+          setError(
+            res.status === 504 || res.status === 502
+              ? `The request timed out at the proxy after ${res.status}. Arming may still be ` +
+                `running in IRIS — check the armed state before retrying.`
+              : `The server returned a non-JSON response (HTTP ${res.status}).`,
+          );
+          return;
+        }
         if (typeof payload['error'] === 'string' && payload['error'] !== '') {
           setError(payload['error']);
         } else if (typeof payload['note'] === 'string' && payload['note'] !== '') {

--- a/iris/labdemo/REST/TriggerDispatcher.cls
+++ b/iris/labdemo/REST/TriggerDispatcher.cls
@@ -49,6 +49,14 @@ Class ProductionGuardian.LabDemo.REST.TriggerDispatcher Extends %CSP.REST
 /// recompile to turn off, and "turn this off now" is the operation most likely to be urgent.
 Parameter FLAGVAR = "PG_DEMO_TRIGGERS";
 
+/// Scenarios that take longer to arm than the web server will wait, so they run as a background job.
+///
+/// A LIST RATHER THAN A DURATION THRESHOLD, because the cost is not measurable before the call: the
+/// only way to know a scenario is slow is to know what it does. `pool_bottleneck` warms a baseline
+/// for 75s; the other two return in under a second. Adding a scenario means deciding which side of
+/// this it falls on, which is the decision that should be explicit.
+Parameter SLOWSCENARIOS = {$listbuild("pool_bottleneck")};
+
 XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
 {
 <Routes>
@@ -93,9 +101,23 @@ ClassMethod Status() As %Status
     // What is actually armed, read from the trigger globals rather than inferred, so the UI can
     // show state instead of assuming its own button presses are the whole truth. Someone driving
     // the terminal at the same time is a normal thing to do in a rehearsal.
+    // KEYED ON WHAT THE SCENARIO *SETS*, NOT ON WHAT IT STASHED. `PoolWas` was the first choice and
+    // it is wrong: every stash is conditional on the value differing from the shipped one, so
+    // arming `pool_bottleneck` on an instance already at pool 1 stashes nothing and the button read
+    // "not armed" while the scenario was fully armed. Measured -- DispatcherMs, RateSecs and
+    // MaxQueued were all set and the UI showed false.
+    //
+    // `DispatcherMs` is set unconditionally and only by this scenario, so it is the honest witness.
+    // It is also set AFTER the 75-second warm-up, which makes the indicator mean "arming has taken
+    // effect" rather than "a request was accepted" -- exactly what a presenter needs from it while a
+    // jobbed scenario is still warming.
+    do out.armed.%Set("pool_bottleneck", ''$data(^ProductionGuardian.Trigger("DispatcherMs")), "boolean")
+
+    // `PathWas` and `PortWas` ARE correct witnesses for their scenarios, because both repoint a
+    // setting to a value that cannot be the shipped one -- so the stash always happens. Kept, rather
+    // than changed for symmetry with the line above.
     do out.armed.%Set("missing_folder", ''$data(^ProductionGuardian.Trigger("PathWas")), "boolean")
     do out.armed.%Set("closed_port", ''$data(^ProductionGuardian.Trigger("PortWas")), "boolean")
-    do out.armed.%Set("pool_bottleneck", ''$data(^ProductionGuardian.Trigger("PoolWas")), "boolean")
 
     write out.%ToJSON()
     quit $$$OK
@@ -148,6 +170,44 @@ ClassMethod Arm() As %Status
             return $$$OK
         }
 
+        // SCENARIOS THAT BLOCK LONGER THAN THE WEB SERVER WILL WAIT MUST BE JOBBED.
+        //
+        // The embedded Apache in this image answers **504 after exactly 60 seconds**, regardless of
+        // what the engine or nginx allow. Measured directly against IRIS with no proxy in front:
+        //
+        //     POST /labdemo/trigger/arm {"scenario":"pool_bottleneck"}  ->  HTTP 504 in 60.2s
+        //
+        // `PoolBottleneck()` waits 75s BEFORE arming anything -- the baseline has to warm at exactly
+        // zero or `queue_buildup` can never fire (see that method's comment, and #43). So the wait is
+        // load-bearing and cannot be shortened, which means the REQUEST has to stop being long.
+        //
+        // Raising timeouts was the wrong fix and I tried it first: nginx 35s -> 180s and the engine
+        // at 150s both sat outside a limit neither of them owned, and the symptom was unchanged.
+        // The 504 came from IRIS itself.
+        //
+        // So a slow scenario is JOBBED and the route answers immediately with `pending`. The UI
+        // already polls the armed state, so it learns the outcome from the state it was reading
+        // anyway rather than from this response -- which is why this is a small change rather than a
+        // new progress channel.
+        //
+        // No captured log for a jobbed scenario: there is no output to capture yet when the response
+        // is written. `detail` carries what the scenario will do instead, which is the same text a
+        // reader wants and is knowable in advance.
+        if $listfind(..#SLOWSCENARIOS, scenario) {
+            job ..JobScenario(scenario)::5
+            if '$test {
+                // Built first: a concatenation inside a %DynamicObject literal is #1021. Second time
+                // in this class, so it is worth the note rather than the silent fix.
+                set jobErr = "could not start the background job for '" _ scenario _ "'"
+                set %response.Status = "503 Service Unavailable"
+                write { "error": (jobErr) }.%ToJSON()
+                return $$$OK
+            }
+            write { "armed": (scenario), "ok": true, "pending": true, "log": "",
+                "note": "Warming the baseline at zero for ~75s before arming, so queue_buildup can fire. The armed indicator will appear when it starts." }.%ToJSON()
+            return $$$OK
+        }
+
         open capturePath:("NRW"):5
         if '$test {
             // Could not open the capture file. Run the trigger anyway with output going nowhere
@@ -181,6 +241,24 @@ ClassMethod Arm() As %Status
         write { "error": ("arm failed: " _ ex.DisplayString()) }.%ToJSON()
         return $$$OK
     }
+}
+
+/// Entry point for a JOBBED scenario. Public because `job` cannot reach a private method.
+///
+/// `job ..Invoke(...)` starts a NEW PROCESS, and a private method is not callable from one --
+/// measured as `<PRIVATE METHOD> 197 Arm+66`, returned as a 200 with an error rather than a crash,
+/// which is why it looked like a logic bug rather than a visibility one.
+///
+/// PUBLIC BUT NOT A WIDER SURFACE. It is not a `%CSP.REST` route, so it is unreachable over HTTP;
+/// it re-checks `Enabled()` so a jobbed call cannot outlive the flag being turned off mid-run; and it
+/// takes only a scenario name, which `Invoke` validates against the same fixed `$case`. An unknown
+/// name is a no-op status rather than a dispatch.
+ClassMethod JobScenario(scenario As %String) As %Status
+{
+    if '..Enabled() {
+        quit $$$ERROR($$$GeneralError, "demo triggers are not enabled")
+    }
+    quit ..Invoke(scenario)
 }
 
 /// Run one named scenario. Private, and the only place the scenario names map to methods.


### PR DESCRIPTION
Reported: clicking **Pool bottleneck** gave

```
Unexpected token '<', "<html> <h"... is not valid JSON
```

## The 60-second limit is IRIS's own, and I found that only by isolating it

`PoolBottleneck()` waits 75s **before** arming anything — the baseline must warm at exactly zero or `queue_buildup` can never fire (#43, and that method's own comment). So the wait is load-bearing and cannot be shortened.

**I raised timeouts first and it was the wrong fix.** nginx 35s → 180s on a new `/api/demo/` location, the engine already at 150s — and the symptom did not change. Still 504, still at **60.2s**. Testing IRIS directly with no proxy in front named the owner:

```
POST /labdemo/trigger/arm {"scenario":"pool_bottleneck"}  ->  HTTP 504 in 60.2s
```

The embedded Apache answers 504 at 60s regardless of what anything outside it allows. So the request had to stop being long, rather than be waited on longer. Slow scenarios are now **jobbed** and the route answers immediately — measured **0.26s** against 60.2s. The UI already polls armed state, so it learns the outcome from state it was reading anyway.

The nginx location is **kept** even though it was not the cause: the shared 35s exists so the engine's own timeout fires first, and while a jobbed arm is fast, `reset` still runs inline. The comment records that it wasn't the fix, because a timeout with no stated reason is one someone later "cleans up".

## Two bugs the fix itself introduced, both found by watching state rather than the response

**1. `job ..Invoke(...)` → `<PRIVATE METHOD>`.** `job` starts a new process and a private method is not callable from one. It came back as a 200 with an error string, so it read as a logic bug rather than a visibility one. `JobScenario()` is public but not a route, re-checks the flag so a jobbed call cannot outlive it being turned off, and still dispatches through the same fixed `$case`.

**2. The armed indicator read `PoolWas`, which is stashed *conditionally*** — only when the pool differs from the shipped value. So arming on an instance already at pool 1 stashed nothing and the button said "not armed" while the scenario was fully armed, with `DispatcherMs`, `RateSecs` and `MaxQueued` all set.

Now keyed on `DispatcherMs`, which this scenario sets unconditionally and nothing else sets. That turns out better than a fix: `DispatcherMs` is set **after** the warm-up, so the indicator means "arming has taken effect" rather than "a request was accepted". Verified across a full warm-up:

```
t+  0s  armed: False
t+ 25s  armed: False
t+ 50s  armed: False
t+ 75s  armed: True     <- arming took effect
t+100s  armed: True
```

## The UI no longer shows a raw parse error either

`res.json()` threw the `SyntaxError` straight at the operator. It now reads text and parses, reporting *"timed out at the proxy after 504 — arming may still be running in IRIS"*. A proxy or gateway returning HTML is a permanent possibility rather than a bug to fix once, and a parse error names the wrong layer entirely: it reads as "the dashboard is broken" when the request never reached the engine.

## Verified end to end through nginx

```
reset            -> all three false
arm              -> 0.26s, valid JSON, ok: true
indicator        -> flips at t+75s
findings         -> 3, with NO error findings — the genuine pool bottleneck:
                    queue_buildup 165 deep, growing_queue_wait 2226x, slow_processing 20x

238 engine tests pass · dashboard tsc clean · engine tsc clean · architecture validator green
```

## One thing I could not verify here, and it is the pre-existing `Reset()` gap

Investigating the `queue_buildup` from this scenario returned a **connectivity** diagnosis with `recommendedAction: null` rather than the pool increase. That looked like my connectivity guard misfiring, but the errors are real and *current* — `#6059` still being written 3 times in the last 5 minutes, long after the port was restored.

That is the `Reset()` gap I flagged on #125: the accumulated backlog keeps retrying against the target that *was* closed, so a later scenario inherits the previous one's error window for ~15 minutes. The guard is reading true evidence and behaving correctly; what is wrong is that the instance is not actually clean. `docker compose restart iris` clears the queue but not the log window.

So **the governed-fix path is unverified in this PR** on an instance that has previously run `closed_port`. It was verified before the guard existed, and the guard's own logic is tested, but the two have not been shown working together on a clean instance. Worth doing on a fresh `compose down -v` before the demo, and worth fixing the `Reset()` gap properly rather than working around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
