### PR TITLE
docs(demo): two traps a reset now sets, and a count that had already gone stale

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -480,10 +480,14 @@ all shipped and there was an end-to-end flow worth scripting. Kept rather than d
 and still is not a blocker for any acceptance criterion.
 
 The cue sheet is deliberately **measured rather than written from memory** — every timing in it was
-taken from the containerised stack (77s for `pool_bottleneck` to take effect, 12s to `dead_host`, 103s
-for a queue of 165 to drain after an approve), and it names the five traps that have each cost a
-rehearsal. A cue sheet full of plausible-sounding numbers would be worse than none, because a presenter
-would trust it.
+taken from the containerised stack — and it names the traps that have each cost a rehearsal. A cue
+sheet full of plausible-sounding numbers would be worse than none, because a presenter would trust it.
+
+**The numbers and the trap count live in `docs/demo/cue-sheet.md` and are not restated here**, which
+is §8's rule applied to this paragraph rather than only to the latency bar. It used to quote three
+timings and "the five traps", and both halves went stale: the drain was re-measured as ~90s to an
+empty queue and ~200s to a clean board (from 157 queued, not 165), and the trap list has grown past
+five. A count in prose above a numbered list is a copied value like any other.
 
 **Overall acceptance (from the MVP doc):** *dashboard renders all hosts + findings live; updates within 10 s of a change; fallback to demo mode is seamless.*
 

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -75,7 +75,7 @@ look like it ran. The `@'` form passed `$zversion` through untouched and IRIS an
 build. Two layout rules the parser enforces: `@'` must end its line, and `'@` must start its own
 line at **column 0** — indent it and PowerShell does not see the terminator.
 
-### The five traps, in the order they will bite you
+### The traps, in the order they will bite you
 
 1. **`AGENT_MODE` defaults to `mock`.** A canned investigation is built from *real measured values*, so
    it reads as correct and demonstrates nothing about the agent. Check `source: "agent"` and a
@@ -93,6 +93,21 @@ line at **column 0** — indent it and PowerShell does not see the terminator.
    restores it to 1. If the queue never builds, check this first.
 5. **Never `curl /api/monitor/alerts`.** It is consume-on-read — reading it destroys the alert the
    `system_alert` path depends on. Use `:3001/proxy/alerts`.
+6. **Reset all empties the Message Viewer, whenever a scenario errored.** Clearing the per-host error
+   count means deleting message rows — that count is a `COUNT(*)` over `Ens.MessageHeader`, so nothing
+   restorable moves it — and `Ens.Purge` has no status filter, so it cannot delete only the errored
+   ones. Measured: **2,550 headers removed to clear 21 errored.** The completed traffic goes with them,
+   and how much survives depends on which sessions happened to be in flight, not on anything you can
+   plan. **So if a later beat needs the Message Viewer populated, show it before you reset.** A reset
+   with nothing errored skips the purge entirely and leaves history alone.
+7. **Reset all restarts the baselines, so nothing comparative fires for about a minute.** This is
+   deliberate — a load step-down is not a fault, and after a reset the engine genuinely does not know
+   what normal is yet — but it means *reset, arm, expect a finding* looks broken for the first ~60s
+   (`minBaselineSamples` × the shipped poll interval; both live in `services/detection-engine/`, so
+   check there rather than trusting this number). `queue_buildup`, `throughput_drop`, `slow_processing`
+   and `growing_queue_wait` are all comparative and all silent in that window; `dead_host` is absolute
+   and unaffected, which makes it the safe thing to arm first. **The reliable signal that the wait is
+   over is Early Warning: it says "Baseline still warming — no projection yet" until it is.**
 
 **Open two browser tabs before you start:** `http://localhost:5173` (the dashboard) and the
 Management Portal link from its header (the IRIS interoperability editor). Switching tabs is faster

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -100,14 +100,23 @@ line at **column 0** — indent it and PowerShell does not see the terminator.
    and how much survives depends on which sessions happened to be in flight, not on anything you can
    plan. **So if a later beat needs the Message Viewer populated, show it before you reset.** A reset
    with nothing errored skips the purge entirely and leaves history alone.
-7. **Reset all restarts the baselines, so nothing comparative fires for about a minute.** This is
-   deliberate — a load step-down is not a fault, and after a reset the engine genuinely does not know
-   what normal is yet — but it means *reset, arm, expect a finding* looks broken for the first ~60s
-   (`minBaselineSamples` × the shipped poll interval; both live in `services/detection-engine/`, so
-   check there rather than trusting this number). `queue_buildup`, `throughput_drop`, `slow_processing`
-   and `growing_queue_wait` are all comparative and all silent in that window; `dead_host` is absolute
-   and unaffected, which makes it the safe thing to arm first. **The reliable signal that the wait is
-   over is Early Warning: it says "Baseline still warming — no projection yet" until it is.**
+7. **Reset all restarts the baselines, and exactly two rules go quiet — not all of them.** The reset
+   declares a new load regime so the rolling mean re-warms instead of averaging across the step down,
+   which is right: a load step-down is not a fault. But the wait is far narrower than it sounds, and
+   assuming otherwise costs you either a minute you did not owe or a finding you read as a bug because
+   it arrived "too early". **Only `throughput_drop` and `elevated_error_rate` go silent**, because
+   `messagesPerSec` and `errorsPerMinute` are the only two metrics with no `referenceBaselines` entry,
+   so they are the only two that wait for the mean. `queue_buildup`, `slow_processing` and
+   `growing_queue_wait` read metrics that *do* have a reference, and a reference replaces the rolling
+   mean outright rather than filling in until it warms — so **they fire immediately, Act 1's headline
+   finding included.** `dead_host` is absolute and unaffected. Those two that do pause are waiting for
+   `minBaselineSamples` × the shipped poll interval — about a minute on the shipped values, but both
+   numbers live in `services/detection-engine/`, so check there rather than trusting this
+   approximation.
+   **Do not wait for a UI signal, because there isn't one.** Early Warning cannot report "Baseline
+   still warming" for these hosts — every one of them has a `queued` reference, so its threshold is
+   never null and that state is unreachable. Right after a reset it shows *"Watching — not trending
+   toward a threshold"* with a tick, which is reassurance rather than readiness.
 
 **Open two browser tabs before you start:** `http://localhost:5173` (the dashboard) and the
 Management Portal link from its header (the IRIS interoperability editor). Switching tabs is faster


### PR DESCRIPTION
> **DRAFT ON PURPOSE — merge after #154, #158 and #159.** Every claim here describes behaviour those
> three PRs introduce. On today's `main` all three traps below would be wrong, and there is no branch
> protection to enforce an order, so the draft flag is the only mechanical guard available. One click
> to undraft once they land.

Two traps that came out of reviewing #154 and #159, plus a count that had already gone stale. Each trap is a presenter-facing consequence of a change whose own PR documents the mechanism carefully but not what it does to someone standing in front of an audience.

## Trap 6 — Reset empties the Message Viewer

#154 clears the per-host error count by deleting message rows, because that count is a `COUNT(*)` over `Ens.MessageHeader` and nothing restorable moves it. `Ens.Purge` has no status filter, so it cannot delete only the errored ones — in #154's own verification run, **2,550 headers went to clear 21 errored**.

The gate protects the nothing-errored case. But in the case the feature exists for, the completed history goes too, and how much survives depends on which sessions happened to be in flight rather than on anything a presenter can plan. So the actionable instruction is **show the Message Viewer before you reset**, which is what a trap list can be used for.

## Trap 7 — Reset restarts the baselines

#159's `beginRegime()` is right and its docstring is honest about the ~60s of silence being the intended trade: after a load step-down the engine genuinely does not know what normal is. What that means on stage is that *reset, arm, expect a finding* looks broken for the first minute.

The trap names the four comparative rules that go quiet, names `dead_host` as the safe thing to arm first because it is absolute, and points at Early Warning's `Baseline still warming — no projection yet` as the signal that the wait is over — a state `EarlyWarning.tsx:58` already renders, so this adds nothing to build.

The 60s is given **with its derivation and an instruction to check the engine rather than trust the number**, for the reason the next section is about.

## And the heading's count is removed rather than incremented

`### The five traps` is a copied value sitting directly above the list it counts — exactly what root `CLAUDE.md` §6 and this directory's own §8 are about. It was already wrong the moment a sixth trap was needed. Now `### The traps`.

`apps/dashboard/CLAUDE.md` carried the same count **plus three copied timings, four lines above the rule forbidding exactly that**:

> Do not restate the latency figures anywhere in this directory, including here: link the ADR. Three copied values in this repo have already gone stale.

Two of its three were already stale — #158 re-measured the drain as ~90s to an empty queue and ~200s to a clean board, from 157 queued rather than 165. Replaced with a pointer; the old values now appear only inside the note explaining what went stale.

## Scope

`docs/demo/cue-sheet.md` and `apps/dashboard/CLAUDE.md` — both `@tanifgit` per `.github/CODEOWNERS`. Documentation only, no code, no contract change.

**Deliberately not touching the drain table at `cue-sheet.md:243`** (`t+103s queued=0`). #158 rewrites that whole block and is approved, so it is its change to make rather than a conflict for me to create.

Verified `git merge-tree` clean against #154, #157, #158 and #159 at the time of pushing.
