### PR TITLE
feat(iris): Reset all now clears the per-host error count, because settings never could

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,12 @@ Armed state is read from IRIS on each poll, so driving the terminal at the same 
 described above, with the same one caveat: a `system_alert` finding outlives it, because the alert
 sits in the metrics proxy's in-memory buffer where IRIS cannot reach.
 
+It is also the one control that is not instant. When a scenario has left errored messages behind,
+Reset purges the message store — the per-host error count on a host tile is a `COUNT(*)` over those
+rows, so nothing restorable clears it — and that scales with how long the stack has been up
+(measured: 0.3s for 2,550 headers, 31.5s for 153,144). A reset with no errors to clear skips the
+purge entirely and returns in well under a second, which is the usual case.
+
 ### Before a rehearsal: three things that will bite
 
 - **`AGENT_MODE` defaults to `mock`.** Rebuild or restart the engine without `PG_AGENT_MODE=live`

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -81,9 +81,12 @@ line at **column 0** — indent it and PowerShell does not see the terminator.
    it reads as correct and demonstrates nothing about the agent. Check `source: "agent"` and a
    non-zero `toolCalls` in any investigation — those two cannot be faked. This is the standing
    pre-demo check and it has caught a real regression.
-2. **`Reset()` cannot clear the event log.** It restores settings, but a previous scenario's errors
-   stay in the 60-minute window and a later diagnosis reads them as evidence. That is exactly how a
-   pool bottleneck got diagnosed as a connectivity failure. **Always purge** (step 5).
+2. **`Reset()` cannot clear the event log** — and note it is now the *only* error store it cannot
+   clear, which is why this trap is easy to talk yourself out of. Reset purges the MESSAGE store, so
+   the error count on a host tile does return to 0. The EVENT LOG is a different table: a previous
+   scenario's errors stay in the 60-minute window and a later diagnosis reads them as evidence. That
+   is exactly how a pool bottleneck got diagnosed as a connectivity failure. So a clean tile does not
+   mean clean evidence — **always purge** (step 5).
 3. **Restarting the `iris` container disarms triggers.** Recompiling `Production.cls` resets its item
    settings, so `FilePath` and `PoolSize` revert. Re-arm after any restart; the rail shows live state.
 4. **`Cloud API` may be left at pool 4** from a previous run of the Smart Resolve beat. `Reset()`

--- a/iris/labdemo/README.md
+++ b/iris/labdemo/README.md
@@ -383,6 +383,16 @@ and timeouts, and re-enables every host. The old instruction here was to remove 
 from `PatientDemographicsOperation` and recompile — the delay is now a global the
 operation reads at runtime, so there is nothing to leave behind in source.
 
+It also **purges the message store, but only when errored messages exist.** The per-host error
+count is `COUNT(*) FROM Ens.MessageHeader WHERE Status = 8` grouped by target host — a property of
+the store rather than of the configuration, which is why it used to survive a reset, a production
+restart and a container restart alike. Nothing restorable moves it, so the rows are deleted.
+The gate matters: a reset after a scenario that errored nothing leaves message history alone, so
+the Message Viewer still has traces to show, and only the run that actually errored pays the purge
+(measured: 0.3s for 2,550 headers, 31.5s for 153,144). `pKeepIntegrity` keeps anything still in
+flight, so a handful of errored rows can survive into the next reset; `Reset()` says so when it
+happens rather than reporting a count that quietly did not reach 0.
+
 ---
 
 ## Verify metrics

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -1,3 +1,5 @@
+Include Ensemble
+
 /// Trigger toggles: induce any of the eight Health Scan finding types on demand.
 ///
 /// Dev A acceptance criterion 3 (spec §3, `iris/CLAUDE.md` §6):
@@ -57,6 +59,12 @@ Parameter CLOSEDPORT = 59999;
 /// NOT CREATED, EVER. `FirstBoot.MakeDirectories()` creates the two real drop directories on every
 /// boot; if this one were in that list the scenario would disarm itself. Checked that it is not.
 Parameter MISSINGPATH = "/tmp/labdemo/hl7-in-missing/";
+
+/// How much message history PurgeErrored() keeps: none.
+///
+/// Ens.Purge's own default is 7 days, which on a demo instance that has been up for an hour would
+/// delete nothing at all and leave the error count exactly where it was.
+Parameter PURGEDAYSTOKEEP = 0;
 
 /// dead_host -- absolute, fires within two polls. The demo's headline finding.
 ClassMethod DeadHost() As %Status
@@ -543,6 +551,13 @@ ClassMethod Reset() As %Status
     if $$$ISERR(sc) {
         quit sc
     }
+
+    // LAST, and after UpdateProduction(), for two reasons. It is the only step whose cost scales
+    // with uptime, so everything cheap has already been restored if it is slow; and the port and
+    // the FilePath are live again by now, so the messages still queued to the operation succeed
+    // rather than the purge racing a host that is still producing the rows it deletes.
+    do ..PurgeErrored()
+
     write !, "  Findings clear on their own within ~10s; a drained queue may leave", !
     write "  growing_queue_wait briefly, which is a true reading of a real wait.", !
     write "  If a class changed, `update` is not enough -- stop and start the production.", !
@@ -878,6 +893,100 @@ ClassMethod RemoveSetting(pItem As %String, pName As %String) As %Status
 ClassMethod UpdateProduction() As %Status
 {
     quit ##class(Ens.Director).UpdateProduction()
+}
+
+/// Purge the errored messages an error scenario left behind, so Reset() clears the per-host error
+/// count on each dashboard host tile.
+///
+/// WHY RESET() COULD NOT ALREADY DO THIS. That count is neither a metric nor a setting: it is
+/// `COUNT(*) FROM Ens.MessageHeader WHERE Status = $$$eMessageStatusError` grouped by
+/// TargetConfigName, computed by `REST/HostStatusDispatcher.ErroredByHost()` because
+/// `iris_interop_messages_errored` carries no `host` label. So it is a property of the MESSAGE
+/// STORE, which is why it survived a container restart, a production restart and every Reset()
+/// before this one -- nothing this class restores can move it, the rows have to go.
+///
+/// ONLY WHEN THERE IS SOMETHING TO PURGE, and that gate is the point rather than an optimisation:
+///   - a reset after a scenario that errored nothing must not delete the demo's message history,
+///     which is what a presenter opens the Message Viewer to show;
+///   - this is the only step in Reset() whose cost scales with how long the stack has been up
+///     (measured: 31.5s to delete 153,144 headers), and the engine abandons /api/demo/reset on a
+///     timeout. A reset with no errors to clear pays one COUNT(*) and nothing else.
+///
+/// ENS.PURGE HAS NO STATUS FILTER -- checked rather than assumed, including `pExtendedOptions`,
+/// which offers StartDateTime, DoNotDeleteEndDateTime, LimitToConfigItems and WQCategory and
+/// nothing about status. `PurgeOneSession()` IS scoped and was rejected: it is a bare
+/// `DELETE FROM Ens.MessageHeader WHERE SessionId = ?` with no integrity check that never touches
+/// bodies, so it would orphan every body it left behind and would happily delete a session still
+/// in flight.
+///
+/// So this purges by DATE and lets pKeepIntegrity protect what is still moving, which it does
+/// exactly. Read from `Ens.Util.MessagePurge.generateDeleteSelectSQL`: a header is eligible only
+/// when no header in its session has a status outside {Completed, Aborted, Error, Discarded}. Error
+/// is INSIDE that set, so an errored message never blocks its own removal, while one still Created
+/// or Queued keeps its whole session. Measured on the live stack: all 845 errored rows removed, the
+/// 6,780 in-flight headers kept, and the proxy then published `errored` 0 on all three application
+/// hosts while `messages` kept climbing -- so throughput and its baseline are untouched.
+///
+/// PURGEDAYSTOKEEP = 0 KEEPS NOTHING, INCLUDING TODAY. Worth stating because "0 days" reads as
+/// "today survives": `Ens.Purge.GetDoNotDeleteDate(0)` returns TOMORROW's local midnight, so the
+/// `TimeCreated <` bound admits everything already written.
+///
+/// RETURNS NOTHING, unlike every other method here. A failed purge must not make Reset() report
+/// failure for the settings it has already restored, so this reports what happened and propagates
+/// no status there is anything useful to do with.
+ClassMethod PurgeErrored() [ Private ]
+{
+    set errored = ..ErroredCount()
+    if errored = 0 {
+        write "  no errored messages in the store; message history left alone", !
+        quit
+    }
+    if errored < 0 {
+        write "  could not count errored messages; skipped the purge", !
+        quit
+    }
+
+    set started = $zh
+    set sc = ##class(Ens.Purge).PurgeMessagesByDate(..#PURGEDAYSTOKEEP, .deleted, 1, 1)
+    set elapsed = $zh - started
+    if $$$ISERR(sc) {
+        write "  PURGE FAILED: ", $system.Status.GetErrorText(sc), !
+        write "    the ", errored, " errored messages remain, so the host error count is unchanged", !
+        quit
+    }
+
+    set remaining = ..ErroredCount()
+    write "  purged ", +$get(deleted), " message headers and ", +$get(deleted("bodies")), " bodies in ", $fnumber(elapsed, "", 1), "s", !
+    write "    host error count ", errored, " -> ", $select(remaining < 0: "unknown", 1: remaining), !
+    if remaining > 0 {
+        // NOT a failure, and said out loud because a count that did not reach 0 otherwise reads as a
+        // purge that half worked: those sessions still hold a message that has not finished, and
+        // pKeepIntegrity is right to refuse them.
+        write "    the ", remaining, " left are in sessions still holding an in-flight message;", !
+        write "    they clear on a later Reset(), once those sessions finish", !
+    }
+}
+
+/// How many errored message headers the store holds, or -1 when that cannot be measured.
+///
+/// -1 RATHER THAN 0, by GetPoolSize()'s rule that an unmeasurable value is not a small one (#33).
+/// Returning 0 from a failed query would have PurgeErrored() print "no errored messages" and skip --
+/// a confident claim about the one number this whole path exists to change.
+ClassMethod ErroredCount() As %Integer [ Private ]
+{
+    set rs = ##class(%SQL.Statement).%ExecDirect(, "SELECT COUNT(*) FROM Ens.MessageHeader WHERE Status = ?", $$$eMessageStatusError)
+    if '$isobject(rs) {
+        quit -1
+    }
+    if 'rs.%Next() {
+        quit -1
+    }
+    // Checked AFTER the fetch, as in HostStatusDispatcher.ErroredByHost(): %SQLCODE is 100 at the
+    // end of a successful result set and only negative on a real error.
+    if rs.%SQLCODE < 0 {
+        quit -1
+    }
+    quit +rs.%GetData(1)
 }
 
 /// stalled_host's configured wait, for the message StalledHost() prints.

--- a/services/detection-engine/src/detect/triggers.ts
+++ b/services/detection-engine/src/detect/triggers.ts
@@ -198,6 +198,17 @@ function parseResult(raw: unknown, scenario: string | null): TriggerResult {
  * ARM'S TIMEOUT IS LARGE ON PURPOSE. `PoolBottleneck()` warms a baseline at zero for 75 seconds
  * before it returns, so a conventional 30s timeout would abort a call that was working and leave
  * the production half-armed with nothing reporting why. Measured: the trigger blocks for ~80s.
+ *
+ * RESET'S IS LARGE FOR A DIFFERENT REASON — it is the only one whose duration depends on how long
+ * the stack has been up. `Triggers.Reset()` purges the message store when an error scenario left
+ * errored headers behind, because the per-host error count is a `COUNT(*)` over those rows and
+ * nothing else clears it. Measured: 31.5s to delete 153,144 headers, i.e. ~4,900/s, and the store
+ * grows for as long as the generator runs. At 60s a long rehearsal day would abort a purge that was
+ * working, and the retry a presenter then makes starts it again from the beginning.
+ *
+ * 120s, staying under nginx's 180s `proxy_read_timeout` on `/api/demo/` so the engine is still the
+ * component that reports a genuine hang rather than nginx serving its own HTML error page — the
+ * failure shape that produced `Unexpected token '<'` when arming outran the shared 35s limit.
  */
 export function liveTriggers(
   baseUrl: string,
@@ -246,7 +257,7 @@ export function liveTriggers(
   return {
     status: async () => parseStatus(await call('/status', undefined, 10_000)),
     arm: async (scenario) => parseResult(await call('/arm', { scenario }, 150_000), scenario),
-    reset: async () => parseResult(await call('/reset', {}, 60_000), null),
+    reset: async () => parseResult(await call('/reset', {}, 120_000), null),
   };
 }
 


### PR DESCRIPTION
## What the error count actually is

Not a metric and not a setting:

```sql
SELECT %EXACT(TargetConfigName), COUNT(*) FROM Ens.MessageHeader
WHERE Status = 8 GROUP BY %EXACT(TargetConfigName)
```

`REST/HostStatusDispatcher.ErroredByHost()` computes it, because
`iris_interop_messages_errored` is emitted once per production with no `host` label. So it is a
property of the **message store** — which is why it survived a container restart, a production
restart and every `Reset()` before this one. Nothing `Reset()` restores can move it.

## What changed

`Triggers.Reset()` purges the errored messages, **only when there are any**. The gate is the point,
not an optimisation:

- a reset after a scenario that errored nothing must not delete the demo's message history, which is
  what a presenter opens the Message Viewer to show;
- it is the only step in `Reset()` whose cost scales with uptime, so the usual reset pays one
  `COUNT(*)` and nothing else (measured: 0.07s).

### Why purge by date rather than by status

`Ens.Purge` has **no status filter** — checked, including `pExtendedOptions`, which offers
`StartDateTime`, `DoNotDeleteEndDateTime`, `LimitToConfigItems`, `WQCategory` and nothing about
status. `PurgeOneSession()` *is* scoped and was rejected: it is a bare
`DELETE FROM Ens.MessageHeader WHERE SessionId = ?` with no integrity check that never touches
bodies, so it would orphan every body it left behind and would happily delete a session still in
flight.

So it purges by date and lets `pKeepIntegrity` protect what is still moving, which it does exactly.
Read from `Ens.Util.MessagePurge.generateDeleteSelectSQL`, a header is eligible only when no header
in its session has a status outside `{Completed, Aborted, Error, Discarded}`. **Error is inside that
set**, so an errored message never blocks its own removal, while one still `Created` or `Queued`
keeps its whole session. Residue is reported rather than left as a count that quietly did not reach 0.

`PURGEDAYSTOKEEP = 0` keeps nothing **including today** — `GetDoNotDeleteDate(0)` returns
*tomorrow's* local midnight. Named because "0 days" reads as "today survives".

The status code is `$$$eMessageStatusError` via `Include Ensemble`, not a second copy of the literal
`8` that `HostStatusDispatcher` derived from the DISPLAYLIST.

### Engine: reset timeout 60s → 120s

Reset is now the one trigger call whose duration depends on uptime (~4,900 headers/s; 31.5s for
153,144 headers). At 60s a long rehearsal day would abort a purge that was working, and the retry a
presenter then makes starts it from the beginning. 120s stays under nginx's existing 180s
`proxy_read_timeout` on `/api/demo/`, so the engine remains the component that reports a real hang.

### `elevated_error_rate` needed no change

`#errorsPerMinute` already returns `null` when the counter goes backwards, and it stores the new
prior *before* that guard — so a purge costs exactly one silent poll and the rate resumes from the
new floor. Confirmed in the engine log: no negative rate, no `NaN`.

## Verified live, through the dashboard's own route

`POST /api/demo/reset` via nginx → engine → IRIS:

```
armed closed_port  ->  Cloud API errored = 21
reset              ->  "purged 2550 message headers and 2548 bodies in 0.3s"
                       "host error count 21 -> 0"
proxy              ->  errored = 0 on Cloud API, EMR Source, Lab Router
SQL                ->  COUNT(*) WHERE Status=8  =  0
history            ->  6,060 headers preserved
second reset       ->  "no errored messages in the store; message history left alone" (0.07s)
findings           ->  elevated_error_rate gone; survivors are true readings of the drained backlog
```

Engine: `typecheck` clean, **375 tests / 74 suites / 0 fail** with the repo root mounted.

## Docs

The cue sheet's event-log trap is **sharpened, not removed**: `Ens.Util.Log` is a different store
and still needs its own purge (step 5), so a clean host tile does not mean clean evidence. That
distinction is now the easiest thing to talk yourself out of, so it says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
