### PR TITLE
fix(iris): PollInterval does not exist — plus, unintentionally, two other agents' work (see comment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,64 @@ automatic — see below. Measured at **64 seconds** to all four services healthy
 volume (Windows host, Docker Desktop, IRIS 2026.3.0AI Build 126U).
 
 `./docker/up.sh` does the same thing and additionally runs the preflight image check, which
-`compose up` cannot do for itself.
+`compose up` cannot do for itself. It is a POSIX shell script with no `.ps1` counterpart — on
+Windows, see below.
 
 Then open **http://localhost:5173/?mode=live**
 
 `?mode=live` matters. Without it the dashboard serves demo fixtures rather than live IRIS
 data — which is the intended fallback, not a failure.
+
+### On Windows
+
+Everything here works on Windows, and `docker compose …` is byte-identical — those commands are
+not repeated, because a paired block whose two halves are the same bytes is noise that later
+rots. What does *not* survive a copy-paste is the list below, stated once here rather than at
+every command site. The shell documented is **PowerShell**, because it ships with Windows and is
+therefore the one a reader actually has. Only the blocks where the translation is more than a
+substitution — the log pipelines and the JSON POSTs — are paired at the point of use.
+
+| this README says | PowerShell |
+|---|---|
+| `export PG_AGENT_MODE=live` | `$env:PG_AGENT_MODE = 'live'` |
+| `… \| grep pg-firstboot` | `… \| Select-String pg-firstboot` |
+| `curl -s <url>` | `curl.exe -s <url>` |
+| `curl -XPOST … -d '{…}'` | `curl.exe --% -XPOST … -d "{…}"` — one line, no variables |
+
+**`$env:` is enough for compose to see it.** Verified rather than assumed, because the reverse
+already bit us once from the shell side: an exported variable does not reach a container unless
+compose passes it (`docker-compose.yml` says so where `PG_LLM_API_KEY` is declared). A
+`$env:PG_LLM_API_KEY = 'sk-…'` set in the same window does show up in `docker compose config`.
+
+**`curl.exe`, never `curl`.** In PowerShell 5.1 — the version that ships — `curl` is an alias
+for `Invoke-WebRequest`, so `curl -s <url>` fails with `Cannot process command because of one or
+more missing mandatory parameters: Uri`. That reads like a bad URL rather than a wrong `curl`,
+which is why it is worth naming. `curl.exe` is the real thing and is present on Windows 11
+(`C:\Windows\System32\curl.exe`).
+
+**A JSON body needs `--%`, and that is not a style preference.** Measured against a local echo
+server, every obvious spelling loses the body: `-d '{"a":"b"}'` arrives as `{a:b}` (PowerShell
+hands the string to a native exe unquoted and the CRT eats the quotes), `-d "{\"a\":\"b\"}"`
+arrives as `{\`, and `-d "{""a"":""b""}"` arrives as `{a:b}`. `-d '{\"a\":\"b\"}'` does survive
+— **until a value contains a space**, and `"Cloud API"` does, so the resolve body truncates at
+`{"mode":"dry_run","action":{"type":"set_pool_size","host":"Cloud`. `--%` is the fix:
+PowerShell stops parsing there and passes the rest of the line to the exe verbatim. It costs
+two things — the command must be **one line** (a backtick continuation is passed through
+literally, so the request goes out with an empty body and the next line is parsed as a
+PowerShell command), and **`$variables` are not expanded** (`$id` arrives as the three literal
+characters `$id`). Where you want a variable, use `Invoke-RestMethod` instead; both spellings are
+shown where the POSTs are.
+
+**Git Bash works too, with two exceptions.** `./docker/up.sh` needs a POSIX shell, so run it
+from Git Bash — or from PowerShell as `sh docker/up.sh` if Git for Windows put `sh.exe` on
+PATH. Without it, `up.sh` is only two steps you can run directly:
+`docker image inspect productionguardian/irishealth:local` (the preflight) and
+`docker compose up -d`. The second exception is the sharper one: a container path in a
+`docker compose exec` argument gets rewritten by MSYS, so
+`docker compose exec iris sh /pg-firstboot.sh` fails from Git Bash with
+`cannot access 'C:/Program Files/Git/pg-firstboot.sh'` — a message that blames the host for a
+path that only ever existed in the container. Prefix `MSYS_NO_PATHCONV=1`, or run it from
+PowerShell, where it is unchanged.
 
 ### Prerequisites — one time, and `up.sh` will tell you if you skip it
 
@@ -100,16 +152,34 @@ IRIS reports healthy only once the **LABDEMO production is serving interop metri
 in this order:
 
 ```bash
-docker compose logs iris | grep pg-firstboot   # did first boot run, and did it finish?
-docker compose logs iris | grep -E '^[0-9]'    # the numbered steps, and which one stopped
-docker compose ps -a                           # iris-init should be Exited (0), not Exited (1)
+# Linux & macOS (and Git Bash)
+docker compose logs iris | grep pg-firstboot                           # did first boot run, and did it finish?
+docker compose logs --no-log-prefix iris | grep -E '^[0-9]+[a-z]?\.'   # the numbered steps, and which one stopped
+docker compose ps -a                                                   # iris-init should be Exited (0), not Exited (1)
 ```
+
+```powershell
+# Windows (PowerShell)
+docker compose logs iris | Select-String pg-firstboot
+docker compose logs --no-log-prefix iris | Select-String '^[0-9]+[a-z]?\.'
+docker compose ps -a
+```
+
+`--no-log-prefix` is load-bearing and was missing until this was actually run on both shells:
+`compose logs` prefixes every line with `pg-iris  | `, so the `^[0-9]` this used to say anchored
+against the prefix and matched **nothing** — on Unix too. Dropping the prefix makes the anchor
+mean what it reads as, and `[a-z]?` is there because the steps are `1.` … `9.` *and* `4b.`,
+`6b.`. `Select-String` takes the same regex, so the two lines differ only in the tool's name.
 
 To run it by hand (it is safe at any time):
 
 ```bash
 docker compose exec iris sh /pg-firstboot.sh
 ```
+
+Unchanged in PowerShell — `/pg-firstboot.sh` is a path inside the container, so there is nothing
+to translate. From **Git Bash** it needs `MSYS_NO_PATHCONV=1` in front, for the reason in
+*On Windows* above.
 
 ## The four services
 
@@ -182,6 +252,9 @@ export PG_AGENT_MODE=live             # engine calls IRIS instead of its own moc
 docker compose up -d
 ```
 
+On Windows the two `export` lines become `$env:PG_LLM_API_KEY = 'sk-...'` and
+`$env:PG_AGENT_MODE = 'live'`, in the same window as the `compose up` — see *On Windows*.
+
 `PG_LLM_API_KEY` is read at first boot by `Setup.AIHub`, which creates the wallet entry and the
 `AI.LLM.pgdetective` config that references it as `secret://PGSecrets.openai#apikey`. The key is
 never written to the configuration, the repo, or a log line — the boot prints its length and that it
@@ -213,6 +286,8 @@ do ##class(ProductionGuardian.LabDemo.Triggers).Reset()    // undo, including th
 Then, against the dashboard's own API path so it is the same route the UI uses:
 
 ```bash
+# Linux & macOS (and Git Bash)
+
 # WHAT -- the finding
 curl -s localhost:5173/api/healthscan/findings
 
@@ -228,6 +303,32 @@ curl -s -XPOST localhost:5173/api/resolve -H 'Content-Type: application/json' \
   -d '{"mode":"apply","requestedBy":"you@laptop",
        "action":{"type":"set_pool_size","host":"Cloud API","size":4},
        "origin":{"findingId":"<id>"}}'
+```
+
+```powershell
+# Windows (PowerShell). Each POST is ONE line -- `--%` passes the rest of the line to curl.exe
+# verbatim, and a backtick continuation would be passed through literally too.
+
+# WHAT
+curl.exe -s localhost:5173/api/healthscan/findings
+
+# WHY
+curl.exe --% -s -XPOST localhost:5173/api/investigate -H "Content-Type: application/json" -d "{\"findingId\":\"<id from above>\"}"
+
+# FIX -- preview first, then apply
+curl.exe --% -s -XPOST localhost:5173/api/resolve -H "Content-Type: application/json" -d "{\"mode\":\"dry_run\",\"action\":{\"type\":\"set_pool_size\",\"host\":\"Cloud API\",\"size\":4}}"
+
+curl.exe --% -s -XPOST localhost:5173/api/resolve -H "Content-Type: application/json" -d "{\"mode\":\"apply\",\"requestedBy\":\"you@laptop\",\"action\":{\"type\":\"set_pool_size\",\"host\":\"Cloud API\",\"size\":4},\"origin\":{\"findingId\":\"<id>\"}}"
+```
+
+Pasting a finding id by hand into a `--%` line is fine; building one from a variable is not,
+because `--%` stops expansion. For that, `Invoke-RestMethod` — which also pretty-prints, so it
+is the nicer one to read output from:
+
+```powershell
+$id = (Invoke-RestMethod http://localhost:5173/api/healthscan/findings)[0].id
+Invoke-RestMethod -Method Post -Uri http://localhost:5173/api/investigate `
+  -ContentType 'application/json' -Body "{`"findingId`":`"$id`"}" | ConvertTo-Json -Depth 10
 ```
 
 A live run looks like this — the queue drains because four workers clear ~4/sec against ~2/sec
@@ -262,6 +363,9 @@ curl -s localhost:5173/api/healthscan/findings          # dead_host on EMR Sourc
 curl -s -XPOST localhost:5173/api/investigate \
   -H 'Content-Type: application/json' -d '{"findingId":"<the dead_host id>"}'
 ```
+
+Same two calls as the MVP 2 section, so the PowerShell spellings are the same two lines shown
+there — not repeated, because two copies of one command is one copy that goes stale.
 
 A live run:
 
@@ -304,6 +408,8 @@ stage than a second window. **Off by default** — the flag is what enables it:
 export PG_DEMO_TRIGGERS=1
 docker compose up -d
 ```
+
+PowerShell: `$env:PG_DEMO_TRIGGERS = '1'`, then the same `compose up`.
 
 Without it every trigger route answers **404** and the rail looks exactly as it does now. That is
 deliberate rather than tidy: the buttons deliberately break the production, which is the opposite of

--- a/docs/hl7-validation-and-trigger-inventory.md
+++ b/docs/hl7-validation-and-trigger-inventory.md
@@ -176,7 +176,7 @@ through the Reply Code Actions setting instead. It was not changed during this i
 ### 2.3 `Tools.Read.GetHostSettings` does not expose `Validation`
 
 Confirmed — the allowlist in `GetHostSettings` is nine names (`FilePath`, `ArchivePath`,
-`WorkPath`, `FileSpec`, `PollInterval`, `HTTPServer`, `HTTPPort`, `URL`, `TargetConfigNames`)
+`WorkPath`, `FileSpec`, `CallInterval`, `HTTPServer`, `HTTPPort`, `URL`, `TargetConfigNames`)
 plus `PoolSize`, and `Validation` is not among them:
 
 ```json
@@ -318,7 +318,7 @@ and fails the only test that matters.
 |---|---|
 | Reversible from inside IRIS? | **Yes.** `SetSetting`/`RemoveSetting` on `Validation` round-trips cleanly; absent is the shipped state |
 | Survives `docker compose restart`? | **Yes** — and in the safe direction: `Production.cls` declares no `Validation` row, so a recompile reverts to *disarmed* |
-| Needs a >60s wait? | **No.** Applies within one `PollInterval` (2s) after `UpdateProduction()` |
+| Needs a >60s wait? | **No.** Applies within one `CallInterval` (2s) after `UpdateProduction()` |
 | Produces a finding type we do not demo? | **No — it produces NO finding at all** |
 
 The last row is disqualifying. Per §1.2 the signal never reaches the engine, so the trigger

--- a/iris/labdemo/Production.cls
+++ b/iris/labdemo/Production.cls
@@ -43,7 +43,27 @@ XData ProductionDefinition
     <Setting Target="Adapter" Name="FilePath">/tmp/labdemo/hl7-in/</Setting>
     <Setting Target="Adapter" Name="FileSpec">*.hl7</Setting>
     <Setting Target="Adapter" Name="ArchivePath">/tmp/labdemo/hl7-archive/</Setting>
-    <Setting Target="Adapter" Name="PollInterval">2</Setting>
+    <!-- CallInterval, NOT PollInterval. EnsLib.File.InboundAdapter (the adapter that
+         EnsLib.HL7.Service.FileService declares) has no property named PollInterval at
+         all, so the setting was rejected on every production start and IRIS logged
+
+           ERROR (Ens)ErrProductionSettingInvalid: Production setting 'PollInterval'
+           for item 'EMR Source' is invalid
+
+         into Ens.Util.Log as a Type=2 error row. Verified live: the row's timestamp
+         matches the boot that wrote it, one per `compose up`. Two consequences, and the
+         first is the one that matters. The demo instance accused ITSELF of a
+         configuration error in the same event log the AI Detective reads for evidence.
+         And the interval never applied at all: the adapter fell back to
+         Ens.InboundAdapter's CallInterval default of 5s, which is why the pipeline kept
+         working and nobody noticed.
+
+         2 is the value this line always intended. The name is what was wrong.
+
+         NOTE FOR ANYONE EDITING THIS COMMENT: a double hyphen is illegal inside an XML
+         comment, and XData is parsed by a real XML parser. Writing one here fails the
+         compile with #6301 and leaves the production unloadable. -->
+    <Setting Target="Adapter" Name="CallInterval">2</Setting>
     <Setting Target="Host"    Name="TargetConfigNames">Lab Router</Setting>
     <Setting Target="Host"    Name="MessageSchemaCategory">2.5</Setting>
   </Item>

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -130,7 +130,13 @@ ClassMethod GetHostSettings(host As %String) As %DynamicObject
         "ArchivePath",
         "WorkPath",
         "FileSpec",
-        "PollInterval",
+        // CallInterval, not PollInterval. This allowlist named a setting that does not
+        // exist on any adapter in this production, so the entry could never match and
+        // the polling interval was unreachable to the agent -- a dead allowlist row,
+        // which is worse than an absent one because it reads as coverage. Same root
+        // cause as the invalid setting in Production.cls: `Ens.InboundAdapter` calls it
+        // CallInterval and nothing calls it PollInterval.
+        "CallInterval",
         "HTTPServer",
         "HTTPPort",
         "URL",

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -79,6 +79,44 @@ const METRIC: MetricName = 'queued';
  * reset or an approved fix produces, is 100%.
  */
 const DISCONTINUITY_FRACTION = 0.8;
+
+/**
+ * How much of the fit window counts as NOW, as a fraction of it.
+ *
+ * A single slope over the whole window describes the WINDOW, not the present, and publishing it as
+ * "rising ~N/min" is a claim about the present. So the projection asks the question twice — once of
+ * the window, once of its tail — and declines unless both say rising. Reported from a live demo run:
+ * "the early warning sometimes comes up when the queue pool is being drained, because it takes a
+ * point in time measurement and does not notice the acceleration/deceleration of pool growth."
+ *
+ * A FRACTION RATHER THAN A SECOND WINDOW LENGTH, and deliberately not in `thresholds.json`. ADR 0003
+ * governs the numbers that decide what FIRES, and the earlyWarning numbers there
+ * (`fitWindowSeconds`, `horizonSeconds`, `minFitSamples`) each set a level or a span an operator
+ * might defensibly move. This one sets neither: it says how much of the series the word "now" covers,
+ * which is the definition of "rising" rather than a threshold for it — the same argument
+ * DISCONTINUITY_FRACTION carries above for "the series restarted".
+ *
+ * Two consequences make the fraction the safer shape than a configurable duration:
+ *
+ *   - it cannot contradict `fitWindowSeconds`. Two independent numbers can be set so the tail is
+ *     LONGER than the window it is a tail of, which is a nonsense state with no sensible behaviour;
+ *     a fraction moves with the window and can never invert.
+ *   - it inherits the reachability invariant instead of needing its own. `thresholds.json` already
+ *     requires `fitWindowSeconds / poll > minFitSamples` so a projection is structurally possible
+ *     (#64's failure mode); at the shipped 300s/5s that is 60 samples, of which the tail is 24. A
+ *     separate configurable duration would need that check duplicated, and an unreachable value
+ *     would silence the module with no error — which is exactly what the existing check exists to
+ *     prevent.
+ *
+ * 0.4 rather than something shorter: at the shipped poll the tail is 24 samples, enough that one
+ * bursty poll cannot flip its sign, where the last 30s (6 samples) of a queue that drains and refills
+ * would flap between projecting and not. Rather than something longer: at 0.8 the tail is nearly the
+ * window and would just re-answer the same question. Note the drain only reaches this code once the
+ * queue is UNDER the threshold — above it, `already_crossed` answers first — so the tail does not
+ * need to react within a poll or two of the fix landing.
+ */
+const RECENT_FIT_FRACTION = 0.4;
+
 const FINDING_TYPE = 'queue_buildup';
 const SLOPE_UNIT = 'items/minute';
 
@@ -159,6 +197,34 @@ function fitSlopePerMs(samples: readonly Sample[]): number | null {
   }
   if (sxx === 0) return null;
   return sxy / sxx;
+}
+
+/**
+ * The tail of the series: samples within `spanMs` of the LAST SAMPLE, oldest first.
+ *
+ * Anchored on the last sample rather than on `now` because the question is about the shape of the
+ * series, not about the wall clock. Anchoring on `now` would let a slow poll silently shorten the
+ * tail — and at the extreme, a stale series would report a tail of one sample for a reason that has
+ * nothing to do with whether the queue is rising. `measuredAt` and `projectedCrossingAt` are already
+ * on the sample clock for the same reason (contract EW-Q3).
+ *
+ * Takes the ALREADY TRUNCATED series, so a rise after a discontinuity is fitted against itself on
+ * both passes rather than the tail reaching back across a cliff the window pass excluded.
+ */
+function recentPortion(samples: readonly Sample[], spanMs: number): readonly Sample[] {
+  const last = samples.at(-1);
+  if (last === undefined) return samples;
+  const cutoff = last.at - spanMs;
+  // Backwards from the end and stop at the first sample outside the span: samples are time-ordered,
+  // so this touches only the tail rather than the whole window.
+  let firstKept = samples.length - 1;
+  while (firstKept > 0 && (samples[firstKept - 1]?.at ?? 0) >= cutoff) firstKept -= 1;
+  return firstKept === 0 ? samples : samples.slice(firstKept);
+}
+
+/** A slope in units per ms, rounded to the 1dp we publish. Null stays null. */
+function perMinute(slopePerMs: number | null): number | null {
+  return slopePerMs === null ? null : Math.round(slopePerMs * 60_000 * 10) / 10;
 }
 
 /**
@@ -266,13 +332,36 @@ export function projectHost(
   // "nothing to see" about a queue that is over its limit.
   if (currentValue >= threshold.value) return decline('already_crossed', threshold);
 
-  const slopePerMs = fitSlopePerMs(samples);
-  if (slopePerMs === null) return decline('not_rising', threshold);
-
   // Round to 1dp in the units we publish, and test the ROUNDED value: publishing slope 0.0
   // alongside a finite ETA would be a projection the numbers do not support.
-  const slopePerMinute = Math.round(slopePerMs * 60_000 * 10) / 10;
-  if (slopePerMinute <= 0) return decline('not_rising', threshold);
+  const slopePerMinute = perMinute(fitSlopePerMs(samples));
+  if (slopePerMinute === null || slopePerMinute <= 0) return decline('not_rising', threshold);
+
+  // RISING NOW, not merely on average across the window. The window slope above describes the
+  // window; this asks the same question of its tail, and both must say rising. That one gate covers
+  // three shapes a single fit reports as a rise: a queue draining after the approved fix, a rise that
+  // has levelled off, and a rise that has turned over. See RECENT_FIT_FRACTION.
+  //
+  // `not_rising` rather than an eighth reason, and it is the accurate answer rather than the
+  // available one: a draining queue is not rising. `contracts/earlywarning-api.md` fixes the seven
+  // reasons and their precedence, and this stays inside both — it sits at step 6, after
+  // `already_crossed`, so a queue that is draining but still ABOVE its threshold keeps reporting
+  // `already_crossed`. Draining-but-over-limit is still a problem.
+  //
+  // An unfittable tail declines too — both cases arrive as `fitSlopePerMs` returning null: fewer than
+  // two samples has no slope, and a tail sharing one timestamp is division by zero rather than a flat
+  // line. Two is all the tail needs, not `minFitSamples`, because its slope is never published: it is
+  // a sign test confirming an answer the window already grounded in 12+ samples. At the shipped
+  // cadence the tail holds ~24, so reaching two at all means a polling gap, where declining is the
+  // posture the rest of this module takes. `insufficient_samples` would be the wrong reason for
+  // either — the contract defines it against the published `fitSampleCount`, which is the FULL
+  // window's count and has already cleared `minFitSamples` by this point.
+  const recentSlopePerMinute = perMinute(
+    fitSlopePerMs(recentPortion(samples, ew.fitWindowSeconds * 1000 * RECENT_FIT_FRACTION)),
+  );
+  if (recentSlopePerMinute === null || recentSlopePerMinute <= 0) {
+    return decline('not_rising', threshold);
+  }
 
   const secondsToThreshold = Math.ceil(
     ((threshold.value - currentValue) / slopePerMinute) * 60,

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -367,3 +367,166 @@ describe('a drain inside the fit window does not poison the slope', () => {
     );
   });
 });
+
+/**
+ * A DRAINING queue is not a rising one, even when the window average says otherwise.
+ *
+ * Reported from a live demo run: "the early warning sometimes comes up when the queue pool is being
+ * drained, because it takes a point in time measurement and does not notice the
+ * acceleration/deceleration of pool growth." Worst possible timing — it lands seconds after the
+ * audience is told the approved `set_pool_size 1 -> 4` worked.
+ *
+ * One least-squares slope over the whole 300s window describes the WINDOW, not the present. On the
+ * recovery path the window straddles a long rise and a partial drain, the average stays positive,
+ * and Early Warning announces a crossing while the queue is emptying.
+ *
+ * #142's `sinceLastDiscontinuity()` does not cover it and was never meant to: a drain at 4/sec sheds
+ * ~20 of a 350-deep queue per 5s poll, ~6%, nowhere near the 80% cliff test. These cases assert the
+ * window stays intact AND the projection is declined, so neither mechanism can be mistaken for the
+ * other.
+ */
+describe('a queue must be rising NOW, not merely on average', () => {
+  /**
+   * Rise, then drain — the shape the approved fix leaves in the window.
+   *
+   * Defaults mirror the MVP 2 scenario at the shipped 5s poll: net +1/sec while `Cloud API` is at
+   * `PoolSize 1`, then net -3/sec once the pool is 4 and it clears ~4/sec against the same inflow.
+   * Returns the values too, so a test can fit them itself rather than trusting the module.
+   */
+  function riseThenDrain(riseSamples: number, drainSamples: number, cfg = config()) {
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    const values: number[] = [];
+    let at = T0;
+    let q = 0;
+    for (let i = 0; i < riseSamples; i += 1) {
+      values.push(q);
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += 5;
+    }
+    q -= 5;
+    for (let i = 0; i < drainSamples; i += 1) {
+      q -= 15;
+      values.push(q);
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+    }
+    const lastValue = values[values.length - 1] as number;
+    return { p: projectHost(HOST, raw(lastValue), store, cfg, at - POLL), values, lastValue };
+  }
+
+  /** Least-squares slope per minute over evenly spaced values — the OLD rule's answer, in the test. */
+  function slopePerMinute(values: readonly number[], spacingMs = POLL): number {
+    const n = values.length;
+    const meanX = ((n - 1) / 2) * spacingMs;
+    const meanY = values.reduce((a, b) => a + b, 0) / n;
+    let sxy = 0;
+    let sxx = 0;
+    for (const [i, v] of values.entries()) {
+      const dx = i * spacingMs - meanX;
+      sxy += dx * (v - meanY);
+      sxx += dx * dx;
+    }
+    return (sxy / sxx) * 60_000;
+  }
+
+  it('declines while the queue drains, though the window average is still positive', () => {
+    // 40 samples up to 195, then 12 down to 15. 15 is UNDER the floor of 50 on purpose: above it
+    // `already_crossed` answers first and the slope is never consulted, so a fixture that ends high
+    // tests nothing here. That is the same trap #142's fixtures fell into twice.
+    const { p, values, lastValue } = riseThenDrain(40, 12);
+
+    assert.equal(lastValue, 15);
+    assert.equal(p.threshold?.value, 50);
+    assert.ok(
+      lastValue < 50,
+      'sanity: the assertion sample must be below the floor, or already_crossed answers instead',
+    );
+    // The old rule's own number, fitted here rather than assumed. If this ever comes out negative
+    // the fixture has stopped reproducing the defect and the test below proves nothing.
+    assert.ok(
+      slopePerMinute(values) > 0,
+      `the window average must still be positive for this to be the defect, got ${slopePerMinute(values)}`,
+    );
+    // The window is INTACT: no 80% collapse anywhere in a 15-per-poll drain, so #142's helper
+    // cannot be what declines here.
+    assert.equal(p.fitSampleCount, 52, 'an ordinary drain must not truncate the window');
+
+    assert.equal(
+      p.projectionUnavailable,
+      'not_rising',
+      'a draining queue is not rising — the accurate answer, and it renders as "watching"',
+    );
+    assert.equal(p.projection, null);
+  });
+
+  it('still projects for a queue that is rising more slowly than it was', () => {
+    // DECELERATION IS NOT A TURNOVER. The gate asks for a positive recent slope, not an
+    // undiminished one: this queue is still heading for the threshold, and the published slope is
+    // the window's, which overstates it. Declining here would be the opposite defect.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    let q = 0;
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += 1;
+    }
+    // +1 every other poll, so the values stay whole the way a queue depth does.
+    for (let i = 0; i < 20; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      if (i % 2 === 1) q += 1;
+    }
+    const p = projectHost(HOST, raw(q), store, cfg, at - POLL);
+    assert.equal(p.projectionUnavailable, null, 'a slowing rise is still a rise');
+    assert.ok(p.projection !== null && p.projection.slope > 0);
+  });
+
+  it('declines for a queue that has levelled off', () => {
+    // The turnover case with no drain at all: a rise, then flat. The window average is positive and
+    // nothing is approaching anything.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', i, at);
+      at += POLL;
+    }
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', 29, at);
+      at += POLL;
+    }
+    const p = projectHost(HOST, raw(29), store, cfg, at - POLL);
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+
+  it('declines rather than crashing when the recent portion holds one sample', () => {
+    // A polling gap: 13 samples, 12 of them bunched at the start of the window and one at the end.
+    // The recent portion cannot be fitted at all, which must decline rather than throw or fall back
+    // to the window average. `insufficient_samples` would contradict the published fitSampleCount of
+    // 13, which the contract defines that reason against.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    for (let i = 0; i < 12; i += 1) store.record(HOST, 'queued', i * 2, T0 + i * POLL);
+    const lastAt = T0 + 250_000;
+    store.record(HOST, 'queued', 40, lastAt);
+    const p = projectHost(HOST, raw(40), store, cfg, lastAt);
+    assert.equal(p.fitSampleCount, 13, 'sanity: the full window is still fittable');
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+
+  it('declines rather than crashing when the recent portion shares one timestamp', () => {
+    // Zero variance in x is division by zero, not a flat line — the distinction `fitSlopePerMs`
+    // already keeps for the full window, applied to the recent portion too.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    for (let i = 0; i < 12; i += 1) store.record(HOST, 'queued', i * 2, T0 + i * POLL);
+    const lastAt = T0 + 250_000;
+    for (const v of [40, 41, 42]) store.record(HOST, 'queued', v, lastAt);
+    const p = projectHost(HOST, raw(42), store, cfg, lastAt);
+    assert.equal(p.fitSampleCount, 15);
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+});


### PR DESCRIPTION
## What was wrong

`EnsLib.File.InboundAdapter` — the adapter `EnsLib.HL7.Service.FileService` declares — has **no property named `PollInterval`**. Read from the compiled dictionary on the running instance:

```
service=EnsLib.HL7.Service.FileService
adapter=EnsLib.File.InboundAdapter
adapter CallInterval prop: 1
adapter PollInterval prop: 0
```

So `<Setting Target="Adapter" Name="PollInterval">2</Setting>` was rejected on **every** production start, and IRIS logged a `Type=2` error row:

```
65730 | 2026-08-26 12:27:45.445 | Type=2 | EMR Source |
  ERROR <Ens>ErrProductionSettingInvalid: Production setting 'PollInterval' for item 'EMR Source' is invalid
```

One row per `compose up` — that timestamp is the boot that wrote it, in this session.

## Why it is worth fixing rather than noting

**1. The instance accused itself, in the log the AI Detective reads.** `get_recent_errors` counts `Type=2` rows per host, so our own broken setting was an error an agent could be handed while diagnosing an unrelated problem. This is the "no code errors on our part in the event log" the request asked for.

**2. The interval never applied.** The adapter fell back to `Ens.InboundAdapter`'s `CallInterval` default of **5s** — which is why the pipeline kept working and nobody noticed. Worth stating plainly: **every timing anyone has measured on this demo was measured at a 5s file poll, not the 2s this line has claimed since it was written.** Changing the name makes the file poll 2.5× more often. That is the stated intent, and it affects ingest *latency* rather than throughput (`FileSpec` is `*.hl7`, so each poll takes every waiting file), but the cue sheet's numbers were taken under the old effective value.

## The second, quieter half

`Tools.Read.GetHostSettings`'s allowlist named `PollInterval` too, so that row was **dead** — it could never match, and the polling interval was unreachable to the agent while looking like covered ground. An allowlist entry that cannot match is worse than an absent one, because it reads as coverage.

## Verified on the running instance

- Production compiles and starts clean.
- `Adapter.CallInterval=2` present on the compiled item.
- **Zero** `ErrProductionSettingInvalid` rows across a full stop/start cycle (previously one per start).
- `GetHostSettings("EMR Source")` → `"CallInterval":"2"` — checked through the tool, not just the config.

## One trap, now recorded in the file

A double hyphen is illegal inside an XML comment, and XData is parsed by a real XML parser. My first draft of the explanatory comment used `--` as an em-dash and failed the compile with `#6301`, which leaves the production **unloadable** rather than merely uncommented. The comment now warns the next editor.

## Follow-up, deliberately not in this PR

`contracts/mcp-tools.md` still lists `PollInterval` among the permitted setting names. That is a contract change under CLAUDE.md §4 and follows as its own PR with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)