### PR TITLE
docs(contracts): not_rising is two fits, not one — the window and its tail

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -36,6 +36,11 @@ never published (so a positive `slope` alongside `projection: null` cannot occur
 tail declines as `not_rising` rather than `insufficient_samples`, which is defined against the full
 window's `fitSampleCount`.
 
+**One older undocumented path is written down at the same time**, found while checking the above: a
+non-finite or `<= 0` `secondsToThreshold` also declines as `not_rising`. It predates the tail test and
+should be unreachable — it would mean the arithmetic disagreed with `already_crossed` a step earlier —
+but it was the third way to reach step 6's reason code and the contract described only one.
+
 
 ## 2026-08-26 — clearing a finding takes the same bar as raising one (#149)
 

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,38 @@ Every contract change, dated, with the reason. Newest first.
 ---
 
 
+## 2026-08-26 — `not_rising` is two fits, not one; documenting behaviour that shipped in #145
+
+**`earlywarning-api.md` §2.1 (the `not_rising` row) and a new §2.2.1.** No schema change, no new
+reason, no change to the precedence order — the seven reasons and their order are unchanged, and a
+consumer sees exactly the same values it did before.
+
+**This documents code already on `main`, which is the problem being fixed.** Step 6 has fitted the
+series **twice** since `d48939e` — once over the 300 s window, once over its most recent 40% — and
+declines unless both are positive. The contract still said *"Fitted slope is `<= 0` after rounding to
+1 decimal"*, singular, which no longer described the implementation: a queue whose window slope is
+positive but whose tail slope is not now reports `not_rising`, and nothing in the contract said so.
+
+The behaviour is right and is what was asked for:
+
+> the early warning sometimes comes up when the queue pool is being drained, because it takes a
+> point in time measurement and does not notice the acceleration/deceleration of pool growth.
+
+One gate covers three shapes a single fit reads as a rise — draining after the approved fix, levelled
+off, turned over — while a queue rising *more slowly* than it was still projects. Five tests cover
+it (`earlywarning.test.ts`).
+
+**Why the contract fell behind.** `d48939e` was squash-merged as PR #145 under a title naming only
+the `PollInterval` fix, because two agents' commits collapsed into one merge. So the change landed
+with no contract amendment and no entry here, and was found only by reading the file. Recorded
+because #84 is open about exactly this class of drift: the code was correct, tested, and invisible.
+
+§2.2.1 also states two things a consumer cannot infer from the reason alone — the tail's slope is
+never published (so a positive `slope` alongside `projection: null` cannot occur), and an unfittable
+tail declines as `not_rising` rather than `insufficient_samples`, which is defined against the full
+window's `fitSampleCount`.
+
+
 ## 2026-08-26 — clearing a finding takes the same bar as raising one (#149)
 
 **`healthscan-api.md` §2.1 (a new paragraph under *Sustained breach*) and Q4.** No schema

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -229,7 +229,7 @@ Never invent a number here; there is a reason code for every case instead.
 | `warming` | No rolling baseline yet, so **no threshold exists to project toward**. Fewer than `minBaselineSamples` (12) in the 1800 s baseline window | `null` | `—`, plus the warming affordance |
 | `insufficient_samples` | Baseline is warm, but the 300 s fit window holds fewer than **12** samples — a newly appeared host, or a gap in polling | non-null | `—` |
 | `already_crossed` | `currentValue >= threshold.value`. There is no time remaining to forecast; the `queue_buildup` finding is the thing to render | non-null | defer to the finding |
-| `not_rising` | Fitted slope is `<= 0` after rounding to 1 decimal. Flat or draining — nothing is approaching anything | non-null | nothing, or a neutral "steady" |
+| `not_rising` | **Either** fit is `<= 0` after rounding to 1 decimal — the 300 s window, **or its most recent 40%**. Flat, draining, levelled off, or turned over — nothing is approaching anything. See §2.2.1 | non-null | nothing, or a neutral "steady" |
 | `beyond_horizon` | Rising, but the projected crossing is more than **1800 s** away | non-null | nothing |
 
 **The horizon is 1800 s because that is the baseline window.** Do not project further forward than
@@ -255,6 +255,42 @@ disagree with live in ways that look like bugs. The order is:
 7. `beyond_horizon`
 
 Otherwise: project.
+
+#### 2.2.1 `not_rising` asks the question twice — the window, and its tail
+
+**A single slope over the 300 s window describes the WINDOW, not the present**, and
+`"rising ~N/min"` is a claim about the present. So step 6 fits twice and declines unless **both**
+fits are positive: once over the whole window, once over its **most recent 40%** (120 s, ~24 samples
+at the shipped 5 s poll). Reported from a live run:
+
+> the early warning sometimes comes up when the queue pool is being drained, because it takes a
+> point in time measurement and does not notice the acceleration/deceleration of pool growth.
+
+One gate covers three shapes a single fit reports as a rise: a queue **draining** after the approved
+fix, a rise that has **levelled off**, and a rise that has **turned over**. A queue rising more
+slowly than it was still projects — decelerating is not falling.
+
+**This adds no eighth reason and does not move the precedence.** `not_rising` is the accurate answer
+and not merely the available one: a draining queue is not rising. It stays at step 6, *after*
+`already_crossed`, so a queue draining while still **above** its threshold keeps reporting
+`already_crossed` — draining-but-over-limit is still a problem.
+
+Two consequences worth stating, because a consumer cannot see them from the reason alone:
+
+- **`slope` is never published for the tail.** The tail fit is a sign test confirming an answer the
+  window already grounded in `minFitSamples`; only the window slope is published. So a positive
+  published `slope` with `projection: null` cannot occur — the decline happens before any projection
+  is built.
+- **An unfittable tail declines too**, and still as `not_rising`: fewer than two samples has no
+  slope, and a tail sharing one timestamp is division by zero. `insufficient_samples` would be the
+  wrong reason, since the contract defines that against the published `fitSampleCount` — the full
+  window's count, which has already cleared `minFitSamples` by step 6.
+
+**The 40% is not configurable, deliberately.** ADR 0003 governs the numbers that decide what fires;
+this one says how much of the series the word "now" covers, which is the definition of "rising"
+rather than a threshold for it. A fraction rather than a duration for two reasons: it can never be
+set longer than the window it is a tail of, and it inherits the existing
+`fitWindowSeconds / poll > minFitSamples` reachability check instead of needing its own.
 
 ### 2.3 Warm-up, and `X-Healthscan-State`
 

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -286,6 +286,13 @@ Two consequences worth stating, because a consumer cannot see them from the reas
   wrong reason, since the contract defines that against the published `fitSampleCount` — the full
   window's count, which has already cleared `minFitSamples` by step 6.
 
+**A third path declines as `not_rising` too, defensively** — and predates the tail test. Once both
+slopes are positive, `secondsToThreshold` is computed; if it comes out non-finite or `<= 0`, step 6
+declines rather than publishing it. That state would mean the arithmetic disagreed with
+`already_crossed` one step earlier, so it should be unreachable — but publishing
+`secondsToThreshold: 0` is exactly the "zero reads as a measurement of now" case §1.4 forbids. A consumer needs no special handling: it is the same reason
+code with the same `null` projection.
+
 **The 40% is not configurable, deliberately.** ADR 0003 governs the numbers that decide what fires;
 this one says how much of the series the word "now" covers, which is the definition of "rising"
 rather than a threshold for it. A fraction rather than a duration for two reasons: it can never be


### PR DESCRIPTION
Closes item 2 of the six reported issues. **The code fix already shipped**; this is the contract catching up.

## What was wrong

`contracts/earlywarning-api.md` §2.1 defined step 6 as:

> `not_rising` | Fitted slope is `<= 0` after rounding to 1 decimal. Flat or draining — nothing is approaching anything

Singular. But since `d48939e`, `earlywarning.ts` fits the series **twice** — once over the 300 s window, once over its most recent 40% (`RECENT_FIT_FRACTION = 0.4`) — and declines unless both are positive. A queue whose window slope is positive but whose tail is flat or falling reports `not_rising`, and nothing in the contract said so.

## What was reported

> the early warning sometimes comes up when the queue pool is being drained, because it takes a point in time measurement and does not notice the acceleration/deceleration of pool growth.

A single slope over 300 s describes the **window**, not the present, and "rising ~N/min" is a claim about the present. The tail test is what makes the two agree. One gate covers three shapes a single fit reads as a rise — draining after the approved fix, levelled off, turned over — while a queue rising *more slowly* than it was still projects, because decelerating is not falling.

## Why the contract fell behind

`d48939e` was squash-merged as #145 under a title naming only the `PollInterval` fix, because two agents' commits collapsed into one merge. So the change landed with no contract amendment and no `CHANGELOG.md` entry, and was found only by reading the file rather than from the changelog. Recorded in the entry because #84 is open about this exact class of drift: the code was correct, tested (5 tests at `test/earlywarning.test.ts:433-520`), and invisible.

## What this PR contains

- **`earlywarning-api.md` §2.1** — the `not_rising` row now says *either* fit
- **`earlywarning-api.md` §2.2.1**, new — the two-fit rule, the three shapes, and two things a consumer cannot infer from the reason alone:
  - the tail slope is **never published**, so a positive `slope` alongside `projection: null` cannot occur
  - an **unfittable tail** declines as `not_rising`, not `insufficient_samples` — that reason is defined against the published `fitSampleCount`, the full window's count, which has already cleared `minFitSamples` by step 6
- **`CHANGELOG.md`** — the §4 entry

No schema change, no eighth reason, no change to the precedence order. `not_rising` stays at step 6 *after* `already_crossed`, so a queue draining while still above its threshold keeps reporting `already_crossed` — draining-but-over-limit is still a problem.

## Verification

`node contracts/validate.mjs` — all checks passed (3 samples, 15 accept, 26 reject, 7 capture claims).

Docs only; no code touched, so the engine suite is unaffected by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)