### PR TITLE
contracts: a tool for the interface map, and trend gains the field that says a queue is draining (#177)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -29,10 +29,19 @@ as a `<send>` inside a routing rule class. A topology hand-built from settings w
 exactly the edge the tool exists for, and would have looked correct. It is also derived from the
 production DEFINITION, so it still answers when a host is dead — which is when an investigation runs.
 
-Two surfaces of that utility were tried and rejected, and §3.14 records why: `FindAllPaths` returns a
-control-character-delimited string (an undocumented internal encoding, and #161 is open about raw
-control characters in source), and `FindSequentialPath` wants a JSON spec whose shape is not documented
-— passing it a path string returns `ERROR #5035 ... 'Parsing error'`.
+Two surfaces of that utility were tried and rejected, and §3.14 records why. `FindAllPaths` is an
+**internal method** — its own dictionary description opens with that word — returning a `%Status` with
+the paths handed back **byref** as `$listbuild` lists, `$lb(Service,Processes,Rules,DTLs,Operations)`,
+per that same description. `FindSequentialPath` wants a JSON spec whose shape is not documented
+anywhere reachable; passing it a path string returns `ERROR #5035 ... 'Parsing error'`.
+
+**An earlier draft of this entry said `FindAllPaths` returned a control-character-delimited string in
+an undocumented encoding. That was wrong** (@Ari-Glikman, #185): the `$c(12)`, `$c(11)` and `$c(1)`
+bytes measured at offsets in the value are `$list` length and type headers, not delimiters, and
+`$listget` reads it in one line — verified, `$listvalid` is 1 with five elements. Corrected here rather
+than quietly dropped, because a wrong-but-plausible rationale is the kind a later reader trusts instead
+of re-checking, and it would have told them the richer surface was undecodable when it is documented.
+"Internal method" is the firmer reason and does not depend on decoding anything.
 
 ### `trend.recentDirection`, and the deviation it works around
 

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,71 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — a tool for the interface map, and `trend` gains the field that says a queue is draining
+
+**Two files, both additive.** `mcp-tools.md` gains one read tool (§3.14, `get_interface_path`);
+`investigation-api.md` §2.2 gains one nullable field on `trend` (`recentDirection`). No existing field
+changes type or meaning, nothing is removed, and a consumer that ignores both behaves as before.
+
+#177, and the topology source was @tanifgit's suggestion: IRIS's own Interface Maps feature.
+
+### Why a tool at all
+
+Every read tool in `mcp-tools.md` is scoped to ONE host, and so is the snapshot §2.2 sends. So AI
+Detective could describe the host it was asked about in detail and had no way to know another host
+existed. Measured: an upstream fault was fixed, 281 accumulated messages flushed through at once,
+`Cloud API` queued 296, and the Detective recommended the MAXIMUM pool of 8 at 0.85 confidence on a
+queue that drained to zero unaided while it answered — its own evidence reading "No errors recorded in
+the last 60 minutes", true of `Cloud API` and false of the production.
+
+### Why IRIS's map rather than reading config
+
+`Ens.InterfaceMaps.Utils` resolves ROUTING RULES, and that is the whole reason. On this production
+`EMR Source -> Lab Router` is a `TargetConfigNames` setting, and `Lab Router -> Cloud API` exists only
+as a `<send>` inside a routing rule class. A topology hand-built from settings would have been missing
+exactly the edge the tool exists for, and would have looked correct. It is also derived from the
+production DEFINITION, so it still answers when a host is dead — which is when an investigation runs.
+
+Two surfaces of that utility were tried and rejected, and §3.14 records why: `FindAllPaths` returns a
+control-character-delimited string (an undocumented internal encoding, and #161 is open about raw
+control characters in source), and `FindSequentialPath` wants a JSON spec whose shape is not documented
+— passing it a path string returns `ERROR #5035 ... 'Parsing error'`.
+
+### `trend.recentDirection`, and the deviation it works around
+
+§2.2 has always specified `slope` as "may be zero or negative here ... because a queue that is draining
+is a fact the agent should see", and its §4 example carries a non-null slope beside
+`thresholdCrossed: true`. **The engine has never delivered that.** It reads `slope` from Early Warning's
+`projection`, which is `null` for `already_crossed` — i.e. for every condition this endpoint is called
+about. So the one fact needed to tell a recovery from a runaway was specified, documented, and absent.
+
+`recentDirection` (from `earlywarning-api.md` §1.5) is the half fixable without reopening that
+contract's §1.4 prohibition on publishing a bare slope beside a withheld forecast: a direction is not a
+rate, so it carries no forecast to mislabel. **The `slope` deviation itself is NOT fixed here** and is
+filed separately — honouring it needs the window slope published or refitted, which is
+`earlywarning-api.md`'s decision rather than this one's.
+
+### Verified end to end, live agent
+
+Same armed scenario, before and after:
+
+| | Before | After |
+|---|---|---|
+| tool calls | 4 | 6 |
+| upstream hosts read | none | both, via `get_recent_errors` |
+| recommendation | `set_pool_size` -> 6 (conf 0.9) | **null** |
+| root cause | "pool size 4 is insufficient" | "`EMR Source` errors #5021, 229 s ago, since ended — backlog draining through" |
+
+And the ordinary rising case still recommends a pool increase (`1 -> 2`, conf 0.9), which is #108's
+standing check and the thing a directive about transients could most easily have broken.
+
+### Consumer impact
+
+**None required.** Both changes are additive. A consumer already handling a `null` `slope` — which is
+what has always arrived — needs no change; `recentDirection` is the field to read instead.
+
+---
+
 ## 2026-08-31 — Early Warning publishes `recentDirection`, so a recovering queue stops reading like a runaway one
 
 **`earlywarning-api.md` only.** Additive: one nullable field on `HostProjection`, plus a

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -125,6 +125,7 @@ The engine builds this from its own in-memory state. It is a closed allowlist:
     "metric": "queued",
     "slope": 124.2,
     "slopeUnit": "items/minute",
+    "recentDirection": "rising",
     "thresholdValue": 50,
     "thresholdCrossed": true,
     "secondsToThreshold": null
@@ -211,9 +212,26 @@ is a description of a slope now, not a prediction of a crossing.
 | `metric` | string | `HostProjection.metric`. Only `queued` in MVP 2. Open string. |
 | `slope` | number | Same fit and same units as `Projection.slope` — OLS over the trailing 300 s. **May be zero or negative here**, unlike in `earlywarning-api.md`, because a queue that is draining is a fact the agent should see rather than a forecast to withhold. |
 | `slopeUnit` | string | Spelled out, e.g. `items/minute`. Carried so the agent never has to infer the unit. |
+| `recentDirection` | string \| **null** | `rising` \| `falling` \| `steady`, from `earlywarning-api.md` §1.5 — the **sign** of the tail fit, measured. `null` when no direction is claimed. **This is the field that says a queue is draining**; see below for why `slope` does not. |
 | `thresholdValue` | number | `Threshold.value` — `max(baseline * 5.0, 50)`. For this scenario the `absoluteFloor` arm of 50 wins, because Cloud API's queue baseline is near zero. |
 | `thresholdCrossed` | boolean | `queued >= thresholdValue`. **Normally `true`** on an investigated finding. Present so the agent never has to infer it from a null ETA. |
 | `secondsToThreshold` | integer \| null | Whole seconds, `> 0`. **`null` whenever `thresholdCrossed` is `true`**, which is the usual case — there is no crossing left to forecast. Never `0`, never negative. |
+
+**`recentDirection` exists because `slope` does not deliver what the row above promises.** `slope` is
+specified here as "may be zero or negative ... because a queue that is draining is a fact the agent
+should see", and the §4 example carries a non-null slope beside `thresholdCrossed: true`. The engine
+does not produce that: it reads `slope` from Early Warning's `projection`, which is `null` for
+`already_crossed` — i.e. for **every** condition this endpoint is ever called about. So the draining
+fact this contract promises has never reached an agent, and the measured consequence was a
+recommendation to enlarge a pool on a queue falling from 261 to 181, because nothing in the input said
+"falling" (#177).
+
+`recentDirection` is the part of that fixable without reopening `earlywarning-api.md` §1.4, which
+forbids publishing a bare slope beside a withheld forecast. A **direction is not a rate**, so it
+carries no forecast to mislabel — the same argument that lets `kind: 'projection'` stay absent below.
+**The `slope` deviation is not fixed by this change and is tracked separately**: honouring it needs the
+window slope published or refitted, which is that contract's decision rather than this one's. Until
+then, read `recentDirection` and treat a `null` `slope` on a crossed threshold as expected.
 
 `trend` is `null` when there is no usable fit at all — a warming baseline, or fewer than 12 samples
 in the fit window. `null` rather than a zero slope, because "not fitted" and "flat" are different

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -212,7 +212,7 @@ is a description of a slope now, not a prediction of a crossing.
 | `metric` | string | `HostProjection.metric`. Only `queued` in MVP 2. Open string. |
 | `slope` | number | Same fit and same units as `Projection.slope` — OLS over the trailing 300 s. **May be zero or negative here**, unlike in `earlywarning-api.md`, because a queue that is draining is a fact the agent should see rather than a forecast to withhold. |
 | `slopeUnit` | string | Spelled out, e.g. `items/minute`. Carried so the agent never has to infer the unit. |
-| `recentDirection` | string \| **null** | `rising` \| `falling` \| `steady`, from `earlywarning-api.md` §1.5 — the **sign** of the tail fit, measured. `null` when no direction is claimed. **This is the field that says a queue is draining**; see below for why `slope` does not. |
+| `recentDirection` | string \| **null** | `rising` \| `falling` \| `steady`, from `earlywarning-api.md` §1.5 — the **sign** of the tail fit, measured. `null` when no direction is claimed. **This is the field that says a queue is draining**; see below for why `slope` does not, and for the two conditions §1.5 attaches to it. |
 | `thresholdValue` | number | `Threshold.value` — `max(baseline * 5.0, 50)`. For this scenario the `absoluteFloor` arm of 50 wins, because Cloud API's queue baseline is near zero. |
 | `thresholdCrossed` | boolean | `queued >= thresholdValue`. **Normally `true`** on an investigated finding. Present so the agent never has to infer it from a null ETA. |
 | `secondsToThreshold` | integer \| null | Whole seconds, `> 0`. **`null` whenever `thresholdCrossed` is `true`**, which is the usual case — there is no crossing left to forecast. Never `0`, never negative. |
@@ -232,6 +232,25 @@ carries no forecast to mislabel — the same argument that lets `kind: 'projecti
 **The `slope` deviation is not fixed by this change and is tracked separately**: honouring it needs the
 window slope published or refitted, which is that contract's decision rather than this one's. Until
 then, read `recentDirection` and treat a `null` `slope` on a crossed threshold as expected.
+
+**`recentDirection` ARRIVES WITH §1.5's TWO CONDITIONS, and they bind harder here than there.** That
+section attaches both to the field, and this contract's consumer is a model — the one already measured
+recommending the maximum pool at 0.85 confidence off an incomplete picture (@Ari-Glikman, #185).
+
+- **It lags a turn by design.** The tail is a 120 s fit, so the sign changes once enough of the tail
+  has turned, not on the first sample that moves. Measured in §1.5 at **~35 seconds and 46 messages of
+  real drain** after a peak before it flipped. So for the opening ~35 s of a genuine drain an agent
+  reads `rising`, and a stale recommendation in that window is the field behaving as specified rather
+  than a defect. **#177 is narrowed by this change, not closed**: the indistinguishable window drops
+  from ~110 s to ~35 s.
+- **`falling` is "coming down", never "recovered".** A queue 200 deep and still above its threshold is
+  falling *and* a live problem. Nothing may conclude that no action is needed from the direction alone —
+  §2.2 carries the depth and the threshold for exactly that judgement, and a producer must weigh the
+  direction against them rather than instead of them.
+
+Both are stated here rather than left in the sibling contract because a consumer reading this object
+has no reason to open that one, and the failure they prevent is the failure this endpoint exists to
+avoid.
 
 `trend` is `null` when there is no usable fit at all — a warming baseline, or fewer than 12 samples
 in the fit window. `null` rather than a zero slope, because "not fitted" and "flat" are different

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1779,10 +1779,16 @@ map instead of a metric.
 
 #### Truncation is reported, never silent
 
-`#MAXPATHS` is 50. `pathsReturned` is what came back, `pathCount` is the true total, and `truncated`
-says whether they differ. Stated because the opposite choice is an open defect elsewhere in this
-contract (#165): a tool that capped silently and published a count of the *capped* list, leaving a
-consumer unable to tell a small production from a clipped one.
+`#MAXPATHS` is 50. `pathsReturned` is what came back, `pathCount` is the true total **of paths this
+host sits on** — including any the cap withheld — and `truncated` says whether they differ. Stated
+because the opposite choice is an open defect elsewhere in this contract (#165): a tool that capped
+silently and published a count of the *capped* list, leaving a consumer unable to tell a small
+production from a clipped one.
+
+**Both counts are scoped to the host asked about**, never to the production. Spelled out because "the
+true total" alone reads just as naturally as production-wide, and that is the reading the first
+implementation shipped (@Ari-Glikman, #186); LABDEMO cannot catch it, because one path collapses both
+readings to `1`.
 
 #### Two things measured, and one that is not
 

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1743,6 +1743,14 @@ the edge this tool exists for, and would have looked correct.
 It is derived from the production **definition**, not from runtime state, which is what makes it usable
 here at all: an investigation runs when a host is broken, and a dead host is still in the map.
 
+**The SQL query is the surface, and the alternatives are internal.** `Ens.InterfaceMaps.Utils` also
+exposes `FindAllPaths` — whose own dictionary description opens with "Internal method", and which hands
+paths back byref as `$lb(Service,Processes,Rules,DTLs,Operations)` lists — and `FindSequentialPath`,
+which takes a JSON spec whose shape is not documented anywhere reachable. The query returns the same
+data already parsed into named columns and is what the portal's own list is built on, so it is the least
+internal of the three. None of them is a published API; this is a dependency on an internal utility
+either way, and that is the honest characterisation.
+
 **No second source of truth.** Root `CLAUDE.md` §6 makes the `<Item>` set in `Production.cls`
 authoritative; this reads IRIS's own derivation of it, so there is nothing here to go stale when the
 production changes.
@@ -1755,6 +1763,14 @@ idle upstream host as a cause. Pair it with the activity, event-log and findings
 which of these hosts is actually in trouble.
 
 #### `known: false` is not an all-clear
+
+**The match is on the config item name, exactly.** Worth stating because `known` carries a
+not-an-all-clear claim and the underlying query is a *term search*: `EnumeratePaths`'s first argument is
+`pSearchTerm`, searched across services, operations, processes, **rules and transforms**. The
+implementation passes it empty and filters rows by exact equality against the config item names on each
+path, so a host name that happens to be a substring of a rule or DTL class name cannot produce
+`known: true` (@Ari-Glikman, #185). "Appears in a path" means "is one of that path's hosts", not
+"occurs somewhere in that path's text".
 
 A host that appears in no path returns `known: false`, `paths: []`, and a `note` saying so explicitly.
 That may mean it is wired to nothing, or that it is referenced only in a way the map cannot resolve.

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -61,6 +61,7 @@ silently disagrees with its neighbour is worse than one that is wrong out loud:
 | `get_event_log_trend` | `PG.Tools.EventLog` | read | `PG_Read` | `PG_Read` | `Ens_Util.Log`, bucketed, **no text** — §3.11 |
 | `get_recent_config_changes` | `PG.Tools.ChangeLog` | read | `PG_Read` | `PG_Read` | `%SYS.Audit`, `ModifyConfiguration` rows, **allowlisted** — §3.12 |
 | `get_active_findings` | `PG.Tools.Findings` | read | `PG_Read` | `PG_Read` | **nothing in IRIS** — the snapshot supplied with the request — §3.13 |
+| `get_interface_path` | `PG.Tools.Topology` | read | `PG_Read` | `PG_Read` | `Ens.InterfaceMaps.Utils` — the production's own interface map — §3.14 |
 | `set_pool_size` | `PG.Tools.Resolve` | **write** | `PG_Read` | **`PG_Resolve`** | `Ens.Config.Production` + `Ens.Director.UpdateProduction()` |
 
 ### The names in this column are section titles, not callable names
@@ -1682,6 +1683,124 @@ answer. §2.1 governs: an unmeasurable value is not a small one, and here the "v
       "message": "Queue depth 486 is 32x baseline" }
   ],
   "asOf": "2026-08-30T09:39:50Z", "state": "ok", "sanitised": true
+}
+```
+
+### 3.14 `get_interface_path` — read, added in MVP 3, and the only tool about RELATIONSHIPS
+
+**Runtime name `GetInterfacePath`.** The production's interface map for one host: which hosts feed it,
+which it feeds, and the routing rules and transformations on each path between them.
+
+**Input**: `host` (optional — omit for every path in the production).
+
+**Output**: `host`, `production`, `known`, `upstream[]`, `downstream[]`, `paths[]`, `pathCount`,
+`pathsReturned`, `truncated`, `basis`, `note`.
+
+`paths[]` entries carry `service`, `processes[]`, `operation`, `rules[]`, `transforms[]`, `hops[]` and
+`position` (`service` | `process` | `operation` — where the requested host sits). `hops[]` is the same
+path in flow order, service first, so a consumer reads neighbours off one sequence rather than
+recomposing them from three columns.
+
+#### Why it exists
+
+**Every other read tool in this family is scoped to one host, and so is the snapshot
+`investigation-api.md` §2.2 sends.** So AI Detective could describe the host it was asked about in
+detail and had no way to know another host existed.
+
+Measured on a live run: an upstream `MissingFolder` fault was fixed, 281 accumulated messages flushed
+through at once, `Cloud API` queued 296, `queue_buildup` fired, and the Detective recommended raising
+the pool to 8 — the maximum of its bounds — at 0.85 confidence, on a queue that drained to zero unaided
+while it answered. Its own evidence read *"No errors recorded in the last 60 minutes"*, which was true
+of `Cloud API` and false of the production: `EMR Source` had been erroring on every poll for twenty
+minutes inside that same window.
+
+A host-scoped tool cannot be *wrong* about another host. It can only be silent, and a model reads
+silence as absence.
+
+#### `upstream` and `downstream` are NEAREST FIRST
+
+For `Cloud API` on the LABDEMO production that is `["Lab Router", "EMR Source"]` — the host that feeds
+it, then the one that feeds that. Ordered because the consumer's question is "who handed me this work",
+and an unordered set makes the immediate feeder indistinguishable from something three hops away. The
+payload's own `note` states the order, since an array's order is not self-describing.
+
+#### It resolves ROUTING RULES, which is the whole reason to use it
+
+This tool computes nothing. It reads `Ens.InterfaceMaps.Utils` — the utility behind the Management
+Portal's Interface Maps page — whose `EnumeratePaths` query returns one row per end-to-end path.
+
+That matters because on this production the two links are declared in completely different places:
+
+```
+EMR Source -> Lab Router     a TargetConfigNames setting on the service
+Lab Router -> Cloud API      a <send target="Cloud API"/> inside RoutingRule.cls
+```
+
+The second is **invisible to anything that reads settings.** The utility walks routing rules, DTLs and
+BPL diagrams to find it. A topology hand-built from `TargetConfigNames` would have been missing exactly
+the edge this tool exists for, and would have looked correct.
+
+It is derived from the production **definition**, not from runtime state, which is what makes it usable
+here at all: an investigation runs when a host is broken, and a dead host is still in the map.
+
+**No second source of truth.** Root `CLAUDE.md` §6 makes the `<Item>` set in `Production.cls`
+authoritative; this reads IRIS's own derivation of it, so there is nothing here to go stale when the
+production changes.
+
+#### WIRING, NOT TRAFFIC — the available misreading
+
+`upstream` means "is configured to feed this host". It is **not** a claim that the host is sending
+anything, has sent anything recently, or is healthy. A consumer that conflates the two will report an
+idle upstream host as a cause. Pair it with the activity, event-log and findings tools to find out
+which of these hosts is actually in trouble.
+
+#### `known: false` is not an all-clear
+
+A host that appears in no path returns `known: false`, `paths: []`, and a `note` saying so explicitly.
+That may mean it is wired to nothing, or that it is referenced only in a way the map cannot resolve.
+**It is not evidence that the host is healthy or that nothing feeds it** — §2.1's rule, applied to a
+map instead of a metric.
+
+#### Truncation is reported, never silent
+
+`#MAXPATHS` is 50. `pathsReturned` is what came back, `pathCount` is the true total, and `truncated`
+says whether they differ. Stated because the opposite choice is an open defect elsewhere in this
+contract (#165): a tool that capped silently and published a count of the *capped* list, leaving a
+consumer unable to tell a small production from a clipped one.
+
+#### Two things measured, and one that is not
+
+**Cost: 33.7 ms** on this production. The utility walks rules and transforms, so that number describes
+three hosts and one path and says nothing about a fifty-host production. A consumer on a large
+production should expect this to be the slowest read in the family.
+
+**The `Processes` separator for a chain of two or more processes is UNVERIFIED.** LABDEMO has exactly
+one business process, so no path in it has two, and the utility's row-building source is not shipped.
+The implementation splits defensively — any control character, or a comma-space — and getting it wrong
+degrades to one unsplit name in `upstream`, not a wrong answer about who is upstream of whom. Stated
+rather than implied, because a caveat that is discovered later reads as a defect.
+
+**The data boundary is not at risk here** the way it is for `get_recent_errors` (§3.4). Every value is
+a config item name, a rule class name or a DTL class name — configuration, per §6. Rule and transform
+class names are included because "which transform runs between these two hosts" is diagnostic; their
+contents are never read.
+
+```jsonc
+// <- host "Cloud API"
+{
+  "host": "Cloud API", "production": "ProductionGuardian.LabDemo.Production", "known": true,
+  "upstream": ["Lab Router", "EMR Source"],
+  "downstream": [],
+  "paths": [
+    { "service": "EMR Source", "processes": ["Lab Router"], "operation": "Cloud API",
+      "rules": ["ProductionGuardian.LabDemo.RoutingRule"],
+      "transforms": ["ProductionGuardian.LabDemo.Transform.HL7ToPID"],
+      "hops": ["EMR Source", "Lab Router", "Cloud API"],
+      "position": "operation" }
+  ],
+  "pathCount": 1, "pathsReturned": 1, "truncated": false,
+  "basis": "Ens.InterfaceMaps.Utils",
+  "note": "upstream and downstream are NEAREST FIRST: ... This describes how the production is WIRED, from its configuration, not what is flowing through it now ..."
 }
 ```
 


### PR DESCRIPTION
Contract half of #177, separate per root `CLAUDE.md` §4. **Two files, both additive** — `mcp-tools.md` gains one read tool (§3.14, `get_interface_path`), `investigation-api.md` §2.2 gains one nullable field on `trend`. No existing field changes type or meaning.

The topology source is @tanifgit's suggestion: **IRIS's own Interface Maps feature.** It turned out to be fully queryable.

## Why a tool at all

Every read tool in `mcp-tools.md` is scoped to **one host**, and so is the snapshot §2.2 sends. So AI Detective could describe the host it was asked about in detail and had no way to know another host existed.

Measured: an upstream fault was fixed, 281 accumulated messages flushed through at once, `Cloud API` queued 296, and the Detective recommended the **maximum** pool of 8 at 0.85 confidence — on a queue that drained to zero unaided while it answered. Its own evidence read *"No errors recorded in the last 60 minutes"*, true of `Cloud API` and false of the production: `EMR Source` had been erroring every poll for twenty minutes inside that window.

A host-scoped tool cannot be *wrong* about another host. It can only be silent, and a model reads silence as absence.

## Why IRIS's map rather than reading config

`Ens.InterfaceMaps.Utils` **resolves routing rules**, and that is the whole reason. On this production:

```
EMR Source -> Lab Router     a TargetConfigNames setting on the service
Lab Router -> Cloud API      a <send target="Cloud API"/> inside RoutingRule.cls
```

The second is invisible to anything that reads settings. The utility walks rules, DTLs and BPL to find it. **A topology hand-built from `TargetConfigNames` would have been missing exactly the edge this tool exists for, and would have looked correct.** It is also derived from the production *definition*, so it still answers when a host is dead — which is when an investigation runs.

§3.14 records the two surfaces of that utility I tried and rejected: `FindAllPaths` returns a control-character-delimited string (undocumented internal encoding, and #161 is open about control chars in source), and `FindSequentialPath` wants a JSON spec whose shape isn't documented — a path string returns `ERROR #5035 ... 'Parsing error'`.

## `trend.recentDirection`, and a deviation it works around

This is the part worth a careful read. §2.2 has **always** specified `slope` as *"may be zero or negative here … because a queue that is draining is a fact the agent should see"*, and its §4 example carries a non-null slope beside `thresholdCrossed: true`.

**The engine has never delivered that.** It reads `slope` from Early Warning's `projection`, which is `null` for `already_crossed` — i.e. for *every* condition this endpoint is called about. So the one fact needed to tell a recovery from a runaway was specified, documented, and absent, and the measured consequence was a recommendation to enlarge a pool on a queue falling 261 → 181.

`recentDirection` (from `earlywarning-api.md` §1.5) is the half fixable without reopening that contract's §1.4 prohibition on a bare slope beside a withheld forecast: **a direction is not a rate**, so it carries no forecast to mislabel — the same argument that lets `kind: 'projection'` stay absent.

**The `slope` deviation is not fixed here** and is filed separately: honouring it needs the window slope published or refitted, which is `earlywarning-api.md`'s decision rather than this one's.

## Stated rather than left to be discovered

- **Cost: 33.7 ms measured**, on three hosts and one path. It walks rules and transforms, so that says nothing about a fifty-host production.
- **The `Processes` separator for a chain of 2+ processes is UNVERIFIED.** LABDEMO has exactly one business process, and the utility's row-building source is not shipped. The implementation splits defensively; getting it wrong degrades to one unsplit name in `upstream`, not a wrong answer about who is upstream of whom.
- **Truncation is reported** (`truncated`, `pathCount` vs `pathsReturned`), because the opposite choice is an open defect in this same contract (#165).

## Consumer impact: none required

Both changes are additive. A consumer already handling a `null` `slope` — which is what has always arrived — needs no change.

`npm run validate` — all checks passed (3 samples, 15 accept, 26 reject, 7 capture claims).

Per §4 this needs review by every other developer. **Not merging this without a nod** — yesterday's self-review arrangement was explicitly for yesterday. Implementation follows in a paired PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)