### PR TITLE
feat(dashboard): the portal link opens the new interop editor, not the Zen page

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -15,10 +15,14 @@ VITE_POLL_INTERVAL_MS=2000
 
 # The Management Portal link in the header. ABSOLUTE, unlike the API base above, because the
 # portal is a different service on a different port and nothing proxies it — the browser has to
-# be told where IRIS is. Defaults to the interop production page on localhost:52773, which is
-# what `docker compose up` publishes; set this when IRIS is elsewhere.
+# be told where IRIS is. Defaults to the interoperability editor for this production on
+# localhost:52773, which is what `docker compose up` publishes; set this when IRIS is elsewhere.
 #
-# The path is `/csp/healthshare/labdemo/...` rather than `/csp/labdemo/...` because this is IRIS
-# for Health, where EnableNamespace creates the HealthShare-prefixed application. Verified 200
-# against the running instance; `/csp/labdemo/EnsPortal.ProductionConfig.zen` returns 404.
-VITE_IRIS_PORTAL_URL=http://localhost:52773/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen
+# THE NEW ANGULAR EDITOR (`/ui/interop/interop-editor/`), not the legacy Zen page. The old
+# `/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen` still answers 200 and works if you
+# prefer it — both were verified against the running instance — but the modern editor is what an
+# operator on a current IRIS build actually uses.
+#
+# KEEP THE QUERY STRING PERCENT-ENCODED. `%24` is `$`, and the editor expects `$NAMESPACE` and
+# `$PRODUCTION` as literal parameter names. Do not rewrite them raw.
+VITE_IRIS_PORTAL_URL=http://localhost:52773/ui/interop/interop-editor/index.html?%24NAMESPACE=LABDEMO&%24PRODUCTION=ProductionGuardian.LabDemo.Production

--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -39,25 +39,35 @@ import { TriggerRail } from './TriggerRail';
 export type View = 'dashboard' | 'brochure' | 'architecture';
 
 /**
- * The IRIS Management Portal, for jumping from a finding to the production that produced it.
+ * The IRIS interoperability editor, for jumping from a finding to the production that produced it.
  *
- * DEFAULTS TO THE INTEROP PRODUCTION PAGE, not the portal home. An operator following a finding
- * wants the host list, and `EnsPortal.ProductionConfig.zen` is one click from every host's settings
- * — where `/csp/sys/UtilHome.csp` is three. Both verified 200 on the EAP image; the interop path is
- * under `/csp/healthshare/labdemo` because this is IRIS for Health, where `EnableNamespace` creates
- * the HealthShare-prefixed application rather than a bare `/csp/labdemo`.
+ * THE NEW ANGULAR UI, not the Zen page. `/ui/interop/interop-editor/` is what current IRIS builds
+ * ship and what an operator on this instance actually uses; the old
+ * `/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen` still answers 200 and remains a working
+ * fallback if anyone needs it, but landing an audience on the legacy portal from a modern dashboard
+ * is a jarring seam. Both verified 200 against the running instance before switching.
+ *
+ * THE QUERY STRING IS PERCENT-ENCODED AND MUST STAY THAT WAY. `%24` is `$`, and the editor expects
+ * `$NAMESPACE` / `$PRODUCTION` as literal parameter names. Writing them raw here works in some
+ * contexts and breaks in others depending on how the URL is parsed, so the encoded form is kept
+ * verbatim as verified — do not "tidy" it.
+ *
+ * NAMESPACE AND PRODUCTION ARE LABDEMO-SPECIFIC, exactly as the old path was. That is not a
+ * regression in generality: this whole default is a convenience for the demo instance, and
+ * `VITE_IRIS_PORTAL_URL` replaces the entire URL for anything else.
  *
  * ABSOLUTE AND CONFIGURABLE, unlike the API base, and the two differ for a real reason. The API is
  * reached through nginx on the dashboard's own origin, so a relative path is correct and keeps the
  * bundle environment-independent. The portal is a *different service on a different port* that
- * nothing proxies, so the browser must be told where it is. `VITE_IRIS_PORTAL_URL` overrides it for
- * a deployment where IRIS is not on localhost:52773.
+ * nothing proxies, so the browser must be told where it is.
  *
  * The port is not read from `docker-compose.yml`'s `PG_IRIS_WEB_PORT`: the bundle is built before
  * compose runs and the browser is on the host, so the build cannot know the mapping. A wrong
  * default is visible and one variable away from fixed, which is the honest trade.
  */
-const DEFAULT_PORTAL_URL = 'http://localhost:52773/csp/healthshare/labdemo/EnsPortal.ProductionConfig.zen';
+const DEFAULT_PORTAL_URL =
+  'http://localhost:52773/ui/interop/interop-editor/index.html' +
+  '?%24NAMESPACE=LABDEMO&%24PRODUCTION=ProductionGuardian.LabDemo.Production';
 
 function portalUrl(): string {
   const configured = import.meta.env.VITE_IRIS_PORTAL_URL;
@@ -179,7 +189,7 @@ export function AppShell({ headerActions, view, onNavigate, children }: AppShell
             href={portalUrl()}
             target="_blank"
             rel="noopener noreferrer"
-            title="Open the IRIS Management Portal's production page in a new tab"
+            title="Open this production in the IRIS interoperability editor, in a new tab"
           >
             <IconProductions size={14} />
             Management Portal


### PR DESCRIPTION
The header's Management Portal link pointed at the legacy Zen page. It now opens the Angular interoperability editor for this production:

```
http://localhost:52773/ui/interop/interop-editor/index.html?%24NAMESPACE=LABDEMO&%24PRODUCTION=ProductionGuardian.LabDemo.Production
```

**Both verified 200** against the running instance before switching — the old Zen page still works and remains a usable fallback, so this is a choice rather than a repair. Landing an audience on the legacy portal from a modern dashboard is a seam worth not having.

## The one thing not to "tidy" later

`%24` is `$`, and the editor expects `$NAMESPACE` / `$PRODUCTION` as literal parameter names. The encoded form is kept verbatim as verified, and the comment says so — rewriting it raw is the obvious next edit and would be wrong.

Concatenated across two source lines rather than one long literal, so neither half is long enough to soft-wrap into something a reader might mis-copy.

## Comments replaced rather than left stale

The old comment explained at length why the path was under `/csp/healthshare/labdemo` rather than `/csp/labdemo` — true when written, and now a fact about a path we no longer use. Replaced with the reason for the new choice, in both `AppShell.tsx` and `.env.example`.

The visible label stays **"Management Portal"**: the editor *is* part of the portal and that is the phrase an audience recognises. Only the tooltip is more precise.

## Verified in the served bundle, not just in source

```
href after rebuild : http://localhost:52773/ui/interop/interop-editor/index.html?%24NAMESPACE=LABDEMO&%24PRODUCTION=ProductionGuardian.LabDemo.Production
resolves           : 200
EnsPortal.ProductionConfig.zen occurrences : 0
tsc --noEmit       : clean
validate-architecture.mjs : green (7 labels, no overlaps)
```

## Scope

This is **one of three** tasks from a batch — the agent handling brochure zoom and the client-facing architecture slides died on a stream timeout with no work committed, so those two are still outstanding and will be redone separately. This one was small and fully verified, so it is landing on its own rather than waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)