### PR TITLE
contracts: get_recent_config_changes gains noOpSaves, and the buffering caveat stops excusing itself (#171)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,54 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-08-31 — `get_recent_config_changes` gains `noOpSaves`, and the buffering caveat stops excusing itself
+
+**`mcp-tools.md` §3.12 only.** Additive: one output field, `noOpSaves`, an integer count. No input
+changes, no existing field changes type or meaning, and `changes[]` keeps its shape — a consumer that
+ignores the new field sees strictly fewer bogus entries, never fewer real ones. Two prose sections are
+rewritten, one of them a correction rather than an addition.
+
+Both halves of #171, which @tanifgit found by comparing three live investigations.
+
+### The correction, which matters more than the field
+
+§3.12 already documented that `%SYS.Audit` rows are not readable the instant they are written. It then
+closed with *"An agent turn spends seconds per tool call, so no consumer of this contract is affected in
+practice; a test that arms and asserts in one breath is."*
+
+**That was wrong.** An investigation of the `MissingFolder` scenario called the tool 16 seconds after the
+`FilePath` edit, received `changes: []`, and reported *"no recent configuration changes were found"* — a
+fabricated negative on the flagship scenario this tool was built for. Re-measured: the row appeared at
+**+36 s**, and a `HTTPPort` edit in the same session appeared at **+24 s**. Tens of seconds, variable,
+and an agent turn sits inside it.
+
+A hazard that is identified and then argued away is worse than one nobody spotted, because the argument
+is what stops the next reader from checking. The paragraph now states the measurement and turns it into
+a consumer rule: **an empty `changes` list must never be reported as "nothing was changed"**, and
+`retention.newest` — already in every payload since MVP 3 — is what separates "no change" from "the log
+has not caught up". No new field was needed for that; the signal was there and nothing read it.
+
+### `noOpSaves`
+
+A count of rows whose `previousValue` equals `newValue`. Those rows are no longer listed in `changes[]`.
+
+They were never operator error. `FirstBoot.ApplyDeploymentSettings()` writes `HTTPServer` and `HTTPPort`
+through `Triggers.SetSetting()` on **every boot**, and `SetSetting()` audited unconditionally, so a
+normal boot left two `X changed from Y to Y` rows in the window every investigation reads. A
+`PoolBottleneck` investigation duly presented both as `Setting Change` evidence on a production nobody
+had reconfigured.
+
+Counted rather than silently dropped, for the reason `suppressed` and `truncated` are counted: a number
+a consumer can read beats a number it cannot. It is a **separate** field from `suppressed`, which means
+"something changed that I may not name" — a different fact from "something was saved and nothing moved",
+and merging them would lose both.
+
+**Why this is a filter and not only a producer fix.** `Triggers.SetSetting()` stops writing them, which
+handles everything this project controls going forward. The tool filters anyway, because the rows already
+in the audit log do not disappear and the Management Portal's own save path is not ours to change.
+
+---
+
 ## 2026-08-30 — two tools: what was CHANGED, and what Guardian is REPORTING
 
 **`mcp-tools.md` §1, §3.12, §3.13, §5.3's role table, and §6.** Additive: twelve tools become

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1448,10 +1448,14 @@ value, and when — read from `%SYS.Audit`. The one question no other tool in th
 **Input**: `host` (optional — omit for every host of this production), `sinceHours` (optional, default
 `168`, `1..720`).
 
-**Output**: `host`, `sinceHours`, `since`, `now`, `changes[]`, `suppressed`, `truncated`, `sanitised`,
-`auditEnabled`, `retention`.
+**Output**: `host`, `sinceHours`, `since`, `now`, `changes[]`, `suppressed`, `noOpSaves`, `truncated`,
+`sanitised`, `auditEnabled`, `retention`.
 
 `changes[]`: `host`, `setting`, `previousValue`, `newValue`, `changedAt`. Newest first.
+
+**A row where `previousValue` equals `newValue` is not a change and is never listed** — it is counted in
+`noOpSaves`. See "A save that moved nothing" below; this is the one shape of row the tool refuses on
+content rather than on the allowlist.
 
 #### The reporting rule is part of the contract, not a prompt detail
 
@@ -1501,6 +1505,27 @@ This is the tool's central caveat and the reason three fields exist that a naive
 - **`suppressed`** — a **count** of changes whose setting name is not allowlisted, never their names.
   Published so "nothing changed" and "something changed that I may not name" are distinguishable
   answers; conflating them is how an agent concludes a host was untouched.
+- **`noOpSaves`** — a **count** of rows where `previousValue` equals `newValue`. A separate number from
+  `suppressed` because it is a different fact: that one says "something changed and I may not name it",
+  this one says "something was saved and nothing moved".
+
+#### A save that moved nothing is not a change, and reporting one is worse than dropping it
+
+`previousValue == newValue` rows are **counted, not listed**. They are produced by ordinary operation,
+not by misuse: `FirstBoot.ApplyDeploymentSettings()` writes `HTTPServer` and `HTTPPort` through
+`Triggers.SetSetting()` on **every boot**, and `Triggers.Reset()` restores settings that are often
+already correct. Until #171, `SetSetting()` audited unconditionally, so a normal boot left two rows in
+the window every investigation reads.
+
+That is a false positive in the one direction this tool is most dangerous. §3.12's own framing tells a
+consumer that "a setting changed shortly before a finding is the likeliest cause of it" — so an agent
+handed `HTTPPort changed from 52773 to 52773` timestamped near a restart has been pointed at a
+non-cause with the tool's full authority behind it. Observed in a `PoolBottleneck` investigation, which
+presented both boot-time no-ops as `Setting Change` evidence on a production nobody had reconfigured.
+
+Fixed at both ends: `Triggers.SetSetting()` no longer audits a save that moved nothing, and this tool
+filters the shape anyway — for the rows already in the log, and for the Management Portal, which this
+project does not control.
 
 **Not every setting change is audited.** `Ens.Config.Production.%Save()` writes no audit row — only the
 Management Portal's own save path does. Measured by arming `Triggers.MissingFolder()` and finding the
@@ -1512,8 +1537,23 @@ setting through `%Save()` is invisible here.
 them — measured: a trigger armed, this tool called from the next line of the same session reported
 `changes: []` with `retention.newest` 101 seconds stale, and the identical call a minute later returned
 the row stamped at the earlier time. So **a caller must not assert a change exists immediately after
-making one.** An agent turn spends seconds per tool call, so no consumer of this contract is affected in
-practice; a test that arms and asserts in one breath is.
+making one.**
+
+**This paragraph used to close by saying no consumer was affected in practice, on the reasoning that an
+agent turn spends seconds per tool call. That was wrong, and it is the whole of #171.** The hazard was
+identified here and then reasoned away, which is worse than not having noticed it: an investigation of
+the `MissingFolder` scenario called the tool **16 seconds** after the `FilePath` edit, got `changes: []`,
+and reported *"no recent configuration changes were found"* — a fabricated negative, on the very
+scenario this tool was built for. Re-measured by arming the trigger and polling for the specific new
+timestamp: the row became visible at **+36 s**, while a `HTTPPort` edit in the same session was visible
+at **+24 s**. So the lag is tens of seconds and variable, and an agent turn is comfortably inside it.
+
+**The consequence for consumers is a rule, not a caveat: an empty `changes` list must never be reported
+as "nothing was changed".** `retention.newest` is what distinguishes the two cases and it is already in
+every payload — if it is older than the condition being diagnosed, the log has not caught up and the
+correct statement is that the audit log cannot answer yet. A consumer that reports absence without
+checking `retention.newest` against the finding's own timestamp is reporting the buffer, not the
+production.
 
 #### The data boundary — `Username` is never read
 
@@ -1539,7 +1579,7 @@ diagnostic weight, while naming a person invites an agent to assign blame it can
       "previousValue": "52773", "newValue": "52771",
       "changedAt": "2026-08-29T16:45:03Z" }
   ],
-  "suppressed": 0, "truncated": false, "sanitised": true, "auditEnabled": true,
+  "suppressed": 0, "noOpSaves": 2, "truncated": false, "sanitised": true, "auditEnabled": true,
   "retention": { "rows": 82, "oldest": "2026-08-11T07:22:41Z", "newest": "2026-08-30T09:02:14Z",
     "note": "IRIS purges audit data on a schedule, and a setting changed through code rather than the Management Portal may not be audited at all -- an empty result is not proof that nothing changed" }
 }


### PR DESCRIPTION
Contract half of #171, split into its own PR per root `CLAUDE.md` §4. `mcp-tools.md` §3.12 only, plus the `CHANGELOG.md` entry. Implementation follows separately.

**Additive and safe:** one integer output field, `noOpSaves`. No input change, no existing field changes type or meaning, `changes[]` keeps its shape. A consumer that ignores the field sees strictly *fewer bogus* entries and never fewer real ones. No JSON schema or sample payload references this tool's output — verified, so `contracts/samples/` and the schemas are untouched.

## The correction matters more than the field

§3.12 already documented that `%SYS.Audit` rows are not readable the instant they are written. It then closed with:

> An agent turn spends seconds per tool call, so **no consumer of this contract is affected in practice**; a test that arms and asserts in one breath is.

That was wrong. An investigation of the `MissingFolder` scenario called the tool **16 seconds** after the `FilePath` edit, received `changes: []`, and reported *"no recent configuration changes were found"* — a fabricated negative on the flagship scenario this tool exists for.

Re-measured by arming the trigger and polling for the specific new timestamp:

```
armed 10:50:04
+1s … +32s   newest visible = 10:49:22   (the previous row)
+36s         newest visible = 10:50:04   <- appears
```

And a `HTTPPort` edit in the same session was visible at **+24 s**. Tens of seconds, variable, and an agent turn sits well inside it.

**A hazard identified and then argued away is worse than one nobody spotted**, because the argument is what stops the next reader from checking. The paragraph now carries the measurement and turns it into a consumer rule: an empty `changes` list must **never** be reported as "nothing was changed", and `retention.newest` — already in every payload since MVP 3 — is what separates "no change" from "the log has not caught up".

Note that half needed **no new field**. The signal was already in the payload and nothing read it.

## `noOpSaves`

A count of rows whose `previousValue` equals `newValue`; those rows are no longer listed.

They are produced by ordinary operation, not misuse. `FirstBoot.ApplyDeploymentSettings()` writes `HTTPServer` and `HTTPPort` through `Triggers.SetSetting()` on **every boot**, and `SetSetting()` audited unconditionally — so a normal boot left two `X changed from Y to Y` rows in the window every investigation reads. A `PoolBottleneck` investigation duly presented both as `Setting Change` evidence on a production nobody had reconfigured.

That is a false positive in the one direction this tool is most dangerous, because §3.12 itself tells the consumer that a setting changed shortly before a finding is the likeliest cause of it.

Kept **separate** from `suppressed`: "something changed that I may not name" and "something was saved and nothing moved" are different facts, and merging them loses both. Counted rather than silently dropped, for the same reason `suppressed` and `truncated` are counted — and because #165 is open about exactly the opposite habit.

## Process note

§4 requires a contract change to be reviewed by every other developer. Ari is out today and I am acting as owner across areas with their agreement, so this is self-reviewed — flagging it because §4 exists precisely so a contract change is not slipped in, and because #165 was found reviewing a `contracts/` PR that merged two minutes after requesting review. Splitting the PR does not add a reviewer today; it does keep the record straight about what changed the contract and when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
