### PR TITLE
fix(iris): a no-op save is not a config change, and an empty audit window is not "nothing changed" (#171)

### DIFF
--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -831,6 +831,35 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     set g = g _ " nothing relevant comes back, say nothing about it -- the absence of a change is not"
     set g = g _ " a finding."
 
+    // AND IT MUST NOT SAY THE OPPOSITE, WHICH IS WHAT IT DID (#171). "Say nothing about it" above was
+    // already the instruction, and a live run on the armed missing-folder scenario returned
+    // "No recent configuration changes were found that could also contribute to this issue" -- while
+    // the FilePath edit sat in the audit log, 16 seconds old and not yet flushed. So the model both
+    // ignored a prohibition phrased as silence AND turned an empty list into a positive claim.
+    //
+    // TELLING IT NOT TO IS NOT ENOUGH ON ITS OWN, so this names the field that settles it.
+    // `retention.newest` is the newest audited change the log can see, and it is in every payload:
+    // if that is older than the finding, the log has not caught up and an empty list means "cannot
+    // tell yet", not "nothing changed". Measured on this instance -- a row written at 10:50:04 first
+    // became queryable at +36s, and a HTTPPort edit in the same session at +24s. Tens of seconds,
+    // variable, and an agent turn sits inside it. `contracts/mcp-tools.md` §3.12 carries the
+    // measurement and made this a consumer rule; this is that rule reaching the model.
+    //
+    // A PROHIBITION NEEDS A SANCTIONED ALTERNATIVE or the model invents one. Offering the "cannot yet
+    // tell" sentence is what stops it reaching for "no changes were found" to fill the same slot.
+    set g = g _ " NEVER state that no configuration change was found, or that nothing was changed."
+    set g = g _ " Audit rows take tens of seconds to become readable, so an empty changes list may"
+    set g = g _ " only mean the log has not caught up. Compare retention.newest with when this"
+    set g = g _ " finding began: if retention.newest is older, say that the audit log cannot answer"
+    set g = g _ " yet and give no verdict on configuration. Otherwise stay silent about"
+    set g = g _ " configuration entirely."
+    // `noOpSaves` exists because these rows used to reach the model AS changes, and it read
+    // `HTTPPort changed from 52773 to 52773` as evidence for a fault nothing had reconfigured. The
+    // tool now filters them, so this is the belt to that braces: a count is not a change, and a model
+    // that sees a non-zero number next to an empty list must not narrate it as one.
+    set g = g _ " noOpSaves counts saves where the value did not move. It is NOT a change: never"
+    set g = g _ " report it as one, and never treat a non-zero count as evidence of anything."
+
     // ATTRIBUTION, RESTATED HERE, and it is a repair rather than a belt-and-braces addition. The
     // directive above cost the reply its evidence attribution: the first version closed with "report
     // it as evidence under the rules in your instructions", and across three consecutive live runs

--- a/iris/labdemo/Tools/ChangeLog.cls
+++ b/iris/labdemo/Tools/ChangeLog.cls
@@ -231,6 +231,7 @@ ClassMethod GetRecentConfigChanges(host As %String = "", sinceHours As %Integer 
 
     set changes = []
     set suppressed = 0
+    set noOpSaves = 0
 
     // Ordered DESC and capped by TOP: the newest changes are the ones a diagnosis turns on, and a
     // clipped scan must clip the OLD end.
@@ -269,6 +270,21 @@ ClassMethod GetRecentConfigChanges(host As %String = "", sinceHours As %Integer 
                 set suppressed = suppressed + 1
                 continue
             }
+            // A SAVE THAT MOVED NOTHING IS NOT A CHANGE (#171). Counted, not listed -- silently
+            // dropping it would repeat #165's shape, and the count is what lets a reader tell "the
+            // config was untouched" from "something was saved and nothing moved".
+            //
+            // Kept even though `Triggers.SetSetting()` no longer writes these: the rows already in the
+            // audit log do not disappear, and the Management Portal's save path is not ours. A producer
+            // fix alone would look correct on a fresh volume and wrong on every existing instance.
+            //
+            // A SEPARATE COUNTER FROM `suppressed`, which means "changed, but I may not name the
+            // setting". Merging them would lose both facts, and this one is the more misleading of the
+            // two if it reaches the model: `HTTPPort changed from 52773 to 52773` reads as a change.
+            if $list(parsed, 2) = $list(parsed, 3) {
+                set noOpSaves = noOpSaves + 1
+                continue
+            }
             if changes.%Size() >= ..#MAXCHANGES {
                 do out.%Set("truncated", 1, "boolean")
                 continue
@@ -281,6 +297,7 @@ ClassMethod GetRecentConfigChanges(host As %String = "", sinceHours As %Integer 
 
     set out.changes = changes
     set out.suppressed = suppressed
+    set out.noOpSaves = noOpSaves
     quit out
 }
 

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -819,7 +819,25 @@ ClassMethod SetSetting(pItem As %String, pTarget As %String, pName As %String, p
     // AFTER the save succeeds, so the audit log never claims a change that did not land. An audit
     // failure does NOT fail the arming: the setting really did change, and refusing to report the
     // change is a smaller wrong than refusing to make it.
-    do ..AuditSettingChange(pItem, pName, previous, pValue)
+    //
+    // AND ONLY IF THE VALUE ACTUALLY MOVED (#171). This used to be unconditional, which meant a save
+    // that changed nothing still wrote `HTTPPort:52773>>52773`. That is not a change, and it is not a
+    // hypothetical: `FirstBoot.ApplyDeploymentSettings()` writes HTTPServer and HTTPPort through this
+    // method on EVERY boot, so a normal boot left two of them in the window every investigation
+    // reads -- and `Reset()` adds more whenever it restores a setting that was already correct. A
+    // `PoolBottleneck` investigation then presented both boot-time rows as `Setting Change` evidence
+    // on a production nobody had reconfigured, which is the worst direction for this to fail in:
+    // `contracts/mcp-tools.md` §3.12 tells the consumer that a setting changed shortly before a
+    // finding is the likeliest cause of it.
+    //
+    // `'found` IS STILL A CHANGE even though `previous` is "". The setting did not exist and now does,
+    // which audits as `Setting:>>value` and is a real diagnosis -- `Tools.ChangeLog.ParseChange()`
+    // keeps an empty previous value deliberately, for exactly this. So the test is on movement, not
+    // on `previous` being non-empty. `found` is set inside the item loop above and survives it;
+    // `$get` guards the path where the loop never assigned it.
+    if '$get(found, 0) || (previous '= pValue) {
+        do ..AuditSettingChange(pItem, pName, previous, pValue)
+    }
     quit $$$OK
 }
 


### PR DESCRIPTION
Implementation half of #171. The contract went in separately as 2f04329 (#172), per root `CLAUDE.md` §4.

Three files, two independent defects that fed AI Detective wrong evidence in **opposite** directions: one withheld a real change, the other manufactured a fake one.

## Defect 1 — a change made seconds ago is invisible, and the model stated the negative as fact

The tool **was** called — this is not #164's "registered but never called" failure. From `Audit.Entry`:

```
10:00:22 | GetRecentConfigChanges | {"host":"EMR Source"} | executed
```

The `FilePath` row it should have found was written at **10:00:06**. Neither `HostOf()` nor `ParseChange()` is at fault; the row parses correctly and the tool returns it now. `%SYS.Audit` rows are simply not queryable for tens of seconds — measured at **+36 s**, with a `HTTPPort` edit in the same session visible at **+24 s**.

§3.12 already documented that buffering and then dismissed it ("no consumer of this contract is affected in practice"). #172 corrects the contract. This PR is the consumer side: `BuildGoal` now **forbids** the claim instead of asking for silence. "Say nothing about it" was already in the prompt and the model wrote *"No recent configuration changes were found"* regardless — a prohibition needs a sanctioned alternative or the model invents one, so it is given the "the audit log cannot answer yet" sentence and pointed at `retention.newest`.

That field is already in every payload and already distinguishes "no change" from "the log has not caught up". **That half needed no new field, only a reader.**

## Defect 2 — no-op saves reported as changes

`SetSetting()` audited unconditionally, so a save that moved nothing wrote `HTTPPort:52773>>52773`. Not hypothetical: `FirstBoot.ApplyDeploymentSettings()` writes `HTTPServer` and `HTTPPort` through it on **every boot**, and `Reset()` adds more whenever it restores a setting that was already correct. A `PoolBottleneck` investigation duly presented two boot-time no-ops as `Setting Change` evidence on a production nobody had reconfigured.

That is the worst direction for this tool to fail in, because §3.12 tells the consumer a setting changed shortly before a finding is the likeliest cause of it. Same family as #159.

**Fixed at both ends deliberately.** `SetSetting()` stops writing them, covering everything this project controls going forward; `ChangeLog` filters the shape anyway, because rows already in the log do not disappear and the Portal's save path is not ours. A producer-only fix would look correct on a fresh volume and wrong on every existing instance.

`'found` is still audited even when `previous` is `""` — a setting that did not exist and now does is a real change — so the test is on *movement*, not on `previous` being non-empty.

## Verified on the live stack, live agent

| Check | Result |
|---|---|
| `noOpSaves` filtering, same window | 6 changes incl. `hl7-in/ >> hl7-in/` → **5 changes + `noOpSaves: 1`** |
| Producer guard: `Reset()` on an already-correct production | **zero** setting-change rows added |
| Boot guard: `compose restart iris` ran `6b. HTTPServer/HTTPPort` | row count stayed at **18** (previously +2 per boot) |
| End to end past the lag | `source: agent`, `toolCalls: 3`, evidence `FilePath changed from '/tmp/labdemo/hl7-in/' to '/tmp/labdemo/hl7-in-missing/' at 2026-08-31T11:06:26Z` attributed to `GetRecentConfigChanges`, `rootCause` naming the change |
| All three new directives | confirmed present in the **compiled** `AgentDispatcher.1.INT` |

The two "new" rows during the Reset test were `Production class compiled` lifecycle rows from my own recompile, which `HostOf()` correctly rejects — not setting changes.

## Not verified, and not claimed

**The empty-`changes` path was not exercised end to end.** `sinceHours` has a floor of 1 and the audit log currently holds visible changes inside that hour, so `changes: []` cannot be produced on demand without purging. The directive is compiled in; whether the model obeys it in that state is untested. That is the one behaviour this PR most wants to guarantee and cannot.

The deeper fix — recording our own changes somewhere immediately queryable so the flagship scenario is deterministic rather than racing a buffer — is written up on #171 and deliberately not attempted here. It adds a second source of truth and dedup logic, and it is a design decision rather than a bug fix.

## Process note

Two of my own test harnesses were wrong before the code was, both matching gotchas this repo already records: a `for` loop typed into an interactive `iris session` does not form a block, and a **braceless `IF` scopes to the end of the line**, so a second `if` on the same line only runs when the first matched. Both produced confident wrong readings.

Self-reviewed; Ari is out today and I am acting as owner across areas with their agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
