### PR TITLE
feat: Guardian reads what CHANGED, and the chat reads what Guardian is REPORTING

### DIFF
--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -13,7 +13,7 @@ Developer A owns:
 |---|---|
 | `iris/setup/` | One-time ObjectScript setup scripts for the demo namespace |
 | `iris/labdemo/` | LABDEMO production class, HL7 generator, trigger toggles |
-| `iris/labdemo/Tools/` | MVP 2: the six MCP tools, the authorization and audit policies, the governed-manager factory |
+| `iris/labdemo/Tools/` | MVP 2: the MCP tools, the authorization and audit policies, the governed-manager factory. **The count is in `contracts/mcp-tools.md` §1 and is not restated here** |
 | `iris/labdemo/Audit/` | MVP 2: the persisted audit trail — AI Hub ships no audit store |
 | `services/metrics-proxy/` | Node.js proxy: polls `/api/monitor/metrics` + `/api/monitor/alerts`, exposes per-host JSON |
 
@@ -114,13 +114,50 @@ npm run mock
 
 ## 7. MVP 2 — the governed MCP tools (read this before touching `Tools/`)
 
-Full measurements are in `docs/mvp2-aihub-verified-api.md`. The four rules that matter here:
+Full measurements are in `docs/mvp2-aihub-verified-api.md`. The rules that matter here — **deliberately
+not counted, for the reason the tool count below is not restated**: this line read "the four rules"
+while the section held six, which is the same staling this file indicts two paragraphs down:
 
 **Every public ClassMethod on a `%AI.Tool` subclass becomes an LLM-callable tool.** Verified by
 reading `%AI.Tool.Generator`. A helper left public on `Tools.Resolve` is a second way to mutate a
 live production. Helpers are `[ Private ]`, and `Setup.AIHub.Run()` prints the discovered tool count
-on every boot so a seventh name shows up at boot rather than in review. **Six is the expected
-count.**
+on every boot so an extra name shows up at boot rather than in review. **The expected count lives in
+`Setup.AIHub.ReportTools()` and in `contracts/mcp-tools.md` §1 — it is deliberately not restated
+here.** This line read "Six is the expected count" from MVP 2 through three families being added, so
+it was wrong by eight: #84's shape, in the file a newcomer trusts. Move the number in `ReportTools()`
+only after reading the discovered names back, which is the discipline every previous bump followed.
+
+**A shared list between two tool classes must be a `Parameter`, not a method.** `Tools.ChangeLog`
+needs `Tools.Read`'s setting allowlist, and a public accessor for it would have become another
+LLM-callable tool that returns setting names to the model. Parameters are cross-class accessible
+(`##class(X).#PARAM`) and generate no tool, so `#SETTINGALLOWLIST` is one — which is also the only
+arrangement that avoids a second copy of the list.
+
+**`Triggers.SetSetting()` writes its own audit row, and it has to.** A setting changed through
+`Ens.Config.Production.%Save()` is **not** audited — only the Management Portal's own save path is,
+measured by arming `MissingFolder()` and finding the newest `ModifyConfiguration` row three days
+stale. So the method emits a byte-compatible row via `$SYSTEM.Security.Audit()` **after** the save
+succeeds, and `get_recent_config_changes` can see what the triggers do. **Note the argument order:
+arg4 lands in `EventData` and arg5 in `Description`** — the reverse of what the names suggest, and
+getting it wrong produces a valid row that the tool's host parse silently discards as a lifecycle
+event. Anything else here that mutates a setting through `%Save()` is invisible to that tool.
+
+**A tool that is registered and described is not a tool that gets CALLED.** Adding a tool takes three
+things, and the third is the one that keeps being forgotten: register it in `Tools.Governance`,
+describe it in the system prompt, and **name it in a `MUST` in the per-request goal**. Measured twice.
+`BuildGoal` already carries that directive for `get_recent_errors` and `get_host_settings` because
+"use the tools" left them uncalled in two of three live runs; `GetRecentConfigChanges` then repeated
+it exactly — registered, its prompt paragraph verified present in the compiled `.INT`, and
+`toolCalls: 2` on the very scenario it was built for, because the model had a satisfying answer after
+two calls and stopped. A description is not a directive.
+
+**And when you add a directive to `BuildGoal`, re-check `evidence[].source`.** The goal is the last
+thing the model reads, so a long block there outcompetes the system prompt. The first version of that
+directive closed by deferring to "the rules in your instructions" and cost every evidence entry its
+attribution across three consecutive runs — `source` unset, which `investigate.ts` maps to `"llm"`, so
+the reply stayed schema-valid while claiming the model had reasoned out values it read from governed
+tools. State a requirement in the same breath as the instruction it applies to; do not point at
+another part of the prompt.
 
 **Governance is per-`%AI.ToolMgr` and held in memory — there is no setting.** So never construct a
 `%AI.ToolMgr` or call `%AI.Agent.UseToolSet` directly: both give you an ungoverned manager with no

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -707,6 +707,53 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "To name a specific path or setting value, read it with get_host_settings. "
     set p = p _ "get_recent_errors gives you the KIND of failure and never the message text. "
 
+    // THE AUDIT TOOL, and this is the one paragraph in this prompt whose main job is a PROHIBITION.
+    //
+    // Named in PascalCase while the two names above are snake_case, and the inconsistency is
+    // deliberate rather than an oversight. `%AI.ToolMgr` derives the tool name from the ClassMethod
+    // name, so `GetRecentConfigChanges` is what `%Discover()` reports and what the model's schema
+    // holds; the snake_case names above work because the model maps them onto the real names by
+    // resemblance, which `REST.ChatDispatcher` records as "a coincidence to stop relying on" after it
+    // silently failed there. Correcting the existing two is #155's job and a contract question; there
+    // is no reason to add a third name that is known not to match.
+    set p = p _ "GetRecentConfigChanges lists recent configuration changes to this production's hosts "
+    set p = p _ "from the IRIS audit log: which setting changed on which host, from what value to what "
+    set p = p _ "value, and when. Call it for any misconfiguration-shaped fault -- a path that does not "
+    set p = p _ "exist, a port nothing answers on, a host that stopped consuming -- because a change "
+    set p = p _ "made shortly before the finding is the likeliest cause and the audit log is the only "
+    set p = p _ "place that says so. "
+
+    // THE PROHIBITION, and it needs to be sharper here than in the chat prompt for a structural
+    // reason: this agent HAS a field for prescribing a setting change. `manualRemediation.target` is
+    // `{host, setting, currentValue}`, so "restore the previous value" is not merely something the
+    // model could say -- it is a shape the reply schema invites. A recently-changed setting plus a
+    // slot for a setting fix is a strong pull toward exactly the recommendation the operator did not
+    // ask for.
+    //
+    // WHY THE OLD VALUE IS RETURNED AT ALL, given that. Withholding it would defeat the tool: "FilePath
+    // changed" is not a diagnosis, and "changed from a directory that exists to one that does not" is.
+    // So the data stays and the restraint lives here. `Tools.ChangeLog`'s class comment carries the
+    // full argument.
+    //
+    // NO STRUCTURAL GUARD, and the reason is worth stating because this class does prefer one where it
+    // exists (`DropUnapplicableAction`). A guard here would have to recognise "revert" in free prose or
+    // match a step's text against a previous value, which is string-matching a recommendation's
+    // MEANING -- it would pass "set FilePath back to /tmp/labdemo/hl7-in/" and fail on a paraphrase.
+    // A field that cannot be checked is worse than a rule that is stated.
+    set p = p _ "A recent change is EVIDENCE, never a recommendation. Report it in rootCause and "
+    set p = p _ "evidence -- name the setting, when it changed, and what it changed from and to, and "
+    set p = p _ "say it may be the cause. You must NOT recommend reverting it, must not put a revert in "
+    set p = p _ "manualRemediation.steps, and must not describe the previous value as the correct one. "
+    set p = p _ "Whoever made the change had a reason you cannot see, and the value they INTENDED may "
+    set p = p _ "be neither the old one nor the new one -- a typo in a new path is not repaired by "
+    set p = p _ "restoring the old path. State the fault and what changed; the operator decides. "
+    // SILENCE IS NOT EVIDENCE. Same sentence as the chat prompt, for the same measured reasons: IRIS
+    // purges audit data on a schedule, and a setting changed through `Ens.Config.Production.%Save()`
+    // rather than the Management Portal is never audited at all.
+    set p = p _ "An empty change list does not prove nothing was changed -- audit data is purged and "
+    set p = p _ "some changes are not audited. Read retention and auditEnabled before saying a host's "
+    set p = p _ "configuration was untouched, and never offer the absence of a change as a finding. "
+
     set p = p _ "Recommend nothing if no bounded action and no manual step fits."
     quit p
 }
@@ -755,6 +802,52 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     set g = g _ " A WIDE WINDOW CONTAINS HISTORY. Check secondsAgo on each code before treating it as"
     set g = g _ " current: errors from 20 minutes ago on a host that is no longer erroring describe"
     set g = g _ " a fault that has ended, and the backlog draining behind it is a different problem."
+
+    // A THIRD MANDATORY CALL, for the reason the two above are mandatory, and it is the same failure
+    // arriving a third time. `SystemPrompt()` describes `GetRecentConfigChanges` and tells the model
+    // to "call it for any misconfiguration-shaped fault" -- which is a description, and descriptions
+    // do not get tools called. Measured on the armed missing-folder scenario, the fault this tool was
+    // built for: `toolCalls: 2`, `GetRecentErrors` and `GetHostSettings`, and a rootCause that named
+    // the non-existent path without mentioning that the path had been changed to it eight minutes
+    // earlier. The tool was registered, the prompt paragraph was in the compiled routine, and the
+    // model still had a satisfying answer after two calls and stopped.
+    //
+    // UNCONDITIONAL, rather than gated on the finding type. "Misconfiguration-shaped" is a judgement
+    // about the DIAGNOSIS and the model cannot make it before gathering evidence, which is the
+    // circularity that left the tool uncalled. The type does not partition the space either: a
+    // `dead_host` is a missing folder or a genuinely stopped host, and a `queue_buildup` following a
+    // PoolSize edit is exactly the case worth catching. The call is one bounded query returning at
+    // most 25 rows of setting names and values, so the cost of always making it is far below the cost
+    // of the one time it mattered and was skipped.
+    //
+    // WHETHER TO REPORT the change remains the model's judgement -- the user's ask was to raise it
+    // "if it fits". This directive removes the discretion about LOOKING, not about concluding, and
+    // says so, because a model told it must call a tool will otherwise find something to say about
+    // the result.
+    set g = g _ " You MUST also call GetRecentConfigChanges before concluding. A setting changed"
+    set g = g _ " shortly before a finding is the likeliest cause of it, and the audit log is the only"
+    set g = g _ " place that records one. If a change is relevant, report it in rootCause and as an"
+    set g = g _ " evidence entry naming the setting, the old and new values and when it changed; if"
+    set g = g _ " nothing relevant comes back, say nothing about it -- the absence of a change is not"
+    set g = g _ " a finding."
+
+    // ATTRIBUTION, RESTATED HERE, and it is a repair rather than a belt-and-braces addition. The
+    // directive above cost the reply its evidence attribution: the first version closed with "report
+    // it as evidence under the rules in your instructions", and across three consecutive live runs
+    // EVERY entry came back `source` unset and `tool` null -- including the two tool reads that had
+    // been correctly attributed as `mcp_tool` in the run immediately before the edit. `investigate.ts`
+    // maps an unrecognised source to `"llm"`, so the reply stayed valid and silently claimed the model
+    // had reasoned out values it had in fact read from governed tools.
+    //
+    // The mechanism is displacement: this block is the last thing the model reads and it is now the
+    // longest instruction about evidence, so a vague pointer at "your instructions" competed with the
+    // system prompt's concrete {label, detail, source, tool} schema and won. Deferring to another part
+    // of the prompt is what failed; naming the requirement in the same breath as the mandatory calls
+    // is what fixes it.
+    set g = g _ " EVERY value you obtained from a tool must be attributed: that evidence entry takes"
+    set g = g _ " source ""mcp_tool"" and tool set to the exact tool name you called. Use source"
+    set g = g _ " ""snapshot"" only for the metrics given to you above. Never leave source or tool"
+    set g = g _ " unset for something you read with a tool."
     quit g
 }
 

--- a/iris/labdemo/REST/ChatDispatcher.cls
+++ b/iris/labdemo/REST/ChatDispatcher.cls
@@ -271,6 +271,14 @@ ClassMethod Ask() As %Status
 {
     set %response.ContentType = "application/json"
     try {
+        // KILLED FIRST, BEFORE THE BODY IS EVEN READ, and the ordering is the whole correctness
+        // argument rather than tidiness. CSP processes are POOLED AND REUSED, so a process-private
+        // global outlives the request that set it: a question arriving without a findings snapshot
+        // would read the PREVIOUS question's and answer confidently about a production state minutes
+        // stale. Killing on the way out instead would be skipped by every early return above --
+        // malformed body, over-long question, small talk -- and by any exception path.
+        kill ^||PGGuardian("chat")
+
         set body = ##class(%DynamicObject).%FromJSON(%request.Content)
         set question = body.%Get("question", "")
 
@@ -296,6 +304,12 @@ ClassMethod Ask() As %Status
             write ..SmallTalkAnswer(kind, question).%ToJSON()
             return $$$OK
         }
+
+        // THE FINDINGS HANDOFF, and it happens AFTER small talk and BEFORE the agent is built.
+        // After, because a greeting needs no snapshot and storing one for it would be work on a path
+        // that never reads it; before, because `Tools.Findings` is registered during `BuildAgent` and
+        // the tool may be called on the first iteration.
+        do ..StashFindings(body)
 
         set agent = ..BuildAgent(.sc)
         if $$$ISERR(sc) {
@@ -337,6 +351,55 @@ ClassMethod Ask() As %Status
     } catch ex {
         return ..Fail(500, "chat failed: " _ ex.DisplayString())
     }
+}
+
+/// Hand the request's findings snapshot to `Tools.Findings` through a process-private global. Private.
+///
+/// THE ENGINE SENDS THE FINDINGS WITH THE QUESTION rather than IRIS fetching them, and the three
+/// reasons are argued in `Tools.Findings`'s class comment — briefly: the engine already holds the
+/// snapshot in the process making this request, IRIS would need an engine URL that three cold boots
+/// have shown going missing, and a findings read has no meaning outside the instant it was asked.
+///
+/// ABSENT IS NORMAL, NOT AN ERROR. An older dashboard build or a hand-rolled POST sends no `findings`
+/// key, and this returns having stored nothing — the tool then answers `supplied: false`, which the
+/// system prompt tells the model not to read as a healthy production. Refusing the request instead
+/// would break a client that worked yesterday for a capability it never asked for.
+///
+/// NOT TRUSTED FOR SIZE. The array arrives over HTTP from another service, and a process-private
+/// global node holds a bounded string, so the element count is capped HERE as well as in the tool.
+/// Two caps rather than one, deliberately: this one protects the global, the tool's protects the
+/// model's context, and the engine's own protects the request. Eight finding types across three hosts
+/// is 24 at the ceiling, so none of the three can clip a real production.
+ClassMethod StashFindings(body As %DynamicObject) [ Private ]
+{
+    if '$isobject(body) {
+        quit
+    }
+    set findings = body.%Get("findings")
+    // %Get returns "" for an absent key and a non-array for a malformed one. Both are "no snapshot
+    // supplied", and neither is worth failing the question over.
+    if '$isobject(findings) || 'findings.%IsA("%Library.DynamicArray") {
+        quit
+    }
+
+    set capped = []
+    set iter = findings.%GetIterator()
+    while iter.%GetNext(.index, .finding) {
+        if capped.%Size() >= ##class(ProductionGuardian.LabDemo.Tools.Findings).#MAXFINDINGS {
+            quit
+        }
+        do capped.%Push(finding)
+    }
+
+    set ^||PGGuardian("chat", "findings") = capped.%ToJSON()
+    // The instant the engine measured them, so the model can say "as of" rather than implying the
+    // reading is from the moment it is speaking. Absent is "" rather than a substituted `$ztimestamp`:
+    // stamping it here would be this class inventing a measurement time for another service's reading.
+    set ^||PGGuardian("chat", "asOf") = body.%Get("findingsAsOf", "")
+    // `ok`, `warming` or `stale`. Stored UNVALIDATED against that set on purpose: the tool treats
+    // anything it does not recognise as `ok`-equivalent phrasing, and an engine that adds a fourth
+    // state should degrade to a plain answer rather than have this class reject a state it predates.
+    set ^||PGGuardian("chat", "state") = body.%Get("findingsState", "")
 }
 
 /// Classify small talk, or "" for anything that should reach the agent. Private.
@@ -636,6 +699,35 @@ ClassMethod SystemPrompt() As %String [ Private ]
     // and getting away with it. That is a coincidence to stop relying on rather than a convention:
     // naming a tool the model cannot call is the same defect class as the two chat defects already
     // written up here, and it fails silently by looking like the model chose not to call anything.
+    // THE FINDINGS TOOL GOES FIRST, because "is anything wrong?" is the commonest question this chat
+    // is asked and it was the one question the chat could not answer. Before MVP 3 it had no tool that
+    // could see a finding at all, so it answered from an activity table -- a live `queue_buildup` on
+    // `Cloud API` went unmentioned while the dashboard showed it in red two panels away. Naming it
+    // first is the same technique as the block below: the model calls the tool that the prose puts
+    // next to the question.
+    set p = p _ "GetActiveFindings is what Production Guardian is reporting about this production "
+    set p = p _ "RIGHT NOW -- every open finding with its host, type, severity, the value that "
+    set p = p _ "triggered it and the baseline it was compared against. Call it FIRST for any question "
+    set p = p _ "about whether something is wrong now, or about a condition the operator names such as "
+    set p = p _ "a queue building, a pool bottleneck, a host being down or errors rising -- and relate "
+    set p = p _ "your answer to the findings it returns rather than inferring the same conclusion from "
+    set p = p _ "throughput. "
+    // `supplied: false` MUST NOT READ AS HEALTHY. The tool says so in its own payload, and the rule is
+    // restated here because this is the one failure in the family where the honest answer and the
+    // reassuring answer are the same shape -- an empty list. See `Tools.Findings`'s class comment.
+    set p = p _ "If it returns supplied: false, no findings snapshot reached this request: say you "
+    set p = p _ "could not read the current findings, and do NOT conclude the production is healthy. "
+    // AN EMPTY LIST IS NOT AN ALL-CLEAR EITHER, in two of the three engine states. This is the same
+    // failure as `supplied: false` wearing the shape of a successful answer, which makes it the more
+    // dangerous of the two -- `count: 0` with `state: warming` is a production nobody has measured yet,
+    // and the reassuring reading of it is available without the model doing anything wrong. The tool
+    // puts the distinction in `note`; this tells the model to read it.
+    set p = p _ "When it returns count: 0, read the state field before saying nothing is wrong: "
+    set p = p _ """warming"" means the engine has no baseline yet and its comparative rules cannot "
+    set p = p _ "fire, so nothing has been measured; ""stale"" means the list is the last one it could "
+    set p = p _ "compute and may be out of date. Report either as such. Only ""ok"" with count: 0 "
+    set p = p _ "supports ""no open findings"". "
+
     set p = p _ "GetActivityCoverage lists which hosts have recorded activity and how far back the "
     set p = p _ "data goes -- call it first when you do not already know a host name or a date range. "
     set p = p _ "GetActivityTrend gives one host's throughput and latency bucket by bucket, so it is "
@@ -654,6 +746,34 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "answers ""are there errors"", ""what is failing"" and ""what went wrong with X"". "
     set p = p _ "GetEventLogTrend gives log volume by severity bucket by bucket, INCLUDING buckets "
     set p = p _ "with none, so it is what answers ""when did the errors start"" or ""has it stopped"". "
+
+    // THE AUDIT TOOL, and the rule it comes with is a PRODUCT rule rather than a prompting nicety.
+    // "Did someone change something" is the first thing an operator asks about a broken host, and on
+    // this instance the answer was sitting in `%SYS.Audit` unread: `EMR Source`'s FilePath and
+    // `Cloud API`'s HTTPPort were both edited within hours of the findings they caused.
+    //
+    // THE PREVIOUS VALUE IS EVIDENCE, NOT A RECOMMENDATION, and the tool deliberately returns it
+    // rather than withholding it -- an agent that can only say "FilePath changed" cannot say "changed
+    // from a directory that exists to one that does not", which is the whole diagnostic content. So the
+    // restraint has to live here, in the prompt. See `Tools.ChangeLog`'s class comment for the full
+    // argument; the operative half is that whoever made the change had a reason this instance cannot
+    // see, and the value they INTENDED may be neither the old one nor the new one.
+    set p = p _ "GetRecentConfigChanges lists configuration changes to this production's hosts from the "
+    set p = p _ "IRIS audit log -- which setting changed on which host, from what value to what value, "
+    set p = p _ "and when. Call it whenever a host is faulting or a finding is open: a change close in "
+    set p = p _ "time to the fault is worth reporting as a possible cause, and a value that looks like a "
+    set p = p _ "typo is worth pointing at. "
+    set p = p _ "But you must NOT recommend reverting a change and must not call the previous value the "
+    set p = p _ "correct one. Whoever made the change had a reason you cannot see, and the value they "
+    set p = p _ "intended may be neither the old one nor the new one. Report what changed and when, say "
+    set p = p _ "it may be related, and leave the decision to the operator. "
+    // SILENCE IS NOT EVIDENCE, and unlike the event log's zero this one genuinely is ambiguous: IRIS
+    // purges audit data on a schedule, and a setting changed through `Ens.Config.Production.%Save()`
+    // rather than the Management Portal is never audited at all. The payload carries `retention` and
+    // `auditEnabled` for exactly this; the sentence is what makes the model read them.
+    set p = p _ "An empty change list does not prove nothing was changed -- audit data is purged on a "
+    set p = p _ "schedule and some changes are not audited. Read the retention and auditEnabled fields "
+    set p = p _ "before saying a host's configuration was untouched. "
 
     // THE "(production)" SCOPE, and this is the measured fact that makes the pair worth having.
     // 91 rows on this instance are production-lifecycle events with a NULL ConfigName -- they belong
@@ -683,13 +803,27 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "which is the production itself rather than a host. Lead with the application hosts and "
     set p = p _ "the production, and mention framework entries only if they are what is failing. "
 
-    // SAYS WHAT IT DOES NOT HAVE. The five tools above are all it is given (GovernAgent's "chat"
+    // SAYS WHAT IT DOES NOT HAVE. The seven tools above are all it is given (GovernAgent's "chat"
     // set), and stating that is what stops the model narrating a tool call it cannot make and then
     // reporting the absence as a finding about the production. The registration is the guard; this
     // sentence only keeps the narrative honest about it.
-    set p = p _ "These five tools are ALL you have. You cannot read the current instantaneous "
-    set p = p _ "status, queue depth or pool size of a host, and you must not claim to have. Every "
-    set p = p _ "number you report is a RECORDED figure over a stated period, so say which period. "
+    //
+    // AMENDED FOR `GetActiveFindings`, CAREFULLY, because this sentence is the one that closed the
+    // 0.12-vs-77.66 defect: asked which host had the highest average queueing time, a model holding
+    // the current-state tools answered 0.12s from `GetProcessingTime` when the recorded answer was
+    // 77.66s, at `confidence: 1`. The findings tool DOES carry current values, so "you cannot read
+    // current state" is no longer true and leaving it would be a lie the model can catch. But the
+    // narrow claim still holds and is the one that matters: there is no tool here that reads a host's
+    // status, queue depth or pool size ON DEMAND, and the findings snapshot covers only hosts with an
+    // open finding. Loosening this to "you have some current data" would reopen the defect; naming
+    // exactly which current data, and for which hosts, does not.
+    set p = p _ "These seven tools are ALL you have. Apart from GetActiveFindings you cannot read a "
+    set p = p _ "host's current status, queue depth or pool size, and you must not claim to have -- "
+    set p = p _ "there is no tool that reads those on demand, and the findings snapshot covers only "
+    set p = p _ "hosts with an open finding, so a host absent from it is UNMEASURED here rather than "
+    set p = p _ "healthy. Every other number you report is a RECORDED figure over a stated period, so "
+    set p = p _ "say which period -- and never answer a question about an average or a trend from a "
+    set p = p _ "finding's currentValue, which is one instant. "
 
     // THE RESOLUTION RULE. Stated as a mapping from the question's own time span, because the model
     // otherwise defaults to `hours` for everything -- which answers "what happened in the last two

--- a/iris/labdemo/Tools/ChangeLog.cls
+++ b/iris/labdemo/Tools/ChangeLog.cls
@@ -1,0 +1,404 @@
+/// MCP read tool over `%SYS.Audit` — WHO CHANGED WHAT, for the production this project reports on.
+///
+/// Implements the one tool in `contracts/mcp-tools.md` §3.12. That contract is authoritative; where
+/// this class and it disagree, the contract is right and this is a bug.
+///
+/// WHY THIS TOOL EXISTS. Every other read tool answers a question about the production's BEHAVIOUR —
+/// what is true now, what throughput did, what the log said. None of them can answer the question an
+/// operator asks first when a host breaks: *did someone change something?* On this instance
+/// `EMR Source`'s `FilePath` and `Cloud API`'s `HTTPPort` were both edited within hours of the
+/// findings they caused, and that fact sat in `%SYS.Audit` with nothing reading it.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// IT REPORTS THE CHANGE AND MUST NOT PRESCRIBE A REVERT
+///
+/// This is a product rule, not an implementation preference, and it is the reason the tool returns
+/// the previous value at all. Whoever made the change had a reason this instance cannot see, and the
+/// value they *intended* may be neither the old one nor the new one — a typo in a new path is not
+/// repaired by restoring the old path. So the OLD VALUE IS EVIDENCE, NOT A RECOMMENDATION.
+///
+/// The rule is enforced in the two system prompts (`REST.AgentDispatcher`, `REST.ChatDispatcher`)
+/// rather than by withholding the previous value, because withholding it would defeat the tool: an
+/// agent that can only say "FilePath changed" cannot say "changed from a directory that exists to one
+/// that does not", which is the whole diagnostic content. Data here, judgement there.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE SCHEMA, MEASURED RATHER THAN ASSUMED
+///
+/// `%SYS.Audit` on this instance holds 162,333 rows across 25 columns. The rows this tool wants are
+/// `Event = 'ModifyConfiguration'` with `EventSource/EventType = %Ensemble/%Production` — 82 of them —
+/// and only 8 of those describe a SETTING change. The rest are lifecycle text
+/// (`Production class compiled`, `Item updated using Management Portal V2 interface`), which is why
+/// the `>>` test below is a filter rather than an assertion.
+///
+/// TWO COLUMNS CARRY EVERYTHING, and their contents were read rather than guessed:
+///
+///   Description   `item EMR Source of ProductionGuardian.LabDemo.Production`
+///   EventData     `FilePath:/tmp/labdemo/hl7-in-missing/>>/tmp/labdemo/hl7-in/`
+///
+/// So `Description` is the SUBJECT and `EventData` is the DETAIL — the opposite of what the names
+/// suggest, and the opposite of the argument order `$SYSTEM.Security.Audit()` takes (see
+/// `Triggers.SetSetting`). Both are `varbinary` in the SQL projection, which is why every predicate
+/// here is on `Event` and `UTCTimeStamp` and the shape tests are done in ObjectScript: `LIKE '%>>%'`
+/// against `EventData` returns SQLCODE -29, so a SQL-side filter on content silently cannot be
+/// written.
+///
+/// HOST ATTRIBUTION COMES FROM `Description`, and it is exact rather than a prefix match. Config item
+/// names contain spaces (`EMR Source`), so the host is what lies between the literal `item ` and the
+/// literal ` of <production class>` — anchored at BOTH ends. A row naming another production is
+/// dropped rather than reported unattributed.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE DATA BOUNDARY
+///
+/// Tool output reaches an external LLM, so metrics and configuration only: never message content,
+/// never PHI (root `CLAUDE.md` §2.1, `contracts/mcp-tools.md` §6). An audit row is *more* dangerous
+/// than a live item read, because it is free text written by whatever performed the change.
+///
+///   RETURNED
+///     host            a config item name. Configuration, and dictionary-anchored by the `item … of`
+///                     parse above.
+///     setting         a setting NAME, and only from `Tools.Read.#SETTINGALLOWLIST` plus the two
+///                     names below. Anything else is counted, never named.
+///     previousValue   a setting VALUE. Permitted for exactly the reason `GetHostSettings` gives —
+///                     it was typed by whoever deployed the production, not derived from a message —
+///                     and only for an allowlisted name.
+///     newValue        same.
+///     changedAt       a clock reading. A timestamp carries nothing a person typed.
+///
+///   COUNTED, NEVER RETURNED
+///     suppressed      rows whose setting name is not allowlisted. The COUNT is published so the
+///                     model can tell "nothing changed" from "something changed that I may not
+///                     name" — those are different answers and conflating them is how an agent
+///                     concludes a host was untouched.
+///
+///   NEVER READ AT ALL
+///     Username        WHO made the change. An operator's identity is neither a metric nor
+///                     configuration, so it fails §2.1 on its face — and the tool does not need it:
+///                     "this was changed 40 minutes ago" carries the whole diagnostic weight, and
+///                     naming a person invites the agent to assign blame it cannot support. The
+///                     column is not selected, so it cannot leak by a later edit to the payload.
+///     ClientIPAddress, OSUsername, CSPSessionID, Roles, Pid, JobId
+///                     identifiers of the actor or the session. Same reasoning as `Username`, and
+///                     none of them answers a diagnostic question.
+///     UserInfo        `varbinary`, caller-supplied, and unbounded. Refused for the reason
+///                     `Tools.EventLog` refuses `TraceCat`: empty on this instance is the
+///                     rare-rather-than-absent shape.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// SILENCE IS NOT EVIDENCE, AND THE PAYLOAD SAYS SO
+///
+/// Two mechanisms make an empty `changes` list uninformative, and a model cannot know either one:
+///
+///   1. **IRIS purges audit data.** Measured — an `AuditChange` / "Delete audit data" pair ran at
+///      2026-08-30 06:00 on this instance. So the log's depth is a property of the instance, not of
+///      the product, and `retention` reports it for the same reason `Tools.EventLog.Retention()`
+///      does.
+///   2. **Not every setting change is audited.** `Ens.Config.Production.%Save()` writes no audit row
+///      — only the Management Portal's own save path does. `Triggers.SetSetting` therefore emits the
+///      row itself; anything else in this codebase that mutates a setting through `%Save()` will be
+///      invisible here. Measured by arming `Triggers.MissingFolder()` and finding no new row.
+///
+/// `auditEnabled` covers the third case: system auditing switched off makes every window empty.
+/// Read from `Security.System.Get()`, not from `Security.System.AuditEnabled()` — that method does
+/// not exist on this instance, which is worth stating because it is the name one reaches for first.
+///
+/// EVERY PUBLIC CLASSMETHOD HERE BECOMES AN LLM-CALLABLE TOOL, verified in `%AI.Tool.Generator`.
+/// Helpers are `[ Private ]` — six of them against one public method, so this class would discover
+/// seven tools if the keyword were ever dropped. One public method, one tool;
+/// `Setup.AIHub.ReportTools()` is what makes a second name a loud defect rather than a quiet one.
+Class ProductionGuardian.LabDemo.Tools.ChangeLog Extends %AI.Tool
+{
+
+/// The production whose changes this tool will report. Same value as `Tools.Read.#PRODUCTION`, and
+/// deliberately NOT imported from `Triggers`, for that class's stated reason: a tool that silently
+/// followed a change to the trigger class would start reporting on a different production than the
+/// one it was authorised for.
+Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
+
+/// Ceiling on `sinceHours`: 30 days.
+///
+/// Wide because the question is "was this touched recently" and a configuration change that broke a
+/// host a fortnight ago is still the answer. It stops at 30 days because beyond that the audit log
+/// on any real instance has been purged, so a wider window would offer coverage it cannot deliver —
+/// and `retention` in the payload is what tells the model where the real edge is.
+Parameter MAXWINDOW = 720;
+
+/// Used when the model omits `sinceHours`. Seven days — see the restatement inside the method for
+/// why an ObjectScript default is not enough on the tool path.
+Parameter DEFAULTWINDOW = 168;
+
+/// Rows read from `%SYS.Audit` before filtering, and it is a SQL `TOP` rather than a loop counter.
+///
+/// `AccessDenied` accounts for 111,228 of this instance's 162,333 audit rows and is still arriving
+/// every ~2.5 s, so the table grows without bound while the population this tool wants does not.
+/// The `Event` predicate excludes them, but a `TOP` is the guard that does not depend on an index
+/// existing.
+Parameter SCANROWS = 400;
+
+/// Changes returned at most, after filtering.
+///
+/// A cap rather than a page, because there is no question this tool answers that needs the 26th most
+/// recent change: the diagnosis turns on what was touched near the fault. `truncated` says when the
+/// cap bit, so the model never reads a clipped list as a complete one.
+Parameter MAXCHANGES = 25;
+
+/// Setting names this tool may report BEYOND `Tools.Read.#SETTINGALLOWLIST`.
+///
+/// Both are configuration a diagnosis turns on, and both are already published by an existing tool —
+/// `PoolSize` by `get_pool_size` and `GetHostSettings`, `Enabled` by `get_host_status` — so naming
+/// them here reveals nothing new. They are separate from the shared list because that list is read
+/// against an item's `Settings` collection, and neither of these is a `Settings` row: `PoolSize` and
+/// `Enabled` are properties of `Ens.Config.Item`. An audit row does not make that distinction, which
+/// is exactly why it has to be made here.
+Parameter EXTRAALLOWED = {$listbuild("PoolSize", "Enabled")};
+
+/// The marker an audited setting change puts between the old and the new value.
+Parameter DELIM = ">>";
+
+/// Recent configuration changes to this production's hosts, from the IRIS audit log — which setting
+/// changed on which host, from what value to what value, and when.
+///
+/// Call this when a host is misbehaving and you want to know whether its configuration was edited
+/// recently. A change close in time to the fault is worth reporting as a possible cause. You must
+/// NOT recommend reverting it and must not describe the previous value as the correct one: whoever
+/// made the change had a reason you cannot see, and the value they intended may be neither the old
+/// one nor the new one. Report the change; leave the decision to the operator.
+///
+/// An empty result does not mean nothing was changed — read `retention` and `auditEnabled` before
+/// saying so.
+ClassMethod GetRecentConfigChanges(host As %String = "", sinceHours As %Integer = 168) As %DynamicObject
+{
+    // AN OMITTED ARGUMENT IS NOT AN INVALID ONE. `%AI.ToolMgr.ExecuteTool` builds the argument list
+    // from the model's JSON and passes "" for a key the model did not send, so the `= 168` above
+    // never applies on the tool path. `GetRecentErrors` shipped broken for exactly this reason from
+    // #106 and it was invisible because every hand-written check passed the argument. Restated, not
+    // relied on.
+    if sinceHours = "" {
+        set sinceHours = ..#DEFAULTWINDOW
+    }
+    if (sinceHours '= (sinceHours \ 1)) || (sinceHours < 1) || (sinceHours > ..#MAXWINDOW) {
+        quit { "error": ("sinceHours must be an integer between 1 and " _ ..#MAXWINDOW),
+            "sanitised": true }
+    }
+
+    set since = ..Since(sinceHours)
+    set out = { "host": null, "sinceHours": (sinceHours), "since": (..IsoUTC(since)),
+        "now": (..IsoUTC($zdatetime($ztimestamp, 3))), "changes": null, "suppressed": 0,
+        "truncated": false, "sanitised": true }
+    // null when unfiltered, so "every host" and "a host whose name is the empty string" are
+    // different payloads rather than the same one.
+    if host '= "" {
+        set out.host = host
+    }
+
+    // THE ALLOWLISTS ARE READ BEFORE THE NAMESPACE SWITCH, and this is a correctness requirement
+    // rather than an ordering preference. `##class(Tools.Read).#SETTINGALLOWLIST` resolves the class at
+    // RUNTIME, and `Tools.Read` does not exist in %SYS -- measured: `<CLASS DOES NOT EXIST>` naming
+    // `ProductionGuardian.LabDemo.Tools.Read`, from inside a method that had compiled cleanly. Reading
+    // it here also costs nothing, since neither list depends on the query.
+    set allowed = ##class(ProductionGuardian.LabDemo.Tools.Read).#SETTINGALLOWLIST
+    set extra = ..#EXTRAALLOWED
+
+    // THE NAMESPACE SWITCH IS THE FIRST THING THAT CAN FAIL, and `new $namespace` is what restores
+    // it: `%SYS.Audit` is only queryable from %SYS, and a tool that left the process in %SYS would
+    // break every subsequent tool call in the same agent turn. Scoped to this frame, so it unwinds
+    // on an exception as well as on a normal return.
+    new $namespace
+    try {
+        set $namespace = "%SYS"
+    } catch switchEx {
+        set out.error = "cannot read the audit log: " _ switchEx.DisplayString()
+        // RETURN, not QUIT. Inside a TRY or CATCH block `QUIT` exits the BLOCK and refuses an argument
+        // -- `quit out` there is compile error #1043, not a method return. The exits below are at top
+        // level and use `quit`, which is the surrounding convention.
+        return out
+    }
+
+    // `%Set` WITH AN EXPLICIT TYPE in all three branches, because `set out.auditEnabled = ""` emits a
+    // JSON empty STRING and "" here means "could not tell". `"auditEnabled": ""` is falsy to most
+    // readers, so it would say "auditing is off" — the opposite of what the helper returns it for.
+    set enabled = ..AuditEnabled()
+    if enabled = "" {
+        do out.%Set("auditEnabled", "", "null")
+    } else {
+        do out.%Set("auditEnabled", ''enabled, "boolean")
+    }
+    // RETENTION FIRST, and unbounded by the window on purpose — same reason as
+    // `Tools.EventLog.Retention()`. A model told "no changes in the last 7 days" needs to know
+    // whether the audit log covers 7 days.
+    set out.retention = ..Retention()
+
+    set changes = []
+    set suppressed = 0
+
+    // Ordered DESC and capped by TOP: the newest changes are the ones a diagnosis turns on, and a
+    // clipped scan must clip the OLD end.
+    set rs = ##class(%SQL.Statement).%ExecDirect(,
+        "SELECT TOP " _ ..#SCANROWS _ " UTCTimeStamp, Description, EventData FROM %SYS.Audit " _
+        "WHERE Event = 'ModifyConfiguration' AND UTCTimeStamp >= ? ORDER BY UTCTimeStamp DESC",
+        since)
+    if rs.%SQLCODE < 0 {
+        // null, not an empty array. A failed query and a quiet production are different facts, and
+        // #33/#49/#58 are what conflating them costs.
+        set out.error = "audit query failed with SQLCODE " _ rs.%SQLCODE
+        quit out
+    }
+
+    while rs.%Next() {
+        set rowHost = ..HostOf(rs.%Get("Description"))
+        if rowHost = "" {
+            // A lifecycle row (`Production class compiled`) or another production's. Neither is a
+            // setting change on a host of ours.
+            continue
+        }
+        if (host '= "") && (rowHost '= host) {
+            continue
+        }
+        set data = rs.%Get("EventData")
+        set stamp = ..IsoUTC(rs.%Get("UTCTimeStamp"))
+        // ONE ROW MAY CARRY SEVERAL SETTINGS, one per line. Measured single-line on this instance,
+        // but a Portal save of two settings at once is one user action and there is no reason to
+        // assume it splits into two rows — so the loop is over lines, not over rows.
+        for line = 1:1:$length(data, $char(10)) {
+            set parsed = ..ParseChange($piece(data, $char(10), line))
+            if parsed = "" {
+                continue
+            }
+            if ($listfind(allowed, $list(parsed, 1)) = 0) && ($listfind(extra, $list(parsed, 1)) = 0) {
+                set suppressed = suppressed + 1
+                continue
+            }
+            if changes.%Size() >= ..#MAXCHANGES {
+                do out.%Set("truncated", 1, "boolean")
+                continue
+            }
+            do changes.%Push({ "host": (rowHost), "setting": ($list(parsed, 1)),
+                "previousValue": ($list(parsed, 2)), "newValue": ($list(parsed, 3)),
+                "changedAt": (stamp) })
+        }
+    }
+
+    set out.changes = changes
+    set out.suppressed = suppressed
+    quit out
+}
+
+/// Whether system auditing is on at all. Private.
+///
+/// `Security.System.Get()` into a by-reference array, because `##class(Security.System).AuditEnabled()`
+/// DOES NOT EXIST on this instance — measured, `<METHOD DOES NOT EXIST>`. Worth naming in a comment
+/// because it is the method a reader will reach for first.
+///
+/// Returns "" rather than 0 when the read fails, so `auditEnabled: null` means "could not tell" and
+/// never "auditing is off" — the two would license opposite conclusions about an empty result.
+ClassMethod AuditEnabled() As %Boolean [ Private ]
+{
+    set sc = ##class(Security.System).Get("", .props)
+    if $$$ISERR(sc) {
+        quit ""
+    }
+    quit $select($data(props("AuditEnabled")): ''props("AuditEnabled"), 1: "")
+}
+
+/// How deep the audit log's `ModifyConfiguration` history actually runs. Private.
+///
+/// Deliberately counts the EVENT, not the whole table: `AccessDenied` dominates the row count here
+/// and its oldest timestamp would advertise coverage this tool cannot deliver.
+ClassMethod Retention() As %DynamicObject [ Private ]
+{
+    set rs = ##class(%SQL.Statement).%ExecDirect(,
+        "SELECT COUNT(*) N, MIN(UTCTimeStamp) O, MAX(UTCTimeStamp) W FROM %SYS.Audit " _
+        "WHERE Event = 'ModifyConfiguration'")
+    if (rs.%SQLCODE < 0) || 'rs.%Next() {
+        quit { "rows": null, "oldest": null, "newest": null }
+    }
+    // BUILT IN A VARIABLE FIRST, not inline in the literal below. A `{}` literal may span lines, but a
+    // `_` concatenation continued onto the next line inside one does not parse -- the compiler reports
+    // #1021 "Expected right bracket" and then reads each continuation line as a command.
+    //
+    // Said in the payload at all because it changes how an empty window should be read, and the model
+    // has no other way to know it.
+    set note = "IRIS purges audit data on a schedule, and a setting changed through code rather " _
+        "than the Management Portal may not be audited at all -- an empty result is not proof " _
+        "that nothing changed"
+    quit { "rows": (rs.%Get("N")), "oldest": (..IsoUTC(rs.%Get("O"))),
+        "newest": (..IsoUTC(rs.%Get("W"))), "note": (note) }
+}
+
+/// The config item named by an audit row's `Description`, or "" if it does not name one of ours.
+/// Private.
+///
+/// ANCHORED AT BOTH ENDS — `item ` at the front and ` of <production class>` at the back — because
+/// config item names contain spaces, so neither `$piece(d, " ", 2)` nor a `[` containment test can
+/// recover `EMR Source`. Anchoring on the production class is also what drops a row describing a
+/// DIFFERENT production, which a containment test on `item ` alone would report as ours.
+ClassMethod HostOf(description As %String) As %String [ Private ]
+{
+    set head = "item "
+    set tail = " of " _ ..#PRODUCTION
+    // Explicit $length arithmetic rather than $extract's `*` offsets: the relative form reads more
+    // neatly and is one platform-version question this class does not need to carry.
+    set len = $length(description)
+    if $extract(description, 1, $length(head)) '= head {
+        quit ""
+    }
+    if $extract(description, len - $length(tail) + 1, len) '= tail {
+        quit ""
+    }
+    quit $extract(description, $length(head) + 1, len - $length(tail))
+}
+
+/// `$listbuild(setting, previousValue, newValue)` for one `Setting:old>>new` line, or "" if the line
+/// is not a setting change. Private.
+///
+/// SPLITS ON THE FIRST `:` AND REFUSES AMBIGUITY. A value may itself contain a colon (`URL:http://…`)
+/// so only the first one delimits the name; a value could in principle contain `>>`, and a line with
+/// more than one delimiter is DROPPED rather than split at a guessed position. Reporting
+/// `previousValue` wrong is worse than reporting nothing: the whole point of the tool is that an
+/// operator may read the old value.
+///
+/// An EMPTY previous value is legitimate and is kept — a setting added rather than edited audits as
+/// `Setting:>>value`, and "this setting did not exist before" is a real diagnosis.
+ClassMethod ParseChange(line As %String) As %String [ Private ]
+{
+    if line '[ ..#DELIM {
+        quit ""
+    }
+    set name = $piece(line, ":", 1)
+    if name = "" {
+        quit ""
+    }
+    set rest = $extract(line, $length(name) + 2, $length(line))
+    if $length(rest, ..#DELIM) '= 2 {
+        quit ""
+    }
+    quit $listbuild(name, $piece(rest, ..#DELIM, 1), $piece(rest, ..#DELIM, 2))
+}
+
+/// The ODBC timestamp `hours` hours ago. Private.
+ClassMethod Since(hours As %Integer) As %String [ Private ]
+{
+    set days = $piece($ztimestamp, ",", 1)
+    set secs = $piece($ztimestamp, ",", 2) - (hours * 3600)
+    while secs < 0 {
+        set days = days - 1
+        set secs = secs + 86400
+    }
+    quit $zdatetime(days _ "," _ secs, 3)
+}
+
+/// ODBC timestamp to ISO 8601 UTC. Private.
+///
+/// `%SYS.Audit.UTCTimeStamp` is already UTC — the column name says so and the values match
+/// `$ZDATETIME($ZTIMESTAMP, 3)` — so the `Z` is a statement of fact rather than a conversion. The
+/// fractional part is dropped: no question this class answers turns on milliseconds.
+ClassMethod IsoUTC(stamp As %String) As %String [ Private ]
+{
+    if stamp = "" {
+        quit ""
+    }
+    quit $translate($piece(stamp, ".", 1), " ", "T") _ "Z"
+}
+
+}

--- a/iris/labdemo/Tools/Findings.cls
+++ b/iris/labdemo/Tools/Findings.cls
@@ -1,0 +1,221 @@
+/// MCP read tool over the detection engine's CURRENT findings — what Production Guardian is
+/// reporting about this production right now.
+///
+/// Implements the one tool in `contracts/mcp-tools.md` §3.13. That contract is authoritative; where
+/// this class and it disagree, the contract is right and this is a bug.
+///
+/// WHY THIS EXISTS. The chat assistant could describe what the production DID — throughput, latency,
+/// what the event log said — and could not see what Production Guardian was SAYING about it. So
+/// "are there any issues right now?" was answered from an activity table, and a live
+/// `queue_buildup` on `Cloud API` went unmentioned while the dashboard showed it in red two panels
+/// away. The user's report is the whole specification: the chat "only checks the tables but not the
+/// findings", and it should relate to them.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE FINDINGS ARE SUPPLIED WITH THE QUESTION, NOT FETCHED
+///
+/// This is the one tool in the family that does not read IRIS. Findings are computed by the detection
+/// engine on `:3002`, outside this instance, so there are only two ways for the agent to see them:
+/// IRIS calls the engine back, or the engine sends them with the question it is already sending.
+///
+/// THE SECOND, and for three reasons rather than convenience:
+///
+///   1. The engine already holds the snapshot in the process handling the request — `index.ts` calls
+///      `engine.snapshot()` one line above the chat call. Fetching it back over the network would be
+///      a round trip to obtain data we are holding.
+///   2. It needs no engine URL inside the IRIS container. A new environment variable is exactly the
+///      thing `iris/CLAUDE.md` records going missing on three separate cold boots — and it would fail
+///      by returning "no findings", which reads as a healthy production.
+///   3. A findings read has no meaning outside the request that asked. `GetQueueDepth` answers the
+///      same question whenever it is called; "what is wrong right now" is a fact about an instant,
+///      and pinning it to the question's instant is more correct than re-reading it mid-turn and
+///      answering about two different moments in one reply.
+///
+/// A TOOL RATHER THAN PROMPT CONTEXT, which was the other option and is a closer call. Injecting the
+/// findings into the goal text would have been fewer moving parts. It loses three things:
+///
+///   - `evidence[].tool` in the reply contract has nothing to name, so a finding-derived claim cannot
+///     be attributed the way every other claim in a chat answer is.
+///   - There is no audit row. "Every tool call is audited, read and write" is a shipped guarantee
+///     (root `CLAUDE.md` §2.1), and a second unlabelled channel of truth into the model quietly
+///     exempts itself from it.
+///   - Every turn pays the tokens, including "what was throughput yesterday", which does not want
+///     them.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE HANDOFF, AND WHY IT IS KILLED BEFORE IT IS SET
+///
+/// `REST.ChatDispatcher.Ask()` writes the supplied array to `^||PGGuardian("chat","findings")` and
+/// this tool reads it. A process-private global, because the agent loop runs in the same job as the
+/// REST request — `agent.Run()` is a synchronous call inside `Ask()` — and per-request state must not
+/// be visible to a concurrent request.
+///
+/// **CSP PROCESSES ARE POOLED AND REUSED**, so a process-private global outlives the request that set
+/// it. A question that supplied no findings would otherwise read the PREVIOUS question's snapshot and
+/// answer confidently about a production state minutes stale. `Ask()` therefore kills the node
+/// unconditionally on entry, before it decides whether to set it. That ordering is the whole
+/// correctness argument: killing on the way out would be skipped by any exception path.
+///
+/// `supplied: false` IS A FIRST-CLASS ANSWER, not an error. It is what the tool returns when the
+/// caller sent no snapshot — an older dashboard build, or a hand-rolled POST — and the tool says so
+/// rather than returning an empty list, because an empty list of findings means "this production is
+/// healthy" and that is the one thing it must never say by accident. Same nullability rule as the
+/// rest of the family (`contracts/mcp-tools.md` §2.1), applied to a list instead of a number.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE DATA BOUNDARY
+///
+/// Every field of a `Finding` is metrics or classification: `host`, `type`, `severity`,
+/// `currentValue`, `baselineValue`, `detectedAt`, and `message` — which is composed by the detection
+/// engine from metric values and never contains log or message text. `contracts/healthscan.d.ts`
+/// §Finding is the authority for that list, and this tool republishes it rather than widening it: an
+/// unrecognised key in the supplied array is DROPPED, so a future engine field cannot reach the LLM
+/// by arriving in a payload.
+///
+/// EVERY PUBLIC CLASSMETHOD HERE BECOMES AN LLM-CALLABLE TOOL, verified in `%AI.Tool.Generator`.
+/// One public method, one tool; the two helpers are `[ Private ]`.
+Class ProductionGuardian.LabDemo.Tools.Findings Extends %AI.Tool
+{
+
+/// The process-private node `REST.ChatDispatcher` writes and this tool reads. Named once, here,
+/// because a mistyped subscript on either side would present as "no findings supplied" — an answer
+/// this tool gives legitimately, so the failure would be indistinguishable from the normal case.
+Parameter HANDOFF = "findings";
+
+/// Findings republished at most.
+///
+/// A cap the ENGINE also applies before sending (see `detect/chat.ts`), so this is the second of two
+/// and deliberately so: the engine's cap keeps the request small and this one keeps a hand-rolled
+/// POST from filling the model's context. Eight finding types across three hosts is 24 at the absolute
+/// ceiling, so 25 cannot clip a real production.
+Parameter MAXFINDINGS = 25;
+
+/// The `Finding` keys this tool will republish, from `contracts/healthscan.d.ts`.
+///
+/// AN ALLOWLIST, for the reason `Tools.Read.#SETTINGALLOWLIST` is one: the array arrives from another
+/// service over HTTP, and copying it through wholesale would put whatever the engine adds next in
+/// front of an external LLM without a decision being taken. Adding a key here is that decision.
+Parameter FINDINGKEYS = {$listbuild(
+    "id",
+    "host",
+    "type",
+    "severity",
+    "currentValue",
+    "baselineValue",
+    "detectedAt",
+    "message")};
+
+/// What Production Guardian is reporting about this production RIGHT NOW: the open findings, each
+/// with its host, type, severity, the value that triggered it, the baseline it was compared against,
+/// and when it was first confirmed.
+///
+/// Call this for any question about whether something is wrong now, or about a condition a user
+/// names — a queue building, a pool bottleneck, a host being down, errors rising. These are CURRENT
+/// readings computed by the detection engine, not recorded averages, so do not mix a value from here
+/// with a figure from the activity or event-log tools without saying which is which.
+///
+/// Pass `host` to narrow to one interoperability host, or omit it for the whole production.
+ClassMethod GetActiveFindings(host As %String = "") As %DynamicObject
+{
+    set out = { "host": null, "supplied": false, "count": null, "findings": null,
+        "asOf": null, "state": null, "sanitised": true }
+    // null when unfiltered, so "every host" and "a host whose name is the empty string" are
+    // different payloads rather than the same one.
+    if host '= "" {
+        set out.host = host
+    }
+
+    if '$data(^||PGGuardian("chat", ..#HANDOFF)) {
+        // NOT an empty list. See the class comment -- an empty findings list asserts a healthy
+        // production, and this is the one condition where that assertion would be unfounded.
+        set out.reason = "no findings snapshot was supplied with this question, so the current " _
+            "findings cannot be read from here -- do not conclude that the production is healthy"
+        quit out
+    }
+
+    try {
+        set raw = ##class(%DynamicArray).%FromJSON(^||PGGuardian("chat", ..#HANDOFF))
+    } catch parseEx {
+        set out.reason = "the supplied findings snapshot could not be parsed: " _
+            parseEx.DisplayString()
+        // RETURN, not QUIT. Inside a TRY or CATCH block `QUIT` exits the BLOCK and refuses an argument
+        // -- `quit out` there is compile error #1043, not a method return. Every other exit in this
+        // method is at top level and uses `quit`, which is the surrounding convention.
+        return out
+    }
+
+    do out.%Set("supplied", 1, "boolean")
+    set out.asOf = $get(^||PGGuardian("chat", "asOf"), "")
+    // `ok`, `warming` or `stale` -- the DETECTION ENGINE's state at the poll these findings came from,
+    // and the reason `count: 0` is not self-explanatory. See the note below.
+    set out.state = $get(^||PGGuardian("chat", "state"), "")
+    set findings = []
+    set iter = raw.%GetIterator()
+    while iter.%GetNext(.index, .finding) {
+        if '$isobject(finding) {
+            continue
+        }
+        if (host '= "") && (finding.%Get("host") '= host) {
+            continue
+        }
+        if findings.%Size() >= ..#MAXFINDINGS {
+            quit
+        }
+        do findings.%Push(..Republish(finding))
+    }
+    set out.findings = findings
+    set out.count = findings.%Size()
+    // Said in the payload because the model cannot otherwise tell an unfiltered empty list from a
+    // filtered one, and "no findings on Cloud API" and "no findings anywhere" support different
+    // answers.
+    //
+    // AND BECAUSE `count: 0` DOES NOT MEAN THE SAME THING IN EVERY ENGINE STATE. Under `warming` the
+    // engine's six comparative rules are silent by design -- below `minBaselineSamples` there is
+    // nothing to compare against -- so an empty list is "not measured yet", and a model that reads it
+    // as health gives a confident all-clear on a production nobody has looked at. Under `stale` the
+    // list is the last one the engine could compute, which is old rather than wrong. Neither is
+    // inferable from the array, so the tool says which it is rather than leaving the emptiness to
+    // speak for itself.
+    if out.count = 0 {
+        set scope = $select(host = "": " on this production", 1: " on " _ host)
+        if out.state = "warming" {
+            set out.note = "the detection engine is still warming up, so its comparative rules are " _
+                "SILENT and no findings can be reported yet" _ scope _ " -- this is not evidence " _
+                "that nothing is wrong"
+        } elseif out.state = "stale" {
+            set out.note = "no open findings" _ scope _ " as of " _ out.asOf _ ", but the engine " _
+                "could not reach the metrics source at that poll, so this list may be out of date"
+        } else {
+            set out.note = "no open findings" _ scope _ " at the instant this question was asked"
+        }
+    }
+    quit out
+}
+
+/// One finding, reduced to the allowlisted keys. Private.
+///
+/// COPIES KEY BY KEY rather than returning the object it was handed. Same reasoning as
+/// `Tools.EventLog`'s two-query split: a filter that removed unwanted keys would be equally correct
+/// today and one edit away from being wrong, while a copy cannot carry a key nobody listed.
+///
+/// A MISSING KEY BECOMES `null`, not an omission, so every finding in the array has the same shape —
+/// a model comparing two findings should not have to notice that one lacks `baselineValue` because it
+/// was warming.
+ClassMethod Republish(finding As %DynamicObject) As %DynamicObject [ Private ]
+{
+    set out = {}
+    set keys = ..#FINDINGKEYS
+    for i = 1:1:$listlength(keys) {
+        set key = $list(keys, i)
+        if finding.%IsDefined(key) {
+            do out.%Set(key, finding.%Get(key))
+        } else {
+            // The explicit "null" type, not `%Set(key, "")` -- the latter emits a JSON empty STRING,
+            // and `"baselineValue": ""` is the fabricated-zero shape wearing different clothes.
+            do out.%Set(key, "", "null")
+        }
+    }
+    quit out
+}
+
+}

--- a/iris/labdemo/Tools/Governance.cls
+++ b/iris/labdemo/Tools/Governance.cls
@@ -87,10 +87,42 @@ Parameter ACTIVITYTOOLS = "ProductionGuardian.LabDemo.Tools.Activity";
 /// on this instance have a NULL `ConfigName`, which no host-filtered query can reach.
 Parameter EVENTLOGTOOLS = "ProductionGuardian.LabDemo.Tools.EventLog";
 
+/// The audit-log read tool — recent configuration changes to this production, from `%SYS.Audit`.
+///
+/// A FOURTH READ CLASS, and it sits on the RECORDED side of the line the `ACTIVITYTOOLS` comment
+/// draws, like `EVENTLOGTOOLS`: it answers "what was changed, and when", never "what is true now".
+/// So it travels with both `"all"` and `"chat"`. The chat needs it for the same reason AI Detective
+/// does — "did someone change something?" is the first question an operator asks about a broken host,
+/// and neither caller could answer it before.
+///
+/// ITS OWN CLASS RATHER THAN A METHOD ON `Tools.Read`, on `Tools.EventLog`'s second reason: a new tool
+/// FAMILY in a new file moves `Setup.AIHub.ReportTools()`'s count by an amount attributable to one
+/// file. The first reason applies too and more sharply — `Tools.Read` reads the LIVE production
+/// definition, and a tool that reads a historical record of it in the same class would be one
+/// docstring away from a model treating an audit row's `newValue` as the current setting.
+Parameter CHANGELOGTOOLS = "ProductionGuardian.LabDemo.Tools.ChangeLog";
+
+/// The current-findings tool — what the detection engine is reporting, supplied with the question.
+///
+/// REGISTERED FOR `"chat"` ONLY, and that is the one asymmetry in this table worth reading twice.
+/// `Tools.Findings` republishes a snapshot the CALLER sent; AI Detective's caller sends none, because
+/// `/api/investigate` already hands the agent the one finding it is asked to explain. Adding this to
+/// `"all"` would give that agent a tool that can only answer `supplied: false`, which costs an
+/// iteration of its five and teaches it that a findings read is unavailable on this instance.
+///
+/// It is also the only tool in the family that reads no IRIS data at all — see its class comment for
+/// why the findings are supplied rather than fetched, and for why the handoff node is killed before it
+/// is set rather than after it is read.
+Parameter FINDINGTOOLS = "ProductionGuardian.LabDemo.Tools.Findings";
+
 /// The write-tool class, in its own class so the RBAC requirement does not leak onto the reads.
 Parameter WRITETOOLS = "ProductionGuardian.LabDemo.Tools.Resolve";
 
-/// A tool manager with both policies registered and both tool sets loaded.
+/// A tool manager with both policies registered and every context-free tool family loaded.
+///
+/// "Context-free" is doing work in that sentence: it means every family except `FINDINGTOOLS`, and the
+/// exclusion is argued at the registration below rather than here. This docstring said "both tool
+/// sets" through two families being added, which is the stale-count shape #84 indicts.
 ///
 /// POLICIES BEFORE TOOL SETS. Registration order is not documented, and the ordering that has been
 /// exercised is this one -- a manager that registered tools first and policies second has never been
@@ -129,6 +161,15 @@ ClassMethod ToolManager(pIncludeWrite As %Boolean = 1, Output pStatus As %Status
     if $$$ISERR(pStatus) {
         quit $$$NULLOREF
     }
+    set pStatus = mgr.RegisterToolSet(..#CHANGELOGTOOLS)
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    // `FINDINGTOOLS` is NOT registered here, unlike every other read family. This factory serves
+    // `..Invoke()` and `Test.GovernanceProof` -- callers with no request context -- and the findings
+    // tool republishes a snapshot supplied with a chat request, so on this path it could only ever
+    // return `supplied: false`. Registering it would make a governed manager advertise a tool that
+    // cannot work through it.
     if pIncludeWrite {
         set pStatus = mgr.RegisterToolSet(..#WRITETOOLS)
         if $$$ISERR(pStatus) {
@@ -200,10 +241,14 @@ ClassMethod GovernAgent(pAgent As %AI.Agent, pIncludeWrite As %Boolean = 1, pToo
 
     // ONE POSITIVE CONDITION PER TOOL SET, spelling the membership out:
     //
-    //     all       READTOOLS  ACTIVITYTOOLS  EVENTLOGTOOLS      AI Detective
-    //     chat                 ACTIVITYTOOLS  EVENTLOGTOOLS      ChatDispatcher
-    //     activity             ACTIVITYTOOLS                     unchanged from before "chat"
-    //     current   READTOOLS                                    live state only
+    //     all       READTOOLS  ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS                  AI Detective
+    //     chat                 ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS  FINDINGTOOLS    ChatDispatcher
+    //     activity             ACTIVITYTOOLS                                                 unchanged from before "chat"
+    //     current   READTOOLS                                                               live state only
+    //
+    // `FINDINGTOOLS` IS IN EXACTLY ONE ROW, deliberately -- see its parameter comment. It is the only
+    // entry here that is not simply "does this caller want history", because the tool republishes what
+    // the caller supplied and AI Detective's caller supplies nothing.
     //
     // Written positively rather than as the `'= "activity"` exclusions this used to hold. With two
     // options an exclusion reads fine; with four, "not activity and not current" is a set a reader has
@@ -222,6 +267,18 @@ ClassMethod GovernAgent(pAgent As %AI.Agent, pIncludeWrite As %Boolean = 1, pToo
     }
     if (pToolSets = "all") || (pToolSets = "chat") {
         set sc = pAgent.ToolManager.RegisterToolSet(..#EVENTLOGTOOLS)
+        if $$$ISERR(sc) {
+            quit sc
+        }
+    }
+    if (pToolSets = "all") || (pToolSets = "chat") {
+        set sc = pAgent.ToolManager.RegisterToolSet(..#CHANGELOGTOOLS)
+        if $$$ISERR(sc) {
+            quit sc
+        }
+    }
+    if pToolSets = "chat" {
+        set sc = pAgent.ToolManager.RegisterToolSet(..#FINDINGTOOLS)
         if $$$ISERR(sc) {
             quit sc
         }

--- a/iris/labdemo/Tools/Read.cls
+++ b/iris/labdemo/Tools/Read.cls
@@ -34,6 +34,40 @@ Class ProductionGuardian.LabDemo.Tools.Read Extends %AI.Tool
 /// reporting on a different production than the one it was authorised for.
 Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
 
+/// The setting names any tool in this project may put in front of an external LLM.
+///
+/// Path and target settings, because those are what a misconfiguration diagnosis needs -- where the
+/// host reads from, where it writes to, and where it sends. Everything else is refused BY
+/// CONSTRUCTION rather than by review: returning a whole `Settings` collection would be one
+/// `Credentials` row away from naming a stored secret, and one future setting away from something
+/// worse, because a production is configured by people and people put surprising things in free-text
+/// settings. Adding a name here is a decision.
+///
+/// `Credentials` is deliberately ABSENT even though it is only an identifier: it names a stored
+/// secret, and an agent has no diagnostic use for it that outweighs saying its name out loud.
+///
+/// A PARAMETER RATHER THAN A LIST INSIDE `GetHostSettings`, because `Tools.ChangeLog` needs the same
+/// answer to a different question -- "may I say this setting's value" is one rule whether the value
+/// came from the live item or from an audit row. A parameter is the only shape that shares it: a
+/// public ClassMethod here would silently become a seventh tool (see the class comment), and a
+/// second copy of the list is the stale-copy defect this project has paid for twice (#84).
+///
+/// CallInterval, not PollInterval. This list named a setting that does not exist on any adapter in
+/// this production, so the entry could never match and the polling interval was unreachable to the
+/// agent -- a dead allowlist row, which is worse than an absent one because it reads as coverage.
+/// Same root cause as the invalid setting in Production.cls: `Ens.InboundAdapter` calls it
+/// CallInterval and nothing calls it PollInterval.
+Parameter SETTINGALLOWLIST = {$listbuild(
+    "FilePath",
+    "ArchivePath",
+    "WorkPath",
+    "FileSpec",
+    "CallInterval",
+    "HTTPServer",
+    "HTTPPort",
+    "URL",
+    "TargetConfigNames")};
+
 /// Report the configured and observed status of one interoperability host.
 ///
 /// Returns status as IRIS reports it, plus whether the host is enabled in the production. Use
@@ -110,15 +144,10 @@ ClassMethod GetPoolSize(host As %String) As %DynamicObject
 /// only, never message content". A setting VALUE is configuration by definition; it was typed by
 /// whoever deployed the production, not derived from a message.
 ///
-/// AN ALLOWLIST OF SETTING NAMES, NOT EVERY SETTING. Returning the whole collection would be one
-/// `Credentials` row away from handing an external LLM the name of a credential set, and one future
-/// setting away from something worse -- a production is configured by people, and people put
-/// surprising things in free-text settings. So the tool names what it will return and refuses the
-/// rest by construction. Adding a name here is a decision, which is the same reasoning as
-/// `Tools.Resolve`'s single whitelisted host and the `#5021` catalogue.
-///
-/// `Credentials` is deliberately ABSENT even though it is only an identifier: it names a stored
-/// secret, and an agent has no diagnostic use for it that outweighs saying its name out loud.
+/// AN ALLOWLIST OF SETTING NAMES, NOT EVERY SETTING -- `#SETTINGALLOWLIST`, which carries the
+/// reasoning and is shared with `Tools.ChangeLog`. Same shape as `Tools.Resolve`'s single
+/// whitelisted host and the `#5021` catalogue: the tool names what it will return and refuses the
+/// rest by construction.
 ClassMethod GetHostSettings(host As %String) As %DynamicObject
 {
     set out = { "host": (host), "found": false, "settings": {} }
@@ -129,24 +158,9 @@ ClassMethod GetHostSettings(host As %String) As %DynamicObject
     }
     do out.%Set("found", 1, "boolean")
 
-    // The allowlist. Path and target settings, because those are what a misconfiguration diagnosis
-    // needs -- where the host reads from, where it writes to, and where it sends.
-    set allowed = $listbuild(
-        "FilePath",
-        "ArchivePath",
-        "WorkPath",
-        "FileSpec",
-        // CallInterval, not PollInterval. This allowlist named a setting that does not
-        // exist on any adapter in this production, so the entry could never match and
-        // the polling interval was unreachable to the agent -- a dead allowlist row,
-        // which is worse than an absent one because it reads as coverage. Same root
-        // cause as the invalid setting in Production.cls: `Ens.InboundAdapter` calls it
-        // CallInterval and nothing calls it PollInterval.
-        "CallInterval",
-        "HTTPServer",
-        "HTTPPort",
-        "URL",
-        "TargetConfigNames")
+    // The allowlist lives in #SETTINGALLOWLIST -- see that parameter for what is on it, what is
+    // deliberately off it, and why it is a parameter rather than a list written here.
+    set allowed = ..#SETTINGALLOWLIST
 
     for i = 1:1:item.Settings.Count() {
         set setting = item.Settings.GetAt(i)

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -783,6 +783,7 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
     // catch it, since it only compares the production NAME (@tanifgit, #66). A trigger that
     // reports armed and is not is the worst failure this class can have.
     set foundItem = 0
+    set previous = ""
     for i = 1:1:def.Items.Count() {
         set item = def.Items.GetAt(i)
         if item.Name '= pItem {
@@ -793,6 +794,9 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
         for j = 1:1:item.Settings.Count() {
             set setting = item.Settings.GetAt(j)
             if setting.Name = pName {
+                // Captured BEFORE the overwrite, and it is the only moment it is knowable -- see
+                // ..AuditSettingChange() for who reads it and why nothing else can supply it.
+                set previous = setting.Value
                 set setting.Value = pValue
                 set found = 1
             }
@@ -808,7 +812,74 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
     if 'foundItem {
         quit $$$ERROR($$$GeneralError, "no such config item: " _ pItem _ " (renamed in Production.cls?)")
     }
-    quit def.%Save()
+    set sc = def.%Save()
+    if $$$ISERR(sc) {
+        quit sc
+    }
+    // AFTER the save succeeds, so the audit log never claims a change that did not land. An audit
+    // failure does NOT fail the arming: the setting really did change, and refusing to report the
+    // change is a smaller wrong than refusing to make it.
+    do ..AuditSettingChange(pItem, pName, previous, pValue)
+    quit $$$OK
+}
+
+/// Record a setting change in `%SYS.Audit` the way the Management Portal records one. Private.
+///
+/// WHY THIS METHOD EXISTS, MEASURED. `Ens.Config.Production.%Save()` writes NO audit row --
+/// only the Management Portal's own save path does. Verified by arming `MissingFolder()` and finding
+/// the newest `ModifyConfiguration` row three days old. So every toggle in this class mutated a live
+/// production setting and left no trace, which is a real gap in the project's own security story
+/// before it is a demo problem: root `CLAUDE.md` §2.1 requires that "the AI changed a production
+/// setting" be attributable, and a trigger changing one was not.
+///
+/// It is also what makes `Tools.ChangeLog` reachable from the demo. Without it the audit-correlation
+/// story could only be shown by editing a setting by hand in the Management Portal, and the two
+/// scenarios that most need it -- the missing folder and the unreachable downstream -- are both armed
+/// from here.
+///
+/// THE ROW IS BYTE-COMPATIBLE WITH A PORTAL ROW, so `Tools.ChangeLog` needs no special case:
+///
+///     Description  item EMR Source of ProductionGuardian.LabDemo.Production
+///     EventData    FilePath:/tmp/labdemo/hl7-in/>>/tmp/labdemo/hl7-in-missing/
+///
+/// **NOTE THE ARGUMENT ORDER.** `$SYSTEM.Security.Audit(source, type, event, ...)` takes the value
+/// that lands in the `EventData` column FOURTH and the one that lands in `Description` FIFTH -- the
+/// reverse of what the parameter names suggest. Measured by writing a row and reading the columns
+/// back, because getting it wrong produces a perfectly valid row that `Tools.ChangeLog` silently
+/// discards (its `HostOf` parse fails and the row is dropped as a lifecycle event).
+///
+/// NOT A NEW AUDIT EVENT. `%Ensemble/%Production/ModifyConfiguration` already exists in
+/// `Security.Events` -- confirmed with `##class(Security.Events).Exists()` -- so this reports a real
+/// change under the event that means what happened, rather than defining a parallel one a reviewer
+/// would have to learn about.
+///
+/// THE ROW IS NOT READABLE THE INSTANT IT IS WRITTEN, and this is worth knowing before it is
+/// rediscovered as a bug. Measured: `MissingFolder()` returned, `Tools.ChangeLog` was called from the
+/// next line of the same session and reported `changes: []` with `retention.newest` 101 seconds stale;
+/// the identical call a minute later returned the row, stamped `10:18:44` -- i.e. it had been written
+/// before the first query and was not yet visible to it. IRIS buffers audit writes and a daemon flushes
+/// them, so there is nothing to fix here and nothing to wait on in this method.
+///
+/// It matters in one place only: **never assert this row exists immediately after arming a trigger.**
+/// A demo is unaffected -- an operator noticing a finding, opening AI Detective and reading its
+/// evidence takes far longer than the flush, and an agent turn spends seconds per tool call regardless.
+///
+/// Returns nothing. A caller that could not act on a failed audit write should not be given a status
+/// to ignore, and `SetSetting` explicitly does not fail on one.
+ClassMethod AuditSettingChange(pItem As %String, pName As %String, pPrevious As %String, pValue As %String) [ Private ]
+{
+    try {
+        do $SYSTEM.Security.Audit(
+            "%Ensemble",
+            "%Production",
+            "ModifyConfiguration",
+            pName _ ":" _ pPrevious _ ">>" _ pValue,
+            "item " _ pItem _ " of " _ ..#PRODUCTION)
+    } catch ex {
+        // Deliberately swallowed and NOT written to the event log. Auditing may be switched off on a
+        // colleague's instance, and a per-toggle warning on a path that works correctly is noise --
+        // `Tools.ChangeLog` publishes `auditEnabled` so the absence is visible where it matters.
+    }
 }
 
 /// MVP 3 scenario 2 — the missing folder. A host that cannot read its inbound directory.

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -377,10 +377,13 @@ ClassMethod CreateRoles() As %Status
 /// Printed on every setup run so the regression is visible at boot rather than in a review.
 ClassMethod ReportTools()
 {
-    // TWELVE since the chat assistant gained the event log, from ten. `Tools.EventLog` adds two read
-    // tools over `Ens_Util.Log` -- GetEventLogSummary and GetEventLogTrend (mcp-tools.md §3.10-3.11).
-    // Before that it was ten, from seven, when `Tools.Activity` added three over
-    // `Ens_Activity_Data.{Seconds,Hours,Days}` (§3.7-3.9).
+    // FOURTEEN since the audit log and the findings snapshot became readable, from twelve. `Tools.ChangeLog`
+    // adds GetRecentConfigChanges over `%SYS.Audit` and `Tools.Findings` adds GetActiveFindings over the
+    // snapshot the engine supplies with a chat request (mcp-tools.md §3.12-3.13) -- one tool each, and
+    // seven `[ Private ]` helpers between them that would make it twenty-one if the keyword were dropped.
+    // Before that it was twelve, from ten, when `Tools.EventLog` added two read tools over `Ens_Util.Log`
+    // -- GetEventLogSummary and GetEventLogTrend (§3.10-3.11). Before that ten, from seven, when
+    // `Tools.Activity` added three over `Ens_Activity_Data.{Seconds,Hours,Days}` (§3.7-3.9).
     //
     // Moved DELIBERATELY and with the tool list read back, which is the discipline the bump to 7
     // established: the guard's whole value is that an unexpected count is loud, and bumping it without
@@ -396,12 +399,19 @@ ClassMethod ReportTools()
     // Verified rather than assumed: `%IsA("%AI.Tool")` on `Tools.ErrorCatalogue` returns 0, and the
     // count read back as 12 after `Tools.HostRoster` landed with two public methods. Listing either here
     // would call `%Discover()` on a class that has no such method.
-    set expected = 12
+    set expected = 14
     set found = 0
     // EVERY TOOL CLASS IS LISTED HERE, not only registered in Governance. A tool class the count does
     // not cover is a class whose accidental extra method nothing catches at boot -- which is the one
     // thing this method exists to prevent.
-    for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Activity", "ProductionGuardian.LabDemo.Tools.EventLog", "ProductionGuardian.LabDemo.Tools.Resolve" {
+    //
+    // `Tools.Findings` IS LISTED EVEN THOUGH `Governance.ToolManager()` DELIBERATELY DOES NOT REGISTER IT.
+    // That asymmetry is the sentence above doing its job: the tool is registered only for the "chat" tool
+    // set (it republishes a snapshot supplied with a chat request, so it could only answer supplied:false
+    // through a context-free manager), and discovery is about what a class EXPOSES rather than about who
+    // is given it. A class left out here because one caller does not want it is a class whose extra
+    // public method reaches an LLM with nothing counting it.
+    for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Activity", "ProductionGuardian.LabDemo.Tools.EventLog", "ProductionGuardian.LabDemo.Tools.ChangeLog", "ProductionGuardian.LabDemo.Tools.Findings", "ProductionGuardian.LabDemo.Tools.Resolve" {
         if '##class(%Dictionary.CompiledClass).%ExistsId(class) {
             write "3. tools ", class, ": NOT COMPILED", !
             continue

--- a/services/detection-engine/src/detect/chat.ts
+++ b/services/detection-engine/src/detect/chat.ts
@@ -21,7 +21,26 @@
  * conversation state is held anywhere in the engine. A held map keyed by conversation id would be
  * state that survives a restart in one direction only — the UI would think it had context that IRIS
  * had lost, which is the disagree-about-what-happened shape this project keeps paying for.
+ *
+ * THE FINDINGS ARE THE ONE THING WE ADD TO THE QUESTION, and the exception is worth arguing because
+ * "we orchestrate, we do not reason" is the rule above. The agent inside IRIS can read what the
+ * production DID — throughput, latency, the event log, recent configuration changes — and could not
+ * see what Production Guardian is SAYING about it, so "are there any issues right now?" was answered
+ * from an activity table while a live `queue_buildup` sat on the dashboard two panels away.
+ *
+ * Findings are computed HERE, so IRIS cannot read them without calling back into this service. We
+ * send them with the question instead: `index.ts` already holds the snapshot in the same process that
+ * handles the request, and a callback would need an engine URL inside the IRIS container — the class
+ * of configuration `iris/CLAUDE.md` records going missing on three separate cold boots, failing as
+ * "no findings", which reads as a healthy production.
+ *
+ * This does not cross the reasoning line: we forward our own measurements verbatim and compose no
+ * narrative from them. `iris/labdemo/Tools/Findings.cls` republishes them as a governed, audited tool
+ * so a finding-derived claim gets `evidence[].tool` attribution like every other claim, and its class
+ * comment carries the rest of the argument.
  */
+
+import type { Finding, HealthScanState } from '../types/healthscan.ts';
 
 /** One prior turn, as the client replays it. */
 export interface ChatTurn {
@@ -89,15 +108,60 @@ export interface ChatResponse {
   };
 }
 
-/** What this service sends the dispatcher. */
+/** What the CLIENT sends us — and nothing more. See `parseChatRequest`. */
 interface ChatRequest {
   question: string;
   history: ChatTurn[];
 }
 
+/**
+ * What we send the dispatcher: the client's question plus our own findings.
+ *
+ * A SEPARATE TYPE FROM `ChatRequest`, and the separation is the security boundary rather than
+ * tidiness. `parseChatRequest` reads a body that arrived over HTTP from a browser; if `findings`
+ * lived on that type, the parser would be one careless `b['findings']` away from letting a caller
+ * post fabricated findings straight through to an external LLM, which would then cite them as
+ * measurements read by a governed tool. Findings can only be attached HERE, from `deps`, so there is
+ * no code path by which a client-supplied value becomes one.
+ */
+interface ChatAgentRequest extends ChatRequest {
+  findings: Finding[];
+  /** ISO seconds of the poll the findings came from, or null before the first poll. */
+  findingsAsOf: string | null;
+  /**
+   * The engine state at that poll, forwarded because an empty list means different things in each.
+   *
+   * `warming` is the one that matters: below `minBaselineSamples` the six comparative rules are
+   * silent by design, so zero findings is "not measured yet" and asserting a healthy production from
+   * it would be exactly the false all-clear this whole feature exists to prevent. `stale` means the
+   * proxy is unreachable and the list is last-known — old, not wrong. `Tools.Findings` republishes
+   * this and the chat prompt is told what each means.
+   */
+  findingsState: HealthScanState;
+}
+
+/** The slice of `EngineSnapshot` this module needs, so a test can supply one without an engine. */
+export interface ChatFindingsSnapshot {
+  findings: Finding[];
+  lastPollAt: number | null;
+  state: HealthScanState;
+}
+
 export interface ChatDeps {
   /** Calls the chat dispatcher in IRIS. Injected so the endpoint is testable without an LLM. */
-  callAgent(request: ChatRequest, timeoutMs: number): Promise<unknown>;
+  callAgent(request: ChatAgentRequest, timeoutMs: number): Promise<unknown>;
+  /**
+   * The current findings, read at the instant the question is answered.
+   *
+   * A SUPPLIER RATHER THAN A VALUE, because the composition root wires this once at startup and the
+   * snapshot must be the one current when the question arrives, not when the wiring ran.
+   *
+   * OPTIONAL, and an absent supplier is not an error: the engine can be wired without one (a test, or
+   * a deployment where the chat is reached before the first poll). It forwards an empty list with
+   * `findingsState: 'warming'`, which is the state that tells the agent NOT to read the emptiness as
+   * health — so the degraded case degrades toward silence rather than toward a false all-clear.
+   */
+  findings?: () => ChatFindingsSnapshot;
   now?: () => number;
   log?: (message: string) => void;
 }
@@ -118,6 +182,16 @@ const MAX_QUESTION = 600;
 
 /** Prior turns forwarded. Mirrors `ChatDispatcher.#MAXHISTORY`. */
 const MAX_HISTORY = 6;
+
+/**
+ * Findings forwarded with a question. Mirrors `Tools.Findings.#MAXFINDINGS`.
+ *
+ * THE FIRST OF TWO CAPS ON PURPOSE, like the question-length cap above and for the same reason in
+ * reverse: this one keeps the request small, and IRIS's keeps a hand-rolled POST from filling the
+ * model's context. Eight finding types across three reported hosts is 24 at the absolute ceiling, so
+ * 25 cannot clip a real production — which is why a cap here needs no accompanying "truncated" flag.
+ */
+const MAX_FINDINGS = 25;
 
 function isoSeconds(ms: number): string {
   return `${new Date(Math.round(ms / 1000) * 1000).toISOString().slice(0, 19)}Z`;
@@ -266,9 +340,24 @@ export async function chat(request: ChatRequest, deps: ChatDeps): Promise<ChatRe
      role `inv-` ids play for an investigation. */
   const requestId = `chat-${started}`;
 
+  /* READ ONCE, HERE, so every field describes the same instant. Reading the snapshot per field would
+     let `findings` and `state` come from different polls, and a stale-vs-ok disagreement between two
+     values in one payload is unreadable from the far side. */
+  const snapshot = deps.findings?.();
+  const outbound: ChatAgentRequest = {
+    ...request,
+    findings: snapshot === undefined ? [] : snapshot.findings.slice(0, MAX_FINDINGS),
+    findingsAsOf:
+      snapshot === undefined || snapshot.lastPollAt === null
+        ? null
+        : isoSeconds(snapshot.lastPollAt),
+    /* No supplier means no measurement, which is what `warming` says. See `ChatDeps.findings`. */
+    findingsState: snapshot === undefined ? 'warming' : snapshot.state,
+  };
+
   let raw: unknown;
   try {
-    raw = await deps.callAgent(request, TIMEOUT_MS);
+    raw = await deps.callAgent(outbound, TIMEOUT_MS);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     deps.log?.(`chat ${requestId} failed: ${message}`);

--- a/services/detection-engine/src/index.ts
+++ b/services/detection-engine/src/index.ts
@@ -200,6 +200,15 @@ const server = createFindingsServer({
         chat: async (body: unknown) =>
           chat(parseChatRequest(body), {
             callAgent: callChatAgent,
+            /* The findings the agent may cite, read fresh per question rather than closed over.
+               This is the whole of the engine's side of "the chat should relate to the findings":
+               we hand over our own measurements and IRIS republishes them as a governed tool. The
+               snapshot is already in hand here -- `snapshot:` above calls the same method -- which
+               is why this needs no callback into this service from the IRIS container. */
+            findings: () => {
+              const snap = engine.snapshot();
+              return { findings: snap.findings, lastPollAt: snap.lastPollAt, state: snap.state };
+            },
             log: (m: string) => console.error(m),
           }),
       }),

--- a/services/detection-engine/test/chat.test.ts
+++ b/services/detection-engine/test/chat.test.ts
@@ -213,19 +213,139 @@ describe('chat', () => {
   });
 
   it('sends the question and history through to the agent unchanged', async () => {
-    let seen: unknown;
+    let seen: Record<string, unknown> | undefined;
     const withHistory = {
       question: 'and yesterday?',
       history: [{ role: 'user' as const, text: 'today?' }],
     };
     await chat(withHistory, {
       callAgent: async (req) => {
-        seen = req;
+        seen = req as unknown as Record<string, unknown>;
         return reply();
       },
       now: () => 1,
     });
-    assert.deepEqual(seen, withHistory);
+    // The CALLER'S two fields, asserted individually rather than by deep-equalling the whole
+    // request. This test used to `deepEqual(seen, withHistory)`, which said two things at once --
+    // "these two fields survive" and "nothing else is added" -- and the second was never the
+    // intent. Attaching findings is the point of the outbound type, so a whole-object equality
+    // here fails the moment the feature works.
+    assert.equal(seen?.['question'], 'and yesterday?');
+    assert.deepEqual(seen?.['history'], [{ role: 'user', text: 'today?' }]);
+    // Its complement is now the test below: the caller's body cannot ADD to the request either.
+  });
+
+  /**
+   * The findings attachment — the engine's whole side of "the chat should relate to the findings".
+   *
+   * WHAT IS WORTH ASSERTING, given the answer comes from a model. Not that the findings help, which
+   * only a live run shows, but that the request cannot MISREPRESENT them. Every test here is about a
+   * shape that would let the model state something untrue about the production:
+   *
+   *   - no supplier must not look like a measured all-clear
+   *   - a caller must not be able to post its own findings
+   *   - `findingsState` must survive, because `count: 0` means four different things and three of
+   *     them are not health (see `iris/labdemo/Tools/Findings.cls`)
+   */
+  const finding = (over: Record<string, unknown> = {}) => ({
+    id: 'f-1',
+    host: 'Cloud API',
+    type: 'queue_buildup',
+    severity: 'critical',
+    currentValue: 70,
+    baselineValue: 0,
+    detectedAt: '2026-08-30T10:26:00Z',
+    message: 'queue depth 70 with no baseline queue',
+    ...over,
+  });
+
+  /** Send a request through `chat` and hand back what the agent was actually called with. */
+  async function outbound(over: Partial<ChatDeps> = {}): Promise<Record<string, unknown>> {
+    let seen: Record<string, unknown> = {};
+    await chat(request, {
+      callAgent: async (req) => {
+        seen = req as unknown as Record<string, unknown>;
+        return reply();
+      },
+      now: () => 1,
+      ...over,
+    });
+    return seen;
+  }
+
+  it('attaches the supplied findings, their poll time and the engine state', async () => {
+    const seen = await outbound({
+      findings: () => ({
+        findings: [finding()] as never,
+        lastPollAt: 1_756_000_000_000,
+        state: 'ok',
+      }),
+    });
+    assert.equal((seen['findings'] as unknown[]).length, 1);
+    assert.equal((seen['findings'] as Record<string, unknown>[])[0]?.['type'], 'queue_buildup');
+    assert.equal(seen['findingsState'], 'ok');
+    assert.match(seen['findingsAsOf'] as string, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  it('sends warming rather than ok when no supplier is wired', async () => {
+    // The DEFAULT MATTERS MORE THAN THE HAPPY PATH. An older or misassembled build with no supplier
+    // sends an empty list, and `ok` + `count: 0` is the one combination the IRIS tool reports as
+    // "no open findings". Defaulting to `warming` makes the absence of a supplier read as "nothing
+    // has been measured", which is true, instead of as an all-clear, which would be invented.
+    const seen = await outbound();
+    assert.deepEqual(seen['findings'], []);
+    assert.equal(seen['findingsState'], 'warming');
+    assert.equal(seen['findingsAsOf'], null);
+  });
+
+  it('sends a null poll time rather than a fabricated timestamp before the first poll', async () => {
+    const seen = await outbound({
+      findings: () => ({ findings: [], lastPollAt: null, state: 'warming' }),
+    });
+    assert.equal(seen['findingsAsOf'], null);
+  });
+
+  it('carries stale through, because a stale list is old rather than wrong', async () => {
+    const seen = await outbound({
+      findings: () => ({ findings: [finding()] as never, lastPollAt: 1, state: 'stale' }),
+    });
+    assert.equal(seen['findingsState'], 'stale');
+  });
+
+  it('caps the findings it sends', async () => {
+    // The cap is the FIRST of two, the second being `Tools.Findings.#MAXFINDINGS`. Eight types
+    // across three hosts is 24 at the ceiling, so this cannot clip a real production -- it bounds a
+    // malformed snapshot, not a busy one.
+    const seen = await outbound({
+      findings: () => ({
+        findings: Array.from({ length: 40 }, (_, i) => finding({ id: `f-${i}` })) as never,
+        lastPollAt: 1,
+        state: 'ok',
+      }),
+    });
+    assert.equal((seen['findings'] as unknown[]).length, 25);
+  });
+
+  it('ignores findings a caller puts in the request body', async () => {
+    // The security half of splitting `ChatAgentRequest` from `ChatRequest`. Findings reach the model
+    // labelled as values read by a governed tool, so a caller-supplied one would be fabricated
+    // evidence wearing that label. `parseChatRequest` never reads the field; this pins that it
+    // cannot arrive by any other route either.
+    const posted = parseChatRequest({
+      question: 'is anything falling behind?',
+      findings: [finding({ message: 'everything is on fire' })],
+      findingsState: 'ok',
+    });
+    let seen: Record<string, unknown> = {};
+    await chat(posted, {
+      callAgent: async (req) => {
+        seen = req as unknown as Record<string, unknown>;
+        return reply();
+      },
+      now: () => 1,
+    });
+    assert.deepEqual(seen['findings'], []);
+    assert.equal(seen['findingsState'], 'warming');
   });
 
   it('stamps answeredAt at second precision with a Z suffix', async () => {


### PR DESCRIPTION
Implements `contracts/mcp-tools.md` §3.12–§3.13. **Based on #162**, not on `main`, so this diff shows only the implementation — retarget to `main` once #162 lands.

Closes both requests:

> *"check audit table for changes and suggest that there may be a change/typo to recently changed value if it fits … you can bring it up in analysis but do not suggest the fix because they likely changed it for a reason and we do not know what they wanted to change it to."*

> *"the ask about activity only checks the tables but not the findings. so when there is an issue, when we chat and ask if there is any issues (like pool bottleneck) it will not relate to the findings. it should."*

## 1. `get_recent_config_changes` — what CHANGED

`Tools.ChangeLog` reads `ModifyConfiguration` rows from `%SYS.Audit`: which setting changed on which host, from what value to what value, and when. Every other read tool answers a question about the production's *behaviour*; none could answer the one an operator asks first.

**A recent change is evidence, never a recommendation.** The prohibition is in both prompts, and sharper in `AgentDispatcher`'s for a structural reason: `manualRemediation.target` is a `{host, setting, currentValue}` slot the reply schema *invites*, so a recently-changed setting plus a slot for a setting fix is a strong pull toward exactly the recommendation the operator did not ask for. The old value is returned anyway — withholding it would defeat the tool — so the restraint is stated rather than engineered. No structural guard, deliberately: it would have to recognise "revert" in free prose, and a field that cannot be checked is worse than a rule that is stated.

**`Triggers.SetSetting()` now writes its own audit row, and that is a security fix rather than test scaffolding.** A setting changed through `Ens.Config.Production.%Save()` is not audited — only the Management Portal's own save path is, measured by arming `MissingFolder()` and finding the newest row three days stale. So a trigger was mutating a live production setting with **no attributable trace**, which root `CLAUDE.md` §2.1 requires. Note `$SYSTEM.Security.Audit()`'s argument order: arg4 → `EventData`, arg5 → `Description`, the reverse of what the names suggest, and getting it wrong produces a valid row the host parse silently discards.

## 2. `get_active_findings` — what Guardian is REPORTING

The engine sends its findings snapshot with the question; `Tools.Findings` republishes it as a governed tool.

- **Over an IRIS→engine callback**, which needs an engine URL inside the container — the class of configuration `iris/CLAUDE.md` records going missing on three separate cold boots, each time failing as "no findings", which reads as a healthy production.
- **Over prompt injection**, which loses `evidence[].tool` attribution, exempts a second channel of truth from the audit guarantee, and taxes every turn including ones that do not want findings.

**`findingsState` is forwarded, stashed and republished** because `count: 0` means four different things and three are not an all-clear. `Ask()` kills the handoff node on **entry**, before deciding whether to set it — CSP processes are pooled and reused, so a question supplying no snapshot would otherwise answer from the previous question's, minutes stale.

## 3. Two defects found by running it live, both fixed here

**A tool that is registered and described is not a tool that gets called.** `GetRecentConfigChanges` shipped registered in `Tools.Governance`, with its system-prompt paragraph verified present in the compiled `.INT` — and `toolCalls: 2` on the missing-folder scenario it exists for, the model satisfied after reading the errors and the settings. `BuildGoal()` already carried a `MUST` for `get_recent_errors` and `get_host_settings` for this exact measured reason, so the third tool repeated a failure the codebase had already written down. Now a third `MUST`, unconditional — "misconfiguration-shaped" is a conclusion, and a model cannot use it to decide what evidence to gather.

**Adding that directive then cost every evidence entry its attribution.** Its first version closed by deferring to "the rules in your instructions", and `source` came back unset across three consecutive runs. `investigate.ts` maps an unrecognised source to `"llm"`, so the reply stayed schema-valid while claiming the model had *reasoned out* values it had in fact read from governed tools — attribution silently lost, in the field the audit story depends on. The goal is the last thing the model reads and now the longest instruction about evidence, so a vague pointer at another part of the prompt competed with the concrete schema and won.

## Verification — live, not mocked

Four containers, `AGENT_MODE=live`, real `gpt-4o-mini`:

| Check | Result |
|---|---|
| chat under `warming`, nothing armed | `toolCalls: 1`, `evidence[].tool: GetActiveFindings`, and the model **refused an all-clear**: "state is 'warming' … not possible to confirm that everything is functioning correctly" |
| chat with `PoolBottleneck()` armed | both real findings cited with their own numbers — queue depth 70, queue wait 7.68 s at 384× baseline — attributed to `GetActiveFindings`, `confidence: 1` |
| AI Detective on the armed `MissingFolder()` `dead_host` | `toolCalls: 3` across three consecutive runs; the 10:27:26 `FilePath` change cited in `rootCause` and as attributed evidence; **no revert in any of the nine remediation steps** |

`supplied: true` is the one thing only a live run could test — it rests on the agent loop running in the CSP request's own process, which is what makes a process-private global a valid handoff.

- Engine suite **395 pass / 0 fail** (389 → 395). One pre-existing test asserted the outbound request deep-equalled the caller's body, which this feature makes false by design; it now asserts the caller's two fields survive, and six new tests cover the attachment — including that a caller **cannot** post its own findings, and that a missing supplier sends `warming` rather than `ok`.
- `npm run typecheck` clean.
- `LoadDir` over `labdemo/` and `setup/` with `ERRORCOUNT 0`; `ReportTools()` reports **14 of 14**.

## Note for the reviewer

Three fabricated `ProbeSetting:a>>b` rows from my argument-order testing are still in `%SYS.Audit` on the dev instance (2026-08-30 09:45–09:47). They are invisible to the tool — their `Description` fails the host parse, which is *why* they were written — but they are invented data in an audit log. Deleting audit rows was correctly blocked as tampering, so this is a call for a human: `Audit.Entry.Purge()`-style cleanup, or leave them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)