### PR TITLE
fix(dashboard): make the host graphs live, and quiet the trigger rail

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -86,18 +86,23 @@ export function App(): JSX.Element {
     [refresh],
   );
 
-  const { failureCount, pollNow } = usePolling({ onTick, intervalMs });
+  const { failureCount, tickCount, pollNow } = usePolling({ onTick, intervalMs });
 
   /* Early Warning rides the SAME tick as the findings poll rather than its own timer: a projection
      shown next to a queue depth from a different moment would be two readings pretending to be one,
      and two independent intervals would drift apart within minutes. Failures are swallowed inside
      the hook -- a missing forecast must never blank a host card that has real metrics on it. */
-  const projections = useProjections(api, failureCount);
+  const projections = useProjections(api, tickCount);
 
   /* The selected host's three series, on the SAME tick as everything else -- so the graphs and the
      numbers beside them describe one moment. Requests nothing while `selectedHost` is null, which is
-     most of the time. `failureCount` is the poll signal, exactly as for `useProjections`. */
-  const hostSeries = useHostSeries(api, selectedHost, failureCount);
+     most of the time. `tickCount` is the poll signal, exactly as for `useProjections`.
+
+     BOTH READ `tickCount`, NOT `failureCount`, and that is the fix for "the graphs are frozen": a
+     success following a success leaves `failureCount` at 0, so the effect keyed on it never re-ran
+     and each of these fetched once per host selection and never again. `failureCount` still goes to
+     the banner below, which is the thing it actually measures. */
+  const hostSeries = useHostSeries(api, selectedHost, tickCount);
 
   /* The activity conversation, NOT keyed to a finding -- unlike `useInvestigation` below, which
      clears itself when the selection changes because an investigation explains one finding. A chat

--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -127,9 +127,14 @@ type Phase = 'idle' | 'activating' | 'activated';
  *
  * `refused` is the local answer to a click that made no request — a different fact from `error`,
  * which is something the server said, and rendered differently for that reason.
+ *
+ * THERE IS NO `log` KIND ANY MORE. The dispatcher still captures and returns the trigger's own
+ * multi-line narration and the engine still carries it — see the `log` comment in `post` — it is
+ * simply not rendered. A kind nothing can construct would be the dead branch that invites someone
+ * to reach for it again.
  */
 interface TriggerMessage {
-  kind: 'log' | 'note' | 'error' | 'refused';
+  kind: 'note' | 'error' | 'refused';
   text: string;
 }
 
@@ -220,25 +225,51 @@ export function TriggerRail(): JSX.Element | null {
         }
 
         /*
-         * THE CAPTURED `log` IS THE POINT OF THIS SLOT, not a debugging leftover. Each trigger writes
-         * what it armed, which findings to expect and which deliberately will NOT fire; the
-         * dispatcher captures that text to a file so it cannot corrupt the JSON body and returns it
-         * (see `TriggerDispatcher.Arm`). It then crossed one process boundary and was dropped by the
-         * engine's own parser, and would have been dropped here too.
+         * ── `log` IS NOT RENDERED. THIS IS A DISPLAY DECISION, MADE HERE. ──
          *
-         * BOTH FIELDS WHEN BOTH ARE PRESENT. A reset returns a long `log` of what it restored AND a
-         * `note` about the one thing it cannot — the buffered `system_alert` — and that note is the
-         * question a presenter asks ten seconds later, so it must not be shadowed by the log. A
-         * jobbed arm is the reverse: `log` is empty because there is no output yet, and `note`
-         * explains the warm-up. Neither case needs a branch.
+         * The field is still returned by `TriggerDispatcher.Arm` and still parsed by the engine's
+         * `triggers.ts`, and both keep their tests and their reasons. It remains genuinely useful to
+         * a `curl` caller: it is each trigger's own account of what it armed, which findings to
+         * expect and which deliberately will NOT fire, and it is the best written explanation of
+         * these scenarios anywhere. Nothing about capturing it was wrong — @Ari-Glikman asked for it
+         * on screen, saw it there, and asked for it to go: "the demo triggers output too much info
+         * when I click on them. I don't need that message. trigger activating/activated is enough."
+         *
+         * ELEVEN LINES OF MONOSPACED NARRATION IN A NAV RAIL was the measured reality, not a
+         * paraphrase: `missing_folder` rendered 11 lines / 726 characters and `closed_port` 4 lines,
+         * under a button whose own state word is two. So it is cut at the point where it becomes
+         * pixels rather than at the point where it is produced — deleting the capture would remove
+         * the text from the API too, and one presenter not wanting it on a projector is not a reason
+         * to stop a terminal from being able to read it.
+         *
+         * ── `note` SURVIVES, AND IT IS THE ONE JUDGEMENT CALL HERE ──
+         *
+         * Both notes this system produces are ONE LINE and each answers a question the state word
+         * immediately provokes, rather than restating it:
+         *
+         *   pool_bottleneck   "Warming the baseline at zero for ~75s before arming, so
+         *                      queue_buildup can fire..."
+         *   reset             "Findings clear within ~10s. A system_alert finding persists until it
+         *                      ages out of the proxy's buffer."
+         *
+         * The first is close to load-bearing. `pool_bottleneck` reads "trigger activating…" for
+         * about 75 seconds — the longest wait in the demo, and the whole reason the middle state
+         * exists (#135) — and a word that sits unchanged that long reads as a hang to everyone
+         * except the person who wrote it. The note is what makes the wait legible. Cutting it would
+         * re-create the defect the three-state rail was built to fix, one layer up.
+         *
+         * The second answers the question a presenter asks ten seconds after pressing Reset: the
+         * finding is still on screen, and the note is the difference between "the reset failed" and
+         * "that one finding lives in the proxy, not in IRIS". Cheaper on screen than being asked.
+         *
+         * So the line kept is the one that explains a state the operator can see and cannot
+         * otherwise account for; the text cut is the one that explains a scenario they chose
+         * deliberately and already know. Both notes are prose, so the `log` kind and its monospaced
+         * styling have no remaining caller.
          */
-        const log = typeof payload['log'] === 'string' ? payload['log'].trim() : '';
         const note = typeof payload['note'] === 'string' ? payload['note'].trim() : '';
-        const text = [log, note].filter((part) => part !== '').join('\n\n');
-        if (text !== '') {
-          // `log` when there is captured output, because that text is preformatted and aligned and is
-          // rendered monospaced; a bare note is prose.
-          say(key, { kind: log !== '' ? 'log' : 'note', text });
+        if (note !== '') {
+          say(key, { kind: 'note', text: note });
         }
       } catch (err) {
         say(key, { kind: 'error', text: err instanceof Error ? err.message : 'request failed' });
@@ -412,9 +443,11 @@ export function TriggerRail(): JSX.Element | null {
  * including errors: swapping a node's role between `status` and `alert` is unreliable, and a failed
  * demo trigger is not an emergency. The error tone is carried by a class and a leading word.
  *
- * The dispatcher's captured log is PLAIN TEXT, not markup, and is rendered as text. `white-space:
- * pre-wrap` keeps its line breaks and two-space indents, which is the whole reason it is readable;
- * `dangerouslySetInnerHTML` would be both wrong and unsafe for output that quotes settings and paths.
+ * WHAT REACHES HERE IS NOW ONE LINE AT MOST — a one-sentence `note`, a server `error`, or a local
+ * `refused` — since the dispatcher's multi-line captured log is no longer rendered (see `post`). All
+ * three are prose rather than preformatted output, so nothing here depends on the log's alignment
+ * surviving. Every kind is still rendered as TEXT and never as markup: these strings quote settings
+ * and filesystem paths, so `dangerouslySetInnerHTML` would be both wrong and unsafe.
  */
 function TriggerNote({ message }: { message: TriggerMessage | undefined }): JSX.Element {
   return (

--- a/apps/dashboard/src/hooks/useHostSeries.ts
+++ b/apps/dashboard/src/hooks/useHostSeries.ts
@@ -1,10 +1,21 @@
 /**
  * One host's metric series, refetched on the same cadence as the findings poll.
  *
- * WHY IT PIGGYBACKS ON `failureCount` RATHER THAN OWNING A TIMER — the same reasoning as
+ * WHY IT PIGGYBACKS ON `usePolling`'s TICK RATHER THAN OWNING A TIMER — the same reasoning as
  * `useProjections`, which this deliberately mirrors rather than reinventing. `usePolling` already
  * pauses while the tab is hidden, backs off on failure and refetches on becoming visible; a second
  * interval here would drift out of step, so the panel's graphs could show a moment the cards do not.
+ *
+ * THE GRAPHS WERE FROZEN AT CLICK TIME UNTIL `tick` BECAME `tickCount` (reported by @Ari-Glikman:
+ * "I would like the graphs to be live, I think they are only to the moment I click on the host").
+ * The mechanism was always right and the SIGNAL was wrong: `tick` was `usePolling`'s `failureCount`,
+ * which on a healthy stack is 0 forever, so the effect below ran once per host selection and never
+ * again. Measured in the served bundle before the fix — one request to `/api/hostseries` across 14
+ * seconds at a 2s cadence, and the queued polyline pinned at 36 points for all of them.
+ *
+ * Nothing in this file needed a new mechanism for that, which is the point of riding a shared timer:
+ * the abort-per-tick, the visibility pausing and the keep-the-previous-series-on-failure rules below
+ * were all written for the polling case and were already correct for it.
  *
  * KEYED ON THE SELECTED HOST, and `null` means no request at all. The panel is closed most of the
  * time and a series is the largest payload the dashboard fetches, so nothing is asked for until a

--- a/apps/dashboard/src/hooks/usePolling.ts
+++ b/apps/dashboard/src/hooks/usePolling.ts
@@ -14,6 +14,13 @@
  * every entry point clears the pending timer first. Rescheduling logic lives in
  * exactly one place so a visibility change and a manual retry cannot each leave
  * a timer chain running.
+ *
+ * OTHER HOOKS RIDE THIS TIMER RATHER THAN OWNING ONE, which is what makes the
+ * "one timer only" rule above true of the whole page rather than only of this
+ * file. `useProjections` and `useHostSeries` each key an effect on `tickCount`
+ * and get the pausing, the backoff and the visibility catch-up for free. That
+ * makes `tickCount` part of this hook's contract, not an incidental return —
+ * see its doc comment for what using `failureCount` for it cost.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -56,12 +63,34 @@ export interface UsePollingResult {
   currentDelayMs: number;
   /** Consecutive failures; 0 after any success. Drives the banner's escalation. */
   failureCount: number;
+  /**
+   * Completed ticks, counting from 0 and incrementing on EVERY tick regardless of outcome.
+   *
+   * THE POLL SIGNAL FOR HOOKS THAT RIDE THIS TIMER, and it exists because `failureCount` was being
+   * used as one and is not one. `useProjections` and `useHostSeries` both keyed an effect on
+   * `failureCount`, documenting it as "changes on every tick (success resets it to 0, failure
+   * increments)" — but a success after a success resets 0 to 0, which is not a change, so React
+   * re-ran neither effect. On a healthy stack both fetched exactly ONCE and never again. Measured in
+   * the served bundle over 14s at a 2s cadence: 1 request to `/api/hostseries` and 0 to
+   * `/api/earlywarning` against 6 to `/hosts`.
+   *
+   * So the signal only worked while the API was failing, which is the inverse of when anyone is
+   * watching. A monotonic counter cannot have that failure mode: it changes on every tick by
+   * construction, and no reader has to reason about whether the previous tick's outcome differed
+   * from this one's.
+   *
+   * INCREMENTED AFTER the tick's own work settles, so a hook keyed on it fetches alongside the next
+   * poll rather than racing this one — and incremented on failure too, because a rider that swallows
+   * its own errors (both do) should still get its chance to retry on the backed-off cadence.
+   */
+  tickCount: number;
   /** Fetch now, resetting backoff and the timer. Wired to the banner's retry. */
   pollNow: () => void;
 }
 
 export function usePolling({ onTick, intervalMs }: UsePollingOptions): UsePollingResult {
   const [failureCount, setFailureCount] = useState(0);
+  const [tickCount, setTickCount] = useState(0);
   const [currentDelayMs, setCurrentDelayMs] = useState(intervalMs);
 
   const timerRef = useRef<number | null>(null);
@@ -104,6 +133,17 @@ export function usePolling({ onTick, intervalMs }: UsePollingOptions): UsePollin
         failuresRef.current += 1;
         setFailureCount(failuresRef.current);
       }
+    }
+
+    /* THE TICK HAPPENED, whatever came of it — announced after the outcome above is recorded so a
+       rider reading both sees one consistent moment. Skipped for an ABORTED tick, because an abort
+       means this tick was superseded by a newer one (or by unmount) and never produced a reading;
+       announcing it would ask every rider to fetch for a moment that does not exist.
+
+       Guarded on `stoppedRef` for the same reason the reschedule below is: a promise resolving after
+       teardown must not set state on an unmounted component. */
+    if (!controller.signal.aborted && !stoppedRef.current) {
+      setTickCount((previous) => previous + 1);
     }
 
     if (stoppedRef.current || document.hidden) return;
@@ -158,5 +198,5 @@ export function usePolling({ onTick, intervalMs }: UsePollingOptions): UsePollin
     void runAndReschedule();
   }, [runAndReschedule, clearTimer]);
 
-  return { currentDelayMs, failureCount, pollNow };
+  return { currentDelayMs, failureCount, tickCount, pollNow };
 }

--- a/apps/dashboard/src/hooks/useProjections.ts
+++ b/apps/dashboard/src/hooks/useProjections.ts
@@ -1,15 +1,17 @@
 /**
  * Early Warning projections, on the same cadence as the findings poll.
  *
- * WHY IT PIGGYBACKS ON `failureCount` RATHER THAN OWNING A TIMER. `usePolling` already decides when
- * to fetch — it pauses while the tab is hidden, backs off on failure, and refetches on becoming
+ * WHY IT PIGGYBACKS ON `usePolling`'s TICK RATHER THAN OWNING A TIMER. `usePolling` already decides
+ * when to fetch — it pauses while the tab is hidden, backs off on failure, and refetches on becoming
  * visible. A second interval here would drift out of step within minutes, so a card could show a
  * queue depth from one moment beside a projection from another. Two readings pretending to be one
  * is the defect `earlywarning-api.md` §1.4 is written against, one level up.
  *
- * `failureCount` changes on every tick (success resets it to 0, failure increments), which makes it
- * a usable "the poll just happened" signal without threading a new callback through `usePolling`.
- * That is a little indirect and it is the reason this comment exists.
+ * `tick` IS `usePolling`'s `tickCount`, AND IT USED TO BE `failureCount`, WHICH DID NOT WORK. The
+ * claim was that `failureCount` "changes on every tick (success resets it to 0, failure
+ * increments)" — but 0 reset to 0 is not a change, so on a healthy stack this effect ran once at
+ * mount and never again. Measured in the served bundle: 0 requests to `/api/earlywarning` over 12s
+ * against 6 to `/hosts`. `tickCount` is monotonic, so it cannot have that failure mode.
  *
  * FAILURES ARE SWALLOWED, DELIBERATELY. A projection is decoration on a card whose metrics are real;
  * losing the forecast must not blank the card or raise the connection banner. So the previous value

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1875,9 +1875,10 @@ button {
   padding: 0 var(--pg-space-4);
   font-size: 10.5px;
   line-height: 1.45;
-  /* The dispatcher's captured log is preformatted plain text — indented lines, aligned arithmetic, an
-     ARMED header. `pre-wrap` is what makes it legible; without it the whole explanation collapses
-     into one paragraph. `break-word` because it quotes filesystem paths that do not wrap. */
+  /* `pre-wrap` KEPT although the preformatted log it was added for is no longer rendered: these are
+     server and dispatcher strings, and one arriving with a line break should break there rather than
+     be reflowed into a run-on sentence. `break-word` because they quote filesystem paths, which have
+     no wrap opportunity of their own. */
   white-space: pre-wrap;
   overflow-wrap: break-word;
   color: rgb(255 255 255 / 62%);
@@ -1887,17 +1888,11 @@ button {
   display: none;
 }
 
-/* The captured trigger log, monospaced because its own alignment is load-bearing. Inset with a rule
-   down the left so a block of narration reads as output belonging to the button above it rather than
-   as more rail chrome. */
-.pg-triggers__msg--log {
-  margin-left: var(--pg-space-4);
-  padding: var(--pg-space-1) 0 var(--pg-space-1) var(--pg-space-2);
-  border-left: 1px solid rgb(255 255 255 / 18%);
-  font-family: var(--pg-font-mono);
-  font-size: 10px;
-  color: rgb(255 255 255 / 66%);
-}
+/* `.pg-triggers__msg--log` was the monospaced, left-ruled block for the dispatcher's captured
+   narration and is gone: the log is no longer rendered, so nothing can construct that kind. Removed
+   rather than left as a dead rule, for the same reason the shared-slot rules above were — a rule
+   matching nothing is what someone reaches for next time. The `log` field itself is unchanged and
+   still returned; see `post` in TriggerRail.tsx. */
 
 /* A refusal is not a failure — nothing went wrong and nothing was sent. Accent tone rather than
    warning, and italic so it reads as the panel answering rather than the server reporting. */


### PR DESCRIPTION
Two things reported by @Ari-Glikman while walking through the demo. Unrelated in the UI, both in `apps/dashboard/**`.

Verified in the **served bundle** after `docker compose up -d --build dashboard`, per `apps/dashboard/CLAUDE.md` §6.1 — not in source, and not via `npm run build`.

---

## 1. The host graphs were frozen — and the cause was not the missing interval it looked like

> *"I would like the graphs to be live, I think they are only to the moment I click on the host."*

`useHostSeries` already had the entire polling mechanism: an effect keyed on a `tick` prop, an `AbortController` per tick, and the deliberate keep-the-previous-series-on-a-failed-parse rule. **The signal was wrong, not the mechanism.**

`App` passed `usePolling`'s `failureCount`, which both `useHostSeries` and `useProjections` documented as *"changes on every tick (success resets it to 0, failure increments)"*. A success after a success resets 0 to 0 — **not a change**, so React re-ran neither effect. The signal only worked while the API was *failing*, which is the inverse of when anyone is watching.

### Early Warning was frozen too

Not in the report, and found only because the fix had to be made in the signal the two hooks share. A projection that never updates looks like a projection. Measured in the served bundle **before** the fix, by instrumenting in-page `fetch` and driving the real UI in Chrome over CDP:

| endpoint | requests | window |
|---|---|---|
| `/api/hostseries` | **1** | 14s (queued polyline pinned at 36 points) |
| `/api/earlywarning` | **0** | 12s |
| `/hosts` | 6 | 12s — the shared timer was fine all along |

### The fix is in `usePolling`, not in the two riders

`usePolling` now returns `tickCount`, a monotonic counter incremented after each tick's outcome is recorded. Both riders key on that.

**Reused rather than reinvented**, per §4.4's *"one timer, owned by `usePolling`"*. A second interval in the panel would drift out of step with the cards, so the graphs could show a moment the numbers beside them do not. A monotonic counter also cannot have the original failure mode — no reader has to reason about whether this tick's outcome differed from the last one's.

Two deliberate details:

- **Incremented on failure as well as success**, because both riders swallow their own errors and should still retry on the backed-off cadence.
- **Not incremented for an aborted tick.** An abort means the tick was superseded and produced no reading; announcing it would ask every rider to fetch for a moment that does not exist. Guarded on `stoppedRef` like the reschedule beside it, so a late promise cannot set state after teardown.

`failureCount` is unchanged and still drives the connection banner, which is the thing it actually measures.

### Evidence the series advances

One request per tick, **no stacking** — inter-request gaps in ms:

```
[1698, 2015, 2005, 2014, 2017, 2015, 2016]      8 requests / 14s at a 2s cadence
```

Point count saturates at the engine's 120-sample window, so it cannot prove liveness by itself. Recording the newest timestamp in each response body does, and with `pool_bottleneck` armed the **rendered** value moves with it:

```
newest 10:52:29Z   Queue depth 29      6 distinct engine samples across 20s,
newest 10:52:34Z   Queue depth 34      at the engine's own 5s cadence
newest 10:52:39Z   Queue depth 39
newest 10:52:44Z   Queue depth 44
newest 10:52:49Z   Queue depth 49
newest 10:52:54Z   Queue depth 54
```

### The other three requirements, each driven through the UI's own path

| requirement | result |
|---|---|
| **Host switch shows no stale data** | Cloud API → Lab Router: first frame reads "Collecting samples", then Lab Router's **own** 1.2/s. **0 of 16 frames** showed the new heading over the old series. |
| **Hidden-tab pausing** | **0 requests** across 8s hidden; **+1 within 1.5s** of becoming visible. |
| **A failed tick does not blank the graphs** | `/api/hostseries` → `ConnectionRefused` for 10s with the rest of the dashboard healthy: 5 failures, **3 polylines still drawn**, `aria-label` byte-identical, and neither "Collecting samples" nor "Not measurable" appeared. Recovered on the next success. |

The host-switch check is compared on **throughput, not queue depth**, and that took two false positives to get right: every idle host has an identical queue series (`"120 samples, latest 0, unchanged"`), so a queue comparison cannot tell "cleared correctly" from "showed the old host's data". Cloud API and EMR Source *also* share a throughput range (0.4–0.6/s), so **Lab Router (0.8–1.2/s) is the only switch this can actually distinguish.**

The keep-the-previous-series rule was already in the hook and written for the fetch-once case. It is now load-bearing every 2 seconds, which is why it was re-proved rather than assumed.

---

## 2. The trigger rail printed too much

> *"the demo triggers output too much info when I click on them. I don't need that message. trigger activating/activated is enough."*

**Cut in the display layer only.** `TriggerDispatcher.Arm` still captures the log and `services/detection-engine/src/detect/triggers.ts` still carries it — tests and comments intact. It remains genuinely useful to a `curl` caller, and the reasoning for capturing it was never wrong; a presenter not wanting it on a projector is not a reason to stop a terminal from reading it. Stated in a comment at the cut site. **No IRIS or engine file is touched.**

What was actually on screen, measured rather than paraphrased:

| trigger | before | after |
|---|---|---|
| `missing_folder` | 11 lines / 726 chars of monospaced narration | **0** |
| `closed_port` | 4 lines / 284 chars | **0** |
| `reset` | 12 lines / 650 chars | **0** |

### `note` is kept — the judgement call

Both notes this system produces are **one line**, and each answers a question the state word provokes rather than restating it:

```
pool_bottleneck   "Warming the baseline at zero for ~75s before arming..."    127 chars
reset             "Findings clear within ~10s. A system_alert finding..."     100 chars
```

The first is close to load-bearing. `pool_bottleneck` reads `trigger activating…` for **~75 seconds** — the longest wait in the demo, and the entire reason the middle state exists (#135). A word unchanged that long reads as a hang to everyone except the person who wrote it, and this note is what makes the wait legible. Cutting it would re-create the defect the three-state rail was built to fix, one layer up.

The second answers the question asked ten seconds after pressing Reset, when a finding is still on screen: it is the difference between *"the reset failed"* and *"that one finding lives in the proxy, not in IRIS"*.

**The line kept explains a state the operator can see and cannot otherwise account for; the text cut explains a scenario they chose deliberately and already know.**

### `error` and both refusals are untouched, and re-proved

Silence there would be a worse bug than the verbosity removed. Forced the arm POST to 504 with an HTML body — the real nginx-timeout shape the code has a branch for — and the rail still renders `Failed: The request timed out at the proxy after 504...`, with the `Failed: ` tag that keeps an error from being signalled by colour alone (§7.3).

Worth noting: intercepting `*/api/demo/trigger*` also matched the `/triggers` **status poll** and hid the whole rail. That is correct app behaviour — `parseState` cannot trust an HTML body — and was my probe's bug, not the UI's.

### Before / after, as rendered on the live rail

| case | before | after |
|---|---|---|
| `missing_folder` armed | `trigger activated` + 11 lines | `trigger activated`, slot **0 chars** |
| second click on it | refusal | refusal, **unchanged** |
| `Reset all` | note + 12-line log | **note only**, 100 chars |
| `pool_bottleneck` | note | `trigger activating…` + note |
| arm fails (504) | `Failed: …` | `Failed: …`, **unchanged** |

The `log` **kind** is removed from `TriggerMessage` rather than left constructible, and `.pg-triggers__msg--log` is deleted rather than left as a dead rule — the same reasoning the shared-slot rules above it were removed with. `white-space: pre-wrap` is **kept** with its comment rewritten: the log it was added for is gone, but a server string arriving with a line break should still break there.

---

## Gates

```
dashboard tsc --noEmit       clean
validate-architecture.mjs    ok — 8 labels, 12 paths, no overlaps
fixtures + fixture-claims    green, 8 scenarios
app.css braces               333 / 333   (was 334/334; one rule removed)
single-file fallback         no non-data: src or href in the served dist/index.html
engine tests                 312 pass / 0 fail
```

**The 308 engine-test baseline in my brief is stale.** Verified rather than assumed, by running the suite against a pristine `git archive` of `HEAD` in a clean directory: **312 there too.** No engine file is touched by this PR — the three modified ones in the working tree belong to a concurrent agent and were left alone.

`app.css` was changed in **two localised hunks** at the existing trigger rules; nothing above was reformatted.

## Notes

§6.1's trap fired on me first, which is worth recording: my opening probe found **no host cards at all** and I nearly diagnosed a missing feature, when Chrome was serving a cached page — the same class of *"healthy container, wrong UI, nothing says why"* that section is written about. Every measurement here is from a hard reload with the cache disabled.

**Stack left demo-ready:** no scenario armed, 0 findings, all three hosts OK with traffic flowing, `Ens.Util.Log` purged (960 rows). The two findings immediately after the drain (`slow_processing`, `growing_queue_wait` on Cloud API) were true readings of a real wait and aged out on their own; re-checked at 0 before finishing.

**Not merging** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
