### PR TITLE
fix(iris): Cloud API shipped a target that never resolved on this stack

### DIFF
--- a/docker/iris-firstboot.sh
+++ b/docker/iris-firstboot.sh
@@ -76,16 +76,24 @@ OBJECTSCRIPT
 # Then the nine steps, in one call. Compile from the read-only source mount so a class
 # change is a restart rather than an image rebuild.
 #
-# SET THE DEPLOYMENT GLOBALS FIRST. Production.cls ships HTTPServer=webgateway-webinar --
-# the verified demo instance's web gateway container name, which does not resolve on the
-# compose network. ApplyDeploymentSettings() exists precisely to override it, but it is a
-# no-op unless these globals are set BEFORE Run() reaches step 6b, and nothing set them:
-# the first clean compose run printed "6b. deployment settings: none set" and Cloud API then
-# sat in Retry with 151 messages queued while every other host read OK.
+# SET THE DEPLOYMENT GLOBALS FIRST. These are now an OVERRIDE rather than a repair:
+# Production.cls ships HTTPServer=127.0.0.1 and HTTPPort=52773, the same values defaulted
+# below, so on this stack step 6b confirms the target instead of rescuing it.
+#
+# IT USED TO BE A REPAIR, AND THAT IS WHY THE GLOBALS ARE STILL SET HERE. Production.cls
+# shipped HTTPServer=webgateway-webinar, the separate demo instance's web gateway container
+# name, which shares no docker network with this stack and so never resolved here.
+# ApplyDeploymentSettings() was the only thing making Cloud API work, and it is a no-op
+# unless these globals are set BEFORE Run() reaches step 6b -- nothing set them, so the
+# first clean compose run printed "6b. deployment settings: none set" and Cloud API sat in
+# Retry with 151 messages queued while every other host read OK.
 #
 # That failure is quiet in the way that matters -- the production runs, metrics flow, the
 # dashboard renders three hosts, and the only clue is one host retrying against a hostname
-# that never existed here.
+# that never existed here. Worse, this script is marker-gated, so the rescue happened once
+# per volume and any later revert to the shipped value was permanent and invisible: that is
+# the "findings appear and disappear with no clear cause" report. Fixing the shipped default
+# is what closed it; keeping these globals keeps a gateway-fronted deployment configurable.
 #
 # THE TARGET IS THIS CONTAINER'S OWN EMBEDDED APACHE. Cloud API runs inside IRIS and the
 # private web server is in the same container, so 127.0.0.1:52773 is both correct and one

--- a/iris/labdemo/Production.cls
+++ b/iris/labdemo/Production.cls
@@ -100,24 +100,69 @@ XData ProductionDefinition
         LogTraceEvents="false"
         Schedule="">
     <!-- HTTPServer/HTTPPort must name the WEB SERVER that fronts this instance, reached
-         from INSIDE the IRIS container. 127.0.0.1:52773 assumed a private web server in
-         the same container; on the verified instance nothing listens there at all (only
-         the superserver on 1972), so every message failed with
+         from INSIDE the IRIS container. This is the SHIPPED value, and what a recompile
+         restores, which is the whole reason it now has to be the working one.
 
-           ERROR #6059: Unable to open TCP/IP socket to server 127.0.0.1:52773
+         THIS SHIPPED `webgateway-webinar:80`, WHICH CAN NEVER RESOLVE FROM THIS STACK.
+         That container belongs to a separate compose project. Measured, with it present
+         on the host:
 
-         and Cloud API sat in Retry having processed zero messages. Same wrong-port
-         assumption as the one corrected in README.md (#48), this time in code (#34).
+           pg-iris networks            ->  production-guardian_default only
+           webgateway-webinar networks ->  iris_default
+           getent hosts webgateway-webinar        ->  no result
+           %Net.HttpRequest to webgateway-webinar ->  #6059 Unable to open TCP/IP socket
 
-         Credentials are REQUIRED: through an external web gateway the REST app answers
-         403 to an unauthenticated request even when /labdemo allows unauthenticated
-         access locally. Verified both ways from inside the container — 403 without,
-         200 {"count":0} with.
+         They share no network, so whether that container is running changes NOTHING here.
+         Do not record this as a dependency on another stack; it is not one.
 
-         Override all three per environment in the Management Portal rather than editing
-         this file; they are the only settings here that depend on the deployment. -->
-    <Setting Target="Adapter" Name="HTTPServer">webgateway-webinar</Setting>
-    <Setting Target="Adapter" Name="HTTPPort">80</Setting>
+         WHY THE VALUE FLAPPED, AND WITH IT THE FINDINGS. Nothing in the repo made this value
+         work; a separate override did. FirstBoot.ApplyDeploymentSettings() rewrites it at
+         first boot from ^ProductionGuardian.Setup, which docker/iris-firstboot.sh sets to
+         127.0.0.1:52773 — so a clean volume delivered and any instance that lost the override
+         did not. That override is marker-gated and never re-applied, and #96 measured it being
+         discarded by a recompile (52773 before, 80 after `ck-d`), leaving Cloud API in Retry
+         with the #6059 above. The result is a target that is correct or broken depending on
+         history no one can see from the file, which is the "findings come and go" report.
+
+         WHAT WAS NOT REPRODUCED, so the next reader does not trust one trigger too far: on a
+         RUNNING production, neither `$system.OBJ.Compile(...,"ck-d")` nor a subsequent
+         UpdateProduction() moved the stored value back to the XData below — the override
+         survived both. So a recompile is a demonstrated way to lose it, not the only way and
+         not a reliable way to demonstrate it. The fix does not depend on knowing the trigger.
+
+         CheckDeploymentTarget() already detects this drift and deliberately only REPORTS it.
+         Making the SHIPPED value the working one removes the drift at the source: whatever
+         reverts to XData now reverts to something that works, and shipped and override agree
+         so there is nothing to report in the default deployment. The override mechanism stays
+         for a deployment that really is gateway-fronted (the demo instance) — it is now an
+         override rather than a repair.
+
+         WHY THE LOOPBACK IS RIGHT AGAIN. #34 moved off 127.0.0.1:52773 because nothing was
+         listening there and every message failed with #6059 on that port. True of the image
+         then, not of the AI Hub image this project ships now. Measured in the running
+         container:
+
+           netstat: tcp 0.0.0.0:52773 LISTEN
+           %Net.HttpRequest localhost:52773 /labdemo/patients -> HTTP 403
+           %Net.HttpRequest pg-iris:52773   /labdemo/patients -> HTTP 403
+
+         403 is the CORRECT answer to an unauthenticated request and is what the Credentials
+         setting below satisfies. So the premise of #34's fix expired when the image changed
+         while the workaround it introduced survived, which is why the measurement is
+         recorded here rather than summarised.
+
+         `127.0.0.1` rather than `localhost` or `pg-iris`, for two reasons: it is the literal
+         PG_IRIS_HTTP_SERVER default in docker/iris-firstboot.sh, so shipped and override now
+         agree and a recompile is a no-op; and the listener above is IPv4-only, so a name that
+         resolves to ::1 first would fail where the address cannot.
+
+         Credentials are REQUIRED: the REST app answers 403 unauthenticated. Verified both ways
+         from inside the container.
+
+         Override per environment via ^ProductionGuardian.Setup or the Management Portal rather
+         than editing this file; these are the only settings here that depend on the deployment. -->
+    <Setting Target="Adapter" Name="HTTPServer">127.0.0.1</Setting>
+    <Setting Target="Adapter" Name="HTTPPort">52773</Setting>
     <Setting Target="Adapter" Name="Credentials">LabDemoREST</Setting>
     <Setting Target="Adapter" Name="URL">/labdemo/patients</Setting>
   </Item>

--- a/iris/labdemo/README.md
+++ b/iris/labdemo/README.md
@@ -65,9 +65,11 @@ class.
 | Allowed authentication | Password (or Unauthenticated for local demo) |
 
 **The port is whichever web server fronts your instance — do not assume 52773.** That is the
-private web server, and it is not always published. On the instance this was verified against
-(`irishealth` behind a `webgateway` container) the only HTTP port is **80**, and 52773 refuses the
-connection outright. Use the same host and port that serve `/api/monitor/metrics` in your browser —
+private web server, and it is not always published. **On this repo's compose stack it *is* 52773**:
+the AI Hub image serves HTTP itself and there is no gateway service, which is why `Production.cls`
+targets `127.0.0.1:52773`. On the older instance this section was verified against (`irishealth`
+behind a `webgateway` container) the only HTTP port is **80**, and 52773 refuses the connection
+outright. Both are real; the point is that it depends on the deployment, so check rather than copy. Use the same host and port that serve `/api/monitor/metrics` in your browser —
 it is the same web server, and the proxy reaches both through one `IRIS_HOST`/`IRIS_PORT` pair.
 
 Verified on that instance, port 80:
@@ -133,13 +135,19 @@ chown -R irisowner:irisowner /tmp/labdemo
 ```
 
 **`Cloud API` must target the web server that fronts the instance, as reached from inside
-it.** `Production.cls` ships `webgateway-webinar:80`, which is specific to the verified
-setup. The old default of `127.0.0.1:52773` assumed a private web server in the same
-container; where there is none, every message fails and the operation sits in `Retry`:
+it.** `Production.cls` ships `127.0.0.1:52773` — the compose stack's IRIS container serves
+HTTP itself, so the target is in the same container and there is no gateway service. It
+briefly shipped `webgateway-webinar:80` instead, which was the *separate* demo instance's
+gateway container: it shares no docker network with this stack, so it never resolved here and
+`Cloud API` only worked while a first-boot override happened to still be in place. Either way
+the failure looks the same — every message fails and the operation sits in `Retry`:
 
 ```
 ERROR #6059: Unable to open TCP/IP socket to server 127.0.0.1:52773
 ```
+
+so **read the hostname in that error**: it names the target actually configured, which is the
+fastest way to tell a wrong setting from a dead web server.
 
 Confirm what actually listens before trusting a port — on the verified instance the IRIS
 container publishes only the superserver on `1972`, and the web gateway is a *separate*

--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -327,17 +327,26 @@ ClassMethod EnableMetrics() As %Status
 
 /// Apply the three settings that depend on the deployment, from overridable globals.
 ///
-/// `Production.cls` ships `webgateway-webinar:80`, which is the verified instance's web
-/// gateway CONTAINER NAME -- correct there and meaningless anywhere else. #72 asks for that
-/// literal to become a compose service name; this is the mechanism that makes it settable
-/// without editing the production, and it is what a container's first boot would call.
+/// `Production.cls` NOW SHIPS `127.0.0.1:52773`, the compose stack's own embedded web server,
+/// so on this stack this method has nothing to correct -- the globals iris-firstboot.sh sets
+/// already match the shipped values. That is deliberate: it used to ship
+/// `webgateway-webinar:80` (the separate demo instance's gateway CONTAINER NAME, which shares
+/// no docker network with this stack and so never resolved here), and this method was the only
+/// thing making the production work. A deployment whose correctness depends on an override
+/// being re-applied is one revert away from broken, which is what #96 and the "findings come
+/// and go" report both were. See the HTTPServer comment in `Production.cls` for the
+/// measurements.
+///
+/// SO THIS IS NOW AN OVERRIDE, NOT A REPAIR, and it still earns its place: an instance that
+/// really is gateway-fronted (the demo instance, #72) sets the globals and gets its own target
+/// without editing the production.
 ///
 ///   set ^ProductionGuardian.Setup("HTTPServer") = "webgateway"
 ///   set ^ProductionGuardian.Setup("HTTPPort")   = 80
 ///
-/// Absent globals leave the shipped values alone, so this is a no-op on the verified
-/// instance -- deliberately, because silently rewriting a working deployment is the defect
-/// Reset() had in #66.
+/// Absent globals leave the shipped values alone -- deliberately, because silently rewriting a
+/// working deployment is the defect Reset() had in #66. That default is now a working target
+/// rather than an unreachable one.
 ClassMethod ApplyDeploymentSettings() As %Status
 {
     set server = $get(^ProductionGuardian.Setup("HTTPServer"), "")
@@ -395,10 +404,16 @@ ClassMethod ApplyDeploymentSettings() As %Status
 /// because nothing is being delivered at all. #96 lost real time to it in that order.
 ///
 /// BOTH SETTINGS REVERT, and #96 says only the port does. Corrected here because the wrong version
-/// sends the next reader looking for adapter fallback behaviour that does not exist:
-/// `Production.cls` ships `HTTPServer` as `webgateway-webinar` (line 99), not `127.0.0.1`. So the
-/// hostname in that error is not a red herring and not a fallback -- it is exactly what a recompile
-/// restored. The error message was accurate; the configuration was wrong.
+/// sends the next reader looking for adapter fallback behaviour that does not exist: the hostname in
+/// that error was not a red herring and not a fallback -- it was exactly what a recompile restored,
+/// because `Production.cls` shipped `webgateway-webinar` at the time. The error message was
+/// accurate; the configuration was wrong.
+///
+/// THE SHIPPED VALUE HAS SINCE BEEN FIXED to `127.0.0.1:52773`, so on this stack a revert now lands
+/// on a working target and the error above should no longer be reachable. This check is kept rather
+/// than deleted for two reasons: it still guards a gateway-fronted deployment, where shipped and
+/// intended genuinely differ and a revert is still silent breakage; and it is the only thing that
+/// would report the drift if the shipped default drifts again.
 ///
 /// REPORTS, DOES NOT REPAIR. Re-applying silently would hide how often this happens, and a boot that
 /// quietly corrects a drift teaches nobody. `Run()` calls this last so a boot ends by confirming the


### PR DESCRIPTION
Closes the "findings appear and disappear with no clear cause" report (item 3).

## The defect

`Production.cls` shipped `HTTPServer=webgateway-webinar`, `HTTPPort=80`. That container belongs to a **different compose project** and shares no docker network with `pg-iris`, so the name can never resolve here — running or not:

| probe | result |
|---|---|
| `pg-iris` networks | `production-guardian_default` only |
| `webgateway-webinar` networks | `iris_default` |
| `getent hosts webgateway-webinar` | no result |
| `%Net.HttpRequest` to it | `#6059 Unable to open TCP/IP socket` |

I want to flag one thing I got wrong on the way, because it is the more tempting explanation: I first assumed the finding flapped according to whether that *other stack happened to be running*. It cannot. The two share no network, so that container's state is irrelevant. Checking it was what found the real mechanism.

## Why it flapped

Nothing in the repo made that value work — a separate override did. `FirstBoot.ApplyDeploymentSettings()` rewrites the target from `^ProductionGuardian.Setup`, which `docker/iris-firstboot.sh` sets to `127.0.0.1:52773`. **That script is marker-gated**, so the rescue ran once per volume and nothing ever re-applied it. #96 already measured the override being discarded by a recompile (52773 before, 80 after `ck-d`), leaving `Cloud API` in Retry with `#6059`.

So the target was correct or broken according to history invisible from the file. `queue_buildup` fired and cleared with no cause a reader could see. #96 is the same defect seen from the inside — it documents the drift and deliberately only *reports* it.

## The fix

Ship the working value, so whatever reverts to XData reverts to something that works, and shipped agrees with the override default.

`127.0.0.1` rather than `localhost` or `pg-iris`, for two reasons: it is the literal `PG_IRIS_HTTP_SERVER` default in `iris-firstboot.sh`, so shipped and override now agree and there is no drift to detect; and the listener is **IPv4-only** (`tcp 0.0.0.0:52773`), so a name resolving to `::1` first would fail where the address cannot.

## Verified live, production running

| check | result |
|---|---|
| `netstat` | `tcp 0.0.0.0:52773 LISTEN` |
| `127.0.0.1` applied, delivery over 60s | `PatientRecord` **60933 → 60968** (+35) |
| `Ens_Util.Log` `Type=2`, last 3 min | **0** |
| errored messages, last 3 min | none |
| `Production.cls` + `FirstBoot.cls` compile from `/pg-src` | OK |
| `bash -n docker/iris-firstboot.sh` | OK |

**What I could NOT reproduce, and said so in the comment rather than glossing it:** on a *running* production, neither `$system.OBJ.Compile(...,"ck-d")` nor a subsequent `UpdateProduction()` moved the stored value back to the XData — the override survived both. A recompile is a *demonstrated* way to lose it (#96), not the only way and not a reliable way to demonstrate it. The fix does not depend on knowing the trigger, which is the reason it is the right shape of fix.

## Kept, not deleted

`VerifyDeploymentSettings()` still earns its place: a genuinely gateway-fronted deployment (the demo instance, #72) still has shipped and intended differ, and a revert there is still silent breakage. It is now an override mechanism rather than a repair.

## Docs corrected because this change falsifies them

Four claims stated the shipped target as `webgateway-webinar:80`:

- `iris/setup/FirstBoot.cls` — `ApplyDeploymentSettings()` and `VerifyDeploymentSettings()` doc blocks
- `iris/labdemo/README.md` — the shipped target; and "do not assume 52773" now records that on *this* stack it **is** 52773, while keeping the older gateway-fronted instance's port 80 as the counter-example
- `docker/iris-firstboot.sh` — the globals are an override now, not a repair

## Scope

No behaviour change outside `Cloud API`'s adapter target. No engine, dashboard, or `contracts/` change. Engine suite re-measured on `main` for the record: **370 tests, 370 pass, 0 fail, 0 skipped**, `tsc --noEmit` clean, on node v24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)