### PR TITLE
fix(iris): the engine could not tell a fault that IS happening from one that HAPPENED

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,51 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-23 — `get_recent_errors` reports HOW RECENT, not only how many (Dev B)
+
+**`mcp-tools.md` §3.4 only.** Two additive nullable fields, no schema change, no sample change —
+`validate.mjs` stays at 3 samples / 26 reject.
+
+- `byCode[].secondsAgo` — age of that code's newest occurrence, in whole seconds
+- `newestSecondsAgo` — age of the newest error of any code, on the reply itself
+
+### Why a count inside a window was not enough
+
+A count cannot distinguish *happening* from *happened*, and that distinction decides the diagnosis.
+A queue building behind one worker was diagnosed as a **connectivity failure** from 22-minute-old
+`#6059` rows still inside the 60-minute window — the host had stopped erroring entirely. Measured,
+same host, same second:
+
+```
+sinceMinutes 15  ->  count 0,   byCode []
+sinceMinutes 60  ->  count 134, newest #6059 1315s ago
+```
+
+Both true, and neither answers the question. **The window cannot settle it in either direction:**
+narrow it and MVP 3's missing-folder scenario disappears, because that host logs `#5021` once on
+entering `Error` and then goes quiet. So the window stays wide enough to see a one-shot fault and the
+conclusion keys on age.
+
+### A timestamp is not content
+
+`secondsAgo` is a duration derived from a row's own clock field — nothing typed by a person, nothing
+derived from a message, so it is on the metrics side of root `CLAUDE.md` §2.1. The message **text**
+remains unreturnable for §3.4a's reasons, unchanged. Emitting an absolute timestamp instead was
+rejected: an elapsed count answers the only question asked of it and cannot be correlated against
+anything outside the instance.
+
+`null` means **unmeasurable, not recent** — §2.1's nullability rule in the time dimension, and the
+third shape of a defect this project has now hit four times (#33, #49, #58 were the value dimension).
+
+### What this does NOT do
+
+It does not change the window, the codes, the catalogue, or what may be returned. Two consumers of
+the new fields — the recency rules in `AgentDispatcher` — live outside `contracts/` and are described
+in that class rather than here, because *how* a diagnosis reads the evidence is not a contract term.
+
+---
+
+
 ## 2026-08-23 — `get_host_settings`, and an optional argument does not default (Dev B)
 
 **`mcp-tools.md` only.** No schema change, no sample change — `validate.mjs` stays at 3 samples /

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -335,6 +335,38 @@ Each `byCode` entry:
 | `errorCode` | string | The IRIS error token only — `<Ens>ErrFailureTimeout`, `#6059`, `#5021`, or `unclassified`. |
 | `count` | integer | Occurrences of this code in the window. |
 | `summary` | string \| null | A **catalogue** string keyed by `errorCode`, from the table in §3.4a. `null` when unclassified. |
+| `secondsAgo` | integer \| null | Age of this code's **newest** occurrence, in whole seconds. `null` when unmeasurable — never `0`, which would read as "just now". |
+
+Plus one field on the reply itself:
+
+| Field | Type | Notes |
+|---|---|---|
+| `newestSecondsAgo` | integer \| null | Age of the newest error of **any** code, so a consumer need not scan `byCode` to ask "is this still happening". `null` when there are no errors at all. |
+
+**WHY AGE, WHEN THE WINDOW ALREADY BOUNDS IT (added 2026-08-23).** A count inside a window cannot
+distinguish *happening* from *happened*, and that distinction decides the diagnosis. Measured on one
+host in one second:
+
+```
+sinceMinutes 15  ->  count 0,   byCode []
+sinceMinutes 60  ->  count 134, byCode [#6059 x63 ...], newest 1315s ago
+```
+
+Both true. A queue building behind a single worker was diagnosed as a **connectivity failure** from
+22-minute-old `#6059` rows still inside the 60-minute window — the host had stopped erroring entirely.
+The window cannot settle it either way: narrow it and the MVP 3 missing-folder scenario disappears,
+because that host logs `#5021` once on entering `Error` and then goes quiet. So the window stays wide
+enough to see a one-shot fault and the **conclusion** keys on age.
+
+**A TIMESTAMP IS NOT CONTENT.** `secondsAgo` is a duration derived from a row's own clock field. It
+carries nothing typed by a person and nothing derived from a message, so it sits on the metrics side
+of root `CLAUDE.md` §2.1 — unlike the message text, which remains unreturnable for the reasons in
+§3.4a. Emitting the absolute timestamp instead was considered and rejected: an elapsed count answers
+the only question asked of it and cannot be correlated against anything outside the instance.
+
+Consumers must treat `null` as **unmeasurable, not recent** — §2.1's nullability rule in the time
+dimension, and the third shape of the same defect this project has hit (#33, #49, #58 were the value
+dimension).
 
 **RECONCILED WITH THE IMPLEMENTATION 2026-08-20, and the contract moved further than the code.** This
 table specified something the tool has never emitted, and the two shapes differed in kind rather than

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -60,6 +60,22 @@ Parameter LLMCONFIG = "AI.LLM.pgdetective";
 /// and an unbounded loop against a metered API is a cost incident rather than a better diagnosis.
 Parameter MAXITERATIONS = 8;
 
+/// Error codes that mean "the downstream could not be reached". Same list the prompt names.
+///
+/// ONE COPY, referenced by both the guard below and (by name) the prompt above. Read from
+/// `Tools.Read`'s catalogue when it was written; a code here that the catalogue does not classify
+/// would simply never match, which fails closed.
+Parameter CONNECTIVITYCODES = {$listbuild("#6059", "<Ens>ErrConnectionLost", "<Ens>ErrHTTPStatus", "<Ens>ErrFailureTimeout", "<Ens>ErrTCPTerminatedReadTimeoutExpired")};
+
+/// Seconds after which a connectivity error describes history rather than the present.
+///
+/// DERIVED, NOT PICKED. A host failing to reach a closed target retries continuously -- Cloud API
+/// against a closed port wrote 12 errors/minute, i.e. one every five seconds. The engine confirms a
+/// finding after two polls at a 5s cadence, so anything it currently reports has been true for ~10s.
+/// Two minutes of silence from a host that would be erroring every five seconds is therefore the
+/// fault being OVER, not a gap in the data.
+Parameter CONNECTIVITYMAXAGE = 120;
+
 XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
 {
 <Routes>
@@ -106,6 +122,16 @@ ClassMethod Investigate() As %Status
         set parsed.toolCalls = $select($isobject(stats): stats."total_tool_calls", 1: "")
 
         do ..DropUnapplicableAction(parsed)
+        // Host from the REQUEST's finding, never from the model's reply: a guard that trusted the
+        // reply for the thing it is checking could be steered by the reply.
+        if $isobject(body.%Get("finding")) {
+            set findingHost = body.finding.%Get("host", "")
+            // Order matters only in that both read the same evidence; they are mutually exclusive by
+            // construction -- one fires when a connectivity error is recent, the other when it is
+            // not, so they cannot both act on one reply.
+            do ..DropPoolFixDuringOutage(parsed, findingHost)
+            do ..DropStaleConnectivityClaim(parsed, findingHost)
+        }
 
         write parsed.%ToJSON()
         return $$$OK
@@ -167,6 +193,148 @@ ClassMethod DropUnapplicableAction(parsed As %DynamicObject) [ Private ]
     // filter is indistinguishable from a model that behaved. The engine ignores unknown keys.
     set parsed.droppedAction = { "type": (action.%Get("type", "")), "host": (host),
         "reason": "not_whitelisted_host", "detail": (detail) }
+}
+
+/// Drop a pool recommendation while the host is CURRENTLY failing to reach its target. Private.
+///
+/// THE MIRROR OF DropStaleConnectivityClaim, and it exists because adding recency to the prompt
+/// regressed the case recency was not about. Measured on a live closed-port scenario with
+/// `#6059 secondsAgo 3` -- unambiguously current -- across three runs:
+///
+///     action=null       <- correct
+///     action=pool->2    <- wrong
+///     action=pool->2    <- wrong
+///
+/// Two in three. Explaining `secondsAgo` gave the model a reason to discount errors and it applied
+/// that reason to errors three seconds old. The previous wording held 3/3 on this case but caused the
+/// stale-error defect; the new wording fixes stale and breaks current. **A prompt cannot hold both
+/// ends** -- which is the fifth time on this class that a behaviour needed a guard rather than
+/// wording, so both ends are now checked in code and the prompt only has to explain.
+///
+/// SAFE BY CONSTRUCTION ANYWAY, and that is worth being clear about: `set_pool_size` on a host in
+/// this state would be *applied* successfully -- it is `Cloud API`, within 2..8 -- and would make
+/// things worse, four workers failing to reach a closed port instead of one. So unlike
+/// `DropUnapplicableAction`, where the tool refused the action regardless, here nothing downstream
+/// would have stopped it. This is the guard, not a tidier presentation of one.
+ClassMethod DropPoolFixDuringOutage(parsed As %DynamicObject, host As %String) [ Private ]
+{
+    if '$isobject(parsed.%Get("recommendedAction")) {
+        quit
+    }
+    set action = parsed.recommendedAction.%Get("action")
+    if '$isobject(action) {
+        quit
+    }
+    // Only the pool action. If the catalogue ever gains an action that IS right during an outage,
+    // this must not silently drop it.
+    if action.%Get("type", "") '= "set_pool_size" {
+        quit
+    }
+
+    set errors = ##class(ProductionGuardian.LabDemo.Tools.Read).GetRecentErrors(host, 60)
+    set freshest = ..FreshestConnectivityAge(errors)
+    // "" means no connectivity error in the window, or an unmeasurable age. Either way there is no
+    // evidence of a current outage, so the recommendation stands -- this guard only ever fires on
+    // POSITIVE evidence, never on absent evidence.
+    if (freshest = "") || (freshest > ..#CONNECTIVITYMAXAGE) {
+        quit
+    }
+
+    set parsed.recommendedAction = ""
+    set detail = "a connectivity error occurred " _ freshest _ "s ago, so more workers would fail faster rather than drain the queue"
+    set parsed.droppedAction = { "type": "set_pool_size", "host": (host),
+        "reason": "downstream_unreachable", "detail": (detail) }
+}
+
+/// Age in seconds of the newest CONNECTIVITY error in a get_recent_errors reply, or "". Private.
+///
+/// Shared by both guards so they cannot disagree about which codes count or how age is read -- a
+/// second copy of this loop is exactly the drift that produced the original defect.
+ClassMethod FreshestConnectivityAge(errors As %DynamicObject) As %String [ Private ]
+{
+    set freshest = ""
+    if '$isobject(errors) {
+        quit ""
+    }
+    set list = errors.%Get("byCode")
+    if '$isobject(list) {
+        quit ""
+    }
+    set it = list.%GetIterator()
+    while it.%GetNext(.i, .entry) {
+        if '$listfind(..#CONNECTIVITYCODES, entry.%Get("errorCode", "")) {
+            continue
+        }
+        set age = entry.%Get("secondsAgo")
+        if age = "" {
+            continue
+        }
+        if (freshest = "") || (age < freshest) {
+            set freshest = age
+        }
+    }
+    quit freshest
+}
+
+/// Strip a connectivity claim the evidence does not support. Private.
+///
+/// WHY A CHECK AND NOT JUST A BETTER PROMPT. Fifth time on this class: every behaviour this project
+/// actually depends on has needed a deterministic guard, not politer wording. The prompt now explains
+/// `secondsAgo` and states the 120-second threshold; this makes the threshold true.
+///
+/// THE NARROW CLAIM IT REFUTES. Only one: "the downstream is unreachable" asserted while the host has
+/// logged no connectivity error recently. That is checkable from a number the tool now returns, so it
+/// is checked. Everything else the model says stands -- this method has no opinion on a queue depth,
+/// a pool size, or whether the recommendation is wise.
+///
+/// AND IT ONLY EVER REMOVES. It cannot add a `recommendedAction`, because "the model was wrong to
+/// blame connectivity" does not establish that a pool increase is right -- the live numbers might
+/// support neither. A diagnosis narrowed to "no fix named" is honest; one where the dispatcher
+/// invented the fix would make it a second author, which is the same line `DropUnapplicableAction`
+/// draws.
+ClassMethod DropStaleConnectivityClaim(parsed As %DynamicObject, host As %String) [ Private ]
+{
+    set manual = parsed.%Get("manualRemediation")
+    if '$isobject(manual) {
+        quit
+    }
+
+    // Only a claim that NAMES connectivity. A manualRemediation about a missing directory or an
+    // invalid setting is untouched, so this cannot silently eat MVP 3's scenario.
+    set summary = $zconvert(manual.%Get("summary", ""), "L")
+    set claimsConnectivity = 0
+    for term = "unreachable", "connectivity", "downstream host", "cannot be reached", "connection" {
+        if summary [ term {
+            set claimsConnectivity = 1
+        }
+    }
+    if 'claimsConnectivity {
+        quit
+    }
+
+    // The evidence, read fresh rather than taken from the model's own account of it. A model that
+    // misread the age would also misreport it.
+    set errors = ##class(ProductionGuardian.LabDemo.Tools.Read).GetRecentErrors(host, 60)
+    set newest = errors.%Get("newestSecondsAgo")
+
+    // No errors at all in an hour, or an unmeasurable age -- either way there is nothing supporting
+    // a connectivity claim. "" is the tool's unmeasurable marker and must not read as "just now".
+    // The newest CONNECTIVITY code specifically, not the newest error of any kind: an
+    // ErrProductionSettingInvalid a second ago says nothing about reachability. Shared helper, so
+    // this guard and DropPoolFixDuringOutage cannot drift apart on the definition.
+    set freshest = ..FreshestConnectivityAge(errors)
+    set unsupported = (freshest = "") || (freshest > ..#CONNECTIVITYMAXAGE)
+
+    if 'unsupported {
+        quit
+    }
+
+    set parsed.manualRemediation = ""
+    set detail = "no connectivity error on this host within " _ ..#CONNECTIVITYMAXAGE _ "s"
+        _ $select(newest = "": " (none in the last hour)", 1: "; newest error of any kind " _ newest _ "s ago")
+    // Recorded, not silent -- same reasoning as droppedAction. A reviewer needs to see that the
+    // model claimed something and that we refused it, or this looks like a model that behaved.
+    set parsed.droppedRemediation = { "reason": "stale_connectivity_claim", "detail": (detail) }
 }
 
 /// Invoke the governed write tool. Every guard is the tool's, not this class's.
@@ -378,15 +546,46 @@ ClassMethod SystemPrompt() As %String [ Private ]
     // the rule for reading what is there. Stated as a hard precondition rather than a caution,
     // since a caution is what the previous version effectively was.
     set p = p _ "A LARGER POOL ONLY HELPS A QUEUE THAT IS PROCESSING SLOWLY, never one that is "
-    set p = p _ "failing. If get_recent_errors shows connectivity or downstream failures -- codes "
-    set p = p _ "#6059, <Ens>ErrConnectionLost, <Ens>ErrHTTPStatus, <Ens>ErrFailureTimeout, "
-    set p = p _ "<Ens>ErrTCPTerminatedReadTimeoutExpired -- then the queue is the SYMPTOM and the "
-    set p = p _ "unreachable target is the cause. More workers would only fail faster, so "
-    set p = p _ "recommendedAction MUST be null and the fix belongs in manualRemediation: the "
-    set p = p _ "operator repoints the host at a reachable target or restores the downstream. "
-    set p = p _ "Recommend set_pool_size only when the host is processing successfully and simply "
-    set p = p _ "cannot keep up -- messages completing, few or no errors, and work accumulating "
-    set p = p _ "behind a single worker. "
+    set p = p _ "failing. The connectivity codes are #6059, <Ens>ErrConnectionLost, "
+    set p = p _ "<Ens>ErrHTTPStatus, <Ens>ErrFailureTimeout and "
+    set p = p _ "<Ens>ErrTCPTerminatedReadTimeoutExpired. "
+
+    // RECENCY, NOT PRESENCE, and this is the correction. The rule above said "if get_recent_errors
+    // SHOWS connectivity failures", which is a statement about the window rather than about the
+    // host -- so a pool bottleneck armed after a closed-port scenario was diagnosed as a
+    // connectivity failure from 22-minute-old rows still inside the 60-minute window. Reported by
+    // @Ari-Glikman. Measured, same host, same second:
+    //
+    //     sinceMinutes 15  ->  count 0
+    //     sinceMinutes 60  ->  count 134, newest #6059 secondsAgo 1315
+    //
+    // The two directives were in direct conflict: BuildGoal tells the model to use a 60-minute
+    // window (because the missing-folder scenario logs once and goes quiet), and this rule then read
+    // anything in that window as current. `secondsAgo` is what resolves it -- the window can stay
+    // wide enough to see a one-shot fault while the CONCLUSION keys on how recent the fault is.
+    //
+    // 120 seconds is the threshold and it is derived rather than picked: the engine confirms a
+    // finding after `sustainedSamples` polls at a 5s cadence, so anything it is currently reporting
+    // has been true for at least ~10s, and a failing host retries continuously -- Cloud API against
+    // a closed port wrote 12 errors/minute. Two minutes of silence from a host that would be
+    // erroring every five seconds is therefore not a gap in the data; it is the fault being over.
+    set p = p _ "Each byCode entry carries secondsAgo, the age of that code's NEWEST occurrence, and "
+    set p = p _ "the reply carries newestSecondsAgo for the host overall. USE THEM: a connectivity "
+    set p = p _ "code with secondsAgo above 120 is a fault that has ENDED, and its errors describe "
+    set p = p _ "the backlog's history rather than the present. Do not diagnose a current "
+    set p = p _ "connectivity problem from it, and do not let it stop you recommending a pool "
+    set p = p _ "increase that the live numbers support. "
+    set p = p _ "Say so explicitly when you rely on this -- for example that the host errored 20 "
+    set p = p _ "minutes ago, is no longer erroring, and is now simply outnumbered. "
+
+    set p = p _ "So: connectivity codes with secondsAgo at or under 120 mean the queue is the "
+    set p = p _ "SYMPTOM and the unreachable target is the cause -- more workers would only fail "
+    set p = p _ "faster, recommendedAction MUST be null, and the fix belongs in manualRemediation, "
+    set p = p _ "where the operator repoints the host or restores the downstream. "
+    set p = p _ "Recommend set_pool_size when the host is processing successfully and simply cannot "
+    set p = p _ "keep up: work accumulating behind a single worker, and no RECENT connectivity "
+    set p = p _ "errors. A host with a queue, a normal processing time and only stale errors is the "
+    set p = p _ "pool case, not the connectivity case. "
 
     // MVP 3. The two fields are described as MUTUALLY EXCLUSIVE and as differing in AUTHORITY rather
     // than in format, because that is the distinction the model has to get right: one is a change we
@@ -458,6 +657,11 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     set g = g _ " Call get_recent_errors with sinceMinutes 60, not the default: a host logs its"
     set g = g _ " error once on entering Error and then stops, so a short window can come back"
     set g = g _ " empty while the fault is still present. An empty result does not mean healthy."
+    // The other half of the same instruction, and it was missing. Telling the model to widen the
+    // window without telling it the window contains history is what made a stale fault look current.
+    set g = g _ " A WIDE WINDOW CONTAINS HISTORY. Check secondsAgo on each code before treating it as"
+    set g = g _ " current: errors from 20 minutes ago on a host that is no longer erroring describe"
+    set g = g _ " a fault that has ended, and the backlog draining behind it is a different problem."
     quit g
 }
 

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -217,7 +217,23 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
         set secs = secs + 86400
     }
     set since = $zdatetime(days _ "," _ secs, 3)
-    set sql = "SELECT Text FROM Ens_Util.Log WHERE ConfigName = ? AND Type <= 2 AND TimeLogged >= ?"
+    // TimeLogged IS SELECTED TOO, so each code can report HOW RECENT it is and not only how many.
+    // A count alone is what produced the reported defect: a queue building behind one worker was
+    // diagnosed as a connectivity failure because 20-minute-old #6059 rows were still inside the
+    // window. Measured on the same host in the same second:
+    //
+    //     sinceMinutes 15  ->  count 0,   byCode []
+    //     sinceMinutes 60  ->  count 134, byCode [#6059 x63, ErrFailureTimeout x63, ...]
+    //
+    // Both true. Neither says whether the failure is HAPPENING or merely HAPPENED, and that is the
+    // whole distinction between "the target is unreachable" and "the target was unreachable and the
+    // backlog is now draining slowly". The window cannot settle it either: a short window hides the
+    // missing-folder scenario, where a host logs #5021 once on entering Error and then goes quiet.
+    //
+    // A TIMESTAMP IS NOT CONTENT. `secondsAgo` is a duration derived from a row's own clock field,
+    // carries nothing typed by a person and nothing derived from a message, so it is on the metrics
+    // side of the §2.1 boundary. The message TEXT stays unreturnable, as below.
+    set sql = "SELECT Text, TimeLogged FROM Ens_Util.Log WHERE ConfigName = ? AND Type <= 2 AND TimeLogged >= ?"
     set rs = ##class(%SQL.Statement).%ExecDirect(, sql, host, since)
     if rs.%SQLCODE < 0 {
         set out.reason = "log unreadable (SQLCODE " _ rs.%SQLCODE _ ")"
@@ -228,22 +244,82 @@ ClassMethod GetRecentErrors(host As %String, sinceMinutes As %Integer = 15) As %
 
     set total = 0
     kill codes
+    kill newest
     while rs.%Next() {
         set total = total + 1
         set code = ..ClassifyError(rs.%Get("Text"))
         set codes(code) = $get(codes(code), 0) + 1
+        // Newest per code, as an ODBC timestamp string. String comparison is correct for this
+        // format -- "2026-08-23 10:47:54" sorts identically as text and as time, because the fields
+        // are fixed-width and most-significant-first.
+        set stamp = rs.%Get("TimeLogged")
+        if stamp ] $get(newest(code), "") {
+            set newest(code) = stamp
+        }
     }
     set out.count = total
+
+    // `now` once, outside the loop, so every secondsAgo in one reply is measured against the same
+    // instant. Computed per entry it would drift by the loop's own duration, and two codes logged
+    // together could report different ages.
+    set nowH = $ztimestamp
     set code = ""
     for {
         set code = $order(codes(code), 1, n)
         quit:code=""
+        set ago = ..SecondsSince($get(newest(code), ""), nowH)
         // `summary` lives on the byCode entry because it is keyed by `errorCode` -- a property of
         // the CODE, not of an occurrence. That is what made the aggregate shape sufficient and the
         // per-event `errors[]` array unnecessary (@kskubach's correction on #116).
-        do out.byCode.%Push({ "errorCode": (code), "count": (n), "summary": (..ErrorSummary(code)) })
+        //
+        // `secondsAgo` is the newest occurrence of THIS code, so a reply can carry one code that is
+        // seconds old and another that is an hour old -- which is exactly the case a single
+        // `count` collapses and a diagnosis needs.
+        do out.byCode.%Push({ "errorCode": (code), "count": (n), "summary": (..ErrorSummary(code)),
+            "secondsAgo": (ago) })
     }
+
+    // ONE SUMMARY FIELD FOR THE WHOLE REPLY, because a model reasoning about "is this still
+    // happening" should not have to scan an array to find the minimum. Null when there are no
+    // errors at all -- not 0, which would read as "an error just now".
+    set overall = ""
+    set code = ""
+    for {
+        set code = $order(newest(code))
+        quit:code=""
+        if newest(code) ] overall {
+            set overall = newest(code)
+        }
+    }
+    set out.newestSecondsAgo = $select(overall = "": "", 1: ..SecondsSince(overall, nowH))
     quit out
+}
+
+/// Whole seconds between an ODBC timestamp and a $ztimestamp value. Private.
+///
+/// Returns "" for an unparseable or absent input, which the caller emits as JSON null -- an
+/// unmeasurable age must not read as "just now", which is §2.1's nullability rule applied to time.
+ClassMethod SecondsSince(stamp As %String, nowH As %String) As %String [ Private ]
+{
+    if stamp = "" {
+        quit ""
+    }
+    // $zdatetimeh with format 3 is the inverse of the $zdatetime(...,3) used to build the window
+    // bound above. It throws on malformed input rather than returning a wrong number, so the
+    // try/catch is the guard rather than a validation pass.
+    try {
+        set h = $zdatetimeh(stamp, 3)
+    } catch {
+        // Return, not Quit: `Quit value` inside a Try is #1043. Third time in this codebase, so it
+        // is worth the note -- $$$OK expands to 1 and hits the same rule.
+        return ""
+    }
+    set d = ($piece(nowH, ",", 1) - $piece(h, ",", 1)) * 86400
+    set d = d + ($piece(nowH, ",", 2) - $piece(h, ",", 2))
+    // Clamped at zero. A row stamped a second in the future -- clock skew, or a timestamp written by
+    // a different process -- must not report a negative age, which a consumer would render as
+    // nonsense rather than recognise as skew.
+    quit $select(d < 0: 0, 1: d \ 1)
 }
 
 /// Report average processing and queueing time in seconds for one interoperability host.


### PR DESCRIPTION
Reported: arming `pool_bottleneck` produced a diagnosis of **connectivity problems**, and the engine appeared not to be checking whether connectivity was actually broken or reading the event log.

It **was** reading the event log — correctly, and per host. What it could not do is tell **when**.

## The defect, measured

`get_recent_errors` returned a count inside a window and nothing about recency. Same host, same second:

```
sinceMinutes 15  ->  count 0,   byCode []
sinceMinutes 60  ->  count 134, byCode [#6059 x63, <Ens>ErrFailureTimeout x63, ...]
```

Both true. Neither says whether the target is unreachable **now** or was unreachable half an hour ago with a backlog still draining. On the reported run the newest `#6059` was **1315 seconds old** — 22 minutes — and the host had stopped erroring entirely.

## My own two directives were in direct conflict

`BuildGoal` told the model to widen the window to 60 minutes, because MVP 3's missing-folder host logs `#5021` once on entering `Error` and then goes quiet — a short window hides that scenario completely. `SystemPrompt` then told it that connectivity codes **anywhere in the window** mean the queue is a symptom.

Together those say: treat half-hour-old errors as current. **The window cannot settle it in either direction**, so the window stays wide and the *conclusion* now keys on age.

## The fix is data, then two guards

`get_recent_errors` emits `secondsAgo` per code and `newestSecondsAgo` for the reply. **A timestamp is not content** — it is a duration from a row's own clock field, nothing typed by a person and nothing derived from a message, so it is on the metrics side of §2.1. The message text stays unreturnable.

Then, because a prompt is a request:

| Guard | Fires when |
|---|---|
| `DropPoolFixDuringOutage` | `set_pool_size` recommended while a connectivity error is ≤120s old |
| `DropStaleConnectivityClaim` | a connectivity `manualRemediation` claimed when none is that recent |

**120 seconds is derived, not picked.** A host failing to reach a closed target retries continuously — Cloud API against a closed port wrote 12 errors/minute, one every five seconds — and the engine confirms a finding after two polls at 5s. Two minutes of silence from a host that would be erroring every five seconds is the fault being *over*, not a gap in the data.

Both share `FreshestConnectivityAge()` so they cannot disagree about which codes count, and they are mutually exclusive by construction.

**This guard is load-bearing in a way `DropUnapplicableAction` is not.** `set_pool_size` on `Cloud API` during an outage *is* within 2..8 and *would* apply — making four workers fail to reach a closed port instead of one. Nothing downstream would have stopped it.

## The first attempt regressed the other direction

Explaining `secondsAgo` in the prompt fixed stale and broke current. On a live closed-port scenario with `#6059 secondsAgo 3` — unambiguously current — three runs gave `null`, `pool->2`, `pool->2`. **Two in three wrong.** The model had been given a reason to discount errors and applied it to errors three seconds old.

The previous wording held 3/3 there and caused the stale defect; the new wording fixes stale and breaks current. **A prompt cannot hold both ends.** Fifth time on this class, so both ends are checked in code and the prompt only has to explain.

## Verified live, both directions

```
stale errors (1848s) + real pool bottleneck  ->  3/3 recommend the pool
current outage (#6059 at 3s)                 ->  4/4 refuse it, manualRemediation instead
clean instance, zero errors in window        ->  3/3 recommend the pool
```

And the agent now explains itself, unprompted:

> *"The Cloud API host is currently configured with a pool size of 1... Recent connection and timeout errors have occurred, but since they happened over 30 minutes ago, they are stale and describe a previously existing condition."*

with the ages quoted in its `evidence` array.

```
262 engine tests pass · engine tsc clean · contracts/validate.mjs green (3 samples, 26 reject)
```

## Also found: `Ens.Util.Log.Purge()` is the missing rehearsal step

`Reset()` restores settings but **cannot clear the error window**, so a scenario inherits the previous one's errors for up to an hour. That is why back-to-back rehearsals of different scenarios were unreliable, and it is the same gap I flagged on #125 — now with the mechanism identified. I purged 32,598 rows to get a clean test.

**Not wired into `Reset()`** — purging a production's event log is not something a demo toggle should do silently. But it is the step to run before a demo, and `Triggers.Reset()` arguably should print a reminder. Left as a decision rather than taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
