### PR TITLE
docs: Windows instructions where they were still missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ substitution — the log pipelines and the JSON POSTs — are paired at the poin
 | this README says | PowerShell |
 |---|---|
 | `export PG_AGENT_MODE=live` | `$env:PG_AGENT_MODE = 'live'` |
+| `VAR=value <cmd>` (one command only) | `$env:VAR = 'value'` on its own line, then `<cmd>` — **and it stays set**, see below |
 | `… \| grep pg-firstboot` | `… \| Select-String pg-firstboot` |
+| `grep -rn "pattern" src/` | `Get-ChildItem -Recurse src \| Select-String "pattern"` — **not** `Select-String -r`, which has no such switch |
 | `curl -s <url>` | `curl.exe -s <url>` |
 | `curl -XPOST … -d '{…}'` | `curl.exe --% -XPOST … -d "{…}"` — one line, no variables |
 
@@ -45,6 +47,25 @@ substitution — the log pipelines and the JSON POSTs — are paired at the poin
 already bit us once from the shell side: an exported variable does not reach a container unless
 compose passes it (`docker-compose.yml` says so where `PG_LLM_API_KEY` is declared). A
 `$env:PG_LLM_API_KEY = 'sk-…'` set in the same window does show up in `docker compose config`.
+
+**There is no one-shot `VAR=value <cmd>` in PowerShell, and the replacement is not one-shot.**
+This is the translation the area READMEs need most — `PROXY_MODE=live npm start`,
+`POLL_INTERVAL_MS=2000 npm start`, `MOCK_FIXTURE=metrics.txt npm run mock` are all written in the
+POSIX form. PowerShell parses the prefix as the *command name*, so it fails with
+`The term 'POLL_INTERVAL_MS=2000' is not recognized as the name of a cmdlet` — which reads as a
+missing program rather than a shell difference. Set it on its own line instead:
+
+```powershell
+$env:PROXY_MODE = 'live'
+npm start
+```
+
+**The variable then persists for the rest of that window**, which the POSIX prefix does not, and
+that difference bites in one specific way: a `$env:POLL_INTERVAL_MS = '2000'` set to watch one
+appear-and-clear cycle is still set the next time you run `npm start` in the same terminal, so the
+engine quietly stays at a compressed poll rate with the invariants that rate breaks. Clear it with
+`Remove-Item Env:\POLL_INTERVAL_MS`, or open a new window. Verified both ways, since "it persists"
+is only useful advice if the undo is stated with it.
 
 **`curl.exe`, never `curl`.** In PowerShell 5.1 — the version that ships — `curl` is an alias
 for `Invoke-WebRequest`, so `curl -s <url>` fails with `Cannot process command because of one or

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -81,6 +81,20 @@ first finding is confirmed. To watch a whole cycle without waiting, compress it 
 POLL_INTERVAL_MS=2000 npm start    # full appear-and-clear cycle, still emits
 ```
 
+```powershell
+# Windows. There is no one-shot VAR=value prefix -- PowerShell reads it as the command name and
+# fails with "The term 'POLL_INTERVAL_MS=2000' is not recognized".
+$env:POLL_INTERVAL_MS = '2000'
+npm start
+Remove-Item Env:\POLL_INTERVAL_MS   # <- do not skip this, see below
+```
+
+**On Windows the compression outlives the demo, and that is the trap.** The POSIX prefix applies to
+one command; `$env:` stays set for the rest of the window, so the next `npm start` in that terminal
+is still at 2000 ms — and per the floors below, that is an engine running outside its designed
+envelope while looking entirely normal. `Remove-Item Env:\POLL_INTERVAL_MS`, or use a fresh window
+for the compressed run.
+
 `POLL_INTERVAL_MS` has floors, and they do not fail loudly. The engine's
 `sustainedSeconds` gate needs `(sustainedSamples - 1) x interval > sustainedSeconds`,
 so **4500 ms already breaks an invariant** and finding types stop emitting entirely
@@ -149,7 +163,9 @@ fixtures and favicon all inlined. Verify by opening it directly from the
 filesystem:
 
 ```bash
-start dist/index.html        # Windows
+start dist/index.html        # Windows -- PowerShell, cmd, and Git Bash all have `start`
+open dist/index.html         # macOS
+xdg-open dist/index.html     # Linux
 ```
 
 If it needs a server, the fallback has failed. Fixtures are imported statically
@@ -210,6 +226,13 @@ client exists, so they land in Phase 2.
 ```bash
 grep -rn "CONTRACT-Q" src/
 ```
+
+```powershell
+Get-ChildItem -Recurse src | Select-String "CONTRACT-Q"
+```
+
+`Select-String` has no `-r`, so the obvious transliteration fails with *"A parameter cannot be found
+that matches parameter name 'r'"* — the recursion is the pipeline's job, not the cmdlet's.
 
 The load-bearing one is **Q4** in `hooks/useHealthScan.ts`: the new-finding
 highlight assumes `finding.id` is stable while a condition persists. If ids churn

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -21,6 +21,13 @@ export PG_DEMO_TRIGGERS=1          # else the rail's trigger buttons do not exis
 docker compose up -d
 ```
 
+```powershell
+# Windows. Set these in the SAME window as the compose up -- compose reads them from the shell.
+$env:PG_AGENT_MODE = 'live'
+$env:PG_DEMO_TRIGGERS = '1'
+docker compose up -d
+```
+
 | # | Check | Command | Expected |
 |---|---|---|---|
 | 1 | All four services healthy | `docker compose ps` | four `(healthy)` |
@@ -28,6 +35,10 @@ docker compose up -d
 | 3 | Trigger buttons exist | `curl -s localhost:5173/api/demo/triggers` | `"enabled": true`, 3 scenarios |
 | 4 | Nothing armed, no findings | `curl -s localhost:5173/api/healthscan/findings` | `[]` |
 | 5 | **Error window is clean** | see below | `purged N` |
+
+On Windows, checks 2–4 are `Select-String listening` rather than `grep listening`, and `curl.exe`
+rather than `curl` — the alias `curl` resolves to in PowerShell binds `-s` to `-SessionVariable` and
+then prompts for a `Uri`, which on stage reads as a hang. Full table: root `README.md` → *On Windows*.
 
 ```bash
 # 5. Reset triggers AND purge the event log. Reset alone is not enough — see the trap below.
@@ -40,6 +51,29 @@ write "purged ",$get(d,0),!
 halt
 EOF
 ```
+
+```powershell
+# Windows. One line for the POST -- `--%` stops PowerShell parsing, so a backtick continuation
+# would be sent as a literal character and the body would go out empty.
+curl.exe --% -s -XPOST -H "Content-Type: application/json" -H "Origin: http://localhost:5173" -d "{}" localhost:5173/api/demo/reset
+
+# PowerShell has no `<<'EOF'`. The equivalent is a SINGLE-quoted here-string, piped in:
+@'
+zn "LABDEMO"
+do ##class(Ens.Util.Log).Purge(.d, 0)
+write "purged ",$get(d,0),!
+halt
+'@ | docker exec -i pg-iris iris session IRIS
+```
+
+**`@'` and not `@"`, for the same reason the bash form quotes its `EOF`.** A double-quoted
+here-string interpolates, and ObjectScript is made of `$`: measured on the running stack, `@"…"@`
+sent `write "PGV|",$zversion,!` as `WRITE "PGV|",,!` — PowerShell had already replaced `$zversion`
+with an empty string, and IRIS echoed a syntactically valid line that printed nothing. That is the
+worst kind of failure to hit on stage, because the here-string above would purge nothing and still
+look like it ran. The `@'` form passed `$zversion` through untouched and IRIS answered with the
+build. Two layout rules the parser enforces: `@'` must end its line, and `'@` must start its own
+line at **column 0** — indent it and PowerShell does not see the terminator.
 
 ### The five traps, in the order they will bite you
 
@@ -294,6 +328,18 @@ do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()
 halt
 EOF
 ```
+
+```powershell
+curl.exe --% -s -XPOST -H "Content-Type: application/json" -H "Origin: http://localhost:5173" -d "{}" localhost:5173/api/demo/reset
+@'
+zn "LABDEMO"
+do ##class(Ens.Util.Log).Purge(.d, 0)
+do ##class(ProductionGuardian.LabDemo.Audit.Entry).Purge()
+halt
+'@ | docker exec -i pg-iris iris session IRIS
+```
+
+Single quotes on the here-string, and `'@` at column 0 — §0 says why.
 
 Purging the audit log is optional but makes "six rows for six tool calls" legible on the next run.
 

--- a/iris/labdemo/README.md
+++ b/iris/labdemo/README.md
@@ -15,6 +15,16 @@ proxy JSON, and in the dashboard, so use them verbatim when reasoning about find
 Class names (`PatientDemographicsOperation`) differ from config item names (`Cloud API`);
 the `<Item Name="...">` set in `Production.cls` is authoritative.
 
+**On Windows:** the ObjectScript in this file is shell-independent — it runs in an IRIS Terminal
+either way, and `Triggers` calls need no translation. The `curl` lines do: in the PowerShell that
+ships with Windows, `curl` is an alias for `Invoke-WebRequest`, so **`curl.exe`** is needed for
+every one of them. `-u user:pass` is the flag that makes this obvious rather than silent: the alias
+answers *"Parameter cannot be processed because the parameter name 'u' is ambiguous"* and lists four
+of its own parameters, which names PowerShell as the culprit. `-s` does not — it binds to
+`-SessionVariable` and the call goes on to prompt for a `Uri`, which reads as a hang. Git Bash has
+the real `curl` and needs nothing. Root `README.md` → *On Windows* is the one place the full
+translation table lives; it is not repeated here.
+
 ---
 
 ## File inventory

--- a/iris/setup/README.md
+++ b/iris/setup/README.md
@@ -22,6 +22,13 @@ do $system.OBJ.Load("/path/to/iris/setup/EnableMetrics.cls", "ck")
 do ##class(ProductionGuardian.Setup.EnableMetrics).Run()
 ```
 
+**The path is on the IRIS instance's filesystem, not your shell's.** So it depends on where IRIS
+runs, not on which OS you are typing from — under this repo's compose it is a container path
+(`/opt/…`), and on a Windows-native instance it is a Windows path,
+`"C:\repos\ProductionGuardian\iris\setup\EnableMetrics.cls"`. Write the backslashes as they are:
+ObjectScript string literals do not treat `\` as an escape, so doubling them is what breaks it.
+Nothing else in this file is shell-dependent — every command here is ObjectScript in a Terminal.
+
 ### Option B: Management Portal
 
 1. Management Portal → System Explorer → Classes → Import

--- a/services/detection-engine/README.md
+++ b/services/detection-engine/README.md
@@ -13,7 +13,7 @@ Requires **Node ≥ 22.18** (native TypeScript type stripping — no build step,
 npm install          # devDependencies only; zero runtime dependencies
 npm start            # mock proxy, serves on :3002
 npm run dev          # same, with --watch
-npm test             # 95 tests
+npm test             # 375 tests
 npm run typecheck    # tsc --noEmit, strict
 ```
 
@@ -26,18 +26,32 @@ curl localhost:3002/api/healthscan/findings
 curl localhost:3002/api/healthscan/health   # operational, not in the contract
 ```
 
-Against Dev A's real proxy:
+Against the real proxy:
 
 ```bash
 PROXY_MODE=live PROXY_BASE_URL=http://localhost:3001 npm start
 ```
+
+```powershell
+# Windows. PowerShell has no one-shot VAR=value prefix -- the line above fails with
+# "The term 'PROXY_MODE=live' is not recognized". Set them, then start:
+$env:PROXY_MODE = 'live'
+$env:PROXY_BASE_URL = 'http://localhost:3001'
+npm start
+```
+
+Both stay set for the rest of that window, unlike the POSIX prefix — so a later `npm start` in the
+same terminal is still in live mode and will sit there failing to reach a proxy that is not up.
+`Remove-Item Env:\PROXY_MODE` undoes it. `curl` is an alias for `Invoke-WebRequest` in the
+PowerShell that ships, so the three lines above need `curl.exe`. Root `README.md` → *On Windows*
+has the full table and is the only place it is written down.
 
 | Env var | Default | Notes |
 |---|---|---|
 | `PORT` | `3002` | |
 | `PROXY_MODE` | `mock` | `mock` \| `live` |
 | `PROXY_BASE_URL` | `http://localhost:3001` | live mode only |
-| `POLL_INTERVAL_MS` | `10000` | matches the proxy's own IRIS poll |
+| `POLL_INTERVAL_MS` | `5000` | matches the proxy's own IRIS poll. **A floor, not a preference** — `src/index.ts` documents the sweep, and `4500` already breaks an invariant |
 
 ## Shape of it
 

--- a/services/metrics-proxy/CLAUDE.md
+++ b/services/metrics-proxy/CLAUDE.md
@@ -142,6 +142,17 @@ To confirm the failure detection actually works, misconfigure it on purpose:
 IRIS_BASE_PATH=wrongprefix npm start   # note: no leading slash — Git Bash rewrites /wrongprefix
 ```
 
+```powershell
+# PowerShell has no one-shot prefix, and no path rewriting either -- the leading slash is fine here
+$env:IRIS_BASE_PATH = '/wrongprefix'
+npm start
+Remove-Item Env:\IRIS_BASE_PATH   # it persists for the window; the POSIX prefix does not
+```
+
+**Clearing it is the point of that last line.** This is a deliberate misconfiguration, so leaving it
+set means the *next* `npm start` in that terminal also 404s every poll — and the symptom, health
+stuck at `starting`, is identical to a real broken instance.
+
 A wrong prefix 404s, so no poll ever completes: smoke fails 7 of 15 and exits 1, starting
 with `a poll has completed — status: starting`. Drop `IRIS_BASE_PATH` entirely instead and
 you get the 200-with-no-interop case, where health reports

--- a/services/metrics-proxy/fixtures/README.md
+++ b/services/metrics-proxy/fixtures/README.md
@@ -3,6 +3,14 @@
 Captures from a live IRIS instance, plus the smaller hand-written excerpts that predate
 them. Committed so every developer mocks against the same bytes (ADR 0004).
 
+**Selecting a fixture on Windows.** The `MOCK_FIXTURE=… npm run mock` and
+`MOCK_HOSTSTATUS=… npm run mock` forms below are POSIX; PowerShell reads the prefix as the command
+name and fails with `The term 'MOCK_FIXTURE=metrics.txt' is not recognized`. Two lines instead —
+`$env:MOCK_FIXTURE = 'metrics.txt'`, then `npm run mock` — and **clear it afterwards**
+(`Remove-Item Env:\MOCK_FIXTURE`), because unlike the POSIX prefix it stays set for the window and
+the next `npm run mock` in that terminal keeps serving the trimmed excerpt while looking like the
+default. Root `README.md` → *On Windows* has the whole table.
+
 | File | Provenance |
 |---|---|
 | `metrics-live-capture.txt` | **Real, and the mock default.** Full 310-line `/api/monitor/metrics` body, IRIS for Health 2024.1 on Windows, captured 2026-08-11 **after** the production items were renamed to the spaced contract names. 12 hosts, 3 application. |


### PR DESCRIPTION
Item 1 of the six reported issues: *"I'd like the readme to include windows instructions, not just unix/linux."*

## Where it already was, and why that wasn't the end of it

The **root** `README.md` grew a thorough *On Windows* section — in `d48939e`, squash-merged as #145 under a title naming only the `PollInterval` fix. Same hidden merge that concealed item 2's code, so this looked unstarted.

It stopped at the root, though. Seven other docs a developer follows were still POSIX-only, and three of them **fail outright** rather than degrading.

## The one that actually breaks

There is no one-shot `VAR=value <cmd>` in PowerShell. It parses the prefix as the *command name*:

```
POLL_INTERVAL_MS=2000 : The term 'POLL_INTERVAL_MS=2000' is not recognized as the name of a cmdlet,
function, script file, or operable program.
```

That reads as a missing program rather than a shell difference. The replacement — `$env:VAR = '...'` on its own line — **is not one-shot**, and that asymmetry is the part worth documenting: it persists for the whole window, so

- a `$env:POLL_INTERVAL_MS = '2000'` set to watch one appear-and-clear cycle is still set at the next `npm start`, leaving the engine at a rate `src/index.ts` says breaks two invariants
- a deliberately-wrong `$env:IRIS_BASE_PATH` set to prove failure detection works keeps 404-ing every poll afterwards, with a symptom identical to a genuinely broken instance

Every site that uses the prefix now carries the `Remove-Item Env:\VAR` undo next to it.

## Per document

| Doc | What it needed |
|---|---|
| `README.md` | two new translation-table rows (env prefix, `grep -rn`) and the persistence caveat |
| `services/detection-engine/README.md` | paired live-proxy start; `curl.exe` note |
| `apps/dashboard/README.md` | paired compressed-poll start (+ trap), `CONTRACT-Q` grep, fallback-open |
| `docs/demo/cue-sheet.md` | pre-flight exports, both `Ens.Util.Log` purges, check-table `grep`/`curl` |
| `iris/labdemo/README.md` | `curl.exe` for every call; why `-u` is the flag that makes it obvious |
| `services/metrics-proxy/fixtures/README.md` | `MOCK_FIXTURE=` / `MOCK_HOSTSTATUS=` selection |
| `services/metrics-proxy/CLAUDE.md` | the deliberate-misconfiguration form |
| `iris/setup/README.md` | the class path is on the **IRIS** filesystem, not the shell's |

`apps/dashboard/fixtures/README.md`, `contracts/README.md` and `docs/decisions/README.md` needed nothing — npm-only, or already carrying their Git Bash caveat.

## Two claims were wrong on the first attempt

Everything here was run on a Windows 11 box rather than recalled, and that caught two:

1. **`Select-String -r` does not exist.** I wrote it into the translation table first. `Select-String : A parameter cannot be found that matches parameter name 'r'.` Recursion is the pipeline's job: `Get-ChildItem -Recurse src | Select-String "pattern"`.
2. **A `@"..."@` here-string interpolates**, so it is the wrong translation of `<<'EOF'`. Measured against the running stack, `write "PGV|",$zversion,!` arrived at IRIS as `WRITE "PGV|",,!` — PowerShell had already blanked `$zversion`, and IRIS echoed a syntactically valid line that printed nothing. **`@'...'@`** passes it through and IRIS answers with the build string.

The second one is the reason the cue-sheet change is worth more than its size: the pre-flight here-string purges the event log, and trap #2 in that same document is *"a previous scenario's errors stay in the 60-minute window and a later diagnosis reads them as evidence"*. A purge that silently does nothing while looking like it ran is exactly the on-stage failure the pre-flight exists to prevent.

Also verified: `$env:` + `Remove-Item Env:\`, `curl -u` reporting `parameter name 'u' is ambiguous`, `start` being present in Git Bash as `/usr/bin/start` (so that line needed the *Unix* halves, not a Windows one), ObjectScript not escaping `\` (`$length("C:\repos\x.cls")` is 14), and both new cue-sheet PowerShell commands run end to end.

## Two verified drifts fixed in passing

Both in `services/detection-engine/README.md`, checked against the code rather than assumed:

- `npm test # 95 tests` → **375** (`ℹ tests 375 / pass 375 / fail 0`)
- `POLL_INTERVAL_MS` default `10000` → **5000** (`DEFAULT_POLL_INTERVAL_MS = 5_000`), with a pointer to the floor sweep in `src/index.ts`

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)