### PR TITLE
fix(dashboard): "Hosts OK" counted a host with three critical findings, and Watching had no icon

### DIFF
--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -24,13 +24,25 @@
  * which is honest about there being no forecast left to make while leaving evidence that the module
  * exists and was watching. A feature nobody can find is indistinguishable from a missing one.
  *
- * Still silent for `not_rising`, `disabled` and `metric_unmeasurable`: those are steady states on a
+ * Still silent for `disabled` and `metric_unmeasurable`: those are steady states on a
  * healthy host, and a row saying "no projection available" on every card would make the grid
  * unreadable for information nobody needs. `warming` and `insufficient_samples` render because they
- * mean "ask again shortly" rather than "nothing is coming".
+ * mean "ask again shortly" rather than "nothing is coming". `not_rising` renders too — see
+ * `SHOWN_REASONS` for why that changed, and why it is the only one that earns an icon.
+ *
+ * ONE REASON CARRIES AN ICON, AND ONLY ONE. `not_rising` is the sole state whose whole content is
+ * reassurance, so a tick makes it readable at a glance instead of as a line of grey text among five
+ * metric rows — asked for after the text-only version shipped, because grey prose next to a queue
+ * depth does not read as "this is fine". The other three states are deliberately left plain:
+ * `already_crossed` is a *spent* forecast reporting that the bad thing happened, and `warming` /
+ * `insufficient_samples` mean "not yet". A tick on any of them would assert something none of them
+ * claims, which is the same class of over-reassurance as the summary tile counting a host with three
+ * critical findings as OK. The icon is decorative only, `aria-hidden` through `icons.tsx`'s shared
+ * `svg()` wrapper; the sentence beside it stays the authoritative statement (§7.3).
  */
 
 import type { HostProjectionView } from '../types/mvp2';
+import { IconWatching } from './icons';
 
 export interface EarlyWarningProps {
   projection: HostProjectionView | null;
@@ -67,7 +79,13 @@ const SHOWN_REASONS: Record<string, string> = {
   not_rising: 'Watching — not trending toward a threshold',
 };
 
-/** Reasons that mean "nothing is happening", styled quieter than a pending forecast. */
+/**
+ * Reasons that mean "nothing is happening", styled quieter than a pending forecast.
+ *
+ * This set is also what earns the checkmark, deliberately as one condition rather than two: quiet
+ * and reassuring are the same property here, and a second set listing the same member would let the
+ * tone and the icon disagree the next time either changes.
+ */
 const QUIET_REASONS = new Set(['not_rising']);
 
 /**
@@ -106,7 +124,12 @@ export function EarlyWarning({ projection }: EarlyWarningProps): JSX.Element | n
     return (
       <div className={`pg-forecast ${tone}`}>
         <span className="pg-forecast__label">Early warning</span>
-        <span className="pg-forecast__body">{shown}</span>
+        <span className="pg-forecast__body">
+          {/* Inside the body rather than beside the label, so the tick sits against the sentence it
+              reinforces and wraps with it. Decorative reinforcement only — the text is the claim. */}
+          {quiet && <IconWatching size={13} className="pg-forecast__icon" />}
+          {shown}
+        </span>
       </div>
     );
   }

--- a/apps/dashboard/src/components/HostCard.tsx
+++ b/apps/dashboard/src/components/HostCard.tsx
@@ -3,13 +3,17 @@
  *
  * Metric values are monospaced and right-aligned so they do not jitter as the
  * numbers change across polls (§7.3). A host with active findings takes a
- * severity-colored left border at its *worst* severity.
+ * severity-colored left border at its *worst* severity, **and** a severity badge
+ * in the header — the border alone signalled severity by colour only, which §7.3
+ * forbids and which let a green `OK` dot sit unqualified beside three critical
+ * findings.
  */
 
 import type { HostView } from '../types/healthscan';
 import type { Severity } from '../types/healthscan';
 import { formatCount, formatDuration, formatRate, formatRelative } from '../lib/format';
 import { StatusDot } from './StatusDot';
+import { SeverityBadge } from './SeverityBadge';
 import { EarlyWarning } from './EarlyWarning';
 import type { HostProjectionView } from '../types/mvp2';
 
@@ -68,9 +72,22 @@ export function HostCard({
 
   return (
     <article className={`pg-host${severityClass}`}>
+      {/* THE BADGE IS HERE BECAUSE THE BORDER IS A COLOUR, and §7.3 forbids severity signalled by
+          colour alone. The `pg-host--<severity>` left border already made this card honest before
+          the badge existed — verified on the live stack, Cloud API carrying three critical findings
+          rendered `pg-host pg-host--critical` — but an operator reading the header saw a green
+          status dot and the word "OK" beside it, with the only contradiction being 3px of red at
+          the card's edge and a finding count at its foot.
+
+          That is the same over-reassurance the summary tile was fixed for, at card scale, and it is
+          NOT fixed by touching `host.status`: contract §4 Q1 has no `Warning`, so `OK` is what IRIS
+          said and what must be rendered (§2.4). The badge sits BESIDE the status rather than
+          replacing it, so the card states both facts — the host is running, and Health Scan has a
+          critical finding on it — which is precisely the state Q1 describes. */}
       <header className="pg-host__header">
         <StatusDot status={host.status} />
         <h3 className="pg-host__name">{host.host}</h3>
+        {worst !== null && <SeverityBadge severity={worst} />}
         <span className="pg-host__type">{host.type}</span>
       </header>
 

--- a/apps/dashboard/src/components/SeveritySummary.tsx
+++ b/apps/dashboard/src/components/SeveritySummary.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { FindingView, HostView } from '../types/healthscan';
-import { countBySeverity } from '../lib/severity';
+import { countBySeverity, hostsWithFindings } from '../lib/severity';
 import { IconCheck, IconCritical, IconInfo, IconWarning, type IconProps } from './icons';
 
 interface TileProps {
@@ -46,10 +46,33 @@ export function SeveritySummary({
   loading,
 }: SeveritySummaryProps): JSX.Element {
   const counts = countBySeverity(findings);
-  /* Only an exact 'OK' counts as healthy. Of the seven statuses the contract
-     enumerates (§4 Q1) that is the only affirmatively-good one, and an
-     unrecognized status stays excluded rather than assumed fine. */
-  const hostsOk = hosts.filter((host) => host.status === 'OK').length;
+
+  /*
+   * "HEALTHY" IS A STATUS **AND** NO FINDINGS. Reported as "there are critical errors but there is
+   * a nice 3 OK on the UI": with three critical findings all on Cloud API, every host still reported
+   * `status: "OK"`, so this tile counted 3 of 3 healthy while the tile beside it counted 3 critical.
+   * Two tiles in the same row, contradicting each other, and the reassuring one was bigger.
+   *
+   * THE PAYLOAD WAS NOT WRONG AND `status` IS NOT WHAT CHANGED. Contract §4 Q1 is explicit that the
+   * IRIS enum has **no `Warning`** — a struggling host genuinely reports `OK` and the *finding*
+   * carries the alarm. So `OK` + a critical finding is a real, correct state, not drift, and the
+   * fix must not invent a `HostStatus` value or rewrite what IRIS said. What was wrong is this
+   * component's arithmetic: it asked `status === 'OK'` and *labelled the answer* "Hosts OK", which
+   * silently promotes "the host process is running" into "the host is fine". Q1 is exactly the
+   * reason those are different claims.
+   *
+   * So the predicate gains the second half of the question. `status === 'OK'` is kept — of the seven
+   * statuses Q1 enumerates it is the only affirmatively-good one, and an unrecognized status stays
+   * excluded rather than assumed fine (§2.4) — and a host named by any finding is now excluded too,
+   * at any severity. Not critical-only: an `info` finding still means Health Scan has something to
+   * say about that host, and "OK" should mean the tile has nothing to say about it. The stricter
+   * reading is the safe direction to be wrong in, because the failure mode being fixed is
+   * over-reassurance.
+   */
+  const flagged = hostsWithFindings(findings);
+  const hostsOk = hosts.filter(
+    (host) => host.status === 'OK' && !flagged.has(host.host),
+  ).length;
 
   return (
     <section className="pg-summary" aria-label="Severity summary">

--- a/apps/dashboard/src/components/icons.tsx
+++ b/apps/dashboard/src/components/icons.tsx
@@ -197,6 +197,28 @@ export const IconRestart: PathIcon = (props) =>
 export const IconCheck: PathIcon = (props) =>
   svg(<path d="M4.5 12.5l5 5 10-11" />, props);
 
+/**
+ * Enclosed check — the Early Warning *watching* state.
+ *
+ * A SEPARATE ICON FROM `IconCheck` ON PURPOSE, though the tick inside is the same gesture.
+ * `IconCheck` is a bare tick used where something *completed* — the reconnected banner, the
+ * "no findings" empty mark, the Hosts OK tile. "Watching" completes nothing; it reports an
+ * ongoing observation with nothing to report, so the ring is the meaning: a tick held inside a
+ * boundary rather than a tick handed over. Reusing the bare tick would have read as a verdict.
+ *
+ * The circle also keeps it off the severity silhouettes. Per the header rule, shapes must be
+ * distinguishable by outline alone — this is a *ring* with a tick, where `IconInfo` is a ring with
+ * a bar and dot, so neither can be misread as the other on a projector.
+ */
+export const IconWatching: PathIcon = (props) =>
+  svg(
+    <>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M8.2 12.4l2.6 2.6 5-5.6" />
+    </>,
+    props,
+  );
+
 /* Nav rail — inert visual context (§7.2), so these are deliberately plain. */
 
 export const IconHome: PathIcon = (props) =>

--- a/apps/dashboard/src/lib/severity.ts
+++ b/apps/dashboard/src/lib/severity.ts
@@ -1,6 +1,6 @@
 /** Severity ordering, coercion and counting. Unknown severity is `info` (§2.4). */
 
-import type { Severity } from '../types/healthscan';
+import type { FindingView, Severity } from '../types/healthscan';
 
 const KNOWN: readonly Severity[] = ['critical', 'warning', 'info'];
 
@@ -28,6 +28,23 @@ export function worstSeverity(severities: readonly Severity[]): Severity | null 
       worst === null || RANK[current] > RANK[worst] ? current : worst,
     null,
   );
+}
+
+/**
+ * The names of every host carrying at least one finding.
+ *
+ * `finding.host` is always exactly a `host.host` value — same string, same case (§4 Q8) — so
+ * membership in this set is the entire host↔finding join. Lives here rather than in a component
+ * because the summary and the grid both need the same answer, and a second `for` loop over
+ * `findings` in a second file is how the two would drift apart.
+ *
+ * Deliberately *not* the worst severity per host: the summary only asks "is anything wrong here",
+ * and `HostGrid.severityByHost` already answers the harder question for the cards.
+ */
+export function hostsWithFindings(findings: readonly FindingView[]): ReadonlySet<string> {
+  const named = new Set<string>();
+  for (const finding of findings) named.add(finding.host);
+  return named;
 }
 
 export type SeverityCounts = Record<Severity, number>;

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -504,6 +504,11 @@ button {
   display: flex;
   align-items: center;
   gap: var(--pg-space-2);
+  /* The severity badge joined this row, and the grid's minimum card is 260px. Four items
+     (dot, name, badge, type) do not always fit one line at that width, so the row wraps
+     rather than squeezing the host name — the name is the card's identity and must stay
+     readable in full. */
+  flex-wrap: wrap;
 }
 
 .pg-host__name {
@@ -1263,6 +1268,16 @@ button {
 .pg-forecast--quiet .pg-forecast__label,
 .pg-forecast--quiet .pg-forecast__body {
   color: var(--pg-text-muted);
+}
+
+/* The watching tick. `--pg-ok` on the ICON only, while the sentence stays muted: the colour is
+   carried by the one element that is explicitly decorative and aria-hidden, so nothing a screen
+   reader or a colour-blind operator relies on depends on it (§7.3). Baseline-shifted rather than
+   flex-aligned so the tick sits on the text's own line and wraps with it. */
+.pg-forecast__icon {
+  margin-right: var(--pg-space-1);
+  vertical-align: -2px;
+  color: var(--pg-ok);
 }
 
 /* ── MVP 3: brochure and architecture views ───────────────────────────────── */


### PR DESCRIPTION
Two defects reported from driving the live UI. Both verified against the running stack before and after, and both are the same failure mode at two scales: **the dashboard being more reassuring than the data supports.**

## Defect 1 — "there are critical errors but there is a nice 3 OK on the UI"

### The payload that proves it

Reproduced on the live stack at `11:36:14Z`:

```
GET /api/healthscan/hosts
[{"host":"Cloud API","type":"operation","status":"OK","queued":0,"messagesPerSec":0.6,
  "errored":715,"avgProcessingTime":0.67,"avgQueueingTime":84.8,"lastActivity":"2026-08-23T11:36:14Z"},
 {"host":"EMR Source","type":"service","status":"OK", ...},
 {"host":"Lab Router","type":"process","status":"OK", ...}]

GET /api/healthscan/findings
[{"id":"f-1192","host":"Cloud API","type":"slow_processing","severity":"critical",
  "currentValue":0.67,"baselineValue":0.05,"message":"Average processing time 670ms is 13x baseline"},
 {"id":"f-1193","host":"Cloud API","type":"growing_queue_wait","severity":"critical",
  "currentValue":84.8,"baselineValue":0.02,"message":"Average queue wait 84.80s is 4240x baseline"}]
```

| | Before | After |
|---|---|---|
| Critical tile | 2 | 2 |
| **Hosts OK tile** | **3 of 3** | **2 of 3** |

Two tiles in the same row contradicting each other — and the reassuring one carries a 26px numeral while the alarm is a row count further down the page.

### The contract subtlety, and how this avoids contradicting Q1

`contracts/healthscan-api.md` §4 Q1 is explicit that the IRIS `status` enum has **no `Warning`**. A struggling host genuinely reports `OK` and *the finding carries the alarm*. So `status: "OK"` alongside a critical finding is a **real, correct, documented state** — not drift, not a bug in the engine.

So the fix deliberately does **not**:

- add a `HostStatus` value (`Warning` does not exist upstream),
- derive or rewrite `host.status` (§2.4 says render what IRIS reports — and the Management Portal is one click away in the header, so a status the dashboard invented would visibly disagree with it),
- touch the engine (§2 ratifies the server-side shape; the payload already carries both facts).

What was actually wrong is one line of arithmetic in `SeveritySummary`: it asked `status === 'OK'` and then *labelled the answer* **"Hosts OK"**, silently promoting *"the host process is running"* into *"the host is fine"*. Q1 is precisely the reason those are two different claims.

The predicate now needs both halves:

```ts
const flagged = hostsWithFindings(findings);
const hostsOk = hosts.filter((host) => host.status === 'OK' && !flagged.has(host.host)).length;
```

`status === 'OK'` is **kept** rather than replaced by "no findings" — the two conditions answer different questions, and dropping the status check loses §2.4's guarantee that an unrecognised status is never shown as healthy. Excluded at **any** severity, not critical-only: an `info` finding still means Health Scan has something to say about that host, and "OK" should mean the tile has nothing to say. When the failure mode is over-reassurance, stricter is the safe direction to be wrong in.

The join lives in `lib/severity.ts` as `hostsWithFindings()` rather than inline, because `HostGrid` already walks `findings` to compute worst-severity-per-host and a second loop in a second file is how the two drift apart. It returns a `Set` of names, not a severity map — the summary only asks "is anything wrong here", and `severityByHost` already answers the harder question.

### Was the host grid already honest? Yes — but by colour alone

Checked before changing anything. `HostCard` takes `pg-host--<worst>` from **findings**, never from status, and the served bundle carries `.pg-host--critical{border-left-color:var(--pg-critical)}`. Cloud API rendered as `pg-host pg-host--critical` throughout. **So only the summary tile was lying about the count** — the grid's answer was right.

But it was right by **colour alone**, which §7.3 explicitly forbids. An operator reading that card's header saw a green status dot and the word `OK`, with the only contradiction being 3px of red at the card's edge and a finding count at its foot.

Added a `SeverityBadge` beside the status dot — icon **plus the word "Critical"**, the same component the findings rows already use, so it needed no new visual language. It sits **beside** the status rather than replacing it, so the card states both facts at once: *the host is running*, and *Health Scan has a critical finding on it*. That is exactly the state Q1 describes, rendered rather than resolved. The header gains `flex-wrap` because four items do not always fit the grid's 260px minimum card, and the host name is the card's identity.

## Defect 2 — the Watching state needed a checkmark

`Watching — not trending toward a threshold` shipped as grey text and reads as prose among five metric rows rather than as reassurance.

New `IconWatching` in `icons.tsx` — inline SVG, house style, one export per icon, `PathIcon`, no icon package (§3).

**A separate icon from `IconCheck`, on purpose.** `IconCheck` is a bare tick used where something *completed* — the reconnected banner, the "no findings" empty mark, the Hosts OK tile. Watching completes nothing; it reports an ongoing observation with nothing to report. The ring is the meaning: a tick held inside a boundary rather than handed over. The ring also keeps the silhouette clear of `IconInfo` (ring + bar + dot), so neither can be misread on a projector — which is the rule the icons file header states.

**One reason carries it, and only one**, gated on the existing `QUIET_REASONS` — the same set that selects the `--quiet` tone, so the tone and the icon cannot disagree later. Deliberately **not** on `already_crossed`, which is a *spent* forecast reporting that the bad thing already happened, and **not** on `warming` / `insufficient_samples`, which mean "not yet". A tick on any of those asserts something none of them claims — the same class of over-reassurance as defect 1, which is why both are in one commit.

Accessibility: the icon is decorative, `aria-hidden` via the shared `svg()` wrapper, and the sentence remains the authoritative statement. `--pg-ok` is applied to the **icon only** while the text stays muted, so the colour is carried entirely by the element nothing depends on.

This **extends** the file's class comment rather than contradicting it. That comment records `already_crossed` and then `not_rising` each being made visible for the same reason; this is the third turn of it — *visible* is not the same as *legible*.

## Tried and rejected

- **A new `HostStatus` value / derived `Warning`.** Against Q1 and §2.4.
- **Fixing it in the engine.** §2 ratifies the server-side shape; this is a display concern and the payload already carries both facts.
- **Counting "hosts with no findings" and dropping the status check.** Loses §2.4's guarantee that an unknown status is never rendered as healthy.

## One thing worth recording about the demo triggers

`closed_port` **masks this defect once fully armed** — it drives Cloud API to `status: "Error"`, which the *old* predicate already excluded, so the tile read 2 of 3 even before the fix. The window that reproduces it is the drain after `reset`, where status returns to `OK` while the cumulative-metric findings (`slow_processing`, `growing_queue_wait`) persist. The trigger built to produce critical findings is the one scenario that hides this particular contradiction.

## Gates

| Gate | Result |
|---|---|
| dashboard `tsc --noEmit` | clean |
| `node tools/validate-architecture.mjs` | green — 7 labels, no overlaps, all within the viewBox |
| engine tests | **238 pass**, 0 fail, 55 suites |
| engine `tsc --noEmit` | clean |
| single-file fallback | `dist/index.html` — **no non-`data:` `src`/`href`** (§6) |

Served bundle verified through nginx on `:5173` after `docker compose up -d --build dashboard`:

```
.pg-forecast__icon css      : true
IconWatching path           : true
host header flex-wrap       : true
compiled predicate          : g.filter(Q=>Q.status==="OK"&&!C.has(Q.host))
quiet-gated icon            : k&&M.jsx(fS,{size:13,className:"pg-forecast__icon"})
```

Stack left demo-ready: all three triggers disarmed, `findings` `[]`, all three hosts `OK` — so "3 of 3" is now a *true* statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
