### PR TITLE
fix: Early Warning says which way a crossed queue is moving (#174)

### DIFF
--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -305,6 +305,30 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
         const queued = host.queued;
         const threshold = 50;
         const rising = queued !== null && queued > 0 && queued < threshold;
+        /*
+         * `recentDirection` (§1.5), from THIS CLIENT'S OWN RECORDED HISTORY rather than invented.
+         *
+         * An approximation of the engine's computation and openly so: there is no 300 s window here,
+         * so the sign comes from the last two recorded `queued` points instead of a least-squares fit
+         * over the tail. The engine's value is the authority; this only has to be *consistent* — the
+         * demo must show a draining queue as `falling`, which is the whole point of #174.
+         *
+         * `null` with fewer than two points, matching the engine: one sample has no direction. And
+         * `rising` is forced whenever a projection exists, because §1.5 makes that an invariant of the
+         * shape rather than a coincidence of the data — a mock that violated it would teach the UI to
+         * handle a state the engine cannot produce.
+         */
+        const points = mockSeries.get(seriesKey(host.host, 'queued')) ?? [];
+        const previous = points.at(-2)?.value;
+        const latest = points.at(-1)?.value;
+        const measuredDirection =
+          previous === undefined || latest === undefined
+            ? null
+            : latest > previous
+              ? ('rising' as const)
+              : latest < previous
+                ? ('falling' as const)
+                : ('steady' as const);
         return {
           host: host.host,
           metric: 'queued',
@@ -312,6 +336,7 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
           measuredAt: at,
           fitSampleCount: 60,
           fitSpanSeconds: 295,
+          recentDirection: rising ? ('rising' as const) : measuredDirection,
           threshold: { value: threshold, basis: 'absoluteFloor', baselineValue: 0, findingType: 'queue_buildup' },
           projection: rising
             ? {

--- a/apps/dashboard/src/api/mvp2Guards.ts
+++ b/apps/dashboard/src/api/mvp2Guards.ts
@@ -26,6 +26,7 @@ import type {
   ManualRemediationView,
   HostProjectionView,
   ProjectionDeclineReason,
+  RecentDirection,
   EvidenceSource,
   InvestigationSource,
   InvestigationState,
@@ -360,6 +361,9 @@ const DECLINE_REASONS: readonly string[] = [
   'beyond_horizon',
 ];
 
+/** §1.5's three members. A fourth arriving is unknown, and unknown means `null` — see below. */
+const RECENT_DIRECTIONS: readonly string[] = ['rising', 'falling', 'steady'];
+
 /**
  * Early Warning projections.
  *
@@ -408,6 +412,16 @@ export function parseProjections(payload: unknown): HostProjectionView[] {
         ? (rawReason as ProjectionDeclineReason)
         : null;
 
+    /* An unknown direction falls back to `null`, NOT to `steady`. §2.4's defensive-rendering rule
+       applied to a new field: `null` renders as no claim, where `steady` would assert that a queue
+       nobody can measure is holding still. Same reasoning as an unknown severity becoming `info`
+       rather than `critical` — the fallback must be the one that claims least. */
+    const rawDirection = entry['recentDirection'];
+    const recentDirection =
+      typeof rawDirection === 'string' && RECENT_DIRECTIONS.includes(rawDirection)
+        ? (rawDirection as RecentDirection)
+        : null;
+
     out.push({
       host,
       metric: str(entry['metric'], 'queued'),
@@ -415,6 +429,7 @@ export function parseProjections(payload: unknown): HostProjectionView[] {
       measuredAt: str(entry['measuredAt']),
       fitSampleCount: nullableNum(entry['fitSampleCount']) ?? 0,
       fitSpanSeconds: nullableNum(entry['fitSpanSeconds']) ?? 0,
+      recentDirection,
       threshold,
       projection,
       projectionUnavailable: reason,

--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -24,6 +24,12 @@
  * which is honest about there being no forecast left to make while leaving evidence that the module
  * exists and was watching. A feature nobody can find is indistinguishable from a missing one.
  *
+ * AND IT NOW SAYS WHICH WAY THE QUEUE IS MOVING (#174). "Threshold reached" was the whole sentence for
+ * a queue climbing and for a queue draining after an approved fix — measured at 110 seconds of
+ * indistinguishable output on the live scenario, against ~20 seconds in which a real forecast exists
+ * at all. `recentDirection` (§1.5) is measured and published on every row, so the three states get
+ * three sentences. See `CROSSED_BY_DIRECTION`, including why none of them earns the tick.
+ *
  * Still silent for `disabled` and `metric_unmeasurable`: those are steady states on a
  * healthy host, and a row saying "no projection available" on every card would make the grid
  * unreadable for information nobody needs. `warming` and `insufficient_samples` render because they
@@ -41,7 +47,7 @@
  * `svg()` wrapper; the sentence beside it stays the authoritative statement (§7.3).
  */
 
-import type { HostProjectionView } from '../types/mvp2';
+import type { HostProjectionView, RecentDirection } from '../types/mvp2';
 import { IconWatching } from './icons';
 
 export interface EarlyWarningProps {
@@ -54,6 +60,29 @@ export interface EarlyWarningProps {
  * `already_crossed` is the one that earns its place by NOT being a forecast: it marks the module as
  * present and watching after the window has closed. The other two mean "ask again shortly".
  */
+/**
+ * `already_crossed`, by which way the queue is actually moving (§1.5, #174).
+ *
+ * THE SAME REASON MEANT TWO OPPOSITE THINGS and read as one sentence. Measured on the live stack: an
+ * armed `queue_buildup` fixed by enlarging the pool drained from 152 to 54 over 22 consecutive polls —
+ * 110 seconds — every one `already_crossed`, rendering identically to the climb through the same
+ * depths. An operator watching a fix work was told only that the threshold had been reached.
+ *
+ * STILL NO TICK, in any of the three. The icon is reserved for `not_rising`, whose whole content is
+ * reassurance; a crossed threshold is a live problem however it is moving, and a tick beside "coming
+ * down" would be the over-reassurance this file's header argues against — the same class as the
+ * summary tile counting a host with three criticals as OK. The tone stays `--spent` for the same
+ * reason: recovering is not resolved.
+ *
+ * A null direction falls back to the unqualified sentence, which is exactly the pre-#174 string. No
+ * claim is made when the engine makes none.
+ */
+const CROSSED_BY_DIRECTION: Record<RecentDirection, string> = {
+  rising: 'Threshold reached and still rising — see the finding below',
+  falling: 'Threshold reached — coming down now; see the finding below',
+  steady: 'Threshold reached — holding steady; see the finding below',
+};
+
 const SHOWN_REASONS: Record<string, string> = {
   warming: 'Baseline still warming — no projection yet',
   insufficient_samples: 'Not enough samples yet for a projection',
@@ -109,7 +138,16 @@ export function EarlyWarning({ projection }: EarlyWarningProps): JSX.Element | n
   const { projection: forecast, projectionUnavailable: reason } = projection;
 
   if (forecast === null) {
-    const shown = reason === null ? undefined : SHOWN_REASONS[reason];
+    /* `already_crossed` is the one reason whose sentence depends on a second field, so it is resolved
+       here rather than by widening SHOWN_REASONS into a nested map that three other reasons would
+       carry a null key for. */
+    const direction = projection.recentDirection;
+    const shown =
+      reason === 'already_crossed' && direction !== null
+        ? CROSSED_BY_DIRECTION[direction]
+        : reason === null
+          ? undefined
+          : SHOWN_REASONS[reason];
     if (shown === undefined) return null;
     /* `already_crossed` reads as spent rather than pending -- it is not waiting for anything, it is
        reporting that the thing it was watching for has happened. The other two are genuinely

--- a/apps/dashboard/src/types/mvp2.ts
+++ b/apps/dashboard/src/types/mvp2.ts
@@ -239,6 +239,15 @@ export type ProjectionDeclineReason =
   | 'not_rising'
   | 'beyond_horizon';
 
+/**
+ * Which way the metric is moving now — `earlywarning-api.md` §1.5.
+ *
+ * A SEPARATE AXIS FROM THE DECLINE REASON, not another member of it: the reason says which state,
+ * this says which way, and `already_crossed` occurs in both directions. `null` means the engine
+ * claims no direction and must never be rendered as `steady`.
+ */
+export type RecentDirection = 'rising' | 'falling' | 'steady';
+
 export interface HostProjectionView {
   host: string;
   metric: string;
@@ -246,6 +255,8 @@ export interface HostProjectionView {
   measuredAt: string;
   fitSampleCount: number;
   fitSpanSeconds: number;
+  /** Measured, so present alongside `currentValue` rather than inside `projection`. §1.5. */
+  recentDirection: RecentDirection | null;
   threshold: {
     value: number | null;
     basis: string;

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -31,6 +31,16 @@ export type ProjectionUnavailableReason =
   | 'not_rising'
   | 'beyond_horizon';
 
+/**
+ * Which way the metric is moving now — contract §1.5. The SIGN of the tail fit, not its magnitude.
+ *
+ * A separate concept from `ProjectionUnavailableReason` and deliberately not folded into it: the
+ * reason answers *which state*, this answers *which way*, and a queue can be over its threshold in
+ * either direction. Publishing it as an eighth reason would have moved the precedence every consumer
+ * enumerating reasons depends on.
+ */
+export type RecentDirection = 'rising' | 'falling' | 'steady';
+
 export interface Threshold {
   value: number;
   basis: 'absoluteFloor' | 'baselineMultiplier';
@@ -55,6 +65,8 @@ export interface HostProjection {
   measuredAt: string;
   fitSampleCount: number;
   fitSpanSeconds: number;
+  /** Contract §1.5. Measured, so present on every row; null means no direction is claimed. */
+  recentDirection: RecentDirection | null;
   threshold: Threshold | null;
   projection: Projection | null;
   projectionUnavailable: ProjectionUnavailableReason | null;
@@ -301,6 +313,36 @@ export function projectHost(
       ? Math.round((last.at - first.at) / 1000)
       : 0;
 
+  /*
+   * THE TAIL FIT, COMPUTED ONCE AND USED TWICE (#174, contract §1.5).
+   *
+   * It was already computed at step 6 as a sign test and then thrown away on every other path — so a
+   * queue draining above its threshold declined as `already_crossed` while this value sat unread.
+   * Now it is measured here, published on every row, and step 6 reads it instead of re-fitting.
+   *
+   * GATED ON `minFitSamples`, and that is §1.5's load-bearing rule rather than caution. The tail is
+   * allowed to decide on as few as two samples BECAUSE the window behind it has already cleared
+   * twelve — it confirms a grounded answer rather than producing one. Published standalone on a
+   * warming host, a sign fitted through three samples would be a claim with nothing behind it, so
+   * `warming` and `insufficient_samples` rows carry null.
+   */
+  const recentSlopePerMinute =
+    fitSampleCount >= ew.minFitSamples
+      ? perMinute(
+          fitSlopePerMs(recentPortion(samples, ew.fitWindowSeconds * 1000 * RECENT_FIT_FRACTION)),
+        )
+      : null;
+  // `-0 > 0` and `-0 < 0` are both false, so a small negative that rounds to zero lands on 'steady'
+  // rather than 'falling' — which is what "rounded to the 1dp we publish" has to mean to be honest.
+  const recentDirection: RecentDirection | null =
+    recentSlopePerMinute === null
+      ? null
+      : recentSlopePerMinute > 0
+        ? 'rising'
+        : recentSlopePerMinute < 0
+          ? 'falling'
+          : 'steady';
+
   const base = {
     host,
     metric: METRIC as string,
@@ -308,6 +350,7 @@ export function projectHost(
     measuredAt,
     fitSampleCount,
     fitSpanSeconds,
+    recentDirection,
   };
 
   const decline = (
@@ -356,10 +399,11 @@ export function projectHost(
   // posture the rest of this module takes. `insufficient_samples` would be the wrong reason for
   // either — the contract defines it against the published `fitSampleCount`, which is the FULL
   // window's count and has already cleared `minFitSamples` by this point.
-  const recentSlopePerMinute = perMinute(
-    fitSlopePerMs(recentPortion(samples, ew.fitWindowSeconds * 1000 * RECENT_FIT_FRACTION)),
-  );
-  if (recentSlopePerMinute === null || recentSlopePerMinute <= 0) {
+  // Reads the value measured above rather than re-fitting: `recentDirection !== 'rising'` is exactly
+  // the old `recentSlopePerMinute === null || <= 0`, since null maps to null and a non-positive
+  // rounded slope maps to 'falling' or 'steady'. One computation, so the published direction and the
+  // gate can never disagree — two fits of the same samples is a way for them to.
+  if (recentDirection !== 'rising') {
     return decline('not_rising', threshold);
   }
 

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -530,3 +530,128 @@ describe('a queue must be rising NOW, not merely on average', () => {
     assert.equal(p.projectionUnavailable, 'not_rising');
   });
 });
+
+/**
+ * `recentDirection` — contract §1.5, and #174.
+ *
+ * THE DEFECT THIS PINS is that `already_crossed` was returned for a queue over its threshold whether
+ * it was climbing or draining, and nothing in the payload distinguished them. Measured on the live
+ * stack: a `queue_buildup` fixed by enlarging the pool spent 22 consecutive polls — 110 seconds —
+ * draining from 152 to 54, every one reporting `already_crossed`, byte-identical to the climb through
+ * the same depths.
+ *
+ * So the two load-bearing cases are the SAME REASON with OPPOSITE directions, asserted as a pair.
+ * Testing only the draining one would pass against an implementation that hardcoded `'falling'`.
+ *
+ * The precedence is deliberately unchanged and is asserted as such: a draining queue still over its
+ * limit is still `already_crossed`, because it is still a problem.
+ */
+describe('recentDirection — which way it is moving now (§1.5)', () => {
+  /** Record an arbitrary series at the shipped poll and project at its last sample. */
+  function series(values: readonly number[], cfg = config()) {
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (const v of values) {
+      store.record(HOST, 'queued', v, at);
+      at += POLL;
+    }
+    const lastAt = at - POLL;
+    return projectHost(HOST, raw(values.at(-1) ?? 0), store, cfg, lastAt);
+  }
+
+  /** Rise to `peak`, then come down by `perSample` — the shape of an approved fix taking effect. */
+  function riseThenDrain(peak: number, perSample: number, drainSamples: number): number[] {
+    const up: number[] = [];
+    for (let v = 0; v < peak; v += 5) up.push(v);
+    const down: number[] = [];
+    let v = peak;
+    for (let i = 0; i < drainSamples; i += 1) {
+      v -= perSample;
+      down.push(v);
+    }
+    return [...up, ...down];
+  }
+
+  it('a queue draining ABOVE its threshold is already_crossed and falling', () => {
+    // The regression. 150 -> 60 at 3/poll over 30 polls: the tail is unambiguously falling and the
+    // depth never drops below the threshold, so the reason cannot change.
+    const p = series(riseThenDrain(150, 3, 30));
+    assert.ok((p.currentValue ?? 0) >= 50, 'sanity: still above the threshold');
+    assert.equal(p.projectionUnavailable, 'already_crossed', 'precedence is unchanged');
+    assert.equal(p.projection, null);
+    assert.equal(p.recentDirection, 'falling');
+  });
+
+  it('a queue RISING above its threshold is already_crossed and rising — the same reason', () => {
+    /* The other half of the pair, and the reason it matters: before this field the two states above
+       and below were one indistinguishable payload. */
+    const p = series(Array.from({ length: 60 }, (_, i) => i * 3));
+    assert.ok((p.currentValue ?? 0) >= 50);
+    assert.equal(p.projectionUnavailable, 'already_crossed');
+    assert.equal(p.recentDirection, 'rising');
+  });
+
+  it('a projection is ALWAYS rising — §1.5s one invariant', () => {
+    // The projection path cannot be reached with a non-positive tail, so this is a property of the
+    // shape rather than of this fixture.
+    const p = ramp(20, 2);
+    assert.ok(p.projection !== null, 'sanity: expected a forecast');
+    assert.equal(p.recentDirection, 'rising');
+  });
+
+  it('a queue draining BELOW its threshold is not_rising and falling', () => {
+    // #142's case, which was already correct. The direction now says the same thing explicitly
+    // rather than leaving "not rising" to cover falling, flat and levelled-off alike.
+    const p = series(riseThenDrain(100, 4, 20));
+    assert.ok((p.currentValue ?? 0) < 50, 'sanity: below the threshold');
+    assert.equal(p.projectionUnavailable, 'not_rising');
+    assert.equal(p.recentDirection, 'falling');
+  });
+
+  it('a flat idle queue is steady, not falling and not null', () => {
+    /* `steady` and `falling` are different claims to an operator: one is "nothing is happening", the
+       other is "it is getting better". A flat series must not read as recovery. */
+    const p = series(Array.from({ length: 20 }, () => 0));
+    assert.equal(p.projectionUnavailable, 'not_rising');
+    assert.equal(p.recentDirection, 'steady');
+  });
+
+  it('is null below minFitSamples — no claim, rather than a sign through three samples', () => {
+    const p = series([0, 1, 2, 3, 5]);
+    assert.equal(p.projectionUnavailable, 'insufficient_samples');
+    assert.equal(p.recentDirection, null, 'a warming row claims no direction');
+  });
+
+  it('is null when the tail shares one timestamp — division by zero is not a flat line', () => {
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    for (let i = 0; i < 12; i += 1) store.record(HOST, 'queued', i * 2, T0 + i * POLL);
+    const lastAt = T0 + 250_000;
+    for (const v of [40, 41, 42]) store.record(HOST, 'queued', v, lastAt);
+    const p = projectHost(HOST, raw(42), store, cfg, lastAt);
+    assert.equal(p.projectionUnavailable, 'not_rising');
+    assert.equal(p.recentDirection, null);
+  });
+
+  it('the KEY is present on every row, whatever the reason', () => {
+    /* Contract §1: a missing key is a violation, a null value is not. Asserted with `in` rather than
+       by reading the value, because `undefined` and `null` both read as absent otherwise. */
+    const disabled = config({ earlyWarning: { ...config().earlyWarning, enabled: false } });
+    const rows = [
+      series([0, 1, 2], disabled),
+      series([5, 5, 5]),
+      ramp(20, 2),
+      series(riseThenDrain(150, 3, 30)),
+    ];
+    for (const p of rows) {
+      assert.ok('recentDirection' in p, `key missing for ${p.projectionUnavailable}`);
+    }
+    // And the unmeasurable case, which has no sample to fit at all.
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    const p = projectHost(HOST, raw(null), store, cfg, T0);
+    assert.equal(p.projectionUnavailable, 'metric_unmeasurable');
+    assert.ok('recentDirection' in p);
+    assert.equal(p.recentDirection, null);
+  });
+});


### PR DESCRIPTION
Closes #174. Contract went in separately as #183, per root `CLAUDE.md` §4.

`already_crossed` was the whole answer for a queue over its threshold whether it was climbing or draining, and the panel rendered **one sentence for both**.

Measured on the live stack: a `queue_buildup` fixed by enlarging the pool 1 → 4 spent **22 consecutive polls — 110 seconds — draining monotonically from 152 to 54, every one `already_crossed`**, byte-identical to the climb through the same depths. A projection with an ETA exists for ~20 s on that scenario, so the indistinguishable state is the one the panel spends most of its life in. An operator watching a fix work was told only that the threshold had been reached.

## The engine was already measuring the answer and throwing it away

§2.2.1's tail fit is a sign test that only ran *after* `already_crossed` had returned. It is now computed once, published on every row as `recentDirection`, and **the step-6 gate reads it instead of re-fitting** — `recentDirection !== 'rising'` is exactly the old `null || <= 0`.

One computation, so the published direction and the gate cannot disagree; two fits of the same samples is a way for them to. All 407 pre-existing tests pass unchanged, which is what makes that refactor safe to claim.

## What it is not

- **Not a slope.** The magnitude stays unpublished — §2.2.1's existing decision, because two rates in one payload leave a reader unable to tell which one `message` was built from.
- **Not an eighth reason.** Precedence is untouched, so no consumer learns a new key (`mvp2Guards.ts` and `mockClient.ts` both enumerate reasons). `already_crossed` still wins for a draining queue — over the limit is a problem however it is moving.

**Gated on `minFitSamples`**, which is §1.5's load-bearing rule rather than caution: the tail may decide on two samples *because* the window behind it has cleared twelve. Published standalone on a warming host, a sign through three samples is a claim with nothing behind it.

`-0` lands on `steady`, not `falling` — what "rounded to the 1dp we publish" has to mean to stay honest.

## UI: three sentences, and none of them earns the tick

The icon stays with `not_rising`, whose whole content is reassurance. A crossed threshold is a live problem however it is moving, and a tick beside "coming down" is exactly the over-reassurance this component's header already argues against — the same class as the summary tile counting a host with three criticals as OK. Tone stays `--spent`: **recovering is not resolved.** A `null` direction falls back to the exact pre-#174 string.

Guard: an unknown direction parses to `null`, **not** `steady` — §2.4's rule, and the fallback must be the one that claims least. The mock derives the sign from its **own recorded history** rather than inventing one, and forces `rising` whenever a projection exists so it cannot teach the UI a state the engine cannot produce.

## Verified live — every state, one continuous run

```
18:33:50      0  not_rising          steady        <- idle, and NOT 'falling'
18:34:26     10  beyond_horizon      rising
18:34:41     42  (projection eta 72) rising        <- §1.5 invariant holds
18:34:51     61  already_crossed     rising        <- climbing over the threshold
18:35:46    153  already_crossed     rising
  ... pool 1 -> 4 applied ...
18:37:06    105  already_crossed     falling       <- THE FIX: was indistinguishable
18:37:51     57  already_crossed     falling
18:37:56     49  not_rising          falling       <- below threshold
```

| Check | Result |
|---|---|
| `npm test` (engine) | **415/415**, 8 new |
| `tsc --noEmit` engine + dashboard | clean |
| Live, all six states | above |

## Known, and documented rather than discovered

**The sign lags a turn**, by up to the tail length: measured at **~35 s and 46 messages of real drain** after the peak before it flipped to `falling`. That is §2.2.1's deliberate trade against flapping — the 40% tail exists so one bursty poll cannot flip the sign — not a defect. §1.5 states the measurement and the consequence: a consumer may build a *coming down* claim on it, never a *recovered* one. Written down because #171's audit-buffering caveat was the same shape of known-but-unstated latency, and arguing it away is what stopped the next reader checking.

**Not changed:** `not_rising`'s copy still reads "Watching — not trending toward a threshold" for a queue draining *below* its threshold. That is accurate and non-alarming already (#142), so widening it was left out rather than bundled in.

Spans `services/detection-engine/**` and `apps/dashboard/**`. Self-reviewed; Ari is out and I am acting as owner across areas with their agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)