### PR TITLE
fix: the chat describes all four things it can read, not one (#175)

### DIFF
--- a/apps/dashboard/src/components/ActivityChat.tsx
+++ b/apps/dashboard/src/components/ActivityChat.tsx
@@ -1,9 +1,15 @@
 /**
- * Activity insights chat — ask a question about interoperability activity in natural language.
+ * Production insights chat — ask a question about this production in natural language.
  *
- * The answer comes from an AI Hub agent inside IRIS that reads `Ens_Activity_Data.{Seconds,Hours,
- * Days}` through governed, audited MCP tools. This component renders what it is given and composes
- * nothing.
+ * The answer comes from an AI Hub agent inside IRIS reading four families of evidence through
+ * governed, audited MCP tools: recorded activity (`Ens_Activity_Data.{Seconds,Hours,Days}`), the
+ * event log, configuration changes from `%SYS.Audit`, and the findings Guardian is currently
+ * reporting. `Tools/Governance.cls`'s `chat` row is the authoritative membership. This component
+ * renders what it is given and composes nothing.
+ *
+ * THE NAME IS ACTIVITY-ONLY AND THE PANEL IS NOT, any more. Kept as `ActivityChat` because renaming
+ * the file would touch every importer for no behavioural gain, but the copy it renders must describe
+ * all four families — it described only activity for two families' worth of releases (#175).
  *
  * THE FOUR THINGS IT MUST NOT GET WRONG, which are `InvestigationPanel`'s three plus one:
  *
@@ -56,16 +62,25 @@ const DEFAULT_MAX_LENGTH = 600;
  *
  * "WHAT CAN YOU DO?" IS FIRST, AND IT IS THE ONE THAT COSTS NOTHING. IRIS classifies it as a
  * capability question and answers it from a fixed catalogue — no model call, no tool call — so it is
- * the cheapest chip here as well as the one that teaches an operator what the other three are
- * examples of. It leads for that reason: the reported defect was that the assistant did not behave
- * like one, and the first thing an assistant should be able to say is what it is for.
+ * the cheapest chip here as well as the one that teaches an operator what the rest are examples of.
+ * It leads for that reason: the reported defect was that the assistant did not behave like one, and
+ * the first thing an assistant should be able to say is what it is for.
+ *
+ * ONE CHIP PER CAPABILITY, which is what #175 was about. The agent reads four families of evidence
+ * (`Tools/Governance.cls`'s `chat` row: activity, event log, configuration changes, active findings)
+ * and every chip here used to be an activity question, so two of the four were undiscoverable — a
+ * capability nobody asks about is indistinguishable from one that does not exist. The findings chip
+ * is second because "is anything wrong" is the commonest question this panel is asked and the one it
+ * could not answer before MVP 3; `ChatDispatcher.SystemPrompt` puts the same tool first for the same
+ * reason. Two activity chips were dropped to make room rather than growing the list past six.
  */
 const SUGGESTIONS: readonly string[] = [
   'What can you do?',
+  'Is anything wrong with the production right now?',
+  'Are there errors in the event log, and when did they start?',
+  'Have any settings been changed recently?',
   'Which host is handling the most messages right now?',
-  'Is anything falling behind? Compare queueing time across hosts.',
   'How has throughput changed over the last few hours?',
-  'What activity history is available, and how far back does it go?',
 ];
 
 function confidenceText(confidence: number | null): string | null {
@@ -124,7 +139,7 @@ export function ActivityChat({
       <div className="pg-chat__head">
         <h2 id="pg-chat-heading" className="pg-section__title">
           <IconMessages size={16} />
-          Ask about activity
+          Ask about this production
         </h2>
         {!empty && (
           <button type="button" className="pg-button pg-button--subtle" onClick={onClear}>
@@ -134,9 +149,10 @@ export function ActivityChat({
       </div>
 
       <p className="pg-chat__intro">
-        Ask about message volume, throughput and latency over time. An AI agent inside IRIS answers
-        by reading the interoperability activity tables through governed, audited tools — it sees
-        counts, durations and configuration only, never message content or patient data.
+        Ask what Guardian is reporting right now, about message volume, throughput and latency over
+        time, about what the production logged, or about recent configuration changes. An AI agent
+        inside IRIS answers by reading those tables through governed, audited tools — it sees
+        counts, durations, severities and configuration only, never message content or patient data.
       </p>
 
       {empty && (

--- a/iris/labdemo/REST/ChatDispatcher.cls
+++ b/iris/labdemo/REST/ChatDispatcher.cls
@@ -565,11 +565,20 @@ ClassMethod SmallTalkAnswer(kind As %String, question As %String) As %DynamicObj
 /// is the same one, arriving from the other direction -- `ErrorSummary` is fixed so a log row cannot
 /// leak through it, and this is fixed so a model cannot invent a capability the system does not have.
 ///
-/// THE CAPABILITY TEXT IS GROUNDED IN THE FIVE TOOLS THIS AGENT IS REGISTERED FOR -- `Tools.Activity`'s
-/// three and `Tools.EventLog`'s two -- and says nothing beyond them. It names what CANNOT be answered
-/// as well, because the two most likely follow-ups are both out of reach: the current instantaneous
-/// state (this agent has the recorded-history tools only -- see `Governance.ACTIVITYTOOLS`) and
-/// anything about message content (no tool will return it).
+/// THE CAPABILITY TEXT IS GROUNDED IN THE TOOLS THIS AGENT IS REGISTERED FOR -- the four families on
+/// `Governance`'s `"chat"` row, which is the authoritative membership -- and says nothing beyond them.
+/// It names what CANNOT be answered as well, because the two most likely follow-ups are both out of
+/// reach: a host's live instantaneous metrics (this agent has no `READTOOLS`) and anything about
+/// message content (no tool will return it).
+///
+/// THE FAMILY COUNT IS NOT WRITTEN AS A NUMBER HERE, deliberately. This comment said "THE FIVE TOOLS
+/// -- `Tools.Activity`'s three and `Tools.EventLog`'s two" while the agent had also been given
+/// `CHANGELOGTOOLS` and `FINDINGTOOLS`, and the reply text below was stale in exactly the same way:
+/// two capabilities worked and nothing described them (#175). A counted list in prose above an
+/// enumeration is #84's shape, and `iris/CLAUDE.md` §7 stopped restating the tool count for the same
+/// reason. **Adding a family means editing the reply text below**, and the chip list in
+/// `ActivityChat.tsx` -- a capability nobody is told about is indistinguishable from one that is
+/// missing, which is the inverse of #164's registered-but-never-called failure and costs the same.
 /// Deliberately no host names: root `CLAUDE.md` §6 makes `Production.cls`'s item set the authority and
 /// a copied list here is what went stale when `FHIR Transform` was removed. The example questions are
 /// about SHAPE for the same reason the panel's suggestion chips are.
@@ -586,35 +595,45 @@ ClassMethod SmallTalkAnswer(kind As %String, question As %String) As %DynamicObj
 ClassMethod SmallTalkText(kind As %String) As %String [ Private ]
 {
     if kind = "greeting" {
-        quit "Hello. I can answer questions about this production's recorded interoperability "
-            _ "activity -- message volume, throughput, and processing and queueing times over a "
-            _ "period you choose -- and about what the production itself logged over that period, "
-            _ "including errors and warnings. Ask me something and I will read the tables for it."
+        quit "Hello. I can tell you what Production Guardian is reporting about this production "
+            _ "right now, and answer questions about its recorded interoperability activity -- "
+            _ "message volume, throughput, and processing and queueing times over a period you "
+            _ "choose -- about what the production itself logged, including errors and warnings, "
+            _ "and about configuration changes to its hosts. Ask me something and I will read the "
+            _ "tables for it."
     }
     if kind = "thanks" {
-        quit "You're welcome. Ask again whenever you want another look at the activity or the "
-            _ "event log."
+        quit "You're welcome. Ask again whenever you want another look at the findings, the "
+            _ "activity, the event log or what has been changed."
     }
     if kind = "farewell" {
-        quit "Goodbye. The activity history and the event log stay here whenever you want to come "
-            _ "back to them."
+        quit "Goodbye. The findings, the activity history, the event log and the change history "
+            _ "stay here whenever you want to come back to them."
     }
     if kind = "capability" {
-        quit "I answer questions about this production's recorded activity and its event log, by "
-            _ "reading the IRIS tables through governed, audited tools. On activity, three things: "
-            _ "which hosts have recorded activity and how far back the history goes; how one host's "
-            _ "throughput and latency have moved over time, bucket by bucket; and how all the hosts "
-            _ "compare over one window, ranked by volume. So ""which host is busiest"", ""is anything "
-            _ "falling behind on queueing time"" and ""how has throughput changed today"" are all "
-            _ "answerable, at ten-second, hourly or daily resolution. On the event log, two more: how "
-            _ "many entries each host wrote at each severity over a window, with the error codes that "
-            _ "appeared and what kind of fault each one is; and how that volume moved over time, so "
-            _ """are there errors"", ""what is failing"" and ""when did it start"" are answerable too. "
-            _ "Entries the production wrote about itself -- starts, stops and failures to start -- are "
-            _ "included, and they are the ones no host-by-host view shows. Two things I cannot do: I "
-            _ "see recorded history rather than the current instantaneous state of a host, and I never "
-            _ "see message content or patient data -- so from the log you get counts, severities, "
-            _ "error codes and the class that logged them, never the logged text itself."
+        quit "I answer questions about this production from four kinds of evidence, all read "
+            _ "through governed, audited tools. First, what Production Guardian is reporting right "
+            _ "now: every open finding with its host, type, severity, the value that triggered it "
+            _ "and the baseline it was compared against -- so ""is anything wrong"" is answered from "
+            _ "the findings themselves rather than inferred from throughput. On recorded activity, "
+            _ "three things: which hosts have recorded activity and how far back the history goes; "
+            _ "how one host's throughput and latency have moved over time, bucket by bucket; and how "
+            _ "all the hosts compare over one window, ranked by volume. So ""which host is busiest"", "
+            _ """is anything falling behind on queueing time"" and ""how has throughput changed "
+            _ "today"" are all answerable, at ten-second, hourly or daily resolution. On the event "
+            _ "log, two more: how many entries each host wrote at each severity over a window, with "
+            _ "the error codes that appeared and what kind of fault each one is; and how that volume "
+            _ "moved over time, so ""are there errors"", ""what is failing"" and ""when did it "
+            _ "start"" are answerable too. Entries the production wrote about itself -- starts, stops "
+            _ "and failures to start -- are included, and they are the ones no host-by-host view "
+            _ "shows. And on configuration: which setting changed on which host, from what value to "
+            _ "what value and when, from the IRIS audit log -- so ""has anything been changed"" is "
+            _ "answerable, though I will not tell you to revert a change, because whoever made it "
+            _ "had a reason I cannot see. Two things I cannot do: I do not see a host's live "
+            _ "instantaneous metrics -- its queue depth or throughput at this second -- only "
+            _ "recorded history and the findings above; and I never see message content or patient "
+            _ "data, so from the log you get counts, severities, error codes and the class that "
+            _ "logged them, never the logged text itself."
     }
     // NO DEFAULT SENTENCE. Every kind `SmallTalkKind` can return is handled above, and "" here would
     // fail `chat.ts`'s `answer` check and surface as `unavailable` -- which is the correct outcome for


### PR DESCRIPTION
Closes #175.

The agent reads **four** families of evidence (`Tools/Governance.cls`'s `chat` row). The UI intro advertised **one**; the canned "What can you do?" advertised **two**.

## All four verified working before any copy changed

Live agent, `gpt-4o-mini`, through `POST /api/chat`:

| Question | Result |
|---|---|
| active findings | `source: agent`, `toolCalls: 1`, attributed `GetActiveFindings` |
| configuration changes | `source: agent`, `toolCalls: 1`, attributed `GetRecentConfigChanges` |
| event log errors | `source: agent`, `toolCalls: 2`, `GetEventLogSummary` + `GetEventLogTrend` |

Nothing was broken. Two capabilities were simply invisible — the **inverse of #164**, where endpoints were served behind a UI that never called them. Capability present + description absent costs the same as the reverse, and it is worse here in one way: `What can you do?` is the first suggestion chip, so the stalest sentence was the most-read one.

`SystemPrompt()` was already current across all four families and is **untouched**. The staleness was confined to the fixed catalogue — no model call, no tool call, no test, which is exactly where it would go unnoticed.

## Dashboard — `ActivityChat.tsx`

- heading `Ask about activity` → **`Ask about this production`**
- intro names all four families, keeping the data-boundary sentence the component's own doc comment (§4) requires
- **one chip per capability, six not seven.** The findings chip is second because "is anything wrong" is the commonest question this panel is asked, and `SystemPrompt` puts that tool first for the same reason. Two activity chips were dropped rather than growing the list.

All three new chips were run against the live agent first — **a chip that returns a dud is worse than no chip.**

## IRIS — `ChatDispatcher.cls`

Capability answer, greeting, thanks and farewell all widened. Verified by re-reading each of the four through the API after compiling.

**One disclaimer is corrected rather than copied.** "I see recorded history rather than the current instantaneous state" became misleading once `FINDINGTOOLS` landed, because findings **are** current. It now names what is actually out of reach — a host's live instantaneous metrics, since this agent has no `READTOOLS`. The never-message-content/never-PHI sentence is unchanged: that is root `CLAUDE.md` §2.1's rule, not copy.

**The class comment stops counting.** It read "THE FIVE TOOLS — `Tools.Activity`'s three and `Tools.EventLog`'s two" while two more families were registered, so the comment and the text it governs went stale together. `iris/CLAUDE.md` §7 already stopped restating the tool count for this reason (#84). Replaced with a pointer to the authoritative `chat` row plus an explicit instruction that adding a family means editing the reply text **and** the chip list — which is the closest thing to a guard available for prose in a compiled class.

## Verified

| Check | Result |
|---|---|
| `npx tsc --noEmit` (dashboard) | clean |
| Class compiled into the live instance | `Load finished successfully` |
| All four fixed replies | re-read through `POST /api/chat`, `source: static`, all four families present |
| Three new chips | real agent answers, tool calls attributed |
| `docker compose up -d --build dashboard` | image rebuilt, container healthy |
| Served bundle | contains the 5 new strings, **0** of the 3 old ones |

## Not done

The component is still named `ActivityChat` and the panel is no longer activity-only. Renaming the file would touch every importer for no behavioural gain, so the header comment states the mismatch instead.

Spans `apps/dashboard/**` and `iris/**`. Self-reviewed; Ari is out and I am acting as owner across areas with their agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)