### PR TITLE
fix(docker): the IRIS healthcheck was writing 17,280 audit rows a day (#166)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,17 +189,45 @@ services:
       test:
         - CMD-SHELL
         - wget -qO- http://localhost:52773/api/monitor/metrics | grep -q 'production="ProductionGuardian.LabDemo.Production"'
-      # 60 x 5s = 5 minutes, which is HEADROOM rather than a measured requirement. Every cold
-      # run measured on this image reaches healthy in ~60s, because LABDEMO ships
-      # interop-enabled and the slow `EnableNamespace` branch never executes here. An earlier
-      # version of this comment justified the budget by "covers a cold EnableNamespace
+      # TWO CADENCES, BECAUSE THIS PROBE IS NOT FREE (#166). Every request to /api/monitor/*
+      # makes IRIS write one `AccessDenied` audit row -- `Security.Services.Exists()` is called
+      # while the request identity is still UnknownUser, which lacks %Admin_Secure:USE. The
+      # request still returns 200 with the full payload, so nothing here ever went red; the cost
+      # is 17,280 audit rows/day from this healthcheck alone, on top of the proxy's 34,560.
+      #
+      # Measured, not assumed: 20 requests to /api/monitor/metrics produced exactly 20 rows,
+      # anonymous and authenticated alike, while 10 to /labdemo/monitor/hoststatus produced
+      # none. So credentials are not the lever and this cadence is.
+      #
+      # A healthcheck keeps probing forever, not just until healthy, which is what makes a 5s
+      # interval expensive for a signal only `depends_on` consumes -- and it pulls the whole
+      # 60 KB metrics payload to grep one label.
+      #
+      # STARTUP DETECTION IS UNCHANGED. `start_interval` probes every 5s until the first
+      # success, so dependents still gate on our production at 5s granularity; `interval` only
+      # governs steady state, cutting this source by 6x to 2,880 rows/day. Needs Docker 25+
+      # (this stack: 29.7.2 / Compose v5.4.0).
+      #
+      # 5 minutes is HEADROOM rather than a measured requirement, and it now buys more than it
+      # did: every cold run measured on this image reaches healthy in ~60s, because LABDEMO
+      # ships interop-enabled and the slow `EnableNamespace` branch never executes here. An
+      # earlier version of this comment justified the budget by "covers a cold EnableNamespace
       # (minutes)", which describes a path that does not run on this image (@tanifgit, #78) --
       # the honest justification is that 5 minutes costs nothing when the normal case is 60s,
       # and an image without the namespace baked in WOULD take the slow path.
-      start_period: 0s
-      interval: 5s
+      #
+      # `retries` DROPS FROM 60 TO 3, AND THAT IS NOT A REDUCTION IN TOLERANCE. It used to carry
+      # the whole startup budget, because `start_period: 0s` meant a probe failing while IRIS
+      # was still booting counted against it -- 60 x 5s was that same 5 minutes, spelled as
+      # retries. `start_period` now covers startup properly (failures inside it neither count
+      # nor mark the container unhealthy), so retries is free to mean what it should: how long a
+      # HEALTHY instance may stay broken before we say so, here 3 x 30s. Total tolerance on a
+      # pathological cold boot goes UP, from 300s to 390s.
+      start_period: 300s
+      start_interval: 5s
+      interval: 30s
       timeout: 10s
-      retries: 60
+      retries: 3
 
   # ─── 3. metrics proxy ───────────────────────────────────────────────────────────────
   metrics-proxy:


### PR DESCRIPTION
Fixes the second-largest source in #166. Partial by design — see the last section.

## What was happening

Every HTTP request to `/api/monitor/*` makes IRIS write one `AccessDenied` audit row. `Security.Services.Exists()` is called while the request identity is still `UnknownUser`, which holds only `%DB_IRISSYS` and so lacks the `%Admin_Secure:USE` that lookup needs. **The request then returns `200` with the full payload**, which is why this was invisible: nothing upstream ever went red, and the only trace of it in the repo was `ChangeLog.cls` working around the resulting table growth (`SCANROWS = 400`, and a `Retention()` that counts only `ModifyConfiguration` because "`AccessDenied` dominates the row count here").

This healthcheck probes `/api/monitor/metrics` **every 5s forever**, not just until healthy, pulling the whole 60 KB payload to `grep` one label — 17,280 rows/day for a signal only `depends_on` consumes.

## Why cadence and not credentials

Measured from `pg-dashboard`, which otherwise never touches `/api/monitor`, so its rows isolate from the proxy's and this probe's:

| request | rows |
|---|---|
| 20 x anonymous `GET /api/monitor/metrics` | **+20** |
| 20 x authenticated `GET /api/monitor/metrics` | **+20** |
| 10 x authenticated `GET /labdemo/monitor/hoststatus` | **+0** |
| 5 x anonymous `GET /labdemo/monitor/hoststatus` (403) | **+0** |

Anonymous `GET` returns `200` here despite `/api/monitor` being `AutheEnabled=64`, and one row is written either way. So the `Authorization` header is not the lever — cadence is the only one that costs nothing else.

## Verification

On the running stack, after `docker compose up -d iris`:

- **healthy after 18s** (warm volume; the measured cold figure is ~60s)
- applied config: `StartPeriod 300s, StartInterval 5s, Interval 30s, Retries 3`
- steady-state probes **30.0s apart** across 5 consecutive `.State.Health.Log` entries
- closed 180s window, `/api/monitor` `AccessDenied` by client:

| client | rows/180s | rate | before |
|---|---|---|---|
| `127.0.0.1` (this probe) | 7 | 0.039/s | 0.200/s |
| `172.19.0.4` (the proxy) | 69 | 0.383/s | unchanged, as intended |

`docker compose config` renders `start_interval` correctly. CI has no compose-validation job, so the live run above is the evidence.

### If you re-measure this, mind the buffering

`%SYS.Audit` rows appear in bursts **>15s and <110s** after the request. Three of my early readings were wrong because of it: a 3-request batch read as "+0 rows" and briefly looked like proof that anonymous requests were free, and a 30s rate sample read 0.8/s where the long-run rate is 0.4/s. Settle ~2 min and prefer a closed timestamp window over a count delta.

## Startup detection is unchanged

That is the whole reason this is safe. `start_interval` probes every 5s until the first success, so dependents still gate on our production at 5s granularity; `interval` governs only steady state. The existing comment at line 159 about "4.0s of margin against a 5s probe interval" therefore still holds unchanged.

`retries` drops 60 -> 3 and **that is not a reduction in tolerance**. It used to carry the whole startup budget, because `start_period: 0s` meant a probe failing while IRIS was still booting counted against it — 60 x 5s was that same 5 minutes, spelled as retries. `start_period` now covers startup properly (failures inside it neither count nor mark the container unhealthy), so `retries` is free to mean what it should: how long a *healthy* instance may stay broken before we say so. Pathological cold-boot tolerance goes **up**, 300s -> 390s.

Requires Docker 25+ for `start_interval`; this stack is 29.7.2 / Compose v5.4.0.

## Scope — what this deliberately does not do

Removes ~14,000 of ~55,000 rows/day. The proxy's 2.5s poll is the larger source (~34,560/day) and is **left alone on purpose**: ADR 0005 and #75 halved it twice for the latency budget.

#166 ranks the rest, including the two I declined to take unilaterally:

- **disabling the `AccessDenied` audit event instance-wide** — the only change that removes all of it, and the only one that loses genuine security signal, so it is an operator's decision rather than a commit
- **granting `%Admin_Secure:USE` to the monitor context** — refused; it would silence the denial by giving security-administration privilege to every unauthenticated monitor request, inverting §2.1's RBAC boundary

Reviewed by me rather than by Ari, who is out today, with their standing agreement that I act as owner across areas for the day. Flagging that explicitly because `docker-compose.yml` is shared root config and would normally take a second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
