### PR TITLE
fix(detection-engine): clearing a finding takes the same bar as raising one (#149)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,46 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-26 — clearing a finding takes the same bar as raising one (#149)
+
+**`healthscan-api.md` §2.1 (a new paragraph under *Sustained breach*) and Q4.** No schema
+change, no field added or removed, no sample change — this documents *when* a finding leaves,
+which the contract described only for arriving.
+
+**Q4 promised two things that the implementation could not both keep.** "ids are stable while
+the condition persists" and "findings disappear when cleared" are only compatible if *cleared*
+and *not breaching on this poll* are the same event. They are not. MVP §6's 2-consecutive-samples
+rule was read as governing appearance alone, so a finding cost **two** samples to arrive and
+**one** to leave, and a condition oscillating around a threshold produced a finding, dropped it,
+and produced the same condition again under a **new `id`** — `f-1000`, gone, back as `f-1001`.
+Reproduced against the shipped defaults (`sustainedSamples: 2`, `sustainedSeconds: 4`), not
+theorised. To a viewer that is findings appearing and vanishing with no cause, which is how it
+was reported.
+
+Clearing now uses the same two gates, read from the same two knobs — no third tunable, because
+"how many samples before I believe this changed" is one question asked in both directions.
+`sustainedSamples: 1` / `sustainedSeconds: 0` still clears on the first non-breaching poll, so
+the old behaviour remains reachable by configuration.
+
+Two consumer-visible consequences, both stated in §2.1:
+
+- a finding may persist **one extra poll** past the condition, showing its last breaching
+  numbers (there is no newer verdict to refresh from)
+- a finding **holds while its inputs are unmeasurable** — Q13's `null`. A rule that declines to
+  evaluate has said "cannot tell", not "not breaching". Each rule now declares the inputs it
+  cannot work without, so the engine can tell the two silences apart; `dead_host` declares none
+  and clears exactly as before.
+
+The same bar now governs a host vanishing from the proxy payload. That half was worse than a
+flap: forgetting on the first absent poll discarded the **rolling baseline** along with the
+findings, so a host that dropped out of one payload came back `warming` and every comparative
+rule was silent for `minBaselineSamples` further polls. The finding did not flicker — it went
+away and could not return, for a reason invisible from outside the process.
+
+**Nothing changes for a consumer that renders whatever the endpoint returns.** What changes is
+that an `id` is now stable for the lifetime of the condition, as Q4 always said it was.
+
+
 ## 2026-08-26 — `type` gains a second source; Q6's "treat unknown as a real value" amended (#127)
 
 **`proxy-api.md` §1.1, §1.3, §5.1 (Q6) and a new §5.1.1; `proxy.schema.json`

--- a/contracts/healthscan-api.md
+++ b/contracts/healthscan-api.md
@@ -125,6 +125,29 @@ Sorted `detectedAt` descending, severity as tiebreak (critical → warning → i
 finding is emitted. A single-sample spike produces nothing. This is why findings are stateful
 and why `id` can be stable (Q4).
 
+**The same bar applies to clearing (2026-08-26).** A confirmed finding disappears once the
+rule has stopped breaching for **the same 2+ consecutive samples**, not on the first
+non-breaching poll. MVP §6 governs appearance, and reading it as governing only appearance
+made a finding cost two samples to arrive and one to leave — so a condition oscillating
+around a threshold produced a finding, dropped it, and produced **the same condition again
+under a new `id`**. That is the asymmetry, and it contradicted Q4: an `id` that survives a
+poll but not a blip is stable for the lifetime of an uninterrupted breach, not for the
+lifetime of the condition.
+
+Two consequences for a consumer, both intended:
+
+- a finding may persist for **one extra poll** after the condition ends, still showing the
+  last breaching numbers — there is no newer verdict to refresh from
+- a finding **holds indefinitely while its inputs are unmeasurable** (Q13's `null`). A rule
+  that declines to evaluate has said "cannot tell", not "not breaching", and an instance
+  that stops publishing a metric must not thereby retract a finding that is still true.
+  `dead_host` is unaffected: it judges `status`, which is always present.
+
+The same bar governs a host **disappearing from the proxy payload**: one absent poll no longer
+forgets it. Forgetting discarded the rolling baseline with the findings, so a host that dropped
+out of a single payload came back `warming` and every comparative rule went silent for
+`minBaselineSamples` more polls — a finding that goes away and cannot return.
+
 ---
 
 ## 3. Errors and empty states
@@ -155,7 +178,7 @@ Dev C raised nine (issue #1); three more surfaced from live IRIS metrics while b
 | **Q1** | Exact `status` enum | **Not** the assumed set. IRIS emits `OK`, `Error`, `Inactive`, `Retry`, `Stopped`, `Unconfigured`; `EnumerateHostStatus` adds `Disabled`. **There is no `Warning`.** Keep rendering unknowns neutrally. |
 | **Q2** | Exact `type` strings | Confirmed — the eight snake_case names as listed, unchanged. |
 | **Q3** | Baseline warm-up | `baselineValue: number \| null`. Your assumption was right. Also surfaced via `X-Healthscan-State: warming`. |
-| **Q4** | Finding lifecycle | **ids are stable** while the condition persists; findings **disappear** when cleared. Both your assumptions hold — keep the highlight animation and the poll-surviving drawer. Sustained-breach state (§2.1) is what makes this cheap for us. |
+| **Q4** | Finding lifecycle | **ids are stable** while the condition persists; findings **disappear** when cleared. Both your assumptions hold — keep the highlight animation and the poll-surviving drawer. Sustained-breach state (§2.1) is what makes this cheap for us. **Amended 2026-08-26:** clearing takes the same 2+ consecutive samples as appearing, and a finding whose inputs are unmeasurable holds rather than clearing — the original one-poll clear broke the id-stability half of this answer. See §2.1. |
 | **Q5** | Ordering | Sorted **server-side**, `detectedAt` desc, severity tiebreak. Your client sort is harmless — keep it. |
 | **Q6** | Units | **Seconds** — confirmed empirically, not assumed. Cloud API configured at 0.05s latency reports `avgProcessingTime: 0.05`; Lab Router reports `0.08`. Your `0.08 → "80 ms"` is correct. |
 | **Q7** | Zero findings / startup | `200` + `[]`, never `404`. See §3 for the full table. |

--- a/services/detection-engine/src/detect/engine.ts
+++ b/services/detection-engine/src/detect/engine.ts
@@ -14,6 +14,7 @@ import type { ThresholdConfig } from '../config/thresholds.ts';
 import { configFor, inertOverrideHosts } from '../config/thresholds.ts';
 import type {
   Finding,
+  FindingType,
   HealthScanState,
   Host,
   HostStatus,
@@ -25,7 +26,7 @@ import { FindingRegistry } from './registry.ts';
 import { HOST_RULES } from './rules/index.ts';
 import { projectHost, type HostProjection } from './earlywarning.ts';
 import { buildHostSeries, type HostSeries } from './series.ts';
-import type { RuleVerdict } from './rules/types.ts';
+import type { RawHostMetrics, RuleInputKey, RuleVerdict } from './rules/types.ts';
 
 /** Metrics that must be warm before a host counts as fully baselined. */
 const BASELINED_METRICS = [
@@ -63,6 +64,8 @@ export class DetectionEngine {
   #projections = new Map<string, HostProjection>();
   /** Cumulative errored counts from the previous poll, for the per-minute rate. */
   #priorErrored = new Map<string, { errored: number; at: number }>();
+  /** Hosts missing from recent payloads, awaiting the absence bar in applyPoll(). */
+  #absent = new Map<string, { firstAbsentAt: number; polls: number }>();
   /** Alert timestamps already reported, so system_alert only fires on new ones. */
   #seenAlerts = new Set<string>();
   #lastPollAt: number | null = null;
@@ -100,6 +103,9 @@ export class DetectionEngine {
       this.#baselines = new BaselineStore(next.baselineWindowSeconds, next.minBaselineSamples);
       this.#registry = new FindingRegistry(next.sustainedSamples, next.sustainedSeconds);
       this.#priorErrored.clear();
+      // The absence bar reads the same two knobs, so a partly-counted absence measured
+      // against the old ones is not comparable to the new ones.
+      this.#absent.clear();
     }
   }
 
@@ -158,21 +164,29 @@ export class DetectionEngine {
         this.#baselines.record(host.host, 'errorsPerMinute', errorsPerMinute, now);
       }
 
+      // Raw nullable values, so a rule can tell "measured zero" from "unknown".
+      // normalizeHost() collapses these for the wire; rules must not see that.
+      const raw = {
+        queued: proxyHost.queued,
+        messagesPerSec: proxyHost.messagesPerSec,
+        errored: proxyHost.errored,
+        avgProcessingTime: proxyHost.avgProcessingTime,
+        avgQueueingTime: proxyHost.avgQueueingTime,
+        lastActivityElapsedSeconds: proxyHost.lastActivityElapsedSeconds,
+      };
+
       const verdicts: RuleVerdict[] = [];
+      // Rules whose silence this poll means "cannot tell", not "not breaching" — one of
+      // their declared inputs was absent. The registry must not read these as a clear.
+      const unmeasurable = new Set<FindingType>();
       for (const rule of HOST_RULES) {
+        if (rule.requires.some((key) => inputValue(raw, errorsPerMinute, key) === null)) {
+          unmeasurable.add(rule.type);
+        }
         const verdict = rule.evaluate({
           host,
           errorsPerMinute,
-          // Raw nullable values, so a rule can tell "measured zero" from "unknown".
-          // normalizeHost() collapses these for the wire; rules must not see that.
-          raw: {
-            queued: proxyHost.queued,
-            messagesPerSec: proxyHost.messagesPerSec,
-            errored: proxyHost.errored,
-            avgProcessingTime: proxyHost.avgProcessingTime,
-            avgQueueingTime: proxyHost.avgQueueingTime,
-            lastActivityElapsedSeconds: proxyHost.lastActivityElapsedSeconds,
-          },
+          raw,
           baselines: this.#baselines,
           config: this.#config,
           now,
@@ -183,38 +197,50 @@ export class DetectionEngine {
       const alertVerdict = this.#evaluateAlerts(host.host, response.alerts, now);
       if (alertVerdict !== null) verdicts.push(alertVerdict);
 
-      this.#registry.update(host.host, verdicts, now);
+      this.#registry.update(host.host, verdicts, now, unmeasurable);
 
       // AFTER recordIfMeasured above, so the fit window includes this poll's sample. Before
       // it, every projection would be one poll stale and `measuredAt` would disagree with
       // `currentValue`.
       this.#projections.set(
         host.host,
-        projectHost(
-          host.host,
-          {
-            queued: proxyHost.queued,
-            messagesPerSec: proxyHost.messagesPerSec,
-            errored: proxyHost.errored,
-            avgProcessingTime: proxyHost.avgProcessingTime,
-            avgQueueingTime: proxyHost.avgQueueingTime,
-            lastActivityElapsedSeconds: proxyHost.lastActivityElapsedSeconds,
-          },
-          this.#baselines,
-          this.#config,
-          now,
-        ),
+        projectHost(host.host, raw, this.#baselines, this.#config, now),
       );
     }
 
-    // A host that left the production should not linger with stale findings.
+    // A host that left the production should not linger with stale findings — but ONE poll
+    // that omits it is not proof it left, and forgetting on that poll is the other half of
+    // "findings appear and disappear with no clear cause".
+    //
+    // It is the worse half, because it does not just retract the finding — it takes the
+    // BASELINE with it. At the shipped minBaselineSamples of 12 and a 5s poll, a host that
+    // dropped out of one payload came back with an empty window, so every comparative rule
+    // was `warming` and SILENT for a further minute. The finding does not flicker; it goes
+    // away and cannot return, for a reason invisible from the outside.
+    //
+    // So absence gets the same two gates as a breach, from the same two knobs — see the
+    // symmetry note in registry.ts. sustainedSamples 1 / sustainedSeconds 0 forgets on the
+    // first absent poll, i.e. the old behaviour exactly.
     for (const known of [...this.#hosts.keys()]) {
-      if (seenHosts.has(known)) continue;
+      if (seenHosts.has(known)) {
+        this.#absent.delete(known);
+        continue;
+      }
+
+      const absent = this.#absent.get(known) ?? { firstAbsentAt: now, polls: 0 };
+      absent.polls += 1;
+      this.#absent.set(known, absent);
+      const gone =
+        absent.polls >= this.#config.sustainedSamples &&
+        now - absent.firstAbsentAt >= this.#config.sustainedSeconds * 1000;
+      if (!gone) continue;
+
       this.#hosts.delete(known);
       this.#projections.delete(known);
       this.#registry.forget(known);
       this.#baselines.forget(known);
       this.#priorErrored.delete(known);
+      this.#absent.delete(known);
     }
 
     this.#warnInertOverrides(seenHosts);
@@ -461,6 +487,18 @@ export function normalizeHost(proxyHost: ProxyHost, now: number): Host {
  */
 function orZero(value: number | null): number {
   return value ?? 0;
+}
+
+/**
+ * One of a rule's declared inputs, by name. `errorsPerMinute` is derived across polls
+ * rather than carried on the sample, so it is not in `raw` and is passed alongside.
+ */
+function inputValue(
+  raw: RawHostMetrics,
+  errorsPerMinute: number | null,
+  key: RuleInputKey,
+): number | null {
+  return key === 'errorsPerMinute' ? errorsPerMinute : raw[key];
 }
 
 /** Contract Q10: IRIS 'actor' means a business process. */

--- a/services/detection-engine/src/detect/registry.ts
+++ b/services/detection-engine/src/detect/registry.ts
@@ -90,14 +90,17 @@ export class FindingRegistry {
    *
    * `unmeasurable` names the rules whose inputs were absent this poll (`Rule.requires`),
    * whose omission therefore means "cannot tell" rather than "not breaching". Those
-   * conditions HOLD: they neither advance toward clearing nor toward confirming. Default
-   * empty, so a caller that does not distinguish gets the old reading.
+   * conditions HOLD: they neither advance toward clearing nor toward confirming.
+   *
+   * Required rather than defaulted to empty. A default would let a caller opt out of the
+   * distinction silently, which is the defect this argument exists to fix, and it would be
+   * a branch no test reaches — pass an empty set explicitly if there is nothing to hold.
    */
   update(
     host: string,
     verdicts: readonly RuleVerdict[],
     now: number,
-    unmeasurable: ReadonlySet<FindingType> = EMPTY_TYPES,
+    unmeasurable: ReadonlySet<FindingType>,
   ): void {
     const breaching = new Set(verdicts.map((v) => v.type));
 
@@ -216,9 +219,6 @@ export class FindingRegistry {
 }
 
 const SEP = '\u0000';
-
-/** Shared empty default for `update`'s `unmeasurable`, so it allocates nothing per poll. */
-const EMPTY_TYPES: ReadonlySet<FindingType> = new Set();
 
 function conditionKey(host: string, type: FindingType): string {
   return `${host}${SEP}${type}`;

--- a/services/detection-engine/src/detect/registry.ts
+++ b/services/detection-engine/src/detect/registry.ts
@@ -15,6 +15,12 @@
  * polling faster to meet the 10s acceptance bar would silently shorten the debounce
  * (#44). Keeping the time gate separate lets the two be tuned independently.
  *
+ * **The bar is SYMMETRIC.** A confirmed finding leaves on the same two gates it arrived
+ * on, rather than on the first non-breaching poll. Promise 1 is why: an id that survives a
+ * poll but not a blip is not stable for the lifetime of the condition, it is stable for the
+ * lifetime of an uninterrupted breach — and the condition outlives the interruption. See
+ * the long note in `update()` for the flap this produced.
+ *
  * State is keyed by (host, type) — one ongoing condition per rule per host.
  */
 
@@ -26,8 +32,12 @@ interface TrackedCondition {
   id: string;
   /** Consecutive breaching samples. Emits once this reaches sustainedSamples. */
   consecutiveBreaches: number;
+  /** Consecutive NON-breaching samples. Clears once this reaches the same bar. */
+  consecutiveClears: number;
   /** When the breach was first OBSERVED. Drives the sustainedSeconds gate. */
   firstSeenAt: number;
+  /** The most recent breaching poll. Drives the clear-side sustainedSeconds gate. */
+  lastBreachAt: number;
   /** When the condition was first CONFIRMED (i.e. became a finding), not first seen. */
   confirmedAt: number | undefined;
   /** Latest verdict, refreshed each poll so values stay current. */
@@ -60,13 +70,35 @@ export class FindingRegistry {
   }
 
   /**
+   * The same two gates, applied to going away. See the header note on symmetry.
+   *
+   * Note it reads `lastBreachAt`, not `firstSeenAt` — the clock the clear side runs on is
+   * "how long since this was last true", which is what a viewer is judging.
+   */
+  #isCleared(condition: TrackedCondition, now: number): boolean {
+    return (
+      condition.consecutiveClears >= this.#sustainedSamples &&
+      now - condition.lastBreachAt >= this.#sustainedMs
+    );
+  }
+
+  /**
    * Apply one poll's verdicts for one host.
    *
    * `verdicts` must contain an entry for every rule that breached, and omit those that
-   * did not — omission is what clears a condition. Rules that returned null are
-   * absent, so we reset their counters.
+   * did not — omission is what clears a condition.
+   *
+   * `unmeasurable` names the rules whose inputs were absent this poll (`Rule.requires`),
+   * whose omission therefore means "cannot tell" rather than "not breaching". Those
+   * conditions HOLD: they neither advance toward clearing nor toward confirming. Default
+   * empty, so a caller that does not distinguish gets the old reading.
    */
-  update(host: string, verdicts: readonly RuleVerdict[], now: number): void {
+  update(
+    host: string,
+    verdicts: readonly RuleVerdict[],
+    now: number,
+    unmeasurable: ReadonlySet<FindingType> = EMPTY_TYPES,
+  ): void {
     const breaching = new Set(verdicts.map((v) => v.type));
 
     for (const verdict of verdicts) {
@@ -77,7 +109,9 @@ export class FindingRegistry {
         const fresh: TrackedCondition = {
           id: `f-${this.#nextId++}`,
           consecutiveBreaches: 1,
+          consecutiveClears: 0,
           firstSeenAt: now,
+          lastBreachAt: now,
           confirmedAt: undefined,
           verdict,
         };
@@ -88,6 +122,12 @@ export class FindingRegistry {
       }
 
       existing.consecutiveBreaches += 1;
+      existing.lastBreachAt = now;
+      // A breach ends any clear streak, so a blip costs the condition nothing. It does NOT
+      // reset firstSeenAt or confirmedAt: an already-confirmed condition that blipped is the
+      // same condition, and re-serving its confirmation clock would make one absent poll
+      // restart the sustained bar and delay the finding all over again.
+      existing.consecutiveClears = 0;
       // Refresh values so the finding shows current numbers, but never touch the id.
       existing.verdict = verdict;
       if (existing.confirmedAt === undefined && this.#isConfirmed(existing, now)) {
@@ -95,12 +135,43 @@ export class FindingRegistry {
       }
     }
 
-    // Anything tracked for this host that did NOT breach this poll is cleared outright.
-    // Resetting rather than decaying is deliberate: MVP §6 says *consecutive* samples.
+    // ---- What did NOT breach this poll -------------------------------------------------
+    //
+    // This is deliberately NOT the mirror image of appearing, in one respect and one only:
+    // an UNCONFIRMED condition still resets outright, because MVP §6 says *consecutive*
+    // samples and that rule governs appearance. A confirmed FINDING is different. It has
+    // been published, Dev B's UI has animated it in, and the contract (healthscan-api.md
+    // Q4) promises its id is stable for the lifetime of the condition. Retracting it on a
+    // single non-breaching poll made appearing cost two samples and disappearing cost one,
+    // and that asymmetry is the flap: a queue oscillating around the floor produced a
+    // finding, dropped it, and produced it again under a NEW id (`f-1000` -> gone -> the
+    // same condition back as `f-1001`), which reads to a viewer as findings appearing and
+    // vanishing with no cause. Reproduced against these defaults, not theorised.
+    //
+    // So clearing gets the same bar as confirming, from the same two knobs — no third
+    // tunable, because "how many samples before I believe this changed" is one question
+    // asked in both directions. sustainedSamples 1 / sustainedSeconds 0 still clears on the
+    // first non-breaching poll, i.e. the old behaviour exactly.
     for (const [key, condition] of [...this.#conditions]) {
       if (!key.startsWith(`${host}${SEP}`)) continue;
       if (breaching.has(condition.verdict.type)) continue;
-      this.#conditions.delete(key);
+
+      // "Cannot tell" is neither a breach nor a clear. Hold, and do not count the poll
+      // toward either gate — an instance that stops publishing a metric must not thereby
+      // retract a finding about it. See Rule.requires.
+      if (unmeasurable.has(condition.verdict.type)) continue;
+
+      if (condition.confirmedAt === undefined) {
+        this.#conditions.delete(key);
+        continue;
+      }
+
+      condition.consecutiveBreaches = 0;
+      condition.consecutiveClears += 1;
+      // While it holds, the finding keeps serving its last breaching numbers — there is no
+      // newer verdict to refresh from. One poll of slightly stale values is the price of
+      // not retracting a true finding, and it is bounded by the gates above.
+      if (this.#isCleared(condition, now)) this.#conditions.delete(key);
     }
   }
 
@@ -145,6 +216,9 @@ export class FindingRegistry {
 }
 
 const SEP = '\u0000';
+
+/** Shared empty default for `update`'s `unmeasurable`, so it allocates nothing per poll. */
+const EMPTY_TYPES: ReadonlySet<FindingType> = new Set();
 
 function conditionKey(host: string, type: FindingType): string {
   return `${host}${SEP}${type}`;

--- a/services/detection-engine/src/detect/rules/index.ts
+++ b/services/detection-engine/src/detect/rules/index.ts
@@ -28,6 +28,10 @@ import {
 const deadHost: Rule = {
   type: 'dead_host',
   absolute: true,
+  // Nothing. It judges `status`, which is always present, and the queue depth below is
+  // decoration it omits when absent rather than a gate. So an unmeasurable poll IS a real
+  // "not breaching" answer here, and this finding must still clear on one.
+  requires: [],
   evaluate({ host, raw, config }: RuleInput): RuleVerdict | null {
     const rule = configFor(config, 'dead_host', host.host);
     if (!rule.enabled) return null;
@@ -56,6 +60,7 @@ const deadHost: Rule = {
 const stalledHost: Rule = {
   type: 'stalled_host',
   absolute: true,
+  requires: ['queued', 'lastActivityElapsedSeconds'],
   evaluate({ host, raw, config, now }: RuleInput): RuleVerdict | null {
     const rule = configFor(config, 'stalled_host', host.host);
     if (!rule.enabled) return null;
@@ -118,6 +123,7 @@ const stalledHost: Rule = {
 const queueBuildup: Rule = {
   type: 'queue_buildup',
   absolute: false,
+  requires: ['queued'],
   evaluate({ host, raw, baselines, config }: RuleInput): RuleVerdict | null {
     const rule = configFor(config, 'queue_buildup', host.host);
     if (!rule.enabled) return null;
@@ -161,6 +167,9 @@ const queueBuildup: Rule = {
 const elevatedErrorRate: Rule = {
   type: 'elevated_error_rate',
   absolute: false,
+  // The DERIVED rate, not `errored`. It is null both when IRIS could not count errors and
+  // on the first poll for a host, where there is no prior sample to difference against.
+  requires: ['errorsPerMinute'],
   evaluate({ host, errorsPerMinute, baselines, config }: RuleInput): RuleVerdict | null {
     const rule = configFor(config, 'elevated_error_rate', host.host);
     if (!rule.enabled) return null;
@@ -200,6 +209,12 @@ function durationRule(
   return {
     type,
     absolute: false,
+    // This pair reads the NORMALIZED host, where an absent duration has already become 0
+    // and falls under the floor — so it never sees a null and cannot return "cannot tell".
+    // Declared anyway, and read from `raw`: the input really is unmeasurable on such a
+    // poll, and a finding that was breaching should hold rather than be retracted by a
+    // gap in the metrics text. Without this the rule clears on the coerced zero.
+    requires: [metric],
     evaluate({ host, baselines, config }: RuleInput): RuleVerdict | null {
       const rule = configFor(config, type, host.host);
       if (!rule.enabled) return null;
@@ -249,6 +264,7 @@ function durationRule(
 const throughputDrop: Rule = {
   type: 'throughput_drop',
   absolute: false,
+  requires: ['messagesPerSec'],
   evaluate({ host, raw, baselines, config }: RuleInput): RuleVerdict | null {
     const rule = configFor(config, 'throughput_drop', host.host);
     if (!rule.enabled) return null;

--- a/services/detection-engine/src/detect/rules/types.ts
+++ b/services/detection-engine/src/detect/rules/types.ts
@@ -73,10 +73,28 @@ export interface RuleVerdict {
   message: string;
 }
 
+/** An input a rule reads: a raw proxy metric, or the rate derived across polls. */
+export type RuleInputKey = keyof RawHostMetrics | 'errorsPerMinute';
+
 export interface Rule {
   readonly type: FindingType;
   /** True when this rule needs no baseline. Only dead_host and system_alert. */
   readonly absolute: boolean;
+  /**
+   * The inputs this rule declines to evaluate without — the ones whose `=== null` guard
+   * returns null from `evaluate`.
+   *
+   * `evaluate` returns ONE undifferentiated null for two different answers: "not
+   * breaching" and "cannot tell". The comment on RuleVerdict below is only true of the
+   * first. The registry reads an absent verdict as a clear, so an unmeasurable poll
+   * silently retracted a finding that was still true — the same conflation #33 and #49
+   * fixed INSIDE the rules, still present in what the rules' silence means.
+   *
+   * Declared rather than inferred because the difference is not visible from the outside.
+   * Keep this in step with the `=== null` guards in evaluate(); a rule that guards on an
+   * input it does not list will still flap.
+   */
+  readonly requires: readonly RuleInputKey[];
   evaluate(input: RuleInput): RuleVerdict | null;
 }
 

--- a/services/detection-engine/test/engine.test.ts
+++ b/services/detection-engine/test/engine.test.ts
@@ -208,9 +208,95 @@ describe('finding lifecycle (contract Q4)', () => {
     engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
     assert.equal(engine.snapshot().findings.length, 1, 'precondition: finding exists');
 
+    // Clearing takes the same two gates as confirming, so it takes the same two polls.
+    for (let i = 0; i < DEFAULT_CONFIG.sustainedSamples; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([proxyHost({ status: 'OK' })]), at);
+    }
+    assert.equal(engine.snapshot().findings.length, 0, 'no tombstones, no resolvedAt');
+  });
+
+  it('holds a confirmed finding through ONE non-breaching poll, id intact', () => {
+    // The flap: appearing cost two samples and disappearing cost one, so a condition
+    // oscillating around a threshold produced a finding, dropped it, and produced the
+    // SAME condition again under a new id. Contract Q4 promises the id is stable for the
+    // lifetime of the condition, and the condition outlives the blip.
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    const first = engine.snapshot().findings[0];
+    assert.ok(first !== undefined, 'precondition: queue_buildup confirmed');
+
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 0 })]), at);
+    assert.equal(engine.snapshot().findings.length, 1, 'one blip must not retract it');
+
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    const back = engine.snapshot().findings[0];
+    assert.ok(back !== undefined);
+    assert.equal(back.id, first.id, 'same condition, same id — not a new finding');
+    assert.equal(back.detectedAt, first.detectedAt, 'and the blip did not re-clock it');
+  });
+
+  it('holds a confirmed finding when its input becomes UNMEASURABLE', () => {
+    // A null queue depth is "cannot tell", not "not breaching". queue_buildup declines to
+    // evaluate on it (#49), and that silence must not read as a clear — an instance that
+    // stops publishing a metric would otherwise retract a finding that is still true.
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    const first = engine.snapshot().findings[0];
+    assert.ok(first !== undefined, 'precondition: queue_buildup confirmed');
+
+    // Well past the clear bar in both polls and seconds.
+    for (let i = 0; i < DEFAULT_CONFIG.sustainedSamples + 3; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([proxyHost({ queued: null })]), at);
+    }
+    const held = engine.snapshot().findings[0];
+    assert.ok(held !== undefined, 'unmeasurable must never clear a finding');
+    assert.equal(held.id, first.id);
+  });
+
+  it('still clears dead_host on the bar, since its inputs are never unmeasurable', () => {
+    // dead_host declares `requires: []` — it judges `status`, which is always present. So
+    // its silence really does mean "not breaching" and the hold above must not apply to it.
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled', queued: null })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ status: 'Disabled', queued: null })]), at);
+    assert.equal(engine.snapshot().findings.length, 1, 'precondition: dead_host confirmed');
+
+    for (let i = 0; i < DEFAULT_CONFIG.sustainedSamples; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([proxyHost({ status: 'OK', queued: null })]), at);
+    }
+    assert.equal(engine.snapshot().findings.length, 0);
+  });
+
+  it('sustainedSamples 1 / sustainedSeconds 0 clears on the first poll, as it always did', () => {
+    // The clear bar reuses the two existing knobs rather than adding a third, so the
+    // degenerate config still means "believe every poll" in both directions. Anyone who
+    // wants the old asymmetric behaviour back has it here.
+    const eager = { ...DEFAULT_CONFIG, sustainedSamples: 1, sustainedSeconds: 0 };
+    const engine = new DetectionEngine(eager);
+    let at = warmUp(engine);
+
+    engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
+    assert.equal(engine.snapshot().findings.length, 1, 'confirms on one sample');
+
     at += POLL_MS;
     engine.applyPoll(response([proxyHost({ status: 'OK' })]), at);
-    assert.equal(engine.snapshot().findings.length, 0, 'no tombstones, no resolvedAt');
+    assert.equal(engine.snapshot().findings.length, 0, 'and clears on one');
   });
 
   it('forgets a host that leaves the production', () => {
@@ -222,11 +308,38 @@ describe('finding lifecycle (contract Q4)', () => {
     engine.applyPoll(response([proxyHost({ status: 'Disabled' })]), at);
     assert.equal(engine.snapshot().findings.length, 1);
 
-    at += POLL_MS;
-    engine.applyPoll(response([]), at);
+    // Absence is held to the same bar, so it takes the same two polls to believe.
+    for (let i = 0; i < DEFAULT_CONFIG.sustainedSamples; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([]), at);
+    }
     const snapshot = engine.snapshot();
     assert.equal(snapshot.hosts.length, 0);
     assert.equal(snapshot.findings.length, 0);
+  });
+
+  it('keeps a host and its warm baseline through ONE absent poll', () => {
+    // Forgetting on the first absent poll discarded the BASELINE too, so a host that
+    // dropped out of one payload came back `warming` — every comparative rule silent for
+    // minBaselineSamples more polls. That is a finding that goes away and cannot return.
+    const engine = new DetectionEngine(DEFAULT_CONFIG);
+    let at = warmUp(engine);
+
+    at += POLL_MS;
+    engine.applyPoll(response([]), at);
+    assert.equal(engine.snapshot().hosts.length, 1, 'last-known host, not blanked');
+
+    // Back on the next poll, and still warm: a breach confirms on the usual two samples
+    // rather than waiting out a fresh baseline window.
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    at += POLL_MS;
+    engine.applyPoll(response([proxyHost({ queued: 100 })]), at);
+    assert.equal(
+      engine.snapshot().findings.filter((f) => f.type === 'queue_buildup').length,
+      1,
+      'baseline survived the gap, so the comparative rule could still fire',
+    );
   });
 });
 
@@ -375,8 +488,10 @@ describe('system_alert', () => {
     engine.applyPoll({ ...response([proxyHost()]), alerts: [alert] }, T0 + 2 * POLL_MS);
     assert.equal(alertCount(), 1, 'still reported while present, not duplicated');
 
-    // The alert ages out of the proxy payload — the finding clears, per contract Q4.
+    // The alert ages out of the proxy payload — the finding clears, per contract Q4, on
+    // the same two-gate bar it confirmed on.
     engine.applyPoll(response([proxyHost()]), T0 + 3 * POLL_MS);
+    engine.applyPoll(response([proxyHost()]), T0 + 4 * POLL_MS);
     assert.equal(alertCount(), 0, 'no tombstone once the alert is gone');
   });
 

--- a/services/detection-engine/test/series.test.ts
+++ b/services/detection-engine/test/series.test.ts
@@ -287,7 +287,19 @@ describe('negative cases (CLAUDE.md §8)', () => {
     }
     assert.equal(points(seriesFor(engine, 'Lab Router', at), 'queued').length, 4);
 
+    // Departure is held to the sustained bar, so one absent poll is not yet a departure —
+    // and until it is, the history stays rather than being thrown away and re-warmed.
     engine.applyPoll(response([proxyHost({ host: 'Cloud API' })]), at);
+    assert.equal(
+      points(seriesFor(engine, 'Lab Router', at), 'queued').length,
+      4,
+      'one absent poll must not discard the window',
+    );
+
+    for (let i = 1; i < DEFAULT_CONFIG.sustainedSamples; i += 1) {
+      at += POLL_MS;
+      engine.applyPoll(response([proxyHost({ host: 'Cloud API' })]), at);
+    }
     const gone = seriesFor(engine, 'Lab Router', at + POLL_MS);
     assert.equal(gone.known, false);
     assert.deepEqual(gone.series.map((s) => s.points), [[], [], []]);


### PR DESCRIPTION
Closes #149. The residual half of the "findings appear and disappear with no clear cause" report; the other half was #147.

Two commits, deliberately separate — the code fix, then the contract amendment it makes necessary (CLAUDE.md §4).

## What was wrong

**Appearing cost two consecutive samples. Leaving cost one poll.** `registry.update()` deleted any tracked condition that did not breach on the current poll, outright. So a condition oscillating around a threshold produced a finding, dropped it, and produced *the same condition* again under a **new id** — measured `f-1000` -> gone -> `f-1001` against the shipped defaults (`sustainedSamples: 2`, `sustainedSeconds: 4`).

That contradicted `healthscan-api.md` Q4. An id that survives a poll but not a blip is stable for the lifetime of an uninterrupted breach, not for the lifetime of the condition — and the condition outlives the blip.

**A rule's `null` meant two different things.** "Not breaching" and "cannot tell" arrived as the same silence. `queue_buildup` declines to evaluate a null depth (#49), so an instance that stopped publishing a metric *retracted a finding that was still true*.

**One absent poll forgot the host and its baseline.** This half is worse than a flap: the departure sweep called `baselines.forget()` alongside `registry.forget()`, so at `minBaselineSamples: 12` and a 5s poll a host that dropped out of one payload came back `warming` and every comparative rule was silent for a further minute. The finding did not flicker — it went away and could not return, for a reason invisible from outside the process.

## The fix

- **Symmetric bar.** Clearing uses the same two gates as confirming, from the same two knobs. No third tunable: "how many samples before I believe this changed" is one question asked in both directions. `sustainedSamples: 1` / `sustainedSeconds: 0` still clears on the first non-breaching poll, so the old behaviour is reachable by configuration — tested.
- **An UNCONFIRMED condition still resets outright.** MVP §6 governs appearance and that part was correct; only a published finding gets hysteresis.
- **`Rule.requires`** — each rule declares the inputs whose `=== null` guard makes it return null. The engine derives the unmeasurable set per poll and the registry *holds* those conditions, counting the poll toward neither gate. `dead_host` declares `[]`: it judges `status`, always present, so its silence really is "not breaching" and it clears as before.
- **Absence debounce**, same two gates, plus `#absent` cleared on a structural `reconfigure`.
- A blip does **not** reset `firstSeenAt`/`confirmedAt` — re-serving the confirmation clock would make one absent poll delay the finding all over again.

## What this is not

Live driving did not find it and does not reproduce it. A real build-up and drain on the stack — 134 samples, 5s apart — confirmed `queue_buildup` on the second breach, held one id for 3+ minutes through cap oscillation at 118–122, and cleared exactly once on a monotonic drain through the floor. It reproduces when a value oscillates *across* the threshold or an input goes unmeasurable. Worth stating, because "cannot reproduce on the happy path" is what left this open.

## Verification

```
tsc --noEmit          clean
node --test           375 tests, 375 pass, 0 fail   (was 370; 3 updated, 5 added)
contracts/validate    all checks passed (3 samples, 15 accept, 26 reject, 7 capture claims)
```

Node 24 — node 20 cannot run these `.ts` files and reports `tests 0` while looking green.

The three updated tests encoded the old one-poll clear (`makes the finding DISAPPEAR…`, `forgets a host that leaves…`, the alert age-out, and the series-departure test) and now poll to the bar. The five added ones cover the blip hold with id intact, the unmeasurable hold, `dead_host` still clearing, the baseline surviving one absent poll, and the 1-sample back-compat config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)