### PR TITLE
feat(dashboard): the brochure can be enlarged and zoomed, because at 68vh it was unreadable

### DIFF
--- a/apps/dashboard/src/components/BrochureLightbox.tsx
+++ b/apps/dashboard/src/components/BrochureLightbox.tsx
@@ -1,0 +1,241 @@
+/**
+ * Full-screen brochure reader — the enlarge-and-zoom half of the Brochure view.
+ *
+ * AN OVERLAY RATHER THAN IN-PLACE ZOOM, and the deciding argument is geometry, not
+ * taste. The brochure is a 1024×1536 portrait page rendered inside a card that sits
+ * beside a 208px nav rail inside a padded content region — so in place, the widest
+ * viewport it can ever have is a few hundred pixels narrower than the screen, and
+ * panning it would mean a second scroll container nested inside the page's own. A
+ * full-viewport overlay hands the page every pixel the presenter actually has, which
+ * is the whole complaint: at 68vh the text is unreadable on a projector.
+ *
+ * Shaped after `FindingDetail` — `position: fixed`, `Esc` closes, focus returns to
+ * the control that opened it — with one deliberate difference. That drawer is
+ * `aria-modal="false"` because the operator must keep seeing the grid behind it.
+ * This one IS modal (`aria-modal="true"` plus the focus trap below), because "give
+ * the brochure the whole screen" means there is nothing behind it left to read, and a
+ * `Tab` that walked into the dashboard underneath would leave focus somewhere the
+ * presenter cannot see.
+ *
+ * ZOOM IS LAYOUT WIDTH, NOT `transform: scale()`. A transform does not change layout,
+ * so a scaled image overflows a scroll container that does not know it grew: the
+ * scrollable area stays the unscaled size and everything outside the transform-origin
+ * corner is unreachable. Setting the image's width instead makes the stage's own
+ * scrollbars exactly the right size, and native scrolling *is* the pan — wheel,
+ * trackpad, scrollbar drag and the arrow keys, none of which a drag handler would have
+ * given for free. No dependency either way (§3); this is the cheaper of the two.
+ *
+ * ZOOM IS A MULTIPLE OF THE STAGE WIDTH, NOT OF THE ASSET'S OWN PIXELS. A ladder
+ * against the file's intrinsic 1024px would read as an honest "100% = 1:1", and would
+ * also compile that number into the UI — the same class of staleness as a copied host
+ * list (root `CLAUDE.md` §6). Against the stage, `1` means "as wide as the panel
+ * allows" on a 1024-wide projector and a 2560-wide laptop alike, and the labels say
+ * "width" rather than "%" so they are not claiming pixel fidelity they do not have.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { IconClose } from './icons';
+
+/**
+ * The zoom ladder, lowest first. Index 0 is fit-to-width and the ladder only climbs:
+ * below fit-width the useful state is "the whole page at once", which is its own mode
+ * rather than a rung.
+ *
+ * The multiplier is carried as a CLASS NAME, not a number. A number could only reach
+ * CSS as an inline custom property, and nothing in this directory sets one — five
+ * rules in `app.css` keep every dimension where the rest of them live (§9).
+ */
+const ZOOM_STEPS = [
+  { label: 'Fit width', className: 'pg-reader__img--w1' },
+  { label: '1.5× width', className: 'pg-reader__img--w15' },
+  { label: '2× width', className: 'pg-reader__img--w2' },
+  { label: '3× width', className: 'pg-reader__img--w3' },
+  { label: '4× width', className: 'pg-reader__img--w4' },
+] as const;
+
+const TOP_STEP = ZOOM_STEPS.length - 1;
+
+export interface BrochureLightboxProps {
+  src: string;
+  /** The same alt text the card uses — one description of the image, not two. */
+  alt: string;
+  onClose: () => void;
+  /**
+   * The image failed to load. Owned by the caller because the card and this overlay
+   * render the same bytes, so a failure in either is the same fact about one asset.
+   */
+  onImageError: () => void;
+}
+
+export function BrochureLightbox({
+  src,
+  alt,
+  onClose,
+  onImageError,
+}: BrochureLightboxProps): JSX.Element {
+  /* Fit-to-width is the default. On the presenter's case — a tall portrait page on a
+     1024px-high laptop — fitting the HEIGHT would render 1536px of page into ~900px of
+     stage, i.e. 0.6x, barely better than the 68vh that made this unreadable in the
+     first place. 1:1 would pin the page to 1024px and leave a 1920-wide screen half
+     empty, so the first thing a presenter did would be to zoom in. Fit-width is the
+     only default that is never smaller than the screen can show, and vertical scroll is
+     the natural gesture on a page taller than it is wide. */
+  const [step, setStep] = useState(0);
+  const [wholePage, setWholePage] = useState(false);
+
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+
+  /* Focus lands on the SCROLLER, not on Close. At fit-width the page is taller than the
+     stage before anything else happens, so panning is the first thing wanted, and arrow
+     keys only pan once the scroll container itself holds focus. Close is last in the
+     toolbar and the toolbar precedes the stage in the DOM, so a single Shift+Tab from
+     here reaches it. */
+  useEffect(() => {
+    stageRef.current?.focus();
+  }, []);
+
+  /* Bound to the document rather than to the overlay, for both jobs:
+       - `Esc` has to work wherever focus is, exactly as the drawer's does.
+       - the trap has to be able to pull focus back IN. A handler on the overlay only
+         sees keys pressed inside it, which is one browser quirk away from a `Tab`
+         landing in the dashboard underneath and never coming back. */
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const root = overlayRef.current;
+      if (root === null) return;
+
+      /* Every focusable this component renders: the toolbar buttons and the stage.
+         Queried at keypress rather than cached, because the zoom buttons disable and
+         re-enable as the ladder is walked and a disabled button is not a tab stop. */
+      const stops = Array.from(
+        root.querySelectorAll<HTMLElement>('button:not([disabled]), [tabindex="0"]'),
+      );
+      const first = stops[0];
+      const last = stops[stops.length - 1];
+      if (first === undefined || last === undefined) return;
+
+      const active = document.activeElement;
+      if (active === null || !root.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  /* Zooming in from "whole page" enters the ladder at its bottom rung rather than
+     remembering where it was: the two are different questions ("show me the shape" vs
+     "let me read it"), and resuming at 4x from a fitted page is a jump nobody asked
+     for. */
+  const zoomIn = useCallback((): void => {
+    setWholePage((page) => {
+      if (!page) setStep((current) => Math.min(current + 1, TOP_STEP));
+      return false;
+    });
+  }, []);
+
+  const zoomOut = useCallback((): void => {
+    setStep((current) => Math.max(current - 1, 0));
+  }, []);
+
+  const canZoomIn = wholePage || step < TOP_STEP;
+  const canZoomOut = !wholePage && step > 0;
+
+  const rung = ZOOM_STEPS[step] ?? ZOOM_STEPS[0];
+  const level = wholePage ? 'Whole page' : rung.label;
+  const imgClass = wholePage ? 'pg-reader__img--page' : rung.className;
+
+  return (
+    /* `aria-labelledby` points at the visible heading rather than repeating it as an
+       `aria-label`, so the accessible name cannot drift from what is on screen — same
+       reasoning as the drawer's. */
+    <div
+      ref={overlayRef}
+      className="pg-reader"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pg-reader-title"
+    >
+      <header className="pg-reader__bar">
+        <h2 id="pg-reader-title" className="pg-reader__title">
+          Brochure
+        </h2>
+
+        <div className="pg-reader__controls">
+          {/* The two fit modes are mutually exclusive, so they are the same
+              `pg-toggle` + `aria-pressed` pattern the Architecture slide picker uses
+              rather than a third way of saying "one of these". */}
+          <div className="pg-toggle" role="group" aria-label="Brochure fit">
+            <button
+              type="button"
+              className={`pg-toggle__option${wholePage ? '' : ' pg-toggle__option--active'}`}
+              onClick={() => setWholePage(false)}
+              aria-pressed={!wholePage}
+            >
+              Fit width
+            </button>
+            <button
+              type="button"
+              className={`pg-toggle__option${wholePage ? ' pg-toggle__option--active' : ''}`}
+              onClick={() => setWholePage(true)}
+              aria-pressed={wholePage}
+            >
+              Whole page
+            </button>
+          </div>
+
+          {/* Words, not glyphs. A projector at the back of a room is the same reason
+              severity carries a label beside its icon (§7.3), and "+"/"−" alone would
+              also leave the buttons with no accessible name worth reading. */}
+          <button type="button" className="pg-button" onClick={zoomOut} disabled={!canZoomOut}>
+            Zoom out
+          </button>
+
+          {/* Announced, because a zoom step changes nothing else a screen reader would
+              notice. Monospaced and min-width in CSS so stepping does not shift the
+              buttons either side of it. */}
+          <span className="pg-reader__level" aria-live="polite">
+            {level}
+          </span>
+
+          <button type="button" className="pg-button" onClick={zoomIn} disabled={!canZoomIn}>
+            Zoom in
+          </button>
+
+          <button type="button" className="pg-button" onClick={onClose}>
+            <IconClose size={14} />
+            Close
+          </button>
+        </div>
+      </header>
+
+      {/* `tabIndex` on a scroll container is what makes the arrow keys pan: a div that
+          scrolls but cannot hold focus is mouse-only. `role="region"` so the label is
+          announced rather than dropped on an unroled element. */}
+      <div
+        ref={stageRef}
+        className="pg-reader__stage"
+        role="region"
+        aria-label="Brochure page — scroll, or use the arrow keys to pan"
+        tabIndex={0}
+      >
+        <img className={`pg-reader__img ${imgClass}`} src={src} alt={alt} onError={onImageError} />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/BrochureView.tsx
+++ b/apps/dashboard/src/components/BrochureView.tsx
@@ -23,13 +23,50 @@
  * The asset still lives in `docs/` — read-only source material (root `CLAUDE.md`
  * §3) — and is referenced across the directory boundary rather than copied, so
  * there is no second file to go stale.
+ *
+ * THE CARD IS A THUMBNAIL AND THE READER IS THE DELIVERABLE. `docs/Brochure.png` is
+ * 1024×1536, and this card bounds it to 68vh — about 0.44 of its own width on a
+ * 1024-high laptop, which reduces the body copy to unreadable grey. So the card's
+ * only real job is "here is the brochure, open it", and it says so; the reading
+ * happens in `BrochureLightbox`, which owns the zoom controls and the reasoning for
+ * them. Nothing about the import-not-serve decision above changes — both render the
+ * same inlined bytes from one import.
  */
 
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import brochureUrl from '../../../../docs/Brochure.png';
+import { BrochureLightbox } from './BrochureLightbox';
+
+/* One description of the image, shared by the card and the reader. Two copies of alt
+   text for one asset is two things to keep in agreement. */
+const BROCHURE_ALT =
+  'Production Guardian brochure: the eight planned modules and the product positioning.';
 
 export function BrochureView(): JSX.Element {
   const [failed, setFailed] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  /* Focus returns to the button that opened the reader (§7.3). Held as a ref to the
+     element rather than looked up by selector as `App.tsx` does for finding rows —
+     that indirection exists because the list re-renders rows across polls and the
+     drawer's opener may be replaced; this trigger is a single stable node in a view
+     that does not poll, so the ref is both simpler and exact. */
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const close = useCallback((): void => {
+    setOpen(false);
+    /* Deferred a frame for the same reason the drawer's is: the overlay is still
+       mounted this tick and its focus trap would take the ring straight back. */
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }, []);
+
+  /* An image that cannot load has nothing to enlarge, so the reader closes with it and
+     the view falls through to the message below. Both surfaces report into this one
+     flag because they render one asset — a failure in either is the same fact. */
+  const handleImageError = useCallback((): void => {
+    setFailed(true);
+    setOpen(false);
+  }, []);
 
   return (
     <section className="pg-view" aria-labelledby="pg-brochure-heading">
@@ -37,6 +74,21 @@ export function BrochureView(): JSX.Element {
         <h2 id="pg-brochure-heading" className="pg-view__title">
           Brochure
         </h2>
+
+        {/* In the head as well as on the image, because the image itself being the
+            control is not discoverable — a labelled button is, and it is the tab stop
+            that reaches the reader from the keyboard. Both call the same handler. */}
+        {!failed && (
+          <button
+            ref={triggerRef}
+            type="button"
+            className="pg-button"
+            onClick={() => setOpen(true)}
+            aria-haspopup="dialog"
+          >
+            Enlarge and zoom
+          </button>
+        )}
       </div>
 
       {failed ? (
@@ -49,12 +101,34 @@ export function BrochureView(): JSX.Element {
         </p>
       ) : (
         <div className="pg-brochure">
-          <img
-            src={brochureUrl}
-            alt="Production Guardian brochure: the eight planned modules and the product positioning."
-            onError={() => setFailed(true)}
-          />
+          {/* A real `<button>` wrapping the image rather than an `onClick` on the
+              `<img>` (§7.3): clicking the page is the gesture an audience expects, and
+              a bare handler on an image is neither focusable nor Enter-activatable.
+              Not a second TAB STOP though — `tabIndex={-1}`, so the labelled button
+              above stays the single keyboard route in and a keyboard user does not meet
+              two stops that do one thing.
+              NOT `aria-hidden`, which was the first thing I wrote and was wrong: it
+              would have removed the brochure's own alt text from the accessibility
+              tree, so the one description of the asset would exist only for sighted
+              users. Out of the tab order and still in the tree is the correct pair. */}
+          <button
+            type="button"
+            className="pg-brochure__open"
+            onClick={() => setOpen(true)}
+            tabIndex={-1}
+          >
+            <img src={brochureUrl} alt={BROCHURE_ALT} onError={handleImageError} />
+          </button>
         </div>
+      )}
+
+      {open && !failed && (
+        <BrochureLightbox
+          src={brochureUrl}
+          alt={BROCHURE_ALT}
+          onClose={close}
+          onImageError={handleImageError}
+        />
       )}
 
       <p className="pg-view__caption">

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1834,3 +1834,142 @@ button {
   opacity: 0.55;
   cursor: default;
 }
+
+/* ── Brochure reader (enlarge + zoom) ──────────────────────────────────────── */
+
+/* The card's image is now a click target. A button wrapper would otherwise bring a
+   browser's default chrome — border, padding, grey background — around a 1.7 MB
+   page. */
+.pg-brochure__open {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+}
+
+.pg-brochure__open:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: 2px;
+}
+
+/* Full viewport, INCLUDING over the header and rail — unlike `.pg-drawer`, which
+   starts below the header because the operator must keep seeing the dashboard behind
+   it. Here the point is the opposite: the brochure gets every pixel there is, which is
+   the only thing that makes its body copy readable on a projector. z-index above the
+   drawer's 20 for the same reason. */
+.pg-reader {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  background: var(--pg-surface-alt);
+  animation: pg-reader-in 160ms ease-out 1;
+}
+
+@keyframes pg-reader-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.pg-reader__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pg-space-4);
+  flex-wrap: wrap;
+  flex: 0 0 auto;
+  padding: var(--pg-space-3) var(--pg-space-5);
+  background: var(--pg-surface);
+  border-bottom: 1px solid var(--pg-border);
+  box-shadow: var(--pg-shadow-card);
+}
+
+.pg-reader__title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--pg-text);
+}
+
+.pg-reader__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--pg-space-3);
+  flex-wrap: wrap;
+}
+
+/* Monospaced and min-width so stepping the ladder cannot shift the buttons either
+   side of it — the same anti-jitter rule the metric rows follow (§7.3). Sized in `ch`
+   against the longest label ("Whole page") rather than a magic pixel count. */
+.pg-reader__level {
+  min-width: 11ch;
+  text-align: center;
+  font-family: var(--pg-font-mono);
+  font-size: 12px;
+  color: var(--pg-text-muted);
+}
+
+/* The scroll container, and therefore the pan surface. `overflow: auto` on a focusable
+   element is what makes the arrow keys work; no drag handler and no dependency. */
+.pg-reader__stage {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: var(--pg-space-4);
+  background: var(--pg-surface-sunk);
+  text-align: center;
+}
+
+.pg-reader__stage:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: -2px;
+}
+
+.pg-reader__img {
+  display: block;
+  margin: 0 auto;
+  border-radius: var(--pg-radius);
+  background: var(--pg-surface);
+}
+
+/* THE ZOOM LADDER. Width, not `transform: scale()`: a transform leaves layout alone,
+   so the stage's scrollable area would stay the unscaled size and most of a zoomed
+   page would be unreachable. Widths are relative to the stage, so "fit width" means
+   the same thing on a 1024px projector and a 2560px laptop.
+   `height: auto` on every rung keeps the 2:3 aspect ratio — a fixed height with a
+   growing width would stretch the page. */
+.pg-reader__img--w1,
+.pg-reader__img--w15,
+.pg-reader__img--w2,
+.pg-reader__img--w3,
+.pg-reader__img--w4 {
+  height: auto;
+  max-width: none;
+}
+
+.pg-reader__img--w1  { width: 100%; }
+.pg-reader__img--w15 { width: 150%; }
+.pg-reader__img--w2  { width: 200%; }
+.pg-reader__img--w3  { width: 300%; }
+.pg-reader__img--w4  { width: 400%; }
+
+/* "Whole page" — bounded by BOTH axes so the full portrait page is on screen at once.
+   Not a rung on the ladder above: it answers "what shape is this document", where the
+   ladder answers "let me read it". */
+.pg-reader__img--page {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/* Only the fade is suppressed. The zoom itself is a layout change with no transition
+   on it, so there is nothing there to honour — and removing it would remove the
+   feature rather than the motion. */
+@media (prefers-reduced-motion: reduce) {
+  .pg-reader {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## The report

> "make the brochure zoomable and enlargeable (currently not)"

`docs/Brochure.png` is 1024×1536. `.pg-brochure img` bounded it to `max-height: 68vh`, and measured in the live dashboard at a 1422×928 viewport the card rendered it at **421×631** — 41% of the asset's own width. The view existed; reading it did not. On a projector the body copy is grey texture.

## Approach: a full-viewport overlay, not in-place zoom

Both were acceptable per the brief. The deciding argument is geometry:

- **In place, the card is the ceiling.** It sits inside a padded content region beside a 208px nav rail, so the widest viewport the image can ever have there is a few hundred pixels narrower than the screen. Measured: the card gives it **421px**, the reader's stage gives it **1392px** — 3.3× more, on the same screen.
- **Nested scrolling.** Panning in place means a second scroll container inside the page's own, and the outer one keeps scrolling once the inner hits its end.

Shaped after `FindingDetail` rather than inventing a pattern: `position: fixed`, `Esc` closes, focus returns to the control that opened it. **One deliberate divergence** — that drawer is `aria-modal="false"` so the operator keeps seeing the grid; this one *is* modal, because "give the brochure the whole screen" means there is nothing behind it left to read. It covers the header and rail, `z-index: 30` above the drawer's `20`.

### Zoom is layout width, not `transform: scale()`

This is the load-bearing implementation choice. A transform does not change layout, so a scaled image overflows a scroll container that does not know it grew: the scrollable area stays the unscaled size and everything outside the transform-origin corner is **unreachable**. Setting the image's `width` makes the stage's own scrollbars exactly the right size — and native scrolling then *is* the pan, so wheel, trackpad, scrollbar drag and arrow keys all work with **no drag handler and no dependency**.

Measured across the ladder, stage `clientWidth` 1392 throughout:

| Level | Image | Stage `scrollWidth` |
|---|---|---|
| Fit width | 1360×2040 | 1392 |
| 1.5× width | 2040×3060 | 2072 |
| 2× width | 2720×4080 | 2752 |
| 3× width | 4080×6120 | 4112 |
| 4× width | 5440×8160 | 5472 |

The scroll extent tracks the image — the property a transform would not have given.

The ladder is a multiple of the **stage** width, not of the asset's 1024 intrinsic pixels. A "100% = 1:1" ladder would read as more honest and would compile the file's dimensions into the UI — the same class of staleness as a copied host list (root `CLAUDE.md` §6). Labels say "width", not "%", so they claim no pixel fidelity they lack.

## Default: fit-width, for the presenter's case

The brief asked this to be explicit. On a tall portrait page and a 1024px-high laptop:

- **Fit-height** renders 1536px into ~870px of stage — **0.57×**, barely better than the 68vh that caused the report.
- **1:1** pins the page to 1024px and leaves a 1920-wide screen a third empty, so the first thing a presenter does is zoom in.
- **Fit-width** is the only default never smaller than the screen can show, and vertical scroll is the natural gesture on a page taller than it is wide.

Verified: at fit width the stage is 867 tall against a 2072 scroll height, so the page overflows vertically and panning is immediately the right gesture.

**"Whole page" is a separate mode, not a rung** — it answers "what shape is this document", where the ladder answers "let me read it". Measured 557×835, fitting the 867-high stage on both axes. Zooming in from it enters at the bottom rung rather than resuming at 4×.

## Keyboard, driven in a real browser over CDP

```
trigger        BUTTON "Enlarge and zoom" aria-haspopup=dialog
Enter          -> role=dialog aria-modal=true
focus lands    div.pg-reader__stage   (the SCROLLER, not Close)
5x ArrowDown   scrollTop 0 -> 94
Tab x9         Fit width, Whole page, Zoom in, Close, stage, then wraps -- all 9 IN
Shift+Tab      from the first control -> the stage (last), still inside
Esc            reader gone, focus back on BUTTON "Enlarge and zoom"
```

Focus lands on the scroller rather than Close because at fit-width the page is already taller than the stage, so panning is the first thing wanted and arrow keys only pan once the scroll container holds focus. Close is last in the toolbar, one `Shift+Tab` away.

The focus trap is bound to the **document**, not the overlay: `Esc` has to work wherever focus is, and a trap on the overlay only sees keys pressed inside it — one browser quirk away from a `Tab` landing in the dashboard underneath and never coming back. Nine consecutive Tabs, every one still inside.

Zoom controls are **words, not glyphs** — "Zoom in", not "+", same reason severity carries a label beside its icon (§7.3). **No new icon was needed**; `IconClose` already existed, so `icons.tsx` is untouched.

## One thing I wrote and fixed before it shipped

The image-wrapping button was `aria-hidden="true"` in my first draft, to keep it out of the tab order. That would have **removed the brochure's own alt text from the accessibility tree**, leaving the single description of the asset available only to sighted users. `tabIndex={-1}` alone is the correct pair: out of the tab order, still in the tree. Verified in the DOM — wrapper `aria-hidden` is `null`, alt text present. The comment says so, because `aria-hidden` is the obvious thing to reach for there.

## What is preserved

**The import-not-serve decision is untouched.** Its comment is extended rather than contradicted — both the card and the reader render the same inlined bytes from the one import, so there is still one copy in git, one artefact, no Dockerfile change, and the single-file fallback holds. A previous attempt at serving the asset was built and reverted; this does not revisit it. The docker build context is unchanged.

**The `failed` state still works**, checked rather than assumed. Pointing the `img` at a broken `src` in the live DOM:

- the paragraph naming `docs/Brochure.png` renders
- the "Enlarge and zoom" button is **withdrawn** (nothing to enlarge)
- an error while the reader is open **closes it**, rather than leaving an overlay over a broken image

Both surfaces report into one flag, since a failure in either is the same fact about one asset.

## Gates

| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `validate-architecture.mjs` | green — 7 labels, no overlaps |
| `app.css` braces | balanced; appended as **one** headed block at the end, nothing above reordered |
| Single-file fallback | **0** non-`data:` `src`/`href` in built `dist/index.html` |
| Console errors | none across the whole interaction |

Bundle, both revisions built clean from `git archive` in the same container:

```
before  2,543,700
after   2,548,467   +4,767  (+0.19%)
```

The 1.7 MB asset was already inlined, so this adds only markup and CSS.

## Notes for the reviewer

- `prefers-reduced-motion` suppresses only the overlay's fade. The zoom itself is a layout change with no transition on it, so there is nothing there to honour — and removing it would remove the feature rather than the motion. Verified in the served bundle: `@media (prefers-reduced-motion: reduce){.pg-reader{animation:none}}`.
- All colour, spacing and radius values are existing tokens; no additions to `tokens.css` were needed. The zoom multipliers are carried as class names rather than an inline custom property, so every dimension stays in `app.css`.
- `app.css` is contended — several agents append to it concurrently. My block is at the end and I verified brace balance after each write. Worth a glance at the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
