### PR TITLE
fix(dashboard): demo-mode host graphs never drew, behind a diff git rendered as binary

### DIFF
--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -233,7 +233,7 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
       for (const { metric, of } of MOCK_SERIES_METRICS) {
         const value = of(host);
         if (value === null || !Number.isFinite(value)) continue;
-        const key = `${host.host} ${metric}`;
+        const key = `${host.host}\u0000${metric}`;
         const points = mockSeries.get(key) ?? [];
         // Same second as the previous point means two reads inside one tick; replace rather than
         // append, so the graph does not gain a vertical pair at one x position.

--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -220,6 +220,17 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
     { metric: 'messagesPerSec', unit: 'per_second', of: (h) => h.messagesPerSec },
   ];
 
+  /* ONE KEY BUILDER, because the writer and the reader had drifted apart and nothing caught it:
+     `recordSeries` composed the key with a `\u0000` separator while `getHostSeries` used a space, so
+     every lookup missed and demo mode served an empty series for every host and metric. Same argument
+     the engine's shared helpers make -- a rule held in two places goes stale in one of them.
+
+     THE SEPARATOR IS AN ESCAPE, NOT A LITERAL CONTROL CHARACTER. A raw NUL byte here made git classify
+     this file as binary, which suppressed its diff in #140 and #144 -- which is why the mismatch above
+     shipped unreviewed. It stays U+0000 rather than a space because no host name or metric can contain
+     one, so two different pairs can never compose the same key. */
+  const seriesKey = (host: string, metric: string): string => `${host}\u0000${metric}`;
+
   /**
    * Append this poll's values to the demo history.
    *
@@ -233,7 +244,7 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
       for (const { metric, of } of MOCK_SERIES_METRICS) {
         const value = of(host);
         if (value === null || !Number.isFinite(value)) continue;
-        const key = `${host.host}\u0000${metric}`;
+        const key = seriesKey(host.host, metric);
         const points = mockSeries.get(key) ?? [];
         // Same second as the previous point means two reads inside one tick; replace rather than
         // append, so the graph does not gain a vertical pair at one x position.
@@ -342,7 +353,7 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
         unit,
         /* A COPY, so a later poll appending to the stored array cannot mutate a series React is
            already rendering. The engine's `recent()` copies for the same reason. */
-        points: [...(mockSeries.get(`${host} ${metric}`) ?? [])],
+        points: [...(mockSeries.get(seriesKey(host, metric)) ?? [])],
       }));
       const recorded = series.some((s) => s.points.length > 0);
       return {


### PR DESCRIPTION
Demo-mode host graphs have never drawn. `recordSeries` stored each point under one key and `getHostSeries` looked it up under another, so every `mockSeries.get` missed.

```
recordSeries   →  mockSeries.set(`${host.host}\u0000${metric}`, …)   // NUL separator
getHostSeries  →  mockSeries.get(`${host} ${metric}`)                // space separator
```

The panel therefore received `points: []` for all three metrics on every host, `recorded` was always `false`, and `polledAt` was always `null` — which is the "collecting" state, permanently, on the one feature whose entire purpose is to draw a series (#139).

**Not a regression.** `mockSeries` does not exist in #140's parent commit, so both halves arrived together and the two sides never agreed at any point. The feature has simply never worked in demo mode.

## Why it survived two reviews

`recordSeries` used a **literal U+0000 control character** rather than the `\u0000` escape. Git classifies any file containing a NUL as binary, so every diff of `mockClient.ts` since #140 has rendered like this:

```
$ git show --stat 9a44346 -- apps/dashboard/src/api/mockClient.ts
 apps/dashboard/src/api/mockClient.ts | Bin 21868 -> 27238 bytes
 1 file changed, 0 insertions(+), 0 deletions(-)
```

#140 introduced it (`Bin 15885 -> 21868`) and #144 changed a further 5,370 bytes behind it. Neither was reviewable — on GitHub the file shows no diff at all. A one-line disagreement between two adjacent functions is precisely the class of defect a diff catches and prose does not, which is why this is filed as two problems rather than one.

It is the only tracked text file in the repo with a NUL — checked across every tracked file rather than assumed.

## Two commits, deliberately

| | |
|---|---|
| `4fd83d2` | Raw NUL → the `\u0000` escape. Byte-identical at runtime, no behaviour change. Makes the file text again. |
| `49f659a` | One shared `seriesKey(host, metric)` that both the writer and the reader call. |

**The first commit's diff is 616 lines and that is correct, not noise.** `core.autocrlf` is `true` and every sibling source file is stored with LF — `mvp2Guards.ts` has 424 bare LF in its blob — but autocrlf deliberately does not convert files it believes are binary. So this one went into the repo with 616 CRLF endings. Removing the NUL lets normalisation run, once. Reviewing `49f659a` alone is the intended path; it is 3 changed lines plus a comment.

## Why a shared builder rather than a corrected literal

Fixing the separator in both places would leave the same failure mode one edit away. This is the argument `Tools.ErrorCatalogue` and `Tools.HostRoster` were extracted on in #153 last week, and it applies unchanged: a rule held in two places goes stale in whichever copy nobody edits.

**The separator stays U+0000 rather than becoming a space**, because a space is legal in a host name — `Cloud API`, `EMR Source` and `Lab Router` all contain one — so `"A B" + " " + "c"` and `"A" + " " + "B c"` compose the same key. A control character cannot collide. It is now written as an escape, which is byte-identical at runtime and keeps the file diffable.

## Verification

```
$ npx tsc --noEmit                 (clean)
$ npm run build                    (clean — architecture validator ok, 8 labels / 12 paths)
$ npm run validate:fixtures        (clean)
```

And the keys checked directly rather than reasoned about:

```
old writer key : "Cloud API\u0000queued"
old reader key : "Cloud API queued"
old match      : MISS  <-- the bug
new both sides : "Cloud API\u0000queued"   HIT
```

**NOT verified in a browser, and this is the gap worth knowing.** `apps/dashboard/` has no test runner and I did not bring up the compose stack, so "the graph now draws" rests on the two keys agreeing, not on a rendered chart. The remaining uncertainty is whether anything *downstream* of `points[]` also assumed the empty array — `HostSeriesView` consumers have only ever been exercised against `[]` in demo mode. Worth opening demo mode and clicking a host at the next rehearsal; `apps/dashboard/CLAUDE.md` §6.1 applies (`docker compose up -d --build dashboard`, since the bundle is compiled into the image).

## Scope

`apps/dashboard/src/api/mockClient.ts` only. No contract change, no `src/` outside `api/`, no new dependency, no host name or count added. Demo-mode path only — `liveClient` builds no such key and is untouched.

Raised while reviewing #153, which is also where #155 and #156 came from.

---

**Reviewer note:** `.github/CODEOWNERS` assigns `/apps/dashboard/` to `@tanifgit`, while root `CLAUDE.md` §3 assigns it to Dev B and `CONTRIBUTING.md` line 92 still says Dev C. Those four files need reconciling (see the process note on #153) — I have not touched them here, because that is its own PR and it needs the roster question settled first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
