### PR TITLE
contracts: currentValue is nullable in prose too, and reversible stops being defined against it (#178)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,57 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-08-31 — `recommendedAction.currentValue` is documented as nullable, and `reversible` stops being defined against it
+
+**`investigation-api.md` §3.3 only. No schema change, no sample change, no field added or removed.**
+This entry corrects PROSE that disagreed with the two machine-readable artefacts it is supposed to
+describe. Implementation half of #178 is separate and changes no contract.
+
+### The disagreement
+
+| Artefact | Said |
+|---|---|
+| `investigation-api.md` §3.3 table | `currentValue` \| **`integer`** |
+| `investigation.schema.json` | `{ "type": ["integer", "null"] }` |
+| `samples/investigation-response.json` | `"currentValue": null` |
+
+So the prose was the outlier, and it was the outlier in the direction that hides a defect: a
+consumer reading the table would build for a value that is always present, and the schema and the
+sample everyone mocks against both permit — and the sample *encodes* — the case that actually
+shipped. Nothing failed, which is the point. `null` was served on **every** investigation and the
+approval label read `increase Cloud API pool ? -> 8`.
+
+A ratified sample carrying the defective value is worse than a gap in the prose, because
+mock-first is what this repo relies on to make "works against the mock" predict "works against the
+real thing" (root `CLAUDE.md` §4). Here it predicted it exactly, and both were wrong.
+
+### What the prose now says
+
+- `currentValue` is `integer | null`, with **when** it is null (the agent did not report it) and what
+  a consumer must do about it (omit the before-value, never render a placeholder). The two `summary`
+  forms are spelled out, because §3.3 makes that string authoritative and rendered as-is.
+- It may be **below `bounds.min`**. `bounds` constrains the *target* of a write, `2..8`; LABDEMO ships
+  `Cloud API` at PoolSize 1, so a reader who validated the current value against the bounds would
+  reject the true value in the shipped configuration.
+- **`reversible` is no longer defined against `currentValue`.** It read *"whether re-applying
+  `currentValue` undoes it"*, which made a `true` flag beside a `null` value look like a contradiction.
+  It is not: `resolve-api.md`'s `reversal` is built from the `before` the **write tool** reports at
+  apply time. That is also the only correct source, because the pool may have changed between the
+  investigation and the approval — so the narrower definition was wrong even when the value was
+  present.
+- The claim that it *"feeds `precondition.poolSize` and the reversal target"* is replaced by an
+  accurate account: `precondition` is optional and a consumer holding `null` must omit it rather
+  than guess.
+
+### Consumer impact
+
+**None required.** No key changes type in the schema, so nothing that validates today stops
+validating, and a consumer already handling `null` — which the schema and the sample have always
+demanded — needs no change. A consumer that trusted the *prose* and assumed a non-null integer was
+already broken against the shipped payload; that is what #178 found.
+
+---
+
 ## 2026-08-31 — `get_recent_config_changes` gains `noOpSaves`, and the buffering caveat stops excusing itself
 
 **`mcp-tools.md` §3.12 only.** Additive: one output field, `noOpSaves`, an integer count. No input

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -382,13 +382,34 @@ spelling, same types — and §1.1 **refuses unknown keys inside `action`** (`ma
 | `action.type` | string | **Enumerated. Exactly one member for MVP 2: `set_pool_size`.** |
 | `action.host` | string | The config item to act on. Equal to `finding.host`, and `Cloud API` is the only whitelisted value (`resolve-api.md` §3). |
 | `action.size` | integer | Target pool size. **`size`, not `proposedValue`** — the name is `resolve-api.md`'s. |
-| `currentValue` | integer | Pool size now, as read by `get_pool_size`. Not the engine's guess. Feeds `precondition.poolSize` on the resolve call and the reversal target. |
+| `currentValue` | integer \| **null** | Pool size now, as read by `get_pool_size` or `get_host_settings`. Not the engine's guess — it holds no production configuration. **`null` when the agent did not report it**; a consumer must then omit the before-value rather than render a placeholder. May be below `bounds.min`, which bounds the *target* only. |
 | `bounds` | object | `{ min: integer, max: integer }`. `2`–`8` per `resolve-api.md` §3. **Advisory** — see below. |
-| `reversible` | boolean | Whether re-applying `currentValue` undoes it. |
+| `reversible` | boolean | Whether the change can be undone. **Independent of `currentValue`** — `POST /api/resolve` captures `before` from the write tool at apply time and builds its own `reversal` from it, so this stays `true` with `currentValue: null`. |
 | `requiresApproval` | boolean | **Always `true` for MVP 2.** |
 | `summary` | string | One line for the approval button's label. Authoritative, render as-is. |
 
 `additionalProperties: false` at both levels.
+
+**`currentValue` is nullable, and `summary` is what a reader actually sees.** The schema has always
+typed it `["integer", "null"]` and `samples/investigation-response.json` has always carried `null`,
+while the table above said `integer` until 2026-08-31 — so the disagreement was between this prose
+and the two machine-readable artefacts, not a behaviour change. It matters because `summary` is
+**authoritative and rendered as-is**, so the producer must not use it to report an absent value:
+
+```
+currentValue: 4      ->  "increase Cloud API pool 4 -> 8"
+currentValue: null   ->  "increase Cloud API pool to 8"
+```
+
+Never a placeholder. A `?` in that string reaches an approval control for a live production write
+(#178).
+
+**Where the before-value is used, and where it is not.** It is advisory context for the human
+approving the action, and it is the value to send as `precondition.poolSize` on the resolve call *if
+a consumer chooses to send one* — that field is optional, and a consumer with `currentValue: null`
+must simply omit it rather than guess. It is **not** the reversal target: `resolve-api.md`'s
+`reversal` is built from the `before` the write tool itself reports at apply time, which is the only
+reading that is correct if the pool changed between the investigation and the approval.
 
 ### 3.3a `manualRemediation` — a fix that is not ours to apply
 


### PR DESCRIPTION
Documentation half of #178, separate per root `CLAUDE.md` §4. **`investigation-api.md` §3.3 only — no schema change, no sample change, no field added or removed.**

## The prose was the outlier

| Artefact | Said |
|---|---|
| §3.3 table | `currentValue` : **`integer`** |
| `investigation.schema.json:33` | `["integer", "null"]` |
| `samples/investigation-response.json:47` | `null` |

And it was the outlier in the direction that hides a defect. A consumer reading the table builds for a value that is always present; the schema permits `null` and the shared sample **encodes** it. So nothing failed validation while `null` was served on *every* investigation and the approval label read `increase Cloud API pool ? -> 8`.

I filed #178 believing this was a schema violation. It is not — I checked, and the schema was right all along. That is the more interesting failure: **a ratified sample carrying the defective value is worse than a gap in the prose**, because mock-first is what makes "works against the mock" predict "works against the real thing" (root `CLAUDE.md` §4). Here it predicted it exactly, and both were wrong.

## Four corrections

- **`currentValue` is `integer | null`**, with *when* it is null (the agent did not report it) and what a consumer must do — omit the before-value, never render a placeholder. Both `summary` forms are spelled out, because §3.3 makes that string authoritative and rendered as-is.
- **It may be below `bounds.min`.** `bounds` constrains the *target* of a write (2..8); LABDEMO ships `Cloud API` at PoolSize 1, so a reader who validated the current value against the bounds would reject the true value in the shipped configuration.
- **`reversible` is no longer defined against `currentValue`.** It read *"whether re-applying `currentValue` undoes it"*, which made `true` beside `null` look self-contradictory. It is not: `reversal` is built from the `before` the **write tool** reports at apply time — which is also the *only* correct source, since the pool may change between the investigation and the approval. The old definition was wrong even when the value was present.
- The **"feeds `precondition.poolSize` and the reversal target"** claim is replaced by an accurate account: `precondition` is optional, and a consumer holding `null` must omit it rather than guess.

## Consumer impact: none required

No key changes type in the schema, so anything that validates today still validates. A consumer already handling `null` — which the schema and the sample have always demanded — needs no change. A consumer that trusted the *prose* was already broken against the shipped payload, which is what #178 found.

Related: #155, also `investigation-api.md` drifting from what is actually true.

## Verified

`npm run validate` — **all checks passed** (3 samples, 15 accept, 26 reject, 7 capture claims).

Per §4 this needs review by every other developer; Ari is out and I am self-reviewing under the standing arrangement. Paired with #181, which is the implementation and touches no contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)