### PR TITLE
fix(detection-engine): the threshold panel stops citing ADR 0003 to the operator (#176)

### DIFF
--- a/services/detection-engine/src/api/settings.ts
+++ b/services/detection-engine/src/api/settings.ts
@@ -89,8 +89,9 @@ export const SETTING_FIELDS: readonly SettingField[] = [
     key: 'rules.queue_buildup.absoluteFloor',
     label: 'Minimum queue depth',
     help:
-      'A queue shallower than this never reports, however far above baseline it is. ADR 0003 ' +
-      'calls this the single biggest false-positive lever: 1 → 5 is 5× baseline and not a problem.',
+      'A queue shallower than this never reports, however far above baseline it is. It is the ' +
+      'main guard against noise on a quiet production, where a queue of 1 rising to 5 is 5× ' +
+      'baseline and not a problem.',
     blastRadius:
       'Lowering this widens what fires on the live production — shallow queues that are ' +
       'currently ignored will start reporting.',

--- a/services/detection-engine/test/settings.test.ts
+++ b/services/detection-engine/test/settings.test.ts
@@ -542,3 +542,39 @@ describe('the settings endpoint over HTTP', () => {
     await new Promise<void>((done) => bare.close(() => done()));
   });
 });
+
+/**
+ * The panel's prose is read by an OPERATOR, and `SETTING_FIELDS` is the one place in this service
+ * where operator-facing copy and developer-facing copy sit in the same literal.
+ *
+ * A `help` string shipped for weeks citing "ADR 0003" (#176) — an unresolvable reference to a
+ * document the product does not surface, next to our own vocabulary for our own false-positive
+ * rate. It reached the browser through `GET /api/settings/thresholds`, so it was a served string
+ * rather than a comment.
+ *
+ * Asserted over the WHOLE array rather than the one field that was wrong, because the leak is a
+ * category and the next one will be in whichever field is added next. This is #84's family: a
+ * reference copied out of a design document goes stale or becomes meaningless in its new context,
+ * and nothing else here would notice.
+ */
+describe('user-visible copy carries no internal references', () => {
+  /* ADR citations, section marks, and issue/PR numbers. Two digits for the last one so a bare "5×"
+     or "1 → 5" in a legitimate example cannot trip it -- the example in the floor's help text is
+     the clearest thing in the panel and must stay. */
+  const INTERNAL = /ADR\s|§|#\d{2,}/;
+
+  for (const field of SETTING_FIELDS) {
+    it(`${field.key} states no ADR, section or issue number`, () => {
+      for (const [name, copy] of [
+        ['label', field.label],
+        ['help', field.help],
+        ['blastRadius', field.blastRadius],
+      ] as const) {
+        assert.ok(
+          !INTERNAL.test(copy),
+          `${field.key}.${name} cites something the operator cannot look up: ${copy}`,
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #176.

One `help` string in `services/detection-engine/src/api/settings.ts`, plus a guard so the next one cannot ship.

## It was served, not just present

Confirmed on the running engine — `GET /api/settings/thresholds` returns **nine** user-visible strings (three `label`, three `help`, three `blastRadius`) and exactly one carried the leak. It reaches the browser, so this was operator-facing copy rather than a comment.

## Two problems in one sentence; the useful half survives

- **`ADR 0003`** — an unresolvable citation. Nothing in the product surfaces ADRs.
- **"the single biggest false-positive lever"** — our vocabulary for our own metric, not the operator's.

`1 → 5 is 5× baseline and not a problem` is kept verbatim: it explains why a floor exists better than any abstract wording, and it was the only part of the sentence doing operator-facing work.

```
- A queue shallower than this never reports, however far above baseline it is. ADR 0003
- calls this the single biggest false-positive lever: 1 → 5 is 5× baseline and not a problem.
+ A queue shallower than this never reports, however far above baseline it is. It is the
+ main guard against noise on a quiet production, where a queue of 1 rising to 5 is 5×
+ baseline and not a problem.
```

The other two `help` strings were already in the right register and are untouched — they are the standard the rewrite matches.

## The guard, and it was checked for the failure direction

Over the **whole** `SETTING_FIELDS` array, not the one field that was wrong, because the leak is a category and the next one will be in whichever field is added next:

```
old string caught : true
new string caught : false
```

A guard that cannot fail is not a guard. Two-plus digits on the `#` branch so a legitimate `5×` or `1 → 5` in an example cannot trip it. #84's family — `SETTING_FIELDS` is the one place in this service where operator prose and developer prose share a literal.

## Deliberately not touched

`apps/dashboard/src/components/HostDetail.tsx:157` mentions `ADR 0002` and a grep for `ADR 000` finds it. It is inside a `{/* … */}` JSX comment and is **never rendered**. Flagged on the issue as well, to save the next reader the false lead.

## Verified

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm test` | **398/398 pass** |
| New guard | 3 fields asserted, passes; fails against the old string |
| Served payload | re-read from the running engine, all nine strings |

Self-reviewed; Ari is out and I am acting as owner across areas with their agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)