### PR TITLE
fix(engine): a drain inside the fit window made Early Warning report not_rising on a rising queue

### DIFF
--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -65,6 +65,20 @@ export interface HostProjection {
  * single-scenario boundary is visible: adding a second is a contract change, not a config edit.
  */
 const METRIC: MetricName = 'queued';
+
+/**
+ * How much of a fall counts as a DISCONTINUITY rather than ordinary draining, as a fraction of the
+ * previous value.
+ *
+ * Deliberately not in `thresholds.json`: ADR 0003 governs the numbers that decide what FIRES, and an
+ * operator would never tune this. It is the definition of "the series restarted", i.e. a sanity check
+ * on the arithmetic rather than a detection threshold.
+ *
+ * 80% is far above ordinary draining. At the shipped 5s poll, a host clearing 4/sec sheds 20 messages
+ * a tick — 6% of a 350-deep queue, nowhere near this. A drain to zero, which is what an operator's
+ * reset or an approved fix produces, is 100%.
+ */
+const DISCONTINUITY_FRACTION = 0.8;
 const FINDING_TYPE = 'queue_buildup';
 const SLOPE_UNIT = 'items/minute';
 
@@ -79,6 +93,47 @@ const SLOPE_UNIT = 'items/minute';
  * by zero rather than a flat line — a distinction worth keeping, since a flat line is
  * `not_rising` and this is "cannot fit".
  */
+/**
+ * Drop everything before the most recent DISCONTINUITY in the series.
+ *
+ * WHY, and this is the defect that made Early Warning useless on the demo scenario: a queue that is
+ * drained — by an operator, by `Triggers.Reset()`, or by the approved fix itself — falls to zero in a
+ * single poll. The trailing window then straddles that cliff, and a least-squares fit over both sides
+ * reports the CLIFF rather than the trend. Measured on a live ramp, the 300s window held:
+ *
+ *     263 268 273 ... 350 355 | 0 0 0 ... 0 | 8 13 18 ... 124 129
+ *
+ * a fall of 355 followed by a genuine climb to 129 — and the fitted slope came out at **-52.7/min**
+ * while the queue was visibly rising about 1/sec. So Early Warning reported `not_rising` right through
+ * the ramp and then jumped straight to `already_crossed`. That is exactly what was reported: "I don't
+ * see it activated when Pool Bottleneck is used. it just goes from nothing to Critical."
+ *
+ * THE SAME RULE THE ERROR RATE ALREADY USES. `engine.ts`'s `#errorsPerMinute` treats a counter going
+ * backwards as "the production restarted, so reset rather than report a negative rate". The difference
+ * is that a queue is NOT a monotonic counter: it drains and refills constantly, and the trend across
+ * that is the real signal. So a small dip must not reset anything, and the test is proportional rather
+ * than "any decrease".
+ *
+ * Returns the samples AFTER the cliff, which means a freshly drained host reports
+ * `insufficient_samples` — an honest "ask again shortly" — rather than a projection fitted across a
+ * discontinuity. That is the right trade: a wrong forecast is worse than a withheld one.
+ */
+function sinceLastDiscontinuity(samples: readonly Sample[]): readonly Sample[] {
+  // Backwards, because only the NEWEST cliff matters: anything older is already excluded by it.
+  // Stopping at the first hit keeps this O(n) and allocation-free when there is no discontinuity,
+  // which is the common case.
+  for (let i = samples.length - 1; i >= 1; i -= 1) {
+    const previous = samples[i - 1]?.value ?? 0;
+    const current = samples[i]?.value ?? 0;
+    // `previous > 0` guards two things: a division that would be meaningless at zero, and the far
+    // more important case of a ramp STARTING from zero — 0 -> 8 is the signal, not a collapse.
+    if (previous > 0 && current < previous * (1 - DISCONTINUITY_FRACTION)) {
+      return samples.slice(i);
+    }
+  }
+  return samples;
+}
+
 function fitSlopePerMs(samples: readonly Sample[]): number | null {
   const n = samples.length;
   if (n < 2) return null;
@@ -163,7 +218,9 @@ export function projectHost(
   now: number,
 ): HostProjection {
   const ew = config.earlyWarning;
-  const samples = baselines.recent(host, METRIC, now, ew.fitWindowSeconds * 1000);
+  const samples = sinceLastDiscontinuity(
+    baselines.recent(host, METRIC, now, ew.fitWindowSeconds * 1000),
+  );
   const first = samples[0];
   const last = samples.at(-1);
 

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -248,3 +248,122 @@ describe('the null-complement invariant', () => {
     }
   });
 });
+
+/**
+ * A drain inside the fit window used to poison the slope.
+ *
+ * Reported from a live demo walkthrough: "I don't see it activated when Pool Bottleneck is used. it
+ * just goes from nothing to Critical." Reproduced on the running stack — the 300s window straddled a
+ * reset, holding
+ *
+ *     263 268 ... 350 355 | 0 0 ... 0 | 8 13 ... 124 129
+ *
+ * and the fit returned **-52.7/min** while the queue climbed ~1/sec. Early Warning therefore reported
+ * `not_rising` throughout the ramp and jumped straight to `already_crossed`.
+ *
+ * These tests pin the fix from both sides: the cliff must not poison a real rise, and an ordinary
+ * drain must NOT be mistaken for one — a queue that dips while draining and refilling is the normal
+ * case, and discarding history on every dip would throw away the trend this module exists to find.
+ */
+describe('a drain inside the fit window does not poison the slope', () => {
+  /** Rise, collapse to zero, then rise again — the shape a reset leaves behind. */
+  function withDrain(preDrain: number, postDrain: number, perSample: number) {
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    let q = 0;
+    for (let i = 0; i < preDrain; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += perSample;
+    }
+    // The cliff: one poll, all the way to zero.
+    q = 0;
+    for (let i = 0; i < postDrain; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += perSample;
+    }
+    const lastAt = at - POLL;
+    const lastValue = q - perSample;
+    return projectHost(HOST, raw(lastValue), store, cfg, lastAt);
+  }
+
+  it('projects from the samples after the drain, not across it', () => {
+    // Pre-drain climbs to 95 (well past the floor of 50); post-drain climbs only to 30, so the
+    // EXPECTED outcome is a projection rather than already_crossed. Fitted across the cliff the
+    // slope is steeply negative; fitted after it, it is +60/min. Getting this wrong first time is
+    // instructive: a post-drain series above the threshold is already_crossed and says nothing
+    // about the slope, so it cannot test this at all.
+    // 14 post-drain samples reach 65, which is past the floor of 50 and therefore already_crossed --
+    // true, but it tests nothing about the slope. 8 reaches 35, under the floor, so a projection is
+    // the correct expectation. minFitSamples is 12, so the truncated window must still be large
+    // enough to fit: 8 alone would be insufficient_samples, which is why the assertion below also
+    // checks the sample count rather than only the reason.
+    const p = withDrain(20, 12, 3);
+    assert.equal(
+      p.projectionUnavailable,
+      null,
+      `a queue rising after a drain must still project, got ${String(p.projectionUnavailable)}`,
+    );
+    assert.ok(p.projection !== null, 'expected a projection');
+    assert.ok(
+      p.projection.slope > 0,
+      `slope must be positive for a rising queue, got ${p.projection.slope}`,
+    );
+  });
+
+  it('does not treat ordinary draining as a discontinuity', () => {
+    // A queue shedding a fifth of itself each poll is draining, not restarting. It must NOT project
+    // a crossing, and the reason must be `not_rising` rather than a cliff-truncated window.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    let q = 400;
+    const values: number[] = [];
+    for (let i = 0; i < 20; i += 1) {
+      values.push(Math.round(q));
+      store.record(HOST, 'queued', Math.round(q), at);
+      at += POLL;
+      q *= 0.8;
+    }
+    const lastValue = values[values.length - 1] as number;
+    const p = projectHost(HOST, raw(lastValue), store, cfg, at - POLL);
+    // A 20%-per-poll drain never trips the 80% cliff test, so the window is intact and the slope is
+    // negative -- which is `not_rising`. What must NOT happen is the window being truncated to a
+    // couple of samples, which would report insufficient_samples and hide a real drain.
+    assert.equal(p.projectionUnavailable, 'not_rising');
+    assert.ok(
+      p.fitSampleCount >= 12,
+      `an ordinary drain must keep its window, got ${p.fitSampleCount} samples`,
+    );
+  });
+
+  it('keeps the whole window when nothing collapsed', () => {
+    // The no-discontinuity path must be unchanged: a plain ramp still projects exactly as before.
+    // 20 samples at +2 reaches 38, under the floor of 50, so a projection is the right expectation --
+    // +5 would reach 95 and be already_crossed, which tests the wrong thing (I made that mistake
+    // twice in this suite before reading the floor).
+    const p = ramp(20, 2);
+    assert.equal(p.projectionUnavailable, null);
+    assert.ok(p.projection !== null && p.projection.slope > 0);
+  });
+
+  it('treats a rise from zero as a ramp starting, not a collapse', () => {
+    // 0 -> 8 is an 800% RISE, but the guard divides by the previous value, so a zero previous must
+    // not be read as a discontinuity. Without the `previous > 0` guard every ramp's first sample
+    // would truncate the window to itself.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (const v of [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 13, 18, 23, 28, 33, 38, 43]) {
+      store.record(HOST, 'queued', v, at);
+      at += POLL;
+    }
+    const p = projectHost(HOST, raw(43), store, cfg, at - POLL);
+    assert.ok(
+      p.fitSampleCount > 2,
+      `the window must not be truncated to the rise itself, got ${p.fitSampleCount} samples`,
+    );
+  });
+});


### PR DESCRIPTION
Reported from a demo walkthrough: *"I don't see it activated when Pool Bottleneck is used. it just goes from nothing to Critical."*

## The cause is not what the symptom suggests

Reproduced on the running stack. The 300s fit window straddled a queue drain, holding:

```
263 268 273 ... 350 355 | 0 0 0 ... 0 | 8 13 18 ... 124 129
```

A fall of 355 followed by a genuine climb to 129 — and the least-squares fit returned **−52.7/min** while the queue was visibly rising ~1/sec. So the module reported `not_rising` right through the ramp and then jumped to `already_crossed`. **Nothing, then critical**, exactly as described.

The fit itself is correct; it was being asked to fit across a discontinuity. **Any** queue drain does this — an operator's reset, `Triggers.Reset()`, or the approved fix draining the backlog — so the demo hit it every single time, and the module was effectively dead on the one scenario it was built for.

## The same rule the error rate already uses

`engine.ts`'s `#errorsPerMinute` treats a counter going backwards as *"the production restarted, so reset rather than report a negative rate"*. `sinceLastDiscontinuity()` applies that to the series, with one difference that matters: **a queue is not a monotonic counter.** It drains and refills constantly and the trend across that is the real signal, so a small dip must not reset anything.

Hence a **proportional** test rather than "any decrease" — a fall to below 20% of the previous sample:

- **Scale-free**, so it behaves the same on a queue of 40 and one of 4,000. An absolute threshold would need tuning per host and per metric, which is ADR 0003's "no numbers in rule logic" problem.
- **80% is far above ordinary draining.** At the shipped 5s poll, a host clearing 4/sec sheds 20 messages a tick — 6% of a 350-deep queue.
- **Not in `thresholds.json`, deliberately.** ADR 0003 governs numbers that decide what *fires*; this is the definition of "the series restarted", a sanity check on the arithmetic, and no operator would tune it.

A freshly drained host now reports `insufficient_samples` — an honest *"ask again shortly"* — rather than a projection fitted across a cliff. A wrong forecast is worse than a withheld one.

## Verified live, which is where it was reported

```
q=0    not_rising                    <- correctly silent (and the false projections it
q=5    beyond_horizon                   used to emit at q=0 are gone too)
q=25   eta=600s  slope=2.5/min
q=35   eta=220s  slope=4.1/min       <- ETA tightening as the ramp steepens
q=40   eta=120s  slope=5.0/min
q=50   already_crossed
```

That is the "queue rising, crosses in ~N minutes" story the module exists for, and **it had never once appeared on this scenario**.

Worth noting the second half of the same defect, now also fixed: before this, Early Warning emitted *projections while the queue sat at zero* (`eta=307s slope=9.8`) — forecasting a crossing from residual noise. It is now silent when nothing is happening and speaks when something is.

## Four tests, and I got the data wrong three times before reading the floor

The threshold is `queue_buildup`'s `absoluteFloor` of 50, so a test series that climbs past it is `already_crossed` and says nothing about the slope. That is recorded in the test comments, because it is the trap anyone extending this suite will hit.

The four pin: a rise after a drain still projects; ordinary draining is **not** treated as a discontinuity and keeps its window; an undisturbed ramp is unchanged; and a rise **from zero** is a ramp starting rather than a collapse — without the `previous > 0` guard, every ramp's first sample would truncate the window to itself.

```
312 engine tests pass (was 308) · engine tsc --noEmit clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)