### PR TITLE
feat: "trigger activated", per-trigger messages, and the third state that was always there

### DIFF
--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -12,9 +12,25 @@
  * `CLAUDE.md` §6). The consequence is that this component renders whatever it is given, including a
  * scenario added later with no dashboard change.
  *
- * ARMED STATE IS ALSO THE SERVER'S. It is read from the trigger globals in IRIS on every poll, not
+ * TRIGGER STATE IS ALSO THE SERVER'S. It is read from the trigger globals in IRIS on every poll, not
  * tracked locally from button presses, because driving the terminal during a rehearsal is normal and
  * a button showing state from its own last click would be confidently wrong.
+ *
+ * THERE ARE THREE STATES, NOT TWO, and the middle one is real rather than cosmetic (#135).
+ *
+ *     not activated     nothing armed
+ *     activating        the request was accepted; the scenario is not in effect yet
+ *     activated         the scenario is live
+ *
+ * `pool_bottleneck` is why. It warms a baseline at zero for ~75 seconds *before* arming anything —
+ * that wait is load-bearing, see `Triggers.PoolBottleneck` and #43 — and it runs as a background
+ * job, so the arm POST returns in ~0.26s. For over a minute the scenario is in neither of the other
+ * two states. Collapsing that into "not activated" invites a second click; collapsing it into
+ * "activated" is a claim a presenter notices is false when no queue appears. The dispatcher reports
+ * both maps and this component renders three phases from them. `missing_folder` and `closed_port`
+ * arm atomically and pass through the middle phase in under a second, with no branch for that case.
+ *
+ * A CLICK ON AN ALREADY-ACTIVATED TRIGGER IS ANSWERED LOCALLY, WITHOUT A REQUEST. See `onArm`.
  *
  * DELIBERATELY STYLED AS SOMETHING THAT BREAKS THINGS. These sit under their own heading, in a
  * warning tone, separate from the two navigation buttons above. The rail already distinguishes inert
@@ -36,13 +52,16 @@ export interface TriggerScenario {
 export interface TriggerState {
   enabled: boolean;
   scenarios: TriggerScenario[];
+  /** In effect — the scenario is live. Not "a request was accepted"; see the file comment. */
   armed: Record<string, boolean>;
+  /** Accepted, not in effect yet. Always false for a scenario that arms atomically. */
+  activating: Record<string, boolean>;
 }
 
 /** Field-by-field. The endpoint is ours, but a shape check here is what keeps a bad payload from
     rendering a broken rail rather than no rail. */
 function parseState(raw: unknown): TriggerState {
-  const off: TriggerState = { enabled: false, scenarios: [], armed: {} };
+  const off: TriggerState = { enabled: false, scenarios: [], armed: {}, activating: {} };
   if (typeof raw !== 'object' || raw === null) return off;
   const r = raw as Record<string, unknown>;
   if (r['enabled'] !== true) return off;
@@ -63,19 +82,36 @@ function parseState(raw: unknown): TriggerState {
     }
   }
 
-  const armed: Record<string, boolean> = {};
-  if (typeof r['armed'] === 'object' && r['armed'] !== null) {
-    for (const [k, v] of Object.entries(r['armed'] as Record<string, unknown>)) {
-      if (typeof v === 'boolean') armed[k] = v;
-    }
+  return {
+    enabled: true,
+    scenarios,
+    armed: parseFlags(r['armed']),
+    // One parser for both maps, so a garbled `activating` cannot make a button behave differently
+    // from a garbled `armed`. An engine or dispatcher predating #135 sends no `activating` field at
+    // all, which parses to `{}` — every scenario then reads not-activating, i.e. the old two-state
+    // behaviour, rather than a crash or an empty rail.
+    activating: parseFlags(r['activating']),
+  };
+}
+
+/** One boolean map from the wire. Only a real boolean: an unparseable value must not read as `true`,
+    because both maps make claims about a live production and one of them refuses a click. */
+function parseFlags(raw: unknown): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  if (typeof raw !== 'object' || raw === null) return out;
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === 'boolean') out[k] = v;
   }
-  return { enabled: true, scenarios, armed };
+  return out;
 }
 
 const BASE = '/api/demo';
 
+/** The `busy` and message key for Reset, which has no scenario id of its own. */
+const RESET_KEY = '__reset__';
+
 /**
- * Poll cadence for the armed state.
+ * Poll cadence for the trigger state.
  *
  * Slower than the findings poll on purpose: arming is a human action taken seconds apart, not a
  * metric stream, and this endpoint reaches into IRIS on every call. 5s is responsive enough that a
@@ -83,13 +119,33 @@ const BASE = '/api/demo';
  */
 const STATUS_POLL_MS = 5000;
 
+/** Which of the three states a scenario is in, as this component renders it. */
+type Phase = 'idle' | 'activating' | 'activated';
+
+/**
+ * One message belonging to one trigger.
+ *
+ * `refused` is the local answer to a click that made no request — a different fact from `error`,
+ * which is something the server said, and rendered differently for that reason.
+ */
+interface TriggerMessage {
+  kind: 'log' | 'note' | 'error' | 'refused';
+  text: string;
+}
+
 export function TriggerRail(): JSX.Element | null {
   const [state, setState] = useState<TriggerState | null>(null);
-  /** The scenario currently being armed, so its own button can show pending without freezing others
-      that are still legitimately clickable. */
+  /** The trigger whose request is in flight, or null. One at a time — see `onArm`. */
   const [busy, setBusy] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [note, setNote] = useState<string | null>(null);
+  /**
+   * Messages keyed by the trigger they belong to.
+   *
+   * PER TRIGGER, NOT ONE SHARED SLOT. A single `error`/`note` pair at the bottom of the panel meant
+   * the output of arming `missing_folder` appeared under `closed_port`'s button as far as an operator
+   * reading top-to-bottom could tell — and the text names a host and a setting, so the
+   * mis-attribution is plausible enough to be believed (@Ari-Glikman, from driving the live UI).
+   */
+  const [messages, setMessages] = useState<Record<string, TriggerMessage>>({});
 
   const refresh = useCallback(async () => {
     try {
@@ -112,11 +168,14 @@ export function TriggerRail(): JSX.Element | null {
     return () => clearInterval(id);
   }, [refresh]);
 
+  /** Replace one trigger's message, leaving every other trigger's alone. */
+  const say = useCallback((key: string, message: TriggerMessage) => {
+    setMessages((prev) => ({ ...prev, [key]: message }));
+  }, []);
+
   const post = useCallback(
-    async (path: string, body: unknown, pending: string) => {
-      setBusy(pending);
-      setError(null);
-      setNote(null);
+    async (path: string, body: unknown, key: string) => {
+      setBusy(key);
       try {
         const res = await fetch(`${BASE}${path}`, {
           method: 'POST',
@@ -145,34 +204,136 @@ export function TriggerRail(): JSX.Element | null {
         } catch {
           // 504/502 specifically, because for a long arm that is the likely one and "still running"
           // is materially different advice from "it failed".
-          setError(
-            res.status === 504 || res.status === 502
-              ? `The request timed out at the proxy after ${res.status}. Arming may still be ` +
-                `running in IRIS — check the armed state before retrying.`
-              : `The server returned a non-JSON response (HTTP ${res.status}).`,
-          );
+          say(key, {
+            kind: 'error',
+            text:
+              res.status === 504 || res.status === 502
+                ? `The request timed out at the proxy after ${res.status}. Arming may still be ` +
+                  `running in IRIS — check the state above before retrying.`
+                : `The server returned a non-JSON response (HTTP ${res.status}).`,
+          });
           return;
         }
         if (typeof payload['error'] === 'string' && payload['error'] !== '') {
-          setError(payload['error']);
-        } else if (typeof payload['note'] === 'string' && payload['note'] !== '') {
-          // A reset reports what it CANNOT undo. Surfaced rather than dropped: "the alert is still
-          // there" is the question a presenter asks ten seconds later.
-          setNote(payload['note']);
+          say(key, { kind: 'error', text: payload['error'] });
+          return;
+        }
+
+        /*
+         * THE CAPTURED `log` IS THE POINT OF THIS SLOT, not a debugging leftover. Each trigger writes
+         * what it armed, which findings to expect and which deliberately will NOT fire; the
+         * dispatcher captures that text to a file so it cannot corrupt the JSON body and returns it
+         * (see `TriggerDispatcher.Arm`). It then crossed one process boundary and was dropped by the
+         * engine's own parser, and would have been dropped here too.
+         *
+         * BOTH FIELDS WHEN BOTH ARE PRESENT. A reset returns a long `log` of what it restored AND a
+         * `note` about the one thing it cannot — the buffered `system_alert` — and that note is the
+         * question a presenter asks ten seconds later, so it must not be shadowed by the log. A
+         * jobbed arm is the reverse: `log` is empty because there is no output yet, and `note`
+         * explains the warm-up. Neither case needs a branch.
+         */
+        const log = typeof payload['log'] === 'string' ? payload['log'].trim() : '';
+        const note = typeof payload['note'] === 'string' ? payload['note'].trim() : '';
+        const text = [log, note].filter((part) => part !== '').join('\n\n');
+        if (text !== '') {
+          // `log` when there is captured output, because that text is preformatted and aligned and is
+          // rendered monospaced; a bare note is prose.
+          say(key, { kind: log !== '' ? 'log' : 'note', text });
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'request failed');
+        say(key, { kind: 'error', text: err instanceof Error ? err.message : 'request failed' });
       } finally {
         setBusy(null);
         // Refresh regardless of outcome. A trigger that errored partway may still have armed
-        // something, so the armed state must be re-read rather than assumed unchanged.
+        // something, so the state must be re-read rather than assumed unchanged.
         void refresh();
       }
     },
-    [refresh],
+    [refresh, say],
   );
 
   if (state === null || !state.enabled) return null;
+
+  /**
+   * The three states, resolved per scenario.
+   *
+   * `armed` WINS over everything, including a local in-flight request, because it is the one fact
+   * read from the production itself. The local `busy` folds into `activating` rather than becoming a
+   * fourth state: "this browser's request is in flight" is precisely "accepted, not in effect yet",
+   * and it covers the gap between the POST returning and the next status poll — which for a
+   * fast-arming scenario is the only window the middle phase is ever visible in.
+   */
+  const phaseOf = (id: string): Phase => {
+    if (state.armed[id] === true) return 'activated';
+    if (state.activating[id] === true) return 'activating';
+    if (busy === id) return 'activating';
+    return 'idle';
+  };
+
+  /**
+   * A trigger click, answered locally where it can be.
+   *
+   * NO REQUEST IS MADE FOR A TRIGGER THAT IS ALREADY ACTIVATED OR STILL ACTIVATING. Deliberately not
+   * "POST and let IRIS refuse": arming is idempotent in the trigger class but not free — the
+   * dispatcher's `$case` runs the method again, `PoolBottleneck` re-enters its 75-second warm-up and
+   * rewrites `RateSecs`/`MaxQueued`, and a second `Arm` on a jobbed scenario starts a second
+   * background job against the same production definition. The information needed to refuse is
+   * already in state this component polls, so spending a round trip to be told what it knows would
+   * also mean the answer arrives late and after a side effect.
+   *
+   * TWO REFUSALS, TWO DIFFERENT SENTENCES, because they are different facts. "This one is already
+   * activated" is about this trigger and is cleared only by Reset. "Another trigger is still
+   * activating" is about the panel and clears itself — conflating them would tell an operator to wait
+   * for something that will never finish, or to reset something that needs a moment.
+   */
+  const onArm = (s: TriggerScenario) => {
+    if (phaseOf(s.id) !== 'idle') {
+      // The owner's wording covers both halves — "while the trigger is activating" AND "until it is
+      // reset" — so one sentence serves both, and Reset is named as the way out of it.
+      say(s.id, {
+        kind: 'refused',
+        text: 'Trigger already activated. Press Reset all to clear it before activating it again.',
+      });
+      return;
+    }
+    if (busy !== null) {
+      /*
+       * ONE ARM AT A TIME, and the protection is real rather than tidiness. The trigger class stashes
+       * each replaced value in one global per setting and every arming method calls
+       * `UpdateProduction()`; two interleaved arms can therefore stash a value the other already
+       * wrote and make `Reset()` restore the wrong one. That is why the original panel disabled every
+       * button while any was pending.
+       *
+       * REFUSED RATHER THAN DISABLED, though, so the reason is legible. A `disabled` button fires no
+       * click, so it can say nothing about why it did nothing — which is how "busy" and "already
+       * activated" ended up looking like one state. The mutual exclusion is unchanged: no second
+       * request is issued either way.
+       */
+      say(s.id, {
+        kind: 'refused',
+        text: 'Another trigger is still activating. Wait for it to finish, then try again.',
+      });
+      return;
+    }
+    void post('/trigger', { scenario: s.id }, s.id);
+  };
+
+  /**
+   * Reset, which must stay reachable at all times — it is the operation that recovers from every
+   * other one, so it is never disabled and never refused for the state of anything else. It will not
+   * stack on itself: two concurrent `Reset()` calls both write the production definition, which is
+   * the same hazard `onArm` guards against.
+   */
+  const onReset = () => {
+    if (busy === RESET_KEY) {
+      say(RESET_KEY, { kind: 'refused', text: 'Reset is already running.' });
+      return;
+    }
+    // Every scenario's message describes a state this reset is about to clear, so they go with it.
+    // Leaving them would put "Trigger already activated" under a button that no longer is.
+    setMessages({});
+    void post('/reset', {}, RESET_KEY);
+  };
 
   return (
     <div className="pg-triggers">
@@ -184,59 +345,87 @@ export function TriggerRail(): JSX.Element | null {
 
       <ul className="pg-rail__list">
         {state.scenarios.map((s) => {
-          const isArmed = state.armed[s.id] === true;
-          const pending = busy === s.id;
+          const phase = phaseOf(s.id);
           return (
-            <li key={s.id}>
+            <li key={s.id} className="pg-triggers__row">
               <button
                 type="button"
-                className={`pg-rail__item pg-rail__item--trigger${
-                  isArmed ? ' pg-rail__item--armed' : ''
-                }`}
-                /* Every button disabled while ANY is pending. Arming two scenarios concurrently
-                   would interleave two sets of setting writes on the same production, and the
-                   trigger class stashes previous values in one global per setting — a concurrent
-                   pair could stash the other's value and make Reset() restore the wrong thing. */
-                disabled={busy !== null}
-                onClick={() => void post('/trigger', { scenario: s.id }, s.id)}
+                className={`pg-rail__item pg-rail__item--trigger pg-rail__item--${phase}`}
+                /* NOT `disabled`. A trigger that will refuse stays focusable and clickable so the
+                   refusal can explain itself in the slot below — see `onArm`. `aria-disabled` is what
+                   tells assistive technology the control will not act, which `disabled` would say at
+                   the cost of making the explanation unreachable by keyboard. */
+                aria-disabled={phase !== 'idle' || busy !== null}
+                onClick={() => onArm(s)}
                 title={`${s.detail}\n\nFires: ${s.findings}`}
               >
                 <span className="pg-rail__trigger-label">
                   {s.label}
-                  {isArmed && <span className="pg-rail__armed-dot" aria-hidden="true" />}
+                  {/* Shape as well as words: a filled disc for activated, a hollow ring for
+                      activating. State is never carried by colour alone (§7.3), and these two are
+                      told apart by silhouette at the back of a room where amber and teal may not
+                      be. */}
+                  {phase !== 'idle' && (
+                    <span
+                      className={`pg-rail__trigger-dot pg-rail__trigger-dot--${phase}`}
+                      aria-hidden="true"
+                    />
+                  )}
                 </span>
-                {/* The pending state is words, not a spinner: PoolBottleneck warms a baseline for
-                    75 seconds and a spinner that long reads as a hang. */}
-                {pending && <span className="pg-rail__trigger-state">arming… up to 90s</span>}
-                {isArmed && !pending && <span className="pg-rail__trigger-state">armed</span>}
+                {/* Words, not a spinner: pool_bottleneck warms a baseline for 75 seconds and a
+                    spinner that long reads as a hang. The word the operator now sees is "activated"
+                    rather than "armed" — same state, plainer language. */}
+                {phase === 'activating' && (
+                  <span className="pg-rail__trigger-state">trigger activating…</span>
+                )}
+                {phase === 'activated' && (
+                  <span className="pg-rail__trigger-state">trigger activated</span>
+                )}
               </button>
+              <TriggerNote message={messages[s.id]} />
             </li>
           );
         })}
-        <li>
+        <li className="pg-triggers__row">
           <button
             type="button"
             className="pg-rail__item pg-rail__item--trigger pg-rail__item--reset"
-            disabled={busy !== null}
-            onClick={() => void post('/reset', {}, '__reset__')}
+            onClick={onReset}
             title="Restore every setting the triggers changed"
           >
             <span className="pg-rail__trigger-label">Reset all</span>
-            {busy === '__reset__' && <span className="pg-rail__trigger-state">resetting…</span>}
+            {busy === RESET_KEY && <span className="pg-rail__trigger-state">resetting…</span>}
           </button>
+          <TriggerNote message={messages[RESET_KEY]} />
         </li>
       </ul>
-
-      {error !== null && (
-        <p className="pg-triggers__error" role="alert">
-          {error}
-        </p>
-      )}
-      {note !== null && (
-        <p className="pg-triggers__note" role="status">
-          {note}
-        </p>
-      )}
     </div>
+  );
+}
+
+/**
+ * One trigger's message slot.
+ *
+ * ALWAYS MOUNTED, even with nothing to say, and hidden by `:empty` when it is. A live region has to
+ * be in the document before its content changes or the change is not announced, and these messages
+ * are answers to a button press — the one case where that matters. `role="status"` for every kind,
+ * including errors: swapping a node's role between `status` and `alert` is unreliable, and a failed
+ * demo trigger is not an emergency. The error tone is carried by a class and a leading word.
+ *
+ * The dispatcher's captured log is PLAIN TEXT, not markup, and is rendered as text. `white-space:
+ * pre-wrap` keeps its line breaks and two-space indents, which is the whole reason it is readable;
+ * `dangerouslySetInnerHTML` would be both wrong and unsafe for output that quotes settings and paths.
+ */
+function TriggerNote({ message }: { message: TriggerMessage | undefined }): JSX.Element {
+  return (
+    <p className={`pg-triggers__msg pg-triggers__msg--${message?.kind ?? 'none'}`} role="status">
+      {message === undefined ? null : (
+        <>
+          {/* A word, so "this failed" is not signalled by the colour of the text alone (§7.3). */}
+          {message.kind === 'error' && <span className="pg-triggers__msg-tag">Failed: </span>}
+          {message.text}
+        </>
+      )}
+    </p>
   );
 }

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1555,11 +1555,19 @@ button {
   outline-offset: -2px;
 }
 
-/* Disabled while any trigger is in flight. Reduced opacity AND not-allowed, because a rail
-   item that merely stops responding reads as broken. */
-.pg-rail__item--trigger:disabled {
-  opacity: 0.5;
+/* A trigger that will refuse the click. `aria-disabled`, not `disabled`, so the refusal can still be
+   spoken in the slot below it (see TriggerRail.tsx) — but it must still LOOK unavailable, because a
+   control that stops acting without looking any different reads as broken. The dimming is
+   deliberately mild: the label and its state word have to stay readable, since they are the reason
+   the click was refused. */
+.pg-rail__item--trigger[aria-disabled='true'] {
+  opacity: 0.72;
   cursor: not-allowed;
+}
+
+/* Hover suppressed on a refusing trigger, so the affordance does not contradict the cursor. */
+.pg-rail__item--trigger[aria-disabled='true']:hover {
+  background: none;
 }
 
 .pg-rail__trigger-label {
@@ -1568,17 +1576,14 @@ button {
   gap: var(--pg-space-2);
 }
 
-/* Armed is signalled by a dot AND the word "armed" below it — never by colour alone (§7.3). */
-.pg-rail__armed-dot {
+/* State is signalled by a dot AND a word below it — never by colour alone (§7.3). The dot's SHAPE
+   carries the difference too: filled for activated, hollow for activating. See the three-state block
+   at the END of this file, which owns the modifiers; this rule is only the shared geometry. */
+.pg-rail__trigger-dot {
   width: 7px;
   height: 7px;
   border-radius: var(--pg-radius-pill);
-  background: var(--pg-warning);
   flex-shrink: 0;
-}
-
-.pg-rail__item--armed {
-  color: var(--pg-text-invert);
 }
 
 .pg-rail__trigger-state {
@@ -1592,21 +1597,9 @@ button {
   font-style: italic;
 }
 
-.pg-triggers__error,
-.pg-triggers__note {
-  margin: var(--pg-space-2) 0 0;
-  padding: 0 var(--pg-space-4);
-  font-size: 10.5px;
-  line-height: 1.45;
-}
-
-.pg-triggers__error {
-  color: var(--pg-warning);
-}
-
-.pg-triggers__note {
-  color: rgb(255 255 255 / 55%);
-}
+/* `.pg-triggers__error` and `.pg-triggers__note` were the SHARED slot at the bottom of the panel and
+   are gone: every message now belongs to one trigger and renders under it (#135). Removed rather than
+   left as dead rules, because a rule matching nothing is what someone reaches for next time. */
 
 /* ── Activity insights chat ────────────────────────────────────────────────────
 
@@ -1833,4 +1826,101 @@ button {
 .pg-button--primary:disabled {
   opacity: 0.55;
   cursor: default;
+}
+
+/* ── Demo triggers: three states, and one message slot per trigger (#135) ───────
+
+   Appended as one block at the END of this file rather than edited into the demo-trigger section
+   above, because that region is contended by several concurrent changes and a mis-split rule here
+   has already caused a real defect in this repo. The two rules the three-state model replaced were
+   changed in place (`.pg-rail__trigger-dot`, the `aria-disabled` styling); everything genuinely new
+   is here.
+
+   All tokens, no literals. The only bare values are the sub-token font sizes the surrounding rail
+   rules already use (10.5px / 10px) and the 1px dot border, matched to the dot geometry above.     */
+
+/* The row is the trigger PLUS its message, so the message is inside the list item and cannot be read
+   as belonging to the next button down — the mis-attribution the shared slot allowed. */
+.pg-triggers__row {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ACTIVATING vs ACTIVATED are told apart by SHAPE first: a hollow ring while it is coming into
+   effect, a filled disc once it is. Colour is the second signal and the state word below the label is
+   the third, so nothing here depends on amber and teal surviving a projector (§7.3). */
+.pg-rail__trigger-dot--activating {
+  background: none;
+  border: 1px solid var(--pg-teal-200);
+}
+
+.pg-rail__trigger-dot--activated {
+  background: var(--pg-warning);
+}
+
+/* Activated is the state that means the production is currently broken on purpose, so it gets the
+   full-contrast label. Activating stays dimmer: nothing has happened to the production yet. */
+.pg-rail__item--activated {
+  color: var(--pg-text-invert);
+}
+
+.pg-rail__item--activating {
+  color: rgb(255 255 255 / 88%);
+}
+
+/* One message slot per trigger, always in the document so a live region exists before it changes, and
+   collapsed by `:empty` when there is nothing to say (see TriggerNote in TriggerRail.tsx). */
+.pg-triggers__msg {
+  margin: var(--pg-space-1) 0 var(--pg-space-2);
+  padding: 0 var(--pg-space-4);
+  font-size: 10.5px;
+  line-height: 1.45;
+  /* The dispatcher's captured log is preformatted plain text — indented lines, aligned arithmetic, an
+     ARMED header. `pre-wrap` is what makes it legible; without it the whole explanation collapses
+     into one paragraph. `break-word` because it quotes filesystem paths that do not wrap. */
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  color: rgb(255 255 255 / 62%);
+}
+
+.pg-triggers__msg:empty {
+  display: none;
+}
+
+/* The captured trigger log, monospaced because its own alignment is load-bearing. Inset with a rule
+   down the left so a block of narration reads as output belonging to the button above it rather than
+   as more rail chrome. */
+.pg-triggers__msg--log {
+  margin-left: var(--pg-space-4);
+  padding: var(--pg-space-1) 0 var(--pg-space-1) var(--pg-space-2);
+  border-left: 1px solid rgb(255 255 255 / 18%);
+  font-family: var(--pg-font-mono);
+  font-size: 10px;
+  color: rgb(255 255 255 / 66%);
+}
+
+/* A refusal is not a failure — nothing went wrong and nothing was sent. Accent tone rather than
+   warning, and italic so it reads as the panel answering rather than the server reporting. */
+.pg-triggers__msg--refused {
+  font-style: italic;
+  color: var(--pg-teal-200);
+}
+
+.pg-triggers__msg--error {
+  color: var(--pg-warning);
+}
+
+/* "Failed:" — the word that keeps an error from being signalled by its colour alone (§7.3). */
+.pg-triggers__msg-tag {
+  font-weight: 600;
+  font-style: normal;
+}
+
+/* The rail collapses to icons below 1100px and `.pg-rail__item` loses its text (`font-size: 0`).
+   These messages are prose that only makes sense beside a readable label, so they collapse with it
+   rather than becoming a column of unattributed sentences. */
+@media (max-width: 1100px) {
+  .pg-triggers__msg {
+    display: none;
+  }
 }

--- a/iris/labdemo/REST/TriggerDispatcher.cls
+++ b/iris/labdemo/REST/TriggerDispatcher.cls
@@ -77,6 +77,17 @@ ClassMethod Enabled() As %Boolean [ Private ]
 }
 
 /// Report what is armed. Also the endpoint the UI uses to decide whether to render the buttons.
+///
+/// PUBLISHES TWO MAPS, `armed` AND `activating`, because there are THREE states and only two of
+/// them were previously observable. See `Scenarios()` for how the pair is derived; the short version
+/// is that "the request was accepted" and "the scenario is in effect" are up to 75 seconds apart for
+/// `pool_bottleneck`, and a presenter watching a button needs to tell those apart from each other
+/// and from nothing having happened.
+///
+/// `armed` KEEPS ITS NAME ON THE WIRE even though the operator-facing word is now "trigger
+/// activated". Two reasons: renaming it would break an older engine or dashboard against a newer
+/// IRIS for no gain, and `armed` is the accurate technical word for what the global witnesses say.
+/// The rename is a wording change in the UI, and it stays one.
 ClassMethod Status() As %Status
 {
     set %response.ContentType = "application/json"
@@ -84,43 +95,94 @@ ClassMethod Status() As %Status
         quit ..Gone()
     }
 
-    // The scenario list is published so the UI does not hardcode it. A button that posts a scenario
-    // this class does not know would 400, and the UI having its own copy of the list is how that
-    // happens -- the same stale-copy argument as the host list in root CLAUDE.md §6.
-    set out = { "enabled": true, "scenarios": [], "armed": {} }
-    do out.scenarios.%Push({ "id": "pool_bottleneck", "label": "Pool bottleneck",
-        "detail": "Throttles the downstream and raises inflow. Queue builds behind one worker; the fix is a bigger pool.",
-        "findings": "queue_buildup, growing_queue_wait" })
-    do out.scenarios.%Push({ "id": "missing_folder", "label": "Missing directory",
-        "detail": "Repoints EMR Source at a directory that does not exist. No governed fix -- the recommendation is words.",
-        "findings": "dead_host" })
-    do out.scenarios.%Push({ "id": "closed_port", "label": "Downstream unreachable",
-        "detail": "Points Cloud API at a closed port. The queue is a symptom; a bigger pool would only fail faster.",
-        "findings": "elevated_error_rate, queue_buildup, throughput_drop" })
+    // ONE PASS OVER ONE TABLE. The published descriptors and both state maps come from the same
+    // `Scenarios()` entries, so a scenario cannot be advertised without a witness pair or carry a
+    // witness pair nobody advertises. Two lists here -- a %Push block plus a separate set of %Set
+    // lines keyed by name -- is what this method had, and it is the stale-copy shape root CLAUDE.md
+    // §6 names: adding a fourth scenario would have advertised a button whose state read `false`
+    // forever.
+    set out = { "enabled": true, "scenarios": [], "armed": {}, "activating": {} }
+    set it = ..Scenarios().%GetIterator()
+    while it.%GetNext(.index, .s) {
+        // Only the four public fields reach the wire. The witness names are an implementation detail
+        // of this class, and a caller keying on them would be reading our globals.
+        do out.scenarios.%Push({ "id": (s.id), "label": (s.label), "detail": (s.detail),
+            "findings": (s.findings) })
 
-    // What is actually armed, read from the trigger globals rather than inferred, so the UI can
-    // show state instead of assuming its own button presses are the whole truth. Someone driving
-    // the terminal at the same time is a normal thing to do in a rehearsal.
-    // KEYED ON WHAT THE SCENARIO *SETS*, NOT ON WHAT IT STASHED. `PoolWas` was the first choice and
-    // it is wrong: every stash is conditional on the value differing from the shipped one, so
-    // arming `pool_bottleneck` on an instance already at pool 1 stashes nothing and the button read
-    // "not armed" while the scenario was fully armed. Measured -- DispatcherMs, RateSecs and
-    // MaxQueued were all set and the UI showed false.
-    //
-    // `DispatcherMs` is set unconditionally and only by this scenario, so it is the honest witness.
-    // It is also set AFTER the 75-second warm-up, which makes the indicator mean "arming has taken
-    // effect" rather than "a request was accepted" -- exactly what a presenter needs from it while a
-    // jobbed scenario is still warming.
-    do out.armed.%Set("pool_bottleneck", ''$data(^ProductionGuardian.Trigger("DispatcherMs")), "boolean")
+        // Read from the trigger globals rather than inferred, so the UI can show state instead of
+        // assuming its own button presses are the whole truth. Someone driving the terminal at the
+        // same time is a normal thing to do in a rehearsal.
+        set requested = ''$data(^ProductionGuardian.Trigger(s.requestWitness))
+        set inEffect = ''$data(^ProductionGuardian.Trigger(s.effectWitness))
 
-    // `PathWas` and `PortWas` ARE correct witnesses for their scenarios, because both repoint a
-    // setting to a value that cannot be the shipped one -- so the stash always happens. Kept, rather
-    // than changed for symmetry with the line above.
-    do out.armed.%Set("missing_folder", ''$data(^ProductionGuardian.Trigger("PathWas")), "boolean")
-    do out.armed.%Set("closed_port", ''$data(^ProductionGuardian.Trigger("PortWas")), "boolean")
+        do out.armed.%Set(s.id, inEffect, "boolean")
+        // ACTIVATING = the request landed and the scenario is not yet in effect. DERIVED, not
+        // stored: a third global tracking "arming in progress" would be state that can disagree with
+        // the two witnesses, and it would have to be cleared on every path a jobbed arm can die on.
+        // This derivation cannot go stale, because it is two $data reads of the witnesses themselves.
+        //
+        // A scenario whose two witnesses are the SAME global is structurally never activating, which
+        // is the right answer for one that arms atomically -- no branch is needed for that case and
+        // none should be added. `missing_folder` and `closed_port` are both that shape.
+        do out.activating.%Set(s.id, (requested && 'inEffect), "boolean")
+    }
 
     write out.%ToJSON()
     quit $$$OK
+}
+
+/// The scenario table: what each one is, and the two globals that witness its state. Private.
+///
+/// THE THREE STATES, AND WHY ONE OF THEM NEEDS TWO WITNESSES.
+///
+///   not activated   neither witness present
+///   activating      the request landed; the scenario is not in effect yet
+///   activated       the scenario is in effect
+///
+/// The middle state is real and observable, not a UI nicety. `PoolBottleneck()` warms the baseline
+/// at zero for 75 seconds BEFORE arming anything -- that wait is load-bearing (see that method, and
+/// #43: a queue forming during warm-up caps the ratio near 2x and `queue_buildup` can then never
+/// fire) -- and it runs as a background job, so the HTTP call returns in ~0.26s. For 75 seconds the
+/// operator has a scenario that was accepted and is doing nothing yet. Reporting that as "not
+/// activated" invites a second click; reporting it as "activated" is a claim the presenter notices
+/// is false when no queue appears.
+///
+/// `effectWitness` IS THE ONE THAT MEANS "IN EFFECT", and for `pool_bottleneck` it is deliberately
+/// NOT the stash. `DispatcherMs` is set unconditionally, only by this scenario, and only AFTER the
+/// warm-up. `PoolWas` is set immediately BEFORE the wait, which makes it an honest witness for "the
+/// request landed" and a wrong one for "armed" -- keying `armed` on it was #129's second bug, where
+/// arming on an instance already at pool 1 stashed nothing and the button read "not armed" while the
+/// scenario was fully armed. Verified on the live instance across one warm-up: `PoolWas` present
+/// with `DispatcherMs` absent during the wait, both present after it.
+///
+/// `PathWas` and `PortWas` serve as BOTH witnesses for their scenarios, because those arm in one
+/// step with nothing to wait for. Listing the same global twice states that, rather than leaving a
+/// reader to infer it from a missing field, and it makes `activating` false by construction instead
+/// of by a special case.
+///
+/// ONE HONEST AMBIGUITY, stated rather than papered over: `PoolWas` present with `DispatcherMs`
+/// absent is also what a jobbed arm that DIED during its warm-up looks like. "Activating" is the
+/// truthful report either way -- this class cannot see the job -- and `Reset()` clears the stash,
+/// which is the recovery for both.
+ClassMethod Scenarios() As %DynamicArray [ Private ]
+{
+    // The scenario list is published so the UI does not hardcode it. A button that posts a scenario
+    // this class does not know would 400, and the UI having its own copy of the list is how that
+    // happens -- the same stale-copy argument as the host list in root CLAUDE.md §6.
+    set out = []
+    do out.%Push({ "id": "pool_bottleneck", "label": "Pool bottleneck",
+        "detail": "Throttles the downstream and raises inflow. Queue builds behind one worker; the fix is a bigger pool.",
+        "findings": "queue_buildup, growing_queue_wait",
+        "requestWitness": "PoolWas", "effectWitness": "DispatcherMs" })
+    do out.%Push({ "id": "missing_folder", "label": "Missing directory",
+        "detail": "Repoints EMR Source at a directory that does not exist. No governed fix -- the recommendation is words.",
+        "findings": "dead_host",
+        "requestWitness": "PathWas", "effectWitness": "PathWas" })
+    do out.%Push({ "id": "closed_port", "label": "Downstream unreachable",
+        "detail": "Points Cloud API at a closed port. The queue is a symptom; a bigger pool would only fail faster.",
+        "findings": "elevated_error_rate, queue_buildup, throughput_drop",
+        "requestWitness": "PortWas", "effectWitness": "PortWas" })
+    quit out
 }
 
 /// Arm one named scenario.

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -13,6 +13,10 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { EngineSnapshot } from '../detect/engine.ts';
+// The off-state payload, imported rather than written out here. It was inlined twice below and
+// gained a third field in #135; two literals that must match a type in another file is the
+// stale-copy shape, and both copies would have been silently short an `activating: {}`.
+import { TRIGGERS_DISABLED } from '../detect/triggers.ts';
 
 export interface ServerOptions {
   port: number;
@@ -291,14 +295,14 @@ export function createFindingsServer(options: ServerOptions): Server {
           // trigger buttons exist", and if IRIS cannot be reached the honest answer is "no". A 5xx
           // would put the connection banner into an error state over an optional demo affordance.
           if (options.triggerStatus === undefined) {
-            sendJson(res, 200, { enabled: false, scenarios: [], armed: {} }, snapshot.state);
+            sendJson(res, 200, TRIGGERS_DISABLED, snapshot.state);
             return;
           }
           options.triggerStatus()
             .then((payload) => sendJson(res, 200, payload, snapshot.state))
             .catch((err: unknown) => {
               log(`trigger status unavailable: ${String(err)}`);
-              sendJson(res, 200, { enabled: false, scenarios: [], armed: {} }, snapshot.state);
+              sendJson(res, 200, TRIGGERS_DISABLED, snapshot.state);
             });
           return;
         }

--- a/services/detection-engine/src/detect/triggers.ts
+++ b/services/detection-engine/src/detect/triggers.ts
@@ -33,14 +33,48 @@ export interface TriggerScenario {
 export interface TriggerStatus {
   enabled: boolean;
   scenarios: TriggerScenario[];
-  /** Per-scenario armed state, read from the trigger globals in IRIS. */
+  /**
+   * Per-scenario **in effect** state, read from the trigger globals in IRIS.
+   *
+   * Means "the scenario is live", not "a request was accepted" — the dispatcher keys it on a global
+   * the scenario sets when it actually takes effect. For `pool_bottleneck` those are ~75s apart.
+   */
   armed: Record<string, boolean>;
+  /**
+   * Per-scenario **accepted but not yet in effect** state.
+   *
+   * A THIRD STATE, not a flag on the second. `pool_bottleneck` warms a baseline at zero for 75s
+   * before it arms anything and runs as a background job, so the arm POST returns in ~0.26s and the
+   * scenario is in neither of the other two states for over a minute. Carried through this service
+   * rather than re-derived in the dashboard: IRIS owns the witnesses, and a browser inferring
+   * "probably still arming" from a timer it started would be wrong the moment someone drives the
+   * terminal — the same reason `armed` is not tracked from button presses.
+   *
+   * Absent for a scenario that arms atomically. An older dispatcher omits the map entirely, which
+   * parses to `{}` — every scenario then reads not-activating, i.e. the previous two-state
+   * behaviour, rather than an empty rail.
+   */
+  activating: Record<string, boolean>;
 }
 
 export interface TriggerResult {
   ok: boolean;
   /** The scenario armed, or null for a reset. */
   armed: string | null;
+  /**
+   * The trigger's own captured narration — what it armed, which findings to expect, and which
+   * deliberately will NOT fire. Empty for a jobbed arm, which has produced no output yet.
+   *
+   * FORWARDED RATHER THAN DROPPED, which it was until #133. The dispatcher goes to real trouble to
+   * capture this — a temp file becomes the current device for the call, because the trigger methods
+   * write to `$io` and would otherwise corrupt the JSON body (see `TriggerDispatcher.Arm`) — and
+   * this service then parsed the reply field-by-field and left `log` out, so the text crossed one
+   * process boundary and died at the next. It is the clearest explanation of each scenario anyone
+   * has written, and the UI now renders it under the button that produced it.
+   *
+   * Multi-line plain text, never markup. The dashboard renders it as text.
+   */
+  log: string;
   /** Present when the dispatcher qualified the outcome — e.g. what a reset cannot undo. */
   note: string | null;
   error: string | null;
@@ -59,7 +93,12 @@ export interface TriggerDeps {
  * able to render disabled buttons, which advertises a capability the deployment declined — the same
  * reasoning as the dispatcher answering 404 rather than 403.
  */
-export const TRIGGERS_DISABLED: TriggerStatus = { enabled: false, scenarios: [], armed: {} };
+export const TRIGGERS_DISABLED: TriggerStatus = {
+  enabled: false,
+  scenarios: [],
+  armed: {},
+  activating: {},
+};
 
 /** Field-by-field, never a cast — the dispatcher's reply crosses a process boundary. */
 function parseScenario(raw: unknown): TriggerScenario | null {
@@ -77,7 +116,14 @@ function parseScenario(raw: unknown): TriggerScenario | null {
   };
 }
 
-function parseStatus(raw: unknown): TriggerStatus {
+/**
+ * Exported for the tests, the same as `parseResolveRequest` and `parseChatRequest`.
+ *
+ * Worth testing directly rather than through `liveTriggers`: this is the only place the three-state
+ * model crosses a process boundary, and the case most likely to break it — a dispatcher that predates
+ * the `activating` field — cannot be produced by the live stack once IRIS is updated.
+ */
+export function parseStatus(raw: unknown): TriggerStatus {
   if (typeof raw !== 'object' || raw === null) return TRIGGERS_DISABLED;
   const r = raw as Record<string, unknown>;
   // `enabled` must be explicitly true. An absent or non-boolean field reads as off, so a garbled
@@ -94,21 +140,36 @@ function parseStatus(raw: unknown): TriggerStatus {
     }
   }
 
-  const armed: Record<string, boolean> = {};
-  const rawArmed = r['armed'];
-  if (typeof rawArmed === 'object' && rawArmed !== null) {
-    for (const [key, value] of Object.entries(rawArmed as Record<string, unknown>)) {
-      // Only a real boolean. An unparseable value must not read as armed=true, since the UI uses
-      // this to decide whether to show "armed" state on a button.
-      if (typeof value === 'boolean') armed[key] = value;
-    }
-  }
+  return {
+    enabled: true,
+    scenarios,
+    armed: parseBooleanMap(r['armed']),
+    // Same parser, and that is the point: the two maps have identical shape and identical failure
+    // behaviour, so a garbled `activating` cannot make a button read differently from a garbled
+    // `armed`. An older dispatcher sends no `activating` at all -> `{}` -> nothing activating.
+    activating: parseBooleanMap(r['activating']),
+  };
+}
 
-  return { enabled: true, scenarios, armed };
+/**
+ * One `Record<string, boolean>` from the wire, field-by-field.
+ *
+ * ONLY A REAL BOOLEAN. An unparseable value must not read as `true`, because both maps drive what a
+ * button says about a live production: `armed: true` claims the scenario is running, and
+ * `activating: true` is what makes a second click refuse. Dropping the key is the safe direction —
+ * it reads as "not in that state", which is the answer a witness we could not read deserves.
+ */
+function parseBooleanMap(raw: unknown): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  if (typeof raw !== 'object' || raw === null) return out;
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'boolean') out[key] = value;
+  }
+  return out;
 }
 
 function parseResult(raw: unknown, scenario: string | null): TriggerResult {
-  const base: TriggerResult = { ok: false, armed: null, note: null, error: null };
+  const base: TriggerResult = { ok: false, armed: null, log: '', note: null, error: null };
   if (typeof raw !== 'object' || raw === null) {
     return { ...base, error: 'trigger dispatcher returned a non-object' };
   }
@@ -122,6 +183,10 @@ function parseResult(raw: unknown, scenario: string | null): TriggerResult {
     // one the UI needs to correlate a response with the button that was pressed — the same reason
     // `requestedBy` is threaded through resolve.ts rather than read back.
     armed: scenario,
+    // The trigger's own narration, forwarded verbatim. Empty string rather than null when absent:
+    // "the trigger printed nothing" and "there was no field" are the same fact to a caller, and one
+    // type means the UI needs no null check before trimming it.
+    log: typeof r['log'] === 'string' ? r['log'] : '',
     note: typeof r['note'] === 'string' && r['note'] !== '' ? r['note'] : null,
     error: null,
   };
@@ -197,6 +262,7 @@ export function disabledTriggers(): TriggerDeps {
   const declined: TriggerResult = {
     ok: false,
     armed: null,
+    log: '',
     note: null,
     error: 'demo triggers are not enabled on this deployment',
   };

--- a/services/detection-engine/test/triggers.test.ts
+++ b/services/detection-engine/test/triggers.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Trigger status parsing — the three-state model as it crosses the process boundary.
+ *
+ * WHY THIS FILE EXISTS AT ALL. The engine holds no trigger logic (`detect/triggers.ts` header), so
+ * for MVP 3 there was nothing here worth a test. `activating` changes that: this parser is the only
+ * place a *state model* crosses from IRIS to the browser, and the case most likely to break it —
+ * a dispatcher that predates the field — is the one the live stack cannot produce once IRIS is
+ * updated. So it is exactly the class `CLAUDE.md` §8 means by "prove rejection too": the negative
+ * and legacy shapes are checked, not just the happy one.
+ *
+ * `parseStatus` is exported for this, the same as `parseResolveRequest` and `parseChatRequest`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { parseStatus, TRIGGERS_DISABLED } from '../src/detect/triggers.ts';
+
+/** The live payload's shape, trimmed to the fields this parser reads. */
+function payload(armed: unknown, activating: unknown): unknown {
+  return {
+    enabled: true,
+    scenarios: [
+      { id: 'pool_bottleneck', label: 'Pool bottleneck', detail: 'd', findings: 'queue_buildup' },
+    ],
+    armed,
+    activating,
+  };
+}
+
+describe('parseStatus — the three states', () => {
+  it('carries activating through as its own map, distinct from armed', () => {
+    // The pool_bottleneck warm-up window, as the dispatcher reports it: the request landed
+    // (`PoolWas` set) and the scenario is not in effect yet (`DispatcherMs` absent).
+    const s = parseStatus(payload({ pool_bottleneck: false }, { pool_bottleneck: true }));
+    assert.equal(s.armed['pool_bottleneck'], false);
+    assert.equal(s.activating['pool_bottleneck'], true);
+  });
+
+  it('reports activated as armed and NOT activating', () => {
+    // After the warm-up. The two maps must not both read true, or the UI has no way to pick a
+    // phase -- and the dispatcher derives `activating` as `requested && !inEffect` for that reason.
+    const s = parseStatus(payload({ pool_bottleneck: true }, { pool_bottleneck: false }));
+    assert.equal(s.armed['pool_bottleneck'], true);
+    assert.equal(s.activating['pool_bottleneck'], false);
+  });
+
+  it('reports a scenario that arms atomically as never activating', () => {
+    // missing_folder and closed_port witness both states with the same global, so the middle state
+    // is false by construction. No special case in the dispatcher, and none needed here.
+    const s = parseStatus(payload({ missing_folder: true }, { missing_folder: false }));
+    assert.equal(s.armed['missing_folder'], true);
+    assert.equal(s.activating['missing_folder'], false);
+  });
+
+  it('an absent activating map parses to {}, not to a crash or a disabled rail', () => {
+    // A dispatcher predating this change. Every scenario then reads not-activating, which is the
+    // pre-#135 two-state behaviour -- degrading to the old UI is correct; hiding the buttons is not.
+    const raw = { enabled: true, scenarios: [], armed: { closed_port: true } };
+    const s = parseStatus(raw);
+    assert.equal(s.enabled, true);
+    assert.deepEqual(s.activating, {});
+    assert.equal(s.armed['closed_port'], true);
+  });
+
+  it('a non-boolean in either map is dropped, never coerced to true', () => {
+    // Both maps make claims about a live production and one of them refuses a click, so a garbled
+    // value must not read as "in that state". Dropping the key means "no", which is the safe answer
+    // to a witness we could not read.
+    const s = parseStatus(
+      payload(
+        { pool_bottleneck: 'true', closed_port: 1, missing_folder: true },
+        { pool_bottleneck: null, closed_port: 'yes' },
+      ),
+    );
+    assert.equal('pool_bottleneck' in s.armed, false);
+    assert.equal('closed_port' in s.armed, false);
+    assert.equal(s.armed['missing_folder'], true);
+    assert.deepEqual(s.activating, {});
+  });
+
+  it('a garbled activating map cannot make a button behave differently from a garbled armed map', () => {
+    // The two maps share one parser precisely so this holds. Asserted rather than left to code
+    // reading, because the previous version had the `armed` loop written out inline and a second
+    // copy for `activating` would have been the obvious way to add it.
+    const bad = { nope: 'x', also: [], nested: {} };
+    const s = parseStatus(payload(bad, bad));
+    assert.deepEqual(s.armed, s.activating);
+    assert.deepEqual(s.armed, {});
+  });
+
+  it('enabled must be explicitly true, and the off payload carries both maps', () => {
+    // A garbled reply cannot switch the buttons on. And TRIGGERS_DISABLED is what api/server.ts
+    // now serves for its two off-state branches, so it has to satisfy the full interface -- it was
+    // two inline literals that would have been silently short the new field.
+    assert.deepEqual(parseStatus({ enabled: 'true', scenarios: [] }), TRIGGERS_DISABLED);
+    assert.deepEqual(parseStatus(null), TRIGGERS_DISABLED);
+    assert.deepEqual(TRIGGERS_DISABLED.activating, {});
+  });
+
+  it('a malformed scenario is skipped rather than rejecting the payload', () => {
+    // Pre-existing behaviour, pinned here because this file is now the parser's test: one bad
+    // scenario must not remove the reset button, which is the one that recovers from everything.
+    const s = parseStatus({
+      enabled: true,
+      scenarios: [{ id: '', label: 'nameless' }, { id: 'closed_port', label: 'Downstream' }],
+      armed: {},
+      activating: {},
+    });
+    assert.equal(s.scenarios.length, 1);
+    assert.equal(s.scenarios[0]?.id, 'closed_port');
+  });
+});


### PR DESCRIPTION
Reported by @Ari-Glikman after driving the live UI:

> instead of "armed" we can say "trigger activated" and if there is any message for it it can be
> right under. if someone tries to click again while the trigger is activating it should say
> "trigger already activated", until it is reset.

All three are done. The third one needed a state the system was already in for 75 seconds at a
time and had no way to report, so most of this PR is about that.

## The three states, and why the middle one is not cosmetic

| state | means | witnesses |
|---|---|---|
| **not activated** | nothing armed | neither present |
| **activating** | the request landed, the scenario is not in effect yet | request present, effect absent |
| **activated** | the scenario is live | effect present |

`pool_bottleneck` is the reason. It warms the baseline at zero for 75s **before** arming anything
-- that wait is load-bearing (#43: a queue forming during warm-up caps the ratio near 2.00 and
`queue_buildup` can then never fire) -- and since #129 it runs as a jobbed process, so the HTTP
call returns immediately. Measured through nginx on `:5173`, one arm, polled every 5s:

```
arm POST returned in 0.0198s
t+  0s   armed=False  activating=True    ->  activating
t+ 39s   armed=False  activating=True    ->  activating
t+ 72s   armed=False  activating=True    ->  activating
t+ 77s   armed=True   activating=False   ->  activated
```

**72 seconds in a state the old payload reported as "not armed"** -- which is exactly the window
in which a presenter clicks again because nothing appears to have happened.

## How it is modelled

`Status()` walks one `Scenarios()` table where each entry names a `requestWitness` and an
`effectWitness`, then derives both maps:

```
armed      = inEffect
activating = requested && 'inEffect
```

| scenario | request witness | effect witness |
|---|---|---|
| `pool_bottleneck` | `PoolWas` | `DispatcherMs` |
| `missing_folder` | `PathWas` | `PathWas` |
| `closed_port` | `PortWas` | `PortWas` |

**Derived, not stored.** A third global tracking "arming in progress" is state that can disagree
with the two witnesses, and it would have to be cleared on every path a jobbed arm can die on.
Two `$data` reads cannot go stale.

**The two atomic scenarios list the same global twice**, so `activating` is false *by
construction* rather than by a special case. Not special-casing them was an explicit requirement;
stating the witness pair is how that is achieved rather than asserted.

**`DispatcherMs` stays the effect witness**, and the reasoning is #129's extended rather than
replaced. That commit moved `armed` *off* `PoolWas` because the stash is conditional -- on an
instance already at pool 1 nothing is stashed and the button read "not armed" while the scenario
was fully armed. `PoolWas` is a bad witness for "armed" and a *good* one for "the request landed":
it is written immediately, before the `hang`. The field that was wrong for one question is right
for the other, and both are now asked.

**One table, not two lists.** The `%Push` block and the `%Set` lines were keyed by name
independently, so a fourth scenario would have been advertised as a button whose state read
`false` forever. Same argument as every host list in this repo (root `CLAUDE.md` section 6).

**The wire keeps the name `armed`.** Renaming it would break an older engine or dashboard against
a newer IRIS for no gain. The rename is a wording change in the UI and it stays one.

## Per-trigger messages, and the text the engine was discarding

Each button owns a message slot inside its own list item. The shared error/note pair at the bottom
of the panel is gone -- it meant arming `missing_folder` printed a paragraph naming `EMR Source`
and a `FilePath` below `closed_port`'s button.

The content is the dispatcher's captured `log`, and finding out why it was empty was the bulk of
this change. `TriggerDispatcher.Arm` goes to real trouble for that text -- a temp file becomes the
current device, because the trigger methods write to `$io` and would otherwise put their narration
in front of the JSON (#128's live-only bug) -- and then `detect/triggers.ts` parsed the reply
field-by-field and **did not list `log`**. It crossed one process boundary and died at the next.

19 lines now render under the button, monospaced and `pre-wrap` because its own indentation and
arithmetic are load-bearing:

```
ARMED  dead_host  (the MVP 3 missing-folder scenario)
  EMR Source FilePath -> /tmp/labdemo/hl7-in-missing/
  dead_host fires (Error is in DEAD_STATUSES).
  stalled_host will NOT fire -- it declines for a host already in DEAD_STATUSES.
  THERE IS NO GOVERNED FIX. The recommendation is words, for an operator to act on
```

Plain text rendered as text -- no `dangerouslySetInnerHTML` for output that quotes paths and
settings. `log` **and** `note` are joined rather than one shadowing the other: a reset returns 14
lines of what it restored plus the note about the buffered `system_alert` it cannot, and a jobbed
arm is the reverse case (empty log, note explains the warm-up). Neither needs a branch.

## "Trigger already activated" makes no request

Not "POST and let IRIS refuse". Arming is idempotent in the trigger class but **not free**: the
`$case` runs the method again, `PoolBottleneck` re-enters its 75s hang and rewrites
`RateSecs`/`MaxQueued`, and a second `Arm` on a jobbed scenario starts a **second background job**
against the same production definition. The UI already polls the state needed to refuse.

Proved with **two independent witnesses** in one browser run, because "no request was made" is the
claim most easily asserted without evidence -- instrumented `window.fetch` in the page *and*
counted POSTs in nginx's access log:

```
before   phase=activated  aria-disabled=true  msgKind=log
click    ->  msgKind=refused "Trigger already activated. Press Reset all to clear it..."
fetches during the window:  /api/healthscan/hosts GET, /api/healthscan/findings GET
nginx POST delta: 0        engine log line delta: 0
```

Only the two unrelated polls. Also verified **during** the activating window, since the wording
covers both halves: clicking `Pool bottleneck` 24s into its warm-up gave the same refusal with the
same zero-request result -- one POST across two clicks.

`aria-disabled`, **not** `disabled`. A `disabled` button fires no click, so it cannot explain why
it did nothing -- which is how "busy" and "already activated" came to look like one state.

## Two refusals, two sentences

The old panel disabled *every* button while any was pending, and that protection is real: the
trigger class stashes each replaced value in one global per setting and every arming method calls
`UpdateProduction()`, so two interleaved arms can stash each other's value and make `Reset()`
restore the wrong one. **Kept** -- no second request is issued either way. What changed is that
the user is told which thing happened:

- `Trigger already activated. Press Reset all to clear it before activating it again.`
- `Another trigger is still activating. Wait for it to finish, then try again.`

Conflating them tells an operator to wait for something that will never finish, or to reset
something that needs a moment. Both verified live.

**One honest caveat**: the busy guard is React state, not a synchronous lock. Clicking two triggers
in the *same tick* let both through, because `setBusy` had not committed; two frames apart it
refuses correctly. The one-at-a-time discipline plus IRIS's own stash-only-if-absent check are
what actually protect `Reset()` -- this message is the explanation, not the lock.

## Reset stays reachable

Never disabled, never refused for anything else's state. Verified in the browser in every state
above: `disabled=false`, no `aria-disabled`, `pointer-events: auto`. It declines only to stack on
itself, and it clears every per-trigger message -- leaving them would put "Trigger already
activated" under a button that no longer is.

## Accessibility (section 7.3)

State is never colour alone. **Activated** is a filled disc plus the words "trigger activated";
**activating** is a hollow *ring* plus "trigger activating..." -- told apart by silhouette where
amber and teal may not survive a projector. An error carries a literal "Failed:". Each slot is a
`role="status"` live region, always mounted so it exists before its content changes; same role for
errors, because swapping a node between `status` and `alert` is unreliable and a failed demo toggle
is not an emergency.

## Engine: a parser change, not logic

This service still holds no trigger logic. `TriggerStatus` gains `activating`, and both maps go
through **one** `parseBooleanMap` -- so a garbled `activating` cannot make a button behave
differently from a garbled `armed`. Asserted in a test rather than left to code reading, because a
second inline loop was the obvious way to add it. A non-boolean is **dropped**, not coerced.

`TRIGGERS_DISABLED` is now imported by `api/server.ts` instead of two inline off-state literals,
both of which would have been silently short the new field. Confirmed with the flag off: the
endpoint serves an empty `activating` map.

`contracts/` needs no change, **checked rather than assumed**: no file under `contracts/` mentions
`/api/demo`, `/labdemo/trigger`, or an armed map. The demo trigger surface has never been
contracted, consistent with it being scaffolding behind a flag.

## Rejected

- **A third global for "arming".** Duplicate state that can disagree with the witnesses.
- **Special-casing the two fast scenarios.** Listing their witness pair says the same thing
  structurally and survives a fourth scenario.
- **Renaming `armed` on the wire.** Breaks version skew both directions for a wording change.
- **Letting the server refuse.** Costs a round trip *and* a side effect to learn what the client
  already knows.
- **Keeping `disabled` and only changing the text.** A disabled button cannot say anything.

## Gates

| gate | result |
|---|---|
| dashboard `tsc --noEmit` | clean |
| `node tools/validate-architecture.mjs` | green -- 7 labels, no overlaps |
| engine `tsc --noEmit` | clean |
| engine tests | **271 pass, 0 fail** (263 before, +8 new parser suite) |
| `app.css` brace balance | 287 / 287 |

Served bundle through nginx on `:5173` carries `trigger activated`, `trigger activating`, both
refusal sentences and `pg-rail__trigger-dot--activating`, and **none** of `pg-triggers__error`,
`pg-rail__armed-dot` or the old pending string.

Stack left reset -- all three triggers not activated, both maps false -- and the error window
purged, since `Reset()` restores settings but cannot clear `Ens.Util.Log` and a scenario otherwise
inherits the previous one's errors for up to an hour (#131).

Files: `iris/labdemo/REST/TriggerDispatcher.cls`,
`services/detection-engine/src/detect/triggers.ts`,
`services/detection-engine/src/api/server.ts`,
`services/detection-engine/test/triggers.test.ts`,
`apps/dashboard/src/components/TriggerRail.tsx`, `apps/dashboard/src/styles/app.css`.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
