### PR TITLE
fix(chat): "hello" answered by reading the activity tables and reciting statistics

### DIFF
--- a/apps/dashboard/src/api/mvp2Guards.ts
+++ b/apps/dashboard/src/api/mvp2Guards.ts
@@ -216,6 +216,11 @@ function parseChatEvidence(value: unknown): ChatEvidenceItemView[] {
  * `unavailable` and an unrecognised source as `none`, so a garbled payload cannot present itself as a
  * complete answer from a live agent — which is the one direction of error that matters, since
  * `source` is the field `iris/CLAUDE.md`'s pre-demo check relies on.
+ *
+ * `static` IS MATCHED EXPLICITLY, alongside `agent`, and it is still pessimistic: an unrecognised
+ * value is `none` as before. Matched rather than folded into `agent` because the panel shows a
+ * different provenance tag for each, and a small-talk reply wearing "Live agent" would claim a
+ * metered call that never happened.
  */
 export function parseChatAnswer(payload: unknown): ChatAnswerView | null {
   if (!isRecord(payload)) return null;
@@ -224,7 +229,8 @@ export function parseChatAnswer(payload: unknown): ChatAnswerView | null {
   const state: ChatState = rawState === 'complete' ? 'complete' : 'unavailable';
 
   const rawSource = payload['source'];
-  const source: ChatSource = rawSource === 'agent' ? 'agent' : 'none';
+  const source: ChatSource =
+    rawSource === 'agent' ? 'agent' : rawSource === 'static' ? 'static' : 'none';
 
   const diagnostics = isRecord(payload['diagnostics']) ? payload['diagnostics'] : {};
 

--- a/apps/dashboard/src/components/ActivityChat.tsx
+++ b/apps/dashboard/src/components/ActivityChat.tsx
@@ -53,8 +53,15 @@ const DEFAULT_MAX_LENGTH = 600;
  * exactly what went stale when `FHIR Transform` was removed. These read as questions an operator
  * would ask of any production, and the agent's own `get_activity_coverage` call is what discovers
  * the host names.
+ *
+ * "WHAT CAN YOU DO?" IS FIRST, AND IT IS THE ONE THAT COSTS NOTHING. IRIS classifies it as a
+ * capability question and answers it from a fixed catalogue — no model call, no tool call — so it is
+ * the cheapest chip here as well as the one that teaches an operator what the other three are
+ * examples of. It leads for that reason: the reported defect was that the assistant did not behave
+ * like one, and the first thing an assistant should be able to say is what it is for.
  */
 const SUGGESTIONS: readonly string[] = [
+  'What can you do?',
   'Which host is handling the most messages right now?',
   'Is anything falling behind? Compare queueing time across hosts.',
   'How has throughput changed over the last few hours?',
@@ -241,6 +248,11 @@ function ChatAnswer({ answer, onRetry, asking }: ChatAnswerProps): JSX.Element {
   const declined = answer.answer === null;
   const confidence = confidenceText(answer.confidence);
   const toolCalls = answer.diagnostics.toolCalls;
+  /* A greeting, a thanks, a farewell or a "what can you do", classified in IRIS and answered from a
+     fixed catalogue with no model call and no tool call. It changes what the provenance row may claim:
+     see the two branches below, and `types/mvp2.ts` `ChatSource` for why it is a third value rather
+     than a degraded `agent`. */
+  const isStatic = answer.source === 'static';
 
   if (declined) {
     return (
@@ -264,18 +276,32 @@ function ChatAnswer({ answer, onRetry, asking }: ChatAnswerProps): JSX.Element {
   return (
     <div className="pg-chat__answer">
       <div className="pg-chat__provenance">
-        <span className="pg-tag pg-tag--ok">Live agent</span>
+        {/* NOT "Live agent" FOR A STATIC REPLY. That tag is the panel's claim that a governed agent
+            ran, and wearing it over catalogue text would assert a metered call that never happened --
+            the same class of over-claim as labelling a mock's output as measured. */}
+        {isStatic ? (
+          <span className="pg-tag">No data needed</span>
+        ) : (
+          <span className="pg-tag pg-tag--ok">Live agent</span>
+        )}
         {answer.diagnostics.model !== null && (
           <span className="pg-tag">{answer.diagnostics.model}</span>
         )}
         {toolCalls !== null &&
           (toolCalls === 0 ? (
-            /* ZERO IS CALLED OUT, not shown as another grey tag. An answer with no tool calls was
-               produced from the model's priors rather than from this production, and that is the one
-               diagnostic a reader must not skim past. */
-            <span className="pg-tag pg-tag--warn">
-              0 tool calls — not read from this production
-            </span>
+            /* ZERO MEANS TWO DIFFERENT THINGS AND THE SOURCE IS WHAT SEPARATES THEM. From the agent it
+               is the warning it has always been: a model answered from its priors about a production
+               it has never seen, and that is the one diagnostic a reader must not skim past. From a
+               static reply it is the honest signal that nothing needed reading -- so it is stated
+               plainly rather than flagged, because a warning on a greeting trains a reader to ignore
+               the warning that matters. */
+            isStatic ? (
+              <span className="pg-tag">0 tool calls — nothing was read</span>
+            ) : (
+              <span className="pg-tag pg-tag--warn">
+                0 tool calls — not read from this production
+              </span>
+            )
           ) : (
             <span className="pg-tag">
               {toolCalls} tool call{toolCalls === 1 ? '' : 's'}

--- a/apps/dashboard/src/types/mvp2.ts
+++ b/apps/dashboard/src/types/mvp2.ts
@@ -112,7 +112,17 @@ export interface InvestigationView {
  */
 export type ChatState = 'complete' | 'unavailable';
 
-export type ChatSource = 'agent' | 'none';
+/**
+ * `static` IS NOT A CANNED ANSWER ABOUT THE PRODUCTION, which is what the paragraph above rules out.
+ *
+ * It is a greeting, a thanks, a farewell or a "what can you do" — classified in
+ * `ChatDispatcher.SmallTalkKind` and answered from a fixed catalogue in IRIS, with no model call and
+ * no tool call. It describes the ASSISTANT, never the data, so it invents nothing: the thing
+ * `unavailable` exists to prevent is a plausible answer to a question about this production, and no
+ * such question can reach this source. The panel labels it, because an answer nothing measured must
+ * not present itself with the same "Live agent" tag as one three tools were read for.
+ */
+export type ChatSource = 'agent' | 'static' | 'none';
 
 /**
  * One value the agent read, and the tool it used.

--- a/iris/labdemo/REST/ChatDispatcher.cls
+++ b/iris/labdemo/REST/ChatDispatcher.cls
@@ -81,6 +81,57 @@
 /// There is deliberately NO attempt to detect a "malicious" question by pattern. A denylist of
 /// phrasings is the shape `Tools.Read.ClassifyError` rejects for PHI and it is weaker here: the
 /// model is not the boundary, the tool surface is.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// SMALL TALK NEVER REACHES THE MODEL, AND THAT IS A CODE DECISION RATHER THAN A PROMPT ONE
+///
+/// Reported: "if i say ""hello"" it spits back some numbers at me. it should read me back the numbers
+/// when asked for." Reproduced through the dashboard's own path before changing anything, and the
+/// numbers are the point -- every one of these READ THE PRODUCTION to answer a pleasantry:
+///
+///     "hello"            -> toolCalls 2 -> "Over the last 3 days, the busiest host was the EMR
+///                                          Source, handling 35,112 messages ..."
+///     "thanks!"          -> toolCalls 2 -> "From August 20, 2026, to August 23, 2026, ..."
+///     "what can you do?" -> toolCalls 1 -> "... Over the last three days, I've recorded activity
+///                                          from 7 hosts ..."
+///
+/// `..SmallTalkKind` classifies the utterance BEFORE an agent is built, and a match is answered from
+/// `..SmallTalkReply` -- fixed text, no provider, no metered call, no tool, `toolCalls: 0`, and
+/// `source: "static"` on the wire so nothing downstream can mistake it for the agent's work.
+///
+/// WHY NOT AN AGENT TURN WITH THE TOOLS WITHHELD, which was the other candidate. Withholding the tool
+/// set would make `toolCalls: 0` structural, exactly as `GovernAgent(agent, 0, "activity")` makes
+/// `SetPoolSize` unreachable -- but it would still be a model composing the sentence, and a model with
+/// no tools can still assert a number from its priors. For a greeting that is a small risk with no
+/// upside: nothing about "hello" needs generating. Static text cannot hallucinate, costs nothing, and
+/// answers identically at every rehearsal. `Tools.Read.ErrorSummary` is the precedent -- a fixed
+/// catalogue looked up by a verified key, chosen so the model cannot author it.
+///
+/// THE CAPABILITY ANSWER IS THE STRONGEST CASE FOR STATIC TEXT, not the weakest. "What can you do" is
+/// a question about THIS SYSTEM, not about the data, so a model answering it is guessing at its own
+/// tool list -- and the observed answer did exactly that, describing itself and then reporting
+/// statistics nobody asked for. The catalogue entry is grounded in the three tools `Tools.Activity`
+/// actually publishes, and if that set ever changes this text is part of the change:
+/// `Setup.AIHub.ReportTools()` already fails a boot on an unexpected tool count, so the drift is
+/// visible at the same place the tool itself is.
+///
+/// FAIL OPEN, DELIBERATELY, AND THE ASYMMETRY IS THE WHOLE DESIGN. An unmatched utterance goes to the
+/// agent with its tools. So the cost of a miss is today's behaviour -- a pleasantry answered with
+/// statistics, which is untidy -- while the cost of a false positive is a real question answered with
+/// a canned greeting, which is worse than the bug being fixed. That is why the match is on the WHOLE
+/// normalised utterance against a closed phrase list and never on a substring: "hello, which host is
+/// busiest?" is a data question and must stay one. `..StripLead` is the one concession, and it only
+/// ever removes a leading pleasantry and re-tests what is left -- so it can turn small talk into a
+/// data question but never the reverse.
+///
+/// AND THE PROMPT IS UNCHANGED, WHICH IS ALSO A DECISION. The obvious edit is a sentence telling the
+/// model not to call a tool for a non-activity question. `BuildGoal` closes with "Answer it using the
+/// tools. Read the values before answering" -- and that line is load-bearing: `AgentDispatcher`
+/// records that without it, two of three live runs wrote a fluent paragraph having read nothing. A
+/// conditional beside it is #131 exactly -- two directives in one prompt, one saying read and one
+/// saying you may not need to, with the model applying the discount where it should not. That defect
+/// cost two of three runs on a live outage. So the classification is decided in code and the prompt
+/// keeps saying one thing.
 Class ProductionGuardian.LabDemo.REST.ChatDispatcher Extends %CSP.REST
 {
 
@@ -129,6 +180,69 @@ Parameter MAXQUESTION = 600;
 /// caller controls.
 Parameter MAXHISTORY = 6;
 
+/// Utterances answered as a greeting, matched on the WHOLE normalised question.
+///
+/// A CLOSED PHRASE LIST COMPARED WHOLE, never a substring or a pattern, and that is what makes the
+/// classifier fail open (class comment). `"hello"` matches; `"hello, which host is busiest?"` does not
+/// -- it is a data question with a pleasantry in front, and `..StripLead` removes the pleasantry and
+/// sends the rest to the agent rather than answering the greeting and dropping the question.
+///
+/// "how are you" and "are you there" sit here rather than in their own kind: both are asking after the
+/// assistant rather than after the production, and a greeting reply answers them correctly.
+///
+/// `"test"` AND `"testing"` ARE DELIBERATELY ABSENT, and they were on this list first. Someone typing
+/// them is checking whether the agent is live, and a static reply is the one answer that makes a dead
+/// agent look alive -- which is the exact failure `iris/CLAUDE.md`'s pre-demo check exists to catch
+/// ("`source: canned` builds a plausible narrative from real measured values, so a rehearsal looks
+/// correct while demonstrating nothing"). Those two go to the agent, where an unconfigured provider
+/// answers 503 and says so.
+Parameter GREETINGS = {$listbuild(
+    "hello", "hi", "hey", "yo", "howdy", "hiya", "greetings", "hello there", "hi there", "hey there",
+    "good morning", "good afternoon", "good evening", "morning", "afternoon", "evening",
+    "how are you", "how are you doing", "hows it going", "how is it going", "are you there",
+    "you there", "anyone there")};
+
+/// Utterances answered as an acknowledgement.
+Parameter THANKS = {$listbuild(
+    "thanks", "thank you", "thankyou", "thanks a lot", "thanks very much", "thank you very much",
+    "many thanks", "much appreciated", "appreciated", "cheers", "ta", "nice one", "great",
+    "perfect", "lovely", "ok", "okay", "got it", "understood", "makes sense", "good to know",
+    "ok thanks", "okay thanks", "great thanks", "perfect thanks", "thanks that helps",
+    "that helps", "helpful")};
+
+/// Utterances answered as a farewell.
+Parameter FAREWELLS = {$listbuild(
+    "bye", "goodbye", "good bye", "bye bye", "byebye", "see you", "see you later", "cya",
+    "later", "good night", "goodnight", "night", "thats all", "that is all",
+    "done", "im done", "i am done", "nothing else", "no more questions", "no thanks",
+    "that will be all", "were done")};
+
+/// Utterances answered with the capability description.
+///
+/// A QUESTION ABOUT THE SYSTEM, NOT ABOUT THE DATA, which is why it is here at all rather than left to
+/// the agent -- see the class comment. `"help"` is included as a bare word because an operator typing
+/// it wants to know what to ask, and the reply is exactly that.
+Parameter CAPABILITY = {$listbuild(
+    "what can you do", "what can you do for me", "what do you do", "what can you help with",
+    "what can you help me with", "what can you tell me", "what can you answer",
+    "what are your capabilities", "capabilities", "what can i ask", "what can i ask you",
+    "what should i ask", "what questions can i ask", "what kind of questions can i ask",
+    "what sort of questions can i ask", "who are you", "what are you", "what is this",
+    "whats this", "how does this work", "how do you work", "how do i use this",
+    "help", "help me", "what now")};
+
+/// Leading pleasantries `..StripLead` will remove before re-testing what is left.
+///
+/// ONE DIRECTION ONLY, and that is the safety property: stripping a lead can turn small talk into a
+/// data question (`"hi, which host is busiest?"` -> a data question) and can never turn a data
+/// question into small talk, because removing words from a real question leaves a real question that
+/// still will not match a phrase above. Ordered LONGEST FIRST so `"hi there"` is removed whole rather
+/// than leaving a stray `"there"`.
+Parameter LEADS = {$listbuild(
+    "good afternoon", "good morning", "good evening", "thank you", "hello there", "hey there",
+    "hi there", "greetings", "howdy", "thanks", "hello", "hiya", "cheers", "hey", "okay", "hi",
+    "ok", "yo", "so", "also", "and", "please")};
+
 XData UrlMap [ XMLNamespace = "http://www.intersystems.com/urlmap" ]
 {
 <Routes>
@@ -151,6 +265,20 @@ ClassMethod Ask() As %Status
         }
         if $length(question) > ..#MAXQUESTION {
             return ..Fail(400, "question must be " _ ..#MAXQUESTION _ " characters or fewer")
+        }
+
+        // SMALL TALK IS ANSWERED HERE, BEFORE AN AGENT EXISTS. See the class comment for why the
+        // classification is code rather than prompt wording, and for the fail-open direction: an
+        // unmatched utterance falls through to the agent with its tools, so a miss costs tidiness
+        // and a false positive would cost a real answer.
+        //
+        // AFTER the length checks, not before. A 600-character "hello" is still a malformed request
+        // by the bound that applies to every question, and answering it would make the cap
+        // conditional on content.
+        set kind = ..SmallTalkKind(question)
+        if kind '= "" {
+            write ..SmallTalkAnswer(kind, question).%ToJSON()
+            return $$$OK
         }
 
         set agent = ..BuildAgent(.sc)
@@ -193,6 +321,210 @@ ClassMethod Ask() As %Status
     } catch ex {
         return ..Fail(500, "chat failed: " _ ex.DisplayString())
     }
+}
+
+/// Classify small talk, or "" for anything that should reach the agent. Private.
+///
+/// Returns one of "greeting", "thanks", "farewell", "capability", or "" -- and "" is the answer for
+/// everything the four phrase lists do not match WHOLE. That is the fail-open direction argued in the
+/// class comment: an unmatched utterance is treated as a data question, so the classifier being wrong
+/// costs a pleasantry answered with statistics rather than a real question answered with a greeting.
+///
+/// THE ORDER OF THE FOUR IS NOT ARBITRARY, though only one overlap exists in practice: `capability`
+/// is tested LAST so that a phrase reading as both a pleasantry and a request for help resolves to the
+/// pleasantry. Nothing currently appears in two lists -- worth keeping true, and cheap to check,
+/// because a phrase in two lists would resolve silently by position rather than by intent.
+ClassMethod SmallTalkKind(question As %String) As %String [ Private ]
+{
+    set normalised = ..Normalise(question)
+    if normalised = "" {
+        // Cannot happen from `Ask` -- a blank question is refused with a 400 before this is called --
+        // but returning "" rather than a kind keeps the method honest if it is ever called directly:
+        // an empty utterance is not a greeting.
+        quit ""
+    }
+    set kind = ..MatchKind(normalised)
+    if kind '= "" {
+        quit kind
+    }
+    // ONE RETRY, on the utterance with a leading pleasantry removed. `"hi, thanks"` and `"ok, bye"`
+    // are small talk with a lead; `"hi, which host is busiest?"` is a data question with one, and
+    // stripping resolves both correctly because the remainder is re-tested against the same closed
+    // lists rather than assumed to be small talk. Not looped: two stacked leads is not an utterance
+    // anyone types, and each additional pass widens what can be swallowed.
+    set stripped = ..StripLead(normalised)
+    if stripped = normalised {
+        quit ""
+    }
+    quit ..MatchKind(stripped)
+}
+
+/// The whole-utterance test against the four lists. Private.
+ClassMethod MatchKind(normalised As %String) As %String [ Private ]
+{
+    if $listfind(..#GREETINGS, normalised) {
+        quit "greeting"
+    }
+    if $listfind(..#THANKS, normalised) {
+        quit "thanks"
+    }
+    if $listfind(..#FAREWELLS, normalised) {
+        quit "farewell"
+    }
+    if $listfind(..#CAPABILITY, normalised) {
+        quit "capability"
+    }
+    quit ""
+}
+
+/// Lowercase, strip punctuation, collapse whitespace. Private.
+///
+/// WHAT IT DOES AND WHY EACH STEP IS NEEDED for the whole-utterance comparison to work at all:
+///
+///   case folded          `"Hello"` and `"hello"` are the same utterance
+///   apostrophes DELETED  `"what's this"` -> `"whats this"`, `"that's all"` -> `"thats all"`. Deleted
+///                        rather than replaced with a space, so the phrase lists above hold the
+///                        contracted form as one word. Both the ASCII `'` and the typographic `'`,
+///                        because a browser or an operating system may substitute the latter and the
+///                        two must not classify differently.
+///   other punctuation    to a SPACE, so `"hello, there"` normalises to `"hello there"` and
+///                        `"hello!"` to `"hello"`
+///   whitespace collapsed to single spaces, then trimmed
+///
+/// NOT a general text sanitiser and not a security control -- the question still reaches the model
+/// verbatim when this does not match (`Ask` passes the original, never the normalised form). This
+/// exists only so a comparison against a fixed list is not defeated by a trailing exclamation mark.
+ClassMethod Normalise(question As %String) As %String [ Private ]
+{
+    set text = $zconvert($zstrip(question, "<>W"), "L")
+    // Apostrophes out first, before the punctuation-to-space pass would turn them into word breaks.
+    set text = $translate(text, "'" _ $char(8217), "")
+    // Every remaining non-alphanumeric to a space. $zstrip with a *-replacement is not available for
+    // "keep these, replace the rest", so this walks the string -- 600 characters at most, and it runs
+    // once per request.
+    set out = ""
+    for i = 1:1:$length(text) {
+        set c = $extract(text, i)
+        set out = out _ $select((c ? 1A) || (c ? 1N): c, 1: " ")
+    }
+    // Collapse runs of spaces. `$zstrip(...,"*C")` would not do it and a loop is clearer than a
+    // repeated $replace whose termination depends on the input.
+    for {
+        set before = out
+        set out = $replace(out, "  ", " ")
+        quit:out=before
+    }
+    quit $zstrip(out, "<>W")
+}
+
+/// Remove one leading pleasantry, or return the input unchanged. Private.
+///
+/// LONGEST MATCH WINS, which is why `..#LEADS` is ordered longest-first -- removing `"hi"` from
+/// `"hi there thanks"` would leave `"there thanks"`, which matches nothing, where removing
+/// `"hi there"` leaves `"thanks"`. Matched on a WORD BOUNDARY (the lead followed by a space, or the
+/// whole string), so `"history"` never has `"hi"` taken off the front.
+ClassMethod StripLead(normalised As %String) As %String [ Private ]
+{
+    // An explicit result variable rather than leaning on what `lead` holds when the loop ends --
+    // `Tools.Activity.IsConfigItem` carries the same note, because breaking a loop leaves the
+    // iteration variable holding whatever was last examined rather than what matched.
+    set found = ""
+    set ptr = 0
+    set leads = ..#LEADS
+    while $listnext(leads, ptr, lead) {
+        // THE LEAD MUST BE FOLLOWED BY A SPACE, so `"history"` never has `"hi"` taken off the front
+        // and there is always a remainder to re-test. An utterance that IS a bare lead therefore does
+        // not match here -- correctly: it already failed `MatchKind`, so a bare lead not in the four
+        // lists is not small talk, and emptying it would make `SmallTalkKind` retry against "".
+        if $extract(normalised, 1, $length(lead) + 1) = (lead _ " ") {
+            set found = lead
+            quit
+        }
+    }
+    if found = "" {
+        quit normalised
+    }
+    quit $zstrip($extract(normalised, $length(found) + 2, $length(normalised)), "<>W")
+}
+
+/// The wire response for a classified utterance. Private.
+///
+/// SHAPED EXACTLY LIKE THE AGENT'S REPLY, field for field, because `chat.ts` validates one shape and
+/// `parseChatReply` returning null would turn a greeting into `state: "unavailable"`. So `answer`,
+/// `evidence`, `confidence`, `model`, `toolCalls` and `question` are all present and all honest:
+///
+///   toolCalls  0   -- TRUE, and the honest signal. Nothing was read because nothing needed reading.
+///                     The panel labels a zero rather than showing it as a bare tag, and #132 made
+///                     that warning about a MODEL answering from its priors -- which this is not, so
+///                     `source` below is what tells the two apart.
+///   model      ""  -- JSON null. No model was called, and naming one would claim a metered call that
+///                     never happened. `iris/CLAUDE.md`'s pre-demo check reads `model: non-null`
+///                     together with `source: agent`, so a null here cannot be mistaken for the agent
+///                     path failing open into a canned reply.
+///   evidence   []  -- there is nothing to cite. A bullet reading "this is a greeting" would be
+///                     provenance theatre.
+///   confidence ""  -- JSON null. A fixed string has no confidence to report; 1 would be a
+///                     self-report about text nobody generated.
+///
+/// `source: "static"` IS THE NEW FIELD AND IT IS THE POINT. `chat.ts` sets `source: "agent"` for
+/// anything the agent answered and `"none"` for a failure, and a greeting is neither -- so it says so.
+/// Without a third value a zero-tool-call answer would be indistinguishable from the agent having
+/// answered from its priors, which is the one thing `toolCalls` exists to surface.
+ClassMethod SmallTalkAnswer(kind As %String, question As %String) As %DynamicObject [ Private ]
+{
+    // Built into a variable first: a concatenation inside a %DynamicObject literal fails to compile
+    // with #1021 Expected right bracket, which this project has hit before.
+    set answer = ..SmallTalkText(kind)
+    quit { "answer": (answer), "evidence": [], "confidence": null, "model": null,
+        "toolCalls": 0, "question": (question), "source": "static", "smallTalk": (kind) }
+}
+
+/// The fixed reply text for each kind. Private.
+///
+/// A CATALOGUE KEYED BY A CLASSIFICATION, and `Tools.Read.ErrorSummary` is the precedent named in the
+/// class comment: fixed strings looked up by a verified key, never text a model authored. The reason
+/// is the same one, arriving from the other direction -- `ErrorSummary` is fixed so a log row cannot
+/// leak through it, and this is fixed so a model cannot invent a capability the system does not have.
+///
+/// THE CAPABILITY TEXT IS GROUNDED IN THE THREE TOOLS `Tools.Activity` PUBLISHES and says nothing
+/// beyond them. It names what CANNOT be answered as well, because the two most likely follow-ups are
+/// both out of reach: the current instantaneous state (this agent has the history tools only -- see
+/// `Governance.ACTIVITYTOOLS`) and anything about message content (no tool will return it).
+/// Deliberately no host names: root `CLAUDE.md` §6 makes `Production.cls`'s item set the authority and
+/// a copied list here is what went stale when `FHIR Transform` was removed. The three example
+/// questions are about SHAPE for the same reason the panel's suggestion chips are.
+///
+/// EACH REPLY INVITES A QUESTION rather than only being polite. A greeting that says "hello" and stops
+/// leaves an operator looking at an empty input, and the reported defect is fundamentally about the
+/// assistant not behaving like one.
+ClassMethod SmallTalkText(kind As %String) As %String [ Private ]
+{
+    if kind = "greeting" {
+        quit "Hello. I can answer questions about this production's recorded interoperability "
+            _ "activity -- message volume, throughput, and processing and queueing times over a "
+            _ "period you choose. Ask me something and I will read the activity tables for it."
+    }
+    if kind = "thanks" {
+        quit "You're welcome. Ask again whenever you want another look at the activity figures."
+    }
+    if kind = "farewell" {
+        quit "Goodbye. The activity history stays here whenever you want to come back to it."
+    }
+    if kind = "capability" {
+        quit "I answer questions about this production's recorded interoperability activity, by "
+            _ "reading the IRIS activity tables through governed, audited tools. Three things: "
+            _ "which hosts have recorded activity and how far back the history goes; how one host's "
+            _ "throughput and latency have moved over time, bucket by bucket; and how all the hosts "
+            _ "compare over one window, ranked by volume. So ""which host is busiest"", ""is anything "
+            _ "falling behind on queueing time"" and ""how has throughput changed today"" are all "
+            _ "answerable, at ten-second, hourly or daily resolution. Two things I cannot do: I see "
+            _ "recorded history rather than the current instantaneous state of a host, and I never "
+            _ "see message content or patient data -- counts, durations and configuration only."
+    }
+    // NO DEFAULT SENTENCE. Every kind `SmallTalkKind` can return is handled above, and "" here would
+    // fail `chat.ts`'s `answer` check and surface as `unavailable` -- which is the correct outcome for
+    // a kind this method does not know, and far better than a generic reply standing in for one.
+    quit ""
 }
 
 /// Build and initialise the governed agent. Private.

--- a/services/detection-engine/src/detect/chat.ts
+++ b/services/detection-engine/src/detect/chat.ts
@@ -53,8 +53,21 @@ export type ChatState = 'complete' | 'unavailable';
  * web application and the agent are all correct at once — which is why `iris/CLAUDE.md`'s pre-demo
  * check turns on this field rather than on the answer looking right. There is deliberately no
  * `canned` chat agent: see `chatUnavailable`.
+ *
+ * `static` IS A THIRD THING AND IT IS NOT A DEGRADED `agent`. A greeting, a thanks, a farewell or a
+ * "what can you do" is classified in `ChatDispatcher.SmallTalkKind` and answered from a fixed
+ * catalogue — no provider, no metered call, no tool, `toolCalls: 0`. Distinguished from `agent`
+ * because otherwise a zero tool count would be ambiguous between "nothing needed reading" and "a
+ * model answered from its priors about a production it has never seen", and the second is the one
+ * `toolCalls` exists to surface. Distinguished from `none` because a `static` answer IS an answer:
+ * `answer` is non-null and `state` is `complete`.
+ *
+ * NOT A NEW WAY TO INVENT DATA. The catalogue describes the assistant, never the production — see
+ * `ChatDispatcher.SmallTalkText`, which is grounded in the three tools `Tools.Activity` publishes and
+ * names no host. `iris/CLAUDE.md`'s pre-demo check is unaffected: it asserts `source: agent` for a
+ * real question, and a real question can never reach this path.
  */
-export type ChatSource = 'agent' | 'none';
+export type ChatSource = 'agent' | 'static' | 'none';
 
 export interface ChatResponse {
   requestId: string;
@@ -275,10 +288,17 @@ export async function chat(request: ChatRequest, deps: ChatDeps): Promise<ChatRe
 
   const finished = now();
   const obj = raw as Record<string, unknown>;
+  /* READ FROM WHAT IRIS SAID, and only the one literal is accepted — anything else, including an
+     absent field, is `agent`. That direction is deliberate: `agent` is the claim `iris/CLAUDE.md`'s
+     pre-demo check treats as load-bearing, and defaulting an unrecognised value to `static` would let
+     a garbled reply present a real agent answer as canned text, which is the reverse of the error
+     worth guarding. An older IRIS that does not send the field at all still reports `agent`, which is
+     what it means. */
+  const source: ChatSource = obj['source'] === 'static' ? 'static' : 'agent';
   return {
     requestId,
     state: 'complete',
-    source: 'agent',
+    source,
     answeredAt: isoSeconds(finished),
     /* IRIS's echo is preferred over our own copy, because it is what the agent actually answered.
        Falling back to the request only when the echo is missing — a UI pairing an answer with a

--- a/services/detection-engine/test/chat.test.ts
+++ b/services/detection-engine/test/chat.test.ts
@@ -234,3 +234,77 @@ describe('chat', () => {
     assert.match(res.answeredAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
   });
 });
+
+/**
+ * `source: "static"` — the small-talk reply, and the two directions that matter.
+ *
+ * A greeting is classified in `ChatDispatcher.SmallTalkKind` and answered from a fixed catalogue with
+ * no model call and no tool call. This service only has to carry the label through faithfully, and
+ * these tests pin BOTH failure directions rather than only the happy one:
+ *
+ *   - a `static` reply must not report `agent`, or the panel would tag catalogue text "Live agent"
+ *   - anything that is NOT the literal `static` must report `agent`, because that is the field
+ *     `iris/CLAUDE.md`'s pre-demo check treats as load-bearing and defaulting the other way would let
+ *     a garbled payload present a real agent answer as canned text
+ */
+describe('chat — a small-talk reply from IRIS', () => {
+  const greeting = { question: 'hello', history: [] };
+
+  /** What the dispatcher sends for a classified utterance: an answer, no evidence, zero tools. */
+  function staticReply(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      answer: 'Hello. I can answer questions about this production’s recorded activity.',
+      evidence: [],
+      confidence: null,
+      model: null,
+      toolCalls: 0,
+      question: 'hello',
+      source: 'static',
+      smallTalk: 'greeting',
+      ...over,
+    };
+  }
+
+  it('carries source static through, with a complete state and a real answer', async () => {
+    const res = await chat(greeting, deps(staticReply()));
+    // COMPLETE, not unavailable: a greeting answered IS an answer, and `answer` is non-null.
+    assert.equal(res.state, 'complete');
+    assert.equal(res.source, 'static');
+    assert.match(res.answer ?? '', /^Hello\./);
+  });
+
+  it('reports zero tool calls and no model, which is the honest shape for it', async () => {
+    const res = await chat(greeting, deps(staticReply()));
+    // 0 rather than null: nothing was read, and the panel says so without flagging it as a warning
+    // (that flag is for an AGENT answer with no reads).
+    assert.equal(res.diagnostics.toolCalls, 0);
+    // Null rather than a model name, because no metered call happened and naming one would claim it.
+    assert.equal(res.diagnostics.model, null);
+    assert.deepEqual(res.evidence, []);
+    assert.equal(res.confidence, null);
+  });
+
+  for (const [name, value] of [
+    ['absent', undefined],
+    ['agent', 'agent'],
+    ['an unrecognised string', 'canned'],
+    ['a non-string', 7],
+    ['null', null],
+  ] as const) {
+    it(`reports agent when source is ${name}, never static`, async () => {
+      // FAILS TOWARDS `agent`, deliberately. An older IRIS sends no `source` at all and still means
+      // agent; and a garbled value must not downgrade a real agent answer into catalogue text.
+      const res = await chat(greeting, deps(reply({ source: value })));
+      assert.equal(res.source, 'agent');
+    });
+  }
+
+  it('still returns unavailable when a static-shaped reply has no answer text', async () => {
+    // `SmallTalkText` returns "" for a kind it does not know, and the correct outcome is the same
+    // refusal any unreadable reply gets -- NOT a `static` answer with an empty bubble.
+    const res = await chat(greeting, deps(staticReply({ answer: '' })));
+    assert.equal(res.state, 'unavailable');
+    assert.equal(res.source, 'none');
+    assert.equal(res.answer, null);
+  });
+});


### PR DESCRIPTION
Reported by @Ari-Glikman:

> the ai assistant chat seems a bit unnatural, for example if i say "hello" it spits back some numbers at me. it should read me back the numbers when asked for.

## Reproduced through the dashboard's own path first

The tool counts are the defect rather than the tone — every pleasantry **read the production**:

```
"hello"            -> toolCalls 2 -> "Over the last 3 days, the busiest host was the EMR Source,
                                     handling 35,112 messages with an average processing time of
                                     0.003935 seconds and no queueing time. The next busiest..."
"thanks!"          -> toolCalls 2 -> "From August 20, 2026, to August 23, 2026, the busiest host
                                     was the 'EMR Source' with 35,112 messages processed..."
"what can you do?" -> toolCalls 1 -> "I can provide information about activity on several hosts...
                                     Over the last three days, I've recorded activity from 7 hosts..."
```

A greeting costing a metered call and two SQL aggregations is the cheap half. The expensive half is `"what can you do?"` — a question about **this system**, answered by a model guessing at its own tool list and then reciting statistics nobody asked for.

## Enforced in code vs requested in the prompt

| Behaviour | Where it lives |
|---|---|
| A classified utterance reaches **no model and no tool** | **Enforced.** `SmallTalkKind` runs before `BuildAgent`, so there is no provider and no tool manager on that path. `toolCalls: 0` is structural. |
| The greeting/thanks/farewell/capability **wording** | **Enforced** (fixed catalogue). Not generated, so it cannot drift or hallucinate. |
| The capability description matches the real tool set | **Requested** — it is prose I wrote, grounded in the three tools `Tools.Activity` publishes. `Setup.AIHub.ReportTools()` already fails a boot on an unexpected tool count, so drift is visible at the same place the tool is. |
| A data question still reads the tables before answering | **Requested, unchanged** — `BuildGoal`'s existing "Read the values before answering". |
| A data question cannot be answered as small talk | **Enforced** — whole-utterance match against closed lists, plus the one-directional `StripLead`. |

**The prompt is deliberately untouched.** The obvious edit is a sentence telling the model not to call a tool for a non-activity question. That is #131 exactly: `BuildGoal` closes with *"Answer it using the tools. Read the values before answering"*, and `AgentDispatcher` records that without it two of three live runs wrote a fluent paragraph having read nothing. A conditional beside it means two directives in one prompt — one saying read, one saying you may not need to — with the model applying the discount where it should not. That shape cost two of three runs on a live outage in #131. Sixth time on this project, so the classification is code and the prompt keeps saying one thing.

## Fail open, and why that direction

An unmatched utterance **goes to the agent with its tools**. A miss costs today's behaviour (a pleasantry answered with statistics — untidy). A false positive costs a real question answered with a canned greeting, which is worse than the bug being fixed. So the match is on the whole normalised utterance against four closed phrase lists and **never** on a substring.

Verified both directions live — 44 positives, 26 negatives. The negatives are the ones that would catch a real defect:

```
"hello"                                  -> greeting
"hello, which host is busiest?"          -> []   falls through; answered with 1 tool call
"hi there, is anything falling behind?"  -> []
"how are you measuring processing time?" -> []
"help me understand the queueing time"   -> []
"what can you do about the Cloud API?"   -> []
"history" / "hindsight"                  -> []   StripLead's word-boundary check
"goodbye messages are piling up"         -> []
"done any messages fail?"                -> []
```

`StripLead` is one-directional by construction: it removes a leading pleasantry and **re-tests the remainder against the same closed lists**, so it can turn small talk into a data question and never the reverse — removing words from a real question leaves a real question that still matches nothing.

### `"test"` and `"testing"` were on the greeting list first and were removed

Someone typing them is checking whether the agent is live, and a static reply is the one answer that makes a **dead agent look alive** — precisely the failure `iris/CLAUDE.md`'s pre-demo check exists to catch. Both now go to the agent, where an unconfigured provider answers 503 and says so.

## The capability answer is static text

It describes what the assistant can do — a fact about the system, not the data — so a model authoring it is a liability, and the observed answer proved it. `Tools.Read.ErrorSummary` is the precedent: a fixed catalogue keyed by a verified code, chosen so the model cannot author it. The text names the three real capabilities, names what **cannot** be answered (no instantaneous state — this agent has the history tools only; no message content — no tool will return any), and names **no host**, per root `CLAUDE.md` §6.

**Rejected: an agent turn with the tools withheld.** It would make `toolCalls: 0` structural, exactly as `GovernAgent(agent, 0, "activity")` makes `SetPoolSize` unreachable — but it would still be a model composing the sentence, and a model with no tools can still assert a number from its priors. Nothing about "hello" needs generating.

## `source: "static"` is a third value, not a degraded `agent`

Without it, `toolCalls: 0` is ambiguous between "nothing needed reading" and "a model answered from its priors about a production it has never seen" — and the second is the one thing `toolCalls` exists to surface.

- static → `No data needed` + `0 tool calls — nothing was read`
- agent with no reads → the existing `pg-tag--warn` `0 tool calls — not read from this production`

A warning on a greeting trains a reader to ignore the warning that matters. It is not `Live agent` either: that tag claims a governed agent ran.

The engine accepts only the literal `"static"`; everything else, **including an absent field**, is `agent`. An older IRIS sends no `source` and still means agent, and a garbled value must not downgrade a real agent answer into canned text. Both directions tested.

## Live after

```
"hello"     -> source static, toolCalls 0, 8ms (was 3446ms)
   "Hello. I can answer questions about this production's recorded interoperability activity --
    message volume, throughput, and processing and queueing times over a period you choose.
    Ask me something and I will read the activity tables for it."

"thanks!"   -> source static, toolCalls 0
   "You're welcome. Ask again whenever you want another look at the activity figures."

"hi there"  -> source static, toolCalls 0   (same greeting text)

"goodbye"   -> source static, toolCalls 0
   "Goodbye. The activity history stays here whenever you want to come back to it."

"what can you do?" -> source static, toolCalls 0
   "I answer questions about this production's recorded interoperability activity, by reading the
    IRIS activity tables through governed, audited tools. Three things: which hosts have recorded
    activity and how far back the history goes; how one host's throughput and latency have moved
    over time, bucket by bucket; and how all the hosts compare over one window, ranked by volume.
    So "which host is busiest", "is anything falling behind on queueing time" and "how has
    throughput changed today" are all answerable, at ten-second, hourly or daily resolution. Two
    things I cannot do: I see recorded history rather than the current instantaneous state of a
    host, and I never see message content or patient data -- counts, durations and configuration
    only."
```

### The must-not-regress case, before and after

```
before  "which host has the worst queueing time?" -> agent, toolCalls 2
        "The host with the worst queueing time is the Cloud API, with an average queueing time of
         27.92 seconds over the last 3 days. The second highest is Lab Router with 0.0003 seconds."

after   same question -> agent, toolCalls 2, confidence 0.95
        "The host with the worst queueing time is Cloud API, with an average queueing time of
         27.20 seconds over the last three days. All other hosts either had no queueing time or
         significantly lower averages, indicating that Cloud API is experiencing a backlog."
```

### Multi-turn, since a static turn joins the transcript the client replays

```
1  "hello"                                             -> static, 0 tools
2  "which host has the worst queueing time?"           -> agent, 2 tools, Cloud API 27.17s
3  "and what was ITS processing time over the same window?"
                                                       -> agent, 1 tool
   "The Cloud API has an average processing time of 0.369 seconds over the same 3-day window
    where it recorded an average queueing time of 27.17 seconds."
```

The pronoun resolved across the static turn.

## Data boundary and governance

Untouched. No new tool, no change to `Governance`, no change to `GovernAgent(agent, 0, "activity")`. The catalogue describes the assistant, never the data — it emits no metric, no host name and no timestamp. `chat.ts` is imported only by `index.ts`'s chat wiring, so AI Detective shares no changed code; regression-checked anyway because the engine container was rebuilt:

```
POST /api/investigate  ->  state complete, source agent, model gpt-4o-mini, toolCalls 2
```

## Gates

- engine `tsc --noEmit` clean
- **271 engine tests pass** against a 263 baseline (+8, all in `chat.test.ts`). Isolated from two concurrent agents' untracked test files by running the suites separately; the whole directory is 308/308.
- dashboard `tsc --noEmit` clean, `validate-architecture.mjs` green (7 labels, no overlaps)
- **Verified in the served bundle**, not only in source: `No data needed`, `nothing was read`, `not read from this production` and `What can you do?` each appear once, and the compiled predicate `M=A.source==="static"` plus the three-way source guard survived TSX and the bundler.

## Wire shape

`/api/chat` gains `source: "static"` and IRIS's reply gains `source` and `smallTalk`. `/api/chat` is deliberately not in `contracts/` yet (flagged in `contracts/CHANGELOG.md`), so this is noted here rather than edited there, per root `CLAUDE.md` §4.

## Left undone / unverified

- **Not driven in a real browser.** Verified through nginx on `:5173` (the browser's path) and in the served bundle's compiled predicates, but not clicked through. The two branches that changed are the provenance tags and the chip list.
- The phrase lists are English-only and finite by design. Fail-open means an unlisted pleasantry gets today's behaviour, which is the acceptable direction.
- The probe subclass used to reach the private classifier was compiled in the container only and deleted; it is not in the repo.

Stack left demo-ready: triggers all disarmed, 0 findings, `Ens.Util.Log` purged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
