### PR TITLE
fix(iris): step 4c must not be able to abort a boot (#166)

### DIFF
--- a/iris/setup/FirstBoot.cls
+++ b/iris/setup/FirstBoot.cls
@@ -340,7 +340,27 @@ ClassMethod ClearPasswordChangeFlag()
 /// application, whose requests audit zero, and that is a `contracts/` change.
 ///
 /// Idempotent: creates the role only if absent, and appends to `MatchRoles` only if not already there.
+///
+/// CANNOT FAIL THE BOOT, and that is deliberate rather than defensive habit. This runs at step 4c,
+/// BEFORE `StartProduction()`, so an exception here would leave the production unstarted -- the
+/// stack would come up with no hosts, over an audit-log fix. `GovernanceSetup()` already made this
+/// exact call for the same reason ("a stack that refuses to come up because an MVP 2 role could not
+/// be created is worse than one that comes up and says so") and solved it by running after the
+/// production starts. This one belongs beside the other web-application setup, so it takes the
+/// other route: catch, report, continue. The worst outcome is the audit noise coming back, which is
+/// visible in the boot log and harmless to Health Scan.
 ClassMethod GrantMonitorSecureRole()
+{
+    try {
+        do ..GrantMonitorSecureRoleInner()
+    } catch e {
+        write "4c. FAILED with ", e.DisplayString(), " -- audit noise (#166) will persist, boot continues", !
+    }
+}
+
+/// The body of `GrantMonitorSecureRole()`. Private, and separate only so the caller above can be a
+/// bare try/catch -- `new $namespace` and an early `quit` do not compose with one in the same method.
+ClassMethod GrantMonitorSecureRoleInner() [ Private ]
 {
     new $namespace
     set $namespace = "%SYS"


### PR DESCRIPTION
Found while preparing the `compose down -v` test @tanifgit asked about — so it is worth fixing *before* that test, not after.

## The problem

`GrantMonitorSecureRole()` runs at step **4c**, before `StartProduction()` at step 7, and `Run()` calls it with a bare `do` and no status check. An exception in it would leave the production **unstarted** — the stack comes up with no hosts, over an audit-log fix.

`GovernanceSetup()` already reasoned this out and says so in its own comment:

> A failure here does NOT fail the boot — MVP 1's Health Scan does not depend on the MCP tools, and a stack that refuses to come up because an MVP 2 role could not be created is worse than one that comes up and says so.

It solved it by running *after* the production starts. This one belongs beside the other web-application setup at step 4, so it takes the other route: catch, report, continue.

Worth guarding rather than reasoning about, because the failure would land exactly where it is least expected — on a genuinely fresh `%SYS`, which is the one path #168 shipped untested and the one `compose down -v` exercises.

## Verified by forcing it

A temporary `throw` at the top of the inner method, compiled and run, then removed:

```
4c. FAILED with PGForcedTest 999  forced failure ... -- audit noise (#166) will persist, boot continues
AFTER: caller still running -- boot would reach StartProduction
```

So the handler renders the exception usefully **and** the caller survives. Throw removed, recompiled, normal path re-confirmed (`role exists` / `already grants`), and `grep PGForcedTest` returns 0.

Body split into a private `Inner` method because `new $namespace` and early `quit`s do not compose with a try/catch in the same method.

## A note on how not to test this

I first "established" that `e.DisplayString()` returned an empty string, and was one step from recording a blank-diagnostic defect in my own handler. That was an artifact of the test, not the code: an interactive `iris session` executes each fed line independently, so a multi-line try/catch typed at the terminal never forms a block — `e` is `<UNDEFINED>` and the closing brace is a `<SYNTAX>` error. A try/catch can only be exercised from inside a compiled method.

Same shape as the `%SYS.Audit` write buffering that produced three wrong readings earlier on #166: the apparatus was wrong and the reading looked like a finding. Recording it because it will catch the next person testing ObjectScript error paths this way.

Reviewed by me rather than by Ari, who is out today, with their standing agreement that I act as owner across areas for the day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
