### PR TITLE
fix: the approval label stops saying "pool ? -> 8" (#178)

### DIFF
--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -582,7 +582,7 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "evidence (array of {label, detail, source, tool} where source is ""mcp_tool"" for a value you read with a tool "
     set p = p _ "or ""snapshot"" for one given to you, and tool is the tool name or null), "
     set p = p _ "confidence (number 0-1, your own judgement), "
-    set p = p _ "recommendedAction ({action: {type, host, size}}) or null, "
+    set p = p _ "recommendedAction ({action: {type, host, size}, currentValue}) or null, "
     set p = p _ "manualRemediation ({summary, steps, target}) or null. "
     // The bounds are READ FROM THE TOOL rather than restated, because a prompt that disagrees with
     // the guard produces a recommendation the guard then refuses -- which is what happened. The
@@ -684,6 +684,24 @@ ClassMethod SystemPrompt() As %String [ Private ]
     // than in format, because that is the distinction the model has to get right: one is a change we
     // may make, the other is a change only a person may make. A prompt that described them as "a
     // structured fix or a written fix" would invite both, or the wrong one.
+    // THE BEFORE-VALUE, AND THIS SIDE IS THE ONLY ONE THAT CAN SUPPLY IT (#178). The engine holds no
+    // production configuration -- `investigate.ts` is passed null for it deliberately -- so with the
+    // field unasked-for the approval label rendered `increase Cloud API pool ? -> 8`, a question mark
+    // on the one string a human reads before authorising a write to a live production.
+    //
+    // ASKED FOR AS A SEPARATE KEY rather than inside `action`, because `action` travels VERBATIM to
+    // `POST /api/resolve` (`investigation-api.md` §3.3) and the write tool's argument list is
+    // `{host, size}`. An extra member inside it would either be forwarded to a tool that does not
+    // take it or have to be stripped on the way -- so it sits beside the action, which is where the
+    // contract already puts it.
+    //
+    // NOT A NEW READ: `get_pool_size` and `get_host_settings` are both mandatory in `BuildGoal`
+    // already, so the value is in the transcript by the time this is answered. The model is told to
+    // report what it read rather than to compute it, because the one thing worse than an absent
+    // before-value is a plausible invented one next to an approve button.
+    set p = p _ "recommendedAction.currentValue is the pool size the host is set to RIGHT NOW, as an "
+    set p = p _ "integer, taken from what get_pool_size or get_host_settings returned for it. Do not "
+    set p = p _ "calculate it and do not guess it: if you did not read it, use null. "
     set p = p _ "Use recommendedAction ONLY for a bounded action from that list. "
     set p = p _ "Use manualRemediation when the fix is real but outside what this system may do -- "
     set p = p _ "for example a directory that must be created on the host, or a setting an operator "

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -292,13 +292,48 @@ function parseAgentReply(
     // the one under investigation is a reasoning failure, and forwarding it would hand a human an
     // approve button for something they did not ask about.
     if (type === 'set_pool_size' && host === finding.host && sizeOk) {
+      /*
+       * THE POOL SIZE NOW, and the agent is the only party in this exchange that read it (#178).
+       *
+       * `currentPoolSize` is the authoritative slot and wins when a caller supplies one, but no
+       * caller does: `index.ts` passes null on purpose, because this service holds no production
+       * config and `Host` carries no pool size. So before this the field was null on EVERY
+       * investigation and the summary rendered `pool ? -> 8` on the one string a human reads before
+       * approving a write to a live production.
+       *
+       * Taken from the reply because the agent HAS the value: `get_pool_size` and
+       * `get_host_settings` are both mandatory calls in `BuildGoal`, and a live run attributed
+       * `Current Pool Size | mcp_tool | GetHostSettings | 4 workers`. It is a transcription by a
+       * model rather than a read by this service, which is why it is validated and why the
+       * authoritative slot keeps precedence rather than being replaced.
+       *
+       * NOT VALIDATED AGAINST `BOUNDS`, deliberately. Those bound the TARGET of a write (2..8); the
+       * value here describes what the production is already set to, and LABDEMO ships `Cloud API` at
+       * PoolSize 1 -- below `BOUNDS.min`. Rejecting it would discard the true value in the shipped
+       * configuration, so the test is only that it is a positive integer.
+       */
+      const claimed = inner['currentValue'] ?? ra['currentValue'];
+      const claimedOk =
+        typeof claimed === 'number' && Number.isInteger(claimed) && claimed >= 1;
+      const current = currentPoolSize ?? (claimedOk ? (claimed as number) : null);
       action = {
         action: { type: 'set_pool_size', host: finding.host, size: size as number },
-        currentValue: currentPoolSize,
+        currentValue: current,
         bounds: { ...BOUNDS },
+        // TRUE EVEN WHEN `currentValue` IS NULL, and that is not an oversight. Reversibility does
+        // not depend on this field: `resolve()` captures `before` from the write tool's own reply
+        // and builds `reversal` from it, so the undo target comes from the instance at apply time
+        // rather than from this number. `investigation-api.md` §3.3 defines the flag against
+        // `currentValue`, which is narrower than how the reversal is actually obtained.
         reversible: true,
         requiresApproval: true,
-        summary: `increase ${finding.host} pool ${currentPoolSize ?? '?'} -> ${size as number}`,
+        // NO `?` PLACEHOLDER. An unknown before-value is omitted rather than printed: §3.3 makes
+        // this string authoritative and tells the consumer to render it as-is, so a placeholder here
+        // becomes a question mark on an approve button. "to 8" states exactly what is known.
+        summary:
+          current === null
+            ? `increase ${finding.host} pool to ${size as number}`
+            : `increase ${finding.host} pool ${current} -> ${size as number}`,
       };
     }
   }

--- a/services/detection-engine/test/recommendedAction.test.ts
+++ b/services/detection-engine/test/recommendedAction.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `recommendedAction` parsing — contract §3.3, and specifically the before-value (#178).
+ *
+ * WHAT MAKES THIS WORTH ITS OWN FILE. `summary` is the label on the control that authorises a write
+ * to a live production, and §3.3 says it is authoritative and must be rendered as-is. So a defect in
+ * this one string is a defect an operator reads and acts on, and it shipped: `currentValue` was null
+ * on every investigation and the summary rendered
+ *
+ *     increase Cloud API pool ? -> 8
+ *
+ * A question mark, on the before-value, next to an approve button. Not an edge case — `index.ts`
+ * passes the authoritative slot as a literal `null` on purpose (this service holds no production
+ * config), so it was every investigation that recommended anything.
+ *
+ * THE ASSERTION THAT MATTERS MOST IS A NEGATIVE ONE: no summary may contain `?`, whatever the reply
+ * looked like. Asserting the happy path only would have passed before the fix too, because the happy
+ * path was never the one that ran.
+ *
+ * The second theme is that a model-supplied number is TRANSCRIBED, not trusted: it is validated, the
+ * authoritative slot outranks it, and a claim that is not a positive integer is dropped rather than
+ * coerced. `0` from a model means "I did not read it" far more often than it means an empty pool.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { investigate } from '../src/detect/investigate.ts';
+import type { Finding, Host } from '../src/types/healthscan.ts';
+
+const HOST: Host = {
+  host: 'Cloud API',
+  type: 'operation',
+  status: 'OK',
+  queued: 486,
+  messagesPerSec: 4,
+  errored: 0,
+  avgProcessingTime: 1.01,
+  avgQueueingTime: 12,
+  lastActivity: '2026-08-31T10:00:00Z',
+};
+
+const FINDING: Finding = {
+  id: 'f-3001',
+  host: 'Cloud API',
+  type: 'queue_buildup',
+  severity: 'critical',
+  currentValue: 486,
+  baselineValue: 0,
+  detectedAt: '2026-08-31T10:00:00Z',
+  message: 'Queue depth 486 is over the floor of 50',
+};
+
+/** An agent that returns exactly the reply given, so the parser is what is under test. */
+function replyWith(reply: unknown) {
+  return {
+    callAgent: async () => reply,
+    source: 'canned' as const,
+    now: () => 1_760_000_000_000,
+  };
+}
+
+/** A whole reply whose `recommendedAction` carries whatever is passed in. */
+function reply(recommendedAction: unknown) {
+  return {
+    rootCause: 'Cloud API cannot keep up with inbound volume.',
+    evidence: [],
+    confidence: 0.8,
+    recommendedAction,
+    manualRemediation: null,
+  };
+}
+
+const ACTION = { type: 'set_pool_size', host: 'Cloud API', size: 8 };
+
+/** `investigate` with no authoritative pool size, which is what `index.ts` actually passes. */
+async function withoutAuthoritative(recommendedAction: unknown) {
+  return investigate(FINDING, HOST, undefined, null, replyWith(reply(recommendedAction)));
+}
+
+test('the agent-reported before-value reaches the summary', async () => {
+  const res = await withoutAuthoritative({ action: ACTION, currentValue: 4 });
+  assert.equal(res.recommendedAction?.currentValue, 4);
+  assert.equal(res.recommendedAction?.summary, 'increase Cloud API pool 4 -> 8');
+});
+
+test('inside `action` is accepted too — the model may put it either place', async () => {
+  /* The prompt asks for it beside the action, because `action` travels verbatim to the write tool.
+     A model that nests it anyway has still read the value, and discarding it over placement would
+     reintroduce the defect for a reason the operator cannot see. */
+  const res = await withoutAuthoritative({ action: { ...ACTION, currentValue: 4 } });
+  assert.equal(res.recommendedAction?.currentValue, 4);
+});
+
+test('an absent before-value is OMITTED, never rendered as a placeholder', async () => {
+  const res = await withoutAuthoritative({ action: ACTION });
+  assert.equal(res.recommendedAction?.currentValue, null, 'unknown stays null, not 0');
+  assert.equal(res.recommendedAction?.summary, 'increase Cloud API pool to 8');
+});
+
+test('NO summary contains a question mark, whatever the reply carried', async () => {
+  // The regression itself. Every shape that reaches the summary builder, in one assertion.
+  for (const ra of [
+    { action: ACTION },
+    { action: ACTION, currentValue: null },
+    { action: ACTION, currentValue: 'four' },
+    { action: ACTION, currentValue: 0 },
+    { action: ACTION, currentValue: -2 },
+    { action: ACTION, currentValue: 2.5 },
+    { action: ACTION, currentValue: 4 },
+  ]) {
+    const res = await withoutAuthoritative(ra);
+    const summary = res.recommendedAction?.summary ?? '';
+    assert.ok(summary !== '', `expected an action for ${JSON.stringify(ra)}`);
+    assert.ok(
+      !summary.includes('?'),
+      `summary must never show a placeholder, got: ${summary}`,
+    );
+  }
+});
+
+test('a claim that is not a positive integer is dropped rather than coerced', async () => {
+  for (const bad of ['four', 0, -2, 2.5, null, {}, []]) {
+    const res = await withoutAuthoritative({ action: ACTION, currentValue: bad });
+    assert.equal(
+      res.recommendedAction?.currentValue,
+      null,
+      `${JSON.stringify(bad)} must not become a before-value`,
+    );
+  }
+});
+
+test('the authoritative slot outranks the model, because one is read and one is transcribed', async () => {
+  const res = await investigate(
+    FINDING,
+    HOST,
+    undefined,
+    3,
+    replyWith(reply({ action: ACTION, currentValue: 4 })),
+  );
+  assert.equal(res.recommendedAction?.currentValue, 3, 'the caller-supplied value must win');
+  assert.equal(res.recommendedAction?.summary, 'increase Cloud API pool 3 -> 8');
+});
+
+test('a before-value BELOW the action bounds is kept — LABDEMO ships pool 1', async () => {
+  /* `BOUNDS` (2..8) constrain the TARGET of a write. `Cloud API` ships at PoolSize 1, so validating
+     the current value against them would discard the true value in the shipped configuration and
+     put the placeholder back on the flagship scenario. */
+  const res = await withoutAuthoritative({ action: ACTION, currentValue: 1 });
+  assert.equal(res.recommendedAction?.currentValue, 1);
+  assert.equal(res.recommendedAction?.summary, 'increase Cloud API pool 1 -> 8');
+});
+
+test('the forwarded action carries only what the write tool takes', async () => {
+  /* A shape invariant, not a value: `action` travels verbatim to `POST /api/resolve`, whose tool
+     argument list is `{host, size}`. If the before-value leaked in here it would be forwarded to a
+     tool that does not accept it. */
+  const res = await withoutAuthoritative({ action: { ...ACTION, currentValue: 4 } });
+  assert.deepEqual(Object.keys(res.recommendedAction?.action ?? {}).sort(), [
+    'host',
+    'size',
+    'type',
+  ]);
+});
+
+test('reversible stays true with no before-value, because the reversal is captured at apply time', async () => {
+  /* `resolve()` builds `reversal` from the write tool's own `before`, so reversibility does not
+     depend on this field. Pinned because §3.3 defines the flag against `currentValue`, and the
+     tempting "fix" is to flip it to false — which would tell an operator a reversible change is
+     not. */
+  const res = await withoutAuthoritative({ action: ACTION });
+  assert.equal(res.recommendedAction?.currentValue, null);
+  assert.equal(res.recommendedAction?.reversible, true);
+  assert.equal(res.recommendedAction?.requiresApproval, true);
+});


### PR DESCRIPTION
Closes #178.

`recommendedAction.currentValue` was null on **every** investigation, so `summary` — which §3.3 makes authoritative and tells the consumer to render as-is — put a **question mark on the before-value** of the one string a human reads before authorising a write to a live production.

## Why it was every investigation, not an edge case

`index.ts:183` passes the authoritative slot as a literal `null`, and the stated reasoning is sound as far as it goes:

> Pool size comes from the projection's own threshold basis where available; the authoritative read is `get_pool_size`, which the AGENT calls. Passing null rather than guessing keeps this service out of the business of reading production config.

The engine genuinely holds no production config — `Host` carries no pool size. What the comment missed is that `investigate.ts` then rendered `${currentPoolSize ?? '?'}` unconditionally.

## The agent is the only party in the exchange that read the value

So it is now asked for it. `get_pool_size` and `get_host_settings` are **already** mandatory calls in `BuildGoal` — the live run on #177 attributed `Current Pool Size | mcp_tool | GetHostSettings | 4 workers` — so this adds **no tool call**, only a field.

**Asked for beside `action`, not inside it.** `action` travels verbatim to `POST /api/resolve` and `resolve-api.md` §1.1 refuses unknown keys in it — something `ResolveAction`'s own doc comment already warns about ("anything advisory has to be a sibling rather than a member"). The parser accepts **either** placement and forwards **neither**: a model that nests it has still read the value, and discarding it over placement would reintroduce the defect for a reason the operator cannot see. Pinned by a shape assertion that `action` stays exactly three keys.

**Transcribed, not trusted:**

- the authoritative slot keeps precedence, so a future caller that really reads it outranks the model
- a claim must be a **positive integer**; anything else is dropped rather than coerced — `0` from a model means "I did not read it" far more often than it means an empty pool
- **not** validated against `BOUNDS`. Those bound the *target* of a write (2..8), and LABDEMO ships `Cloud API` at **PoolSize 1** — rejecting a below-min current value would discard the true value in the shipped configuration and put the placeholder straight back on the flagship scenario

**An unknown before-value is omitted rather than placeheld:** `increase Cloud API pool to 8`.

## One correction to my own issue

I wrote that `reversible: true` with a null `currentValue` "asserts a property the payload cannot support". That was **overstated**, and it deliberately stays `true`: `resolve()` builds `reversal` from the write tool's own `before`, captured at apply time, so reversibility never depended on this field. §3.3 defines the flag against `currentValue`, which is narrower than how the reversal is actually obtained. Pinned by a test, because the tempting "fix" is to flip it to false and tell an operator a reversible change is not.

## Verified live, pool 1 → 2

```json
{ "action": { "type": "set_pool_size", "host": "Cloud API", "size": 2 },
  "currentValue": 1,
  "bounds": { "min": 2, "max": 8 },
  "reversible": true, "requiresApproval": true,
  "summary": "increase Cloud API pool 1 -> 2" }
```

`source: agent`, `toolCalls: 3`, real `gpt-4o-mini`, armed `PoolBottleneck` at the shipped PoolSize 1 — which exercises the below-`BOUNDS.min` case rather than a convenient one.

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm test` | **407/407 pass** (9 new) |
| Guard checked in the failing direction | against the old `investigate.ts`, **5 of 9 fail**, including "NO summary contains a question mark" |
| Live end to end | `currentValue: 1`, summary has no `?` |

## Left for a separate PR

The **prose/schema disagreement** the issue also raised: `investigation-api.md:385` types the field `integer` while `investigation.schema.json:33` says `["integer","null"]` and the shared sample carries `null`. Null is still reachable (an agent that does not supply it), so the prose is what needs correcting — and per root `CLAUDE.md` §4 a `contracts/` change is its own PR with a CHANGELOG entry. Filed next; this PR changes no contract.

Spans `services/detection-engine/**` and `iris/**`. Self-reviewed; Ari is out and I am acting as owner across areas with their agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)