### PR TITLE
fix(engine): a window-average slope announced a crossing while the queue drained

### DIFF
--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -79,6 +79,44 @@ const METRIC: MetricName = 'queued';
  * reset or an approved fix produces, is 100%.
  */
 const DISCONTINUITY_FRACTION = 0.8;
+
+/**
+ * How much of the fit window counts as NOW, as a fraction of it.
+ *
+ * A single slope over the whole window describes the WINDOW, not the present, and publishing it as
+ * "rising ~N/min" is a claim about the present. So the projection asks the question twice — once of
+ * the window, once of its tail — and declines unless both say rising. Reported from a live demo run:
+ * "the early warning sometimes comes up when the queue pool is being drained, because it takes a
+ * point in time measurement and does not notice the acceleration/deceleration of pool growth."
+ *
+ * A FRACTION RATHER THAN A SECOND WINDOW LENGTH, and deliberately not in `thresholds.json`. ADR 0003
+ * governs the numbers that decide what FIRES, and the earlyWarning numbers there
+ * (`fitWindowSeconds`, `horizonSeconds`, `minFitSamples`) each set a level or a span an operator
+ * might defensibly move. This one sets neither: it says how much of the series the word "now" covers,
+ * which is the definition of "rising" rather than a threshold for it — the same argument
+ * DISCONTINUITY_FRACTION carries above for "the series restarted".
+ *
+ * Two consequences make the fraction the safer shape than a configurable duration:
+ *
+ *   - it cannot contradict `fitWindowSeconds`. Two independent numbers can be set so the tail is
+ *     LONGER than the window it is a tail of, which is a nonsense state with no sensible behaviour;
+ *     a fraction moves with the window and can never invert.
+ *   - it inherits the reachability invariant instead of needing its own. `thresholds.json` already
+ *     requires `fitWindowSeconds / poll > minFitSamples` so a projection is structurally possible
+ *     (#64's failure mode); at the shipped 300s/5s that is 60 samples, of which the tail is 24. A
+ *     separate configurable duration would need that check duplicated, and an unreachable value
+ *     would silence the module with no error — which is exactly what the existing check exists to
+ *     prevent.
+ *
+ * 0.4 rather than something shorter: at the shipped poll the tail is 24 samples, enough that one
+ * bursty poll cannot flip its sign, where the last 30s (6 samples) of a queue that drains and refills
+ * would flap between projecting and not. Rather than something longer: at 0.8 the tail is nearly the
+ * window and would just re-answer the same question. Note the drain only reaches this code once the
+ * queue is UNDER the threshold — above it, `already_crossed` answers first — so the tail does not
+ * need to react within a poll or two of the fix landing.
+ */
+const RECENT_FIT_FRACTION = 0.4;
+
 const FINDING_TYPE = 'queue_buildup';
 const SLOPE_UNIT = 'items/minute';
 
@@ -159,6 +197,34 @@ function fitSlopePerMs(samples: readonly Sample[]): number | null {
   }
   if (sxx === 0) return null;
   return sxy / sxx;
+}
+
+/**
+ * The tail of the series: samples within `spanMs` of the LAST SAMPLE, oldest first.
+ *
+ * Anchored on the last sample rather than on `now` because the question is about the shape of the
+ * series, not about the wall clock. Anchoring on `now` would let a slow poll silently shorten the
+ * tail — and at the extreme, a stale series would report a tail of one sample for a reason that has
+ * nothing to do with whether the queue is rising. `measuredAt` and `projectedCrossingAt` are already
+ * on the sample clock for the same reason (contract EW-Q3).
+ *
+ * Takes the ALREADY TRUNCATED series, so a rise after a discontinuity is fitted against itself on
+ * both passes rather than the tail reaching back across a cliff the window pass excluded.
+ */
+function recentPortion(samples: readonly Sample[], spanMs: number): readonly Sample[] {
+  const last = samples.at(-1);
+  if (last === undefined) return samples;
+  const cutoff = last.at - spanMs;
+  // Backwards from the end and stop at the first sample outside the span: samples are time-ordered,
+  // so this touches only the tail rather than the whole window.
+  let firstKept = samples.length - 1;
+  while (firstKept > 0 && (samples[firstKept - 1]?.at ?? 0) >= cutoff) firstKept -= 1;
+  return firstKept === 0 ? samples : samples.slice(firstKept);
+}
+
+/** A slope in units per ms, rounded to the 1dp we publish. Null stays null. */
+function perMinute(slopePerMs: number | null): number | null {
+  return slopePerMs === null ? null : Math.round(slopePerMs * 60_000 * 10) / 10;
 }
 
 /**
@@ -266,13 +332,36 @@ export function projectHost(
   // "nothing to see" about a queue that is over its limit.
   if (currentValue >= threshold.value) return decline('already_crossed', threshold);
 
-  const slopePerMs = fitSlopePerMs(samples);
-  if (slopePerMs === null) return decline('not_rising', threshold);
-
   // Round to 1dp in the units we publish, and test the ROUNDED value: publishing slope 0.0
   // alongside a finite ETA would be a projection the numbers do not support.
-  const slopePerMinute = Math.round(slopePerMs * 60_000 * 10) / 10;
-  if (slopePerMinute <= 0) return decline('not_rising', threshold);
+  const slopePerMinute = perMinute(fitSlopePerMs(samples));
+  if (slopePerMinute === null || slopePerMinute <= 0) return decline('not_rising', threshold);
+
+  // RISING NOW, not merely on average across the window. The window slope above describes the
+  // window; this asks the same question of its tail, and both must say rising. That one gate covers
+  // three shapes a single fit reports as a rise: a queue draining after the approved fix, a rise that
+  // has levelled off, and a rise that has turned over. See RECENT_FIT_FRACTION.
+  //
+  // `not_rising` rather than an eighth reason, and it is the accurate answer rather than the
+  // available one: a draining queue is not rising. `contracts/earlywarning-api.md` fixes the seven
+  // reasons and their precedence, and this stays inside both — it sits at step 6, after
+  // `already_crossed`, so a queue that is draining but still ABOVE its threshold keeps reporting
+  // `already_crossed`. Draining-but-over-limit is still a problem.
+  //
+  // An unfittable tail declines too — both cases arrive as `fitSlopePerMs` returning null: fewer than
+  // two samples has no slope, and a tail sharing one timestamp is division by zero rather than a flat
+  // line. Two is all the tail needs, not `minFitSamples`, because its slope is never published: it is
+  // a sign test confirming an answer the window already grounded in 12+ samples. At the shipped
+  // cadence the tail holds ~24, so reaching two at all means a polling gap, where declining is the
+  // posture the rest of this module takes. `insufficient_samples` would be the wrong reason for
+  // either — the contract defines it against the published `fitSampleCount`, which is the FULL
+  // window's count and has already cleared `minFitSamples` by this point.
+  const recentSlopePerMinute = perMinute(
+    fitSlopePerMs(recentPortion(samples, ew.fitWindowSeconds * 1000 * RECENT_FIT_FRACTION)),
+  );
+  if (recentSlopePerMinute === null || recentSlopePerMinute <= 0) {
+    return decline('not_rising', threshold);
+  }
 
   const secondsToThreshold = Math.ceil(
     ((threshold.value - currentValue) / slopePerMinute) * 60,

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -367,3 +367,166 @@ describe('a drain inside the fit window does not poison the slope', () => {
     );
   });
 });
+
+/**
+ * A DRAINING queue is not a rising one, even when the window average says otherwise.
+ *
+ * Reported from a live demo run: "the early warning sometimes comes up when the queue pool is being
+ * drained, because it takes a point in time measurement and does not notice the
+ * acceleration/deceleration of pool growth." Worst possible timing — it lands seconds after the
+ * audience is told the approved `set_pool_size 1 -> 4` worked.
+ *
+ * One least-squares slope over the whole 300s window describes the WINDOW, not the present. On the
+ * recovery path the window straddles a long rise and a partial drain, the average stays positive,
+ * and Early Warning announces a crossing while the queue is emptying.
+ *
+ * #142's `sinceLastDiscontinuity()` does not cover it and was never meant to: a drain at 4/sec sheds
+ * ~20 of a 350-deep queue per 5s poll, ~6%, nowhere near the 80% cliff test. These cases assert the
+ * window stays intact AND the projection is declined, so neither mechanism can be mistaken for the
+ * other.
+ */
+describe('a queue must be rising NOW, not merely on average', () => {
+  /**
+   * Rise, then drain — the shape the approved fix leaves in the window.
+   *
+   * Defaults mirror the MVP 2 scenario at the shipped 5s poll: net +1/sec while `Cloud API` is at
+   * `PoolSize 1`, then net -3/sec once the pool is 4 and it clears ~4/sec against the same inflow.
+   * Returns the values too, so a test can fit them itself rather than trusting the module.
+   */
+  function riseThenDrain(riseSamples: number, drainSamples: number, cfg = config()) {
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    const values: number[] = [];
+    let at = T0;
+    let q = 0;
+    for (let i = 0; i < riseSamples; i += 1) {
+      values.push(q);
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += 5;
+    }
+    q -= 5;
+    for (let i = 0; i < drainSamples; i += 1) {
+      q -= 15;
+      values.push(q);
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+    }
+    const lastValue = values[values.length - 1] as number;
+    return { p: projectHost(HOST, raw(lastValue), store, cfg, at - POLL), values, lastValue };
+  }
+
+  /** Least-squares slope per minute over evenly spaced values — the OLD rule's answer, in the test. */
+  function slopePerMinute(values: readonly number[], spacingMs = POLL): number {
+    const n = values.length;
+    const meanX = ((n - 1) / 2) * spacingMs;
+    const meanY = values.reduce((a, b) => a + b, 0) / n;
+    let sxy = 0;
+    let sxx = 0;
+    for (const [i, v] of values.entries()) {
+      const dx = i * spacingMs - meanX;
+      sxy += dx * (v - meanY);
+      sxx += dx * dx;
+    }
+    return (sxy / sxx) * 60_000;
+  }
+
+  it('declines while the queue drains, though the window average is still positive', () => {
+    // 40 samples up to 195, then 12 down to 15. 15 is UNDER the floor of 50 on purpose: above it
+    // `already_crossed` answers first and the slope is never consulted, so a fixture that ends high
+    // tests nothing here. That is the same trap #142's fixtures fell into twice.
+    const { p, values, lastValue } = riseThenDrain(40, 12);
+
+    assert.equal(lastValue, 15);
+    assert.equal(p.threshold?.value, 50);
+    assert.ok(
+      lastValue < 50,
+      'sanity: the assertion sample must be below the floor, or already_crossed answers instead',
+    );
+    // The old rule's own number, fitted here rather than assumed. If this ever comes out negative
+    // the fixture has stopped reproducing the defect and the test below proves nothing.
+    assert.ok(
+      slopePerMinute(values) > 0,
+      `the window average must still be positive for this to be the defect, got ${slopePerMinute(values)}`,
+    );
+    // The window is INTACT: no 80% collapse anywhere in a 15-per-poll drain, so #142's helper
+    // cannot be what declines here.
+    assert.equal(p.fitSampleCount, 52, 'an ordinary drain must not truncate the window');
+
+    assert.equal(
+      p.projectionUnavailable,
+      'not_rising',
+      'a draining queue is not rising — the accurate answer, and it renders as "watching"',
+    );
+    assert.equal(p.projection, null);
+  });
+
+  it('still projects for a queue that is rising more slowly than it was', () => {
+    // DECELERATION IS NOT A TURNOVER. The gate asks for a positive recent slope, not an
+    // undiminished one: this queue is still heading for the threshold, and the published slope is
+    // the window's, which overstates it. Declining here would be the opposite defect.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    let q = 0;
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      q += 1;
+    }
+    // +1 every other poll, so the values stay whole the way a queue depth does.
+    for (let i = 0; i < 20; i += 1) {
+      store.record(HOST, 'queued', q, at);
+      at += POLL;
+      if (i % 2 === 1) q += 1;
+    }
+    const p = projectHost(HOST, raw(q), store, cfg, at - POLL);
+    assert.equal(p.projectionUnavailable, null, 'a slowing rise is still a rise');
+    assert.ok(p.projection !== null && p.projection.slope > 0);
+  });
+
+  it('declines for a queue that has levelled off', () => {
+    // The turnover case with no drain at all: a rise, then flat. The window average is positive and
+    // nothing is approaching anything.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', i, at);
+      at += POLL;
+    }
+    for (let i = 0; i < 30; i += 1) {
+      store.record(HOST, 'queued', 29, at);
+      at += POLL;
+    }
+    const p = projectHost(HOST, raw(29), store, cfg, at - POLL);
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+
+  it('declines rather than crashing when the recent portion holds one sample', () => {
+    // A polling gap: 13 samples, 12 of them bunched at the start of the window and one at the end.
+    // The recent portion cannot be fitted at all, which must decline rather than throw or fall back
+    // to the window average. `insufficient_samples` would contradict the published fitSampleCount of
+    // 13, which the contract defines that reason against.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    for (let i = 0; i < 12; i += 1) store.record(HOST, 'queued', i * 2, T0 + i * POLL);
+    const lastAt = T0 + 250_000;
+    store.record(HOST, 'queued', 40, lastAt);
+    const p = projectHost(HOST, raw(40), store, cfg, lastAt);
+    assert.equal(p.fitSampleCount, 13, 'sanity: the full window is still fittable');
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+
+  it('declines rather than crashing when the recent portion shares one timestamp', () => {
+    // Zero variance in x is division by zero, not a flat line — the distinction `fitSlopePerMs`
+    // already keeps for the full window, applied to the recent portion too.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    for (let i = 0; i < 12; i += 1) store.record(HOST, 'queued', i * 2, T0 + i * POLL);
+    const lastAt = T0 + 250_000;
+    for (const v of [40, 41, 42]) store.record(HOST, 'queued', v, lastAt);
+    const p = projectHost(HOST, raw(42), store, cfg, lastAt);
+    assert.equal(p.fitSampleCount, 15);
+    assert.equal(p.projectionUnavailable, 'not_rising');
+  });
+});


### PR DESCRIPTION
> **READ THIS FIRST — the diff below is ALREADY ON `main`.** While this branch was being written, a
> concurrent session switched the shared working copy from `devB/ew-draining` to `devA/callinterval`
> between the branch being created and the commit being made, so the commit landed on that branch and
> was squash-merged into `main` inside **#145** (`fix(iris): the poll interval setting was named
> PollInterval`). The engine content on `main` is byte-identical to this branch —
> `git diff main devB/ew-draining -- services/detection-engine` is empty. This PR therefore exists as
> the **review record** for a change that reached `main` without one, and as the place the reasoning
> lives instead of inside #145's unrelated squash message. **Close it rather than merge it**, unless
> you would rather revert the engine files out of #145 and land them here properly.

## The defect

Reported after a demo run: *"the early warning sometimes comes up when the queue pool is being
drained, because it takes a point in time measurement and does not notice the
acceleration/deceleration of pool growth."*

Confirmed. `projectHost` fitted **one** least-squares slope over the whole `fitWindowSeconds` window
and published a projection whenever that slope came out positive. An average over the window is a
statement about the window; *"Queue depth N rising ~X/min; at this rate it crosses 50 in ~M min"* is a
statement about the present. On the demo's own recovery path the window holds a long rise followed by
a partial drain, the average stays positive, and Early Warning announces a crossing while the queue is
visibly emptying — seconds after the audience is told the approved `set_pool_size 1 -> 4` worked.

**#142's `sinceLastDiscontinuity()` does not cover it and was never meant to.** It drops samples
before a >=80% single-sample collapse; a drain at 4/sec sheds ~20 of a 350-deep queue per 5s poll,
about 6%, so it never trips. The two mechanisms answer different questions — *"did the series
restart"* and *"is it rising now"*.

### Reproduced as a failing test first

`test/earlywarning.test.ts`, `a queue must be rising NOW, not merely on average`. The fixture is 40
samples rising 5/poll to 195, then 12 draining 15/poll to 15 — net +1/sec then net -3/sec, the MVP 2
scenario's own rates at the shipped 5s poll. Before the fix it returned a projection with
`slope = +25.1/min`; after it, `not_rising`.

The test asserts the traps as well as the behaviour, because a fixture that passes for the wrong
reason proves nothing:

- **ends at 15, under the `absoluteFloor` of 50.** Above the floor `already_crossed` answers first and
  the slope is never consulted — the trap #142's fixtures fell into twice.
- **fits the window itself and asserts that slope is still positive.** If the fixture ever stops
  reproducing the defect, this fails rather than passing quietly.
- **asserts `fitSampleCount === 52`**, so #142's helper cannot be what declines.

## The fix

Fit the window **and** its most recent portion, and decline unless **both** slopes are positive. One
gate covers three shapes a single fit reports as a rise: the post-fix drain, a rise that has levelled
off, and a rise that has turned over.

**`not_rising`, not an eighth reason.** `contracts/earlywarning-api.md` fixes the seven reasons and
their precedence, and `contracts/` is read-only to an implementation task (root `CLAUDE.md` §4). This
is not a workaround — a draining queue is not rising, and `EarlyWarning.tsx` already renders that
reason as *"Watching — not trending toward a threshold"* with a tick, which is a true and reassuring
thing to say about a queue that is emptying. **A distinct `draining` reason would be a reasonable
follow-up contract change** if the demo wants to *narrate* the recovery rather than merely decline to
forecast it.

**Precedence unchanged.** The new test sits at step 6, after `already_crossed`, so a queue that is
draining but still *above* its threshold keeps reporting `already_crossed` — draining-but-over-limit
is still a problem. Nothing on the wire changes shape, and the published `slope` is still the full
window's fit: the tail is a sign test whose slope is never published.

## Where the new number lives, and why

`RECENT_FIT_FRACTION = 0.4` of `fitWindowSeconds`, **hardcoded in the module, as a fraction** — the
same call `DISCONTINUITY_FRACTION` made, for the same reason. ADR 0003 governs the numbers that decide
what **fires**, and the `earlyWarning` numbers in `thresholds.json` each set a level or a span an
operator might defensibly move. This one sets neither: it says how much of the series the word "now"
covers, which is the *definition* of "rising" rather than a threshold for it.

A fraction rather than a second duration is what decided the placement:

- **it cannot contradict `fitWindowSeconds`.** Two independent numbers can be set so the tail is
  longer than the window it is a tail of — a nonsense state with no sensible behaviour. A fraction
  moves with the window and can never invert.
- **it inherits the reachability invariant instead of needing its own.** `validateConfig` already
  requires `fitWindowSeconds / poll > minFitSamples` so a projection is structurally possible (#64's
  failure mode in a new place). At the shipped 300s/5s that is 60 samples, of which the tail is 24. A
  configurable duration would need that check duplicated **plus** a row in `api/settings.ts`'s
  allowlist and its metadata, and an unreachable value would silence the module with no error.

`0.4` rather than shorter: 24 samples is enough that one bursty poll cannot flip the sign, where the
last 30 s (6 samples) of a queue that drains and refills would flap between projecting and not.
Rather than longer: at 0.8 the tail is nearly the window and would just re-answer the same question.
The tail does not need to react within a poll or two of the fix landing, because above the threshold
`already_crossed` answers first.

## Degenerate tails decline rather than crash

Both cases arrive as `fitSlopePerMs` returning `null`: fewer than two samples has no slope, and a tail
sharing one timestamp is division by zero rather than a flat line. **Two samples is all the tail
needs, not `minFitSamples`**, because its slope is never published — it confirms an answer the window
already grounded in 12+ samples, and at the shipped cadence the tail holds ~24, so reaching two at all
means a polling gap where declining is the posture the rest of the module takes.
`insufficient_samples` would be the wrong reason for either: the contract defines it against the
published `fitSampleCount`, which is the **full** window's count and has already cleared
`minFitSamples` by that point.

## Tests

Five new, one of which is the reproduction. The other four: a **decelerating** rise still projects
(deceleration is not a turnover, and declining there would be the opposite defect); a queue that has
**levelled off** declines; and the two degenerate tails decline rather than throw.

```
$ npm run typecheck
> tsc --noEmit          (clean)

$ npm test
tests 370
suites 74
pass 370
fail 0
```

365 before, 370 after. **Not verified on the live stack** — the compose stack is in use for a separate
investigation and was deliberately not rebuilt or restarted. The one thing unit tests cannot confirm
is that a bursty live ramp keeps a positive tail slope throughout the ~100 s window in which a
projection is expected; the 24-sample tail is chosen to make that stable, but it is worth a glance at
the next rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
