### PR TITLE
feat: AI Detective can see what feeds the host it is investigating (#177)

### DIFF
--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -746,6 +746,34 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "errors. A host with a queue, a normal processing time and only stale errors is the "
     set p = p _ "pool case, not the connectivity case. "
 
+    // THE INTERFACE MAP, AND IT IS THE FIRST TOOL HERE THAT IS NOT ABOUT ONE HOST (#177).
+    //
+    // Named in the form the runtime accepts -- `GetInterfacePath` -- for the reason recorded above the
+    // activity tools: `%AI.ToolMgr` derives the tool name from the ClassMethod name, and the
+    // snake_case spelling in the contract's section titles is not callable. Naming a tool the model
+    // cannot call fails silently, looking like a model that chose not to call anything.
+    //
+    // WHAT IT FIXES. Every other read tool is host-scoped, and so is the snapshot, so the model had no
+    // way to know another host existed. Measured: an upstream `MissingFolder` fault was fixed, 281
+    // accumulated messages flushed through at once, `Cloud API` queued 296, and the Detective
+    // recommended pool 8 -- the maximum -- at 0.85 confidence on a queue that drained to zero unaided
+    // while it answered. Its own evidence read "No errors recorded in the last 60 minutes", true of
+    // `Cloud API` and false of the production: `EMR Source` had been erroring every poll for twenty
+    // minutes inside that window.
+    //
+    // THE WIRING/TRAFFIC DISTINCTION IS SPELLED OUT because it is the available misreading. The map is
+    // built from configuration, so "upstream" means "is configured to feed this host", not "is sending
+    // it anything now" -- and a model that conflated the two would report an idle upstream host as a
+    // cause.
+    set p = p _ "GetInterfacePath returns this production's interface map for one host: which hosts "
+    set p = p _ "feed it (upstream) and which it feeds (downstream), NEAREST FIRST, with the routing "
+    set p = p _ "rules and transformations on each path. It is derived from the production's "
+    set p = p _ "configuration, so it says how the production is WIRED and not what is flowing now: an "
+    set p = p _ "upstream host is one configured to feed this one, which is not evidence that it sent "
+    set p = p _ "anything. Use it whenever a finding could have been caused somewhere else, and use the "
+    set p = p _ "host names it returns as the argument to the other read tools -- that is how you look "
+    set p = p _ "at a host other than the one under investigation. "
+
     // SIZE THE POOL, DO NOT DOUBLE IT. The model reliably suggested `current + 1` -- 1 -> 2 -- which
     // on the demo scenario is EXACTLY break-even and therefore fixes nothing. Measured live at pool 2
     // with 2 msg/sec arriving and 1.01s of work each: queue 112, 112, 114 over 50 seconds. It was not
@@ -1022,6 +1050,85 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     // that sees a non-zero number next to an empty list must not narrate it as one.
     set g = g _ " noOpSaves counts saves where the value did not move. It is NOT a change: never"
     set g = g _ " report it as one, and never treat a non-zero count as evidence of anything."
+
+    // A FOURTH MANDATORY CALL, AND IT IS MANDATORY FOR THE REASON THE OTHER THREE ARE (#177).
+    //
+    // `iris/CLAUDE.md` §7: register it, describe it, and name it in a MUST -- and the third is the one
+    // that keeps being skipped. Measured twice already, on `get_recent_errors` and then again on
+    // `GetRecentConfigChanges`, which was registered with its prompt paragraph verified present in the
+    // compiled routine and still went uncalled because the model had a satisfying answer after two
+    // calls and stopped.
+    //
+    // UNCONDITIONAL, rather than gated on the finding type or on the model's judgement -- the same
+    // argument the config-change directive above makes, arriving with more force. "Might this have been
+    // caused elsewhere?" is a judgement about the DIAGNOSIS, and the model cannot make it before
+    // gathering evidence, which is the circularity that leaves a tool uncalled. One bounded query,
+    // measured at 33.7 ms, against the one time it mattered and was skipped.
+    set g = g _ " You MUST also call GetInterfacePath on this host before concluding, to find out what"
+    set g = g _ " feeds it. Every other tool here answers about ONE host, so without this you cannot"
+    set g = g _ " tell whether the cause is upstream."
+
+    // AND THE REASONING IT IS FOR, which is the whole point of the tool and is stated as a QUESTION TO
+    // ANSWER rather than as a conclusion to reach. The failure being designed out is confident sizing
+    // arithmetic on a backlog that is already draining: measured at pool 4, queue 296 falling to 0
+    // unaided, and a recommendation of 8 at 0.85 confidence.
+    //
+    // POSITIVE EVIDENCE ONLY, and this is load-bearing. `DropPoolFixDuringOutage` in this class already
+    // establishes the rule -- it "only ever fires on POSITIVE evidence, never on absent evidence" --
+    // and the same discipline has to bind the model here, or a directive about transients becomes a
+    // reason to hedge on the ordinary sustained rise. That rise is the flagship scenario and #108's
+    // standing acceptance check; making the Detective timid about it would be a worse defect than the
+    // one being fixed.
+    //
+    // THE THREE SIGNALS ARE NAMED because "consider whether it is transient" is a description, and
+    // descriptions do not change behaviour. Each is already obtainable: the trend is in this goal, the
+    // upstream host names come from the tool above, and `secondsAgo` is already in `get_recent_errors`.
+    // AND THEN READ THE UPSTREAM HOST, AS ITS OWN MUST. This was one clause of a longer sentence in
+    // the first version and the model did exactly what §7 predicts: it called GetInterfacePath,
+    // correctly reported that `Lab Router` and `EMR Source` feed `Cloud API`, and then never looked at
+    // either of them. Measured on the armed transient -- `toolCalls: 4`, upstream named in evidence,
+    // and a recommendation to raise the pool 4 -> 6 on a queue falling 261 -> 181.
+    //
+    // Knowing the name and reading the host are different acts, and only the second is a MUST here.
+    set g = g _ " Having the upstream names is not enough: you MUST then call get_recent_errors with"
+    set g = g _ " sinceMinutes 60 on EACH host in the upstream list, nearest first, and read secondsAgo"
+    set g = g _ " on what comes back. An error on THIS host and an error on the host feeding it are"
+    set g = g _ " different faults with different fixes, and 'no errors' about this host says nothing"
+    set g = g _ " about the production."
+    // EACH, NOT THE NEAREST, and this is a measured correction rather than a thoroughness reflex. With
+    // "the nearest upstream host" the model read `Lab Router` -- which was genuinely clean -- and
+    // reached the right verdict by the weaker route of "no ongoing fault anywhere", never seeing that
+    // `EMR Source` two hops up had been in Error for twenty minutes and was fixed three minutes
+    // earlier. Same conclusion, but the diagnosis an operator needs is the second one, and on a
+    // scenario where the nearest host DID have a stale error the weaker route would have misread it.
+    //
+    // Bounded by `#MAXITERATIONS` (8) rather than by a cap here: the measured run used 5 of 8, so a
+    // second upstream read fits, and a chain long enough to exhaust the budget stops on its own.
+    set g = g _ " A fault two hops upstream is still the cause of your queue."
+
+    set g = g _ " Then decide whether this host is the CAUSE or the VICTIM, using evidence and never"
+    set g = g _ " assumption. A queue can build on a host that is keeping up perfectly, because"
+    set g = g _ " something upstream stopped and was then fixed, releasing a backlog that is now"
+    set g = g _ " draining THROUGH this host. Three things distinguish that from a genuine sustained"
+    set g = g _ " rise, and you must check all three: trend.recentDirection, where ""falling"" means"
+    set g = g _ " the queue is already coming down on the pool it already has; whether the upstream"
+    set g = g _ " host you just read has errors that have ENDED, which secondsAgo tells you; and"
+    set g = g _ " whether the pool was already enlarged shortly before now, which"
+    set g = g _ " GetRecentConfigChanges shows."
+    set g = g _ " If those say the backlog is draining through after an upstream fault that has ended,"
+    set g = g _ " say so in rootCause, name the upstream host, and set recommendedAction to null --"
+    set g = g _ " enlarging a pool that is already clearing its backlog fixes nothing and is a"
+    set g = g _ " configuration change nobody needed. Only conclude this on POSITIVE evidence: a queue"
+    set g = g _ " that is rising, or an upstream host with no ended fault, is the ordinary case and"
+    set g = g _ " still wants the pool sized properly. Absence of evidence is not evidence of a"
+    set g = g _ " transient."
+    // THE LAG IS STATED, because the field it points at has one. `earlywarning-api.md` §1.5 measured
+    // the tail fit taking ~35s to turn after a real peak, so a burst that has just landed still reads
+    // "rising" while it drains. A model told only "falling means draining" would read the inverse as
+    // "rising means growing" and reach the confident wrong answer faster.
+    set g = g _ " trend.recentDirection is fitted over the recent past and takes tens of seconds to"
+    set g = g _ " turn, so ""rising"" shortly after a burst arrived does not prove the queue is still"
+    set g = g _ " growing. Weigh it with the upstream errors rather than on its own."
 
     // ATTRIBUTION, RESTATED HERE, and it is a repair rather than a belt-and-braces addition. The
     // directive above cost the reply its evidence attribution: the first version closed with "report

--- a/iris/labdemo/Tools/Governance.cls
+++ b/iris/labdemo/Tools/Governance.cls
@@ -115,6 +115,27 @@ Parameter CHANGELOGTOOLS = "ProductionGuardian.LabDemo.Tools.ChangeLog";
 /// is set rather than after it is read.
 Parameter FINDINGTOOLS = "ProductionGuardian.LabDemo.Tools.Findings";
 
+/// The interface-map tool — which host feeds which, from the production's own configuration.
+///
+/// REGISTERED FOR `"all"` ONLY, which makes it the mirror image of `FINDINGTOOLS` above. AI Detective
+/// is the caller that needs it: every other read tool in this family is scoped to ONE host, and so is
+/// the snapshot `/api/investigate` sends, so before this the agent could not tell that any other host
+/// existed. Measured on #177 -- an upstream fault was fixed, the flushed backlog queued on
+/// `Cloud API`, and the Detective recommended doubling a pool on a queue that was draining unaided,
+/// having never looked at the host that caused it.
+///
+/// NOT GIVEN TO `"chat"` YET, deliberately and not for lack of use: "what feeds Cloud API" is a fair
+/// chat question. It is held back because the chat's capability text and its suggestion chips
+/// enumerate what it can read (#175), so a fifth family there is a copy change in two more places and
+/// belongs with that work rather than smuggled in with a Detective fix.
+///
+/// ITS OWN CLASS, on `Tools.EventLog`'s and `Tools.ChangeLog`'s reason: a new tool FAMILY in a new
+/// file moves `Setup.AIHub.ReportTools()`'s count by an amount attributable to one file. The stronger
+/// reason here is subject matter -- this is the only tool that describes RELATIONSHIPS between hosts
+/// rather than the state of one, and putting it on `Tools.Read` would leave a model one docstring away
+/// from reading "upstream" as a live traffic claim.
+Parameter TOPOLOGYTOOLS = "ProductionGuardian.LabDemo.Tools.Topology";
+
 /// The write-tool class, in its own class so the RBAC requirement does not leak onto the reads.
 Parameter WRITETOOLS = "ProductionGuardian.LabDemo.Tools.Resolve";
 
@@ -162,6 +183,12 @@ ClassMethod ToolManager(pIncludeWrite As %Boolean = 1, Output pStatus As %Status
         quit $$$NULLOREF
     }
     set pStatus = mgr.RegisterToolSet(..#CHANGELOGTOOLS)
+    if $$$ISERR(pStatus) {
+        quit $$$NULLOREF
+    }
+    // Context-free, unlike `FINDINGTOOLS`: the interface map is read from the production definition, so
+    // it answers the same question through this manager as through an agent's.
+    set pStatus = mgr.RegisterToolSet(..#TOPOLOGYTOOLS)
     if $$$ISERR(pStatus) {
         quit $$$NULLOREF
     }
@@ -241,13 +268,18 @@ ClassMethod GovernAgent(pAgent As %AI.Agent, pIncludeWrite As %Boolean = 1, pToo
 
     // ONE POSITIVE CONDITION PER TOOL SET, spelling the membership out:
     //
-    //     all       READTOOLS  ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS                  AI Detective
-    //     chat                 ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS  FINDINGTOOLS    ChatDispatcher
-    //     activity             ACTIVITYTOOLS                                                 unchanged from before "chat"
-    //     current   READTOOLS                                                               live state only
+    //     all       READTOOLS  ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS                  TOPOLOGYTOOLS  AI Detective
+    //     chat                 ACTIVITYTOOLS  EVENTLOGTOOLS  CHANGELOGTOOLS  FINDINGTOOLS                   ChatDispatcher
+    //     activity             ACTIVITYTOOLS                                                                unchanged from before "chat"
+    //     current   READTOOLS                                                                               live state only
     //
-    // `FINDINGTOOLS` IS IN EXACTLY ONE ROW, deliberately -- see its parameter comment. It is the only
-    // entry here that is not simply "does this caller want history", because the tool republishes what
+    // TWO FAMILIES NOW SIT IN EXACTLY ONE ROW EACH, from opposite ends: `FINDINGTOOLS` is chat-only
+    // because AI Detective's caller supplies no snapshot, and `TOPOLOGYTOOLS` is Detective-only because
+    // the chat's own capability text enumerates what it can read (#175) and widening it belongs with
+    // that copy rather than with a Detective fix. Both are argued at their parameters.
+    //
+    // `FINDINGTOOLS` is the only entry here that is not simply "does this caller want history",
+    // because the tool republishes what
     // the caller supplied and AI Detective's caller supplies nothing.
     //
     // Written positively rather than as the `'= "activity"` exclusions this used to hold. With two
@@ -279,6 +311,12 @@ ClassMethod GovernAgent(pAgent As %AI.Agent, pIncludeWrite As %Boolean = 1, pToo
     }
     if pToolSets = "chat" {
         set sc = pAgent.ToolManager.RegisterToolSet(..#FINDINGTOOLS)
+        if $$$ISERR(sc) {
+            quit sc
+        }
+    }
+    if pToolSets = "all" {
+        set sc = pAgent.ToolManager.RegisterToolSet(..#TOPOLOGYTOOLS)
         if $$$ISERR(sc) {
             quit sc
         }

--- a/iris/labdemo/Tools/Topology.cls
+++ b/iris/labdemo/Tools/Topology.cls
@@ -90,6 +90,13 @@
 /// #165 is open against exactly the opposite choice -- a tool that capped silently and published a
 /// count of the capped list, so a consumer could not tell a small production from a clipped one.
 ///
+/// **THE COUNTING AND TRUNCATION BRANCHES CANNOT BE REACHED ON LABDEMO, SO CHECK THEM BY READING.**
+/// Three defects here in review were all in that dead zone -- a production-wide `pathCount`, a
+/// `truncated` a non-matching row could set, and a note reading "50 of 50" -- because one path and one
+/// matching host collapse `pathCount`, `pathsReturned` and `total` to 1, and 50 paths are unreachable.
+/// Every one of them would have published a confident wrong number to a model. Anything touching the
+/// row loop wants a >50-path production in your head, since there is not one to run against.
+///
 /// CONFIGURATION ONLY, so §6's data boundary is not at risk here in the way it is for
 /// `GetRecentErrors`: every value is a config item name, a rule class name or a DTL class name. No
 /// message content, no PHI, nothing read from `Ens_Util.Log`. Rule and transform CLASS names are
@@ -263,7 +270,7 @@ ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
         set out.downstream = downstream
         do out.%Set("known", out.known, "boolean")
     }
-    set out.note = ..Note(host, out.known, paths.%Size(), truncated)
+    set out.note = ..Note(host, out.known, paths.%Size(), truncated, total)
     quit out
 }
 
@@ -306,7 +313,7 @@ ClassMethod PositionOf(host As %String, svc As %String, op As %String, procs As 
 /// reads the thing it was handed. The three sentences that matter are the ORDER of the arrays, that a
 /// wiring map is not a statement about current traffic, and -- when the host is not in the map -- that
 /// this is not evidence the host is fine.
-ClassMethod Note(host As %String, known As %Boolean, returned As %Integer, truncated As %Boolean) As %String [ Private ]
+ClassMethod Note(host As %String, known As %Boolean, returned As %Integer, truncated As %Boolean, total As %Integer) As %String [ Private ]
 {
     if (host '= "") && 'known {
         quit host _ " does not appear in any path of this production's interface map. That may mean "
@@ -318,8 +325,13 @@ ClassMethod Note(host As %String, known As %Boolean, returned As %Integer, trunc
         _ "configuration, not what is flowing through it now -- a host being upstream does not mean "
         _ "it is currently sending anything."
     if truncated {
-        set note = note _ " The path list is TRUNCATED at " _ returned _ " of " _ ..#MAXPATHS
-            _ "; pathCount is the true total."
+        // `total`, NOT `#MAXPATHS` (@Ari-Glikman, #186). `truncated` is only set once `paths` has
+        // reached the cap, so `returned` is always exactly `#MAXPATHS` here -- the sentence read
+        // "TRUNCATED at 50 of 50", a complete-looking ratio in the same breath as the word TRUNCATED,
+        // and the one number that informs the reader was the one not passed in. The prose is what the
+        // model consumes, so this is not the cosmetic defect the same sentence would be on a dashboard.
+        set note = note _ " The path list is TRUNCATED at " _ returned _ " of " _ total
+            _ " paths this host sits on; pathCount carries the true total."
     }
     quit note
 }

--- a/iris/labdemo/Tools/Topology.cls
+++ b/iris/labdemo/Tools/Topology.cls
@@ -1,0 +1,308 @@
+/// MCP read tool over the production's INTERFACE MAP — which host feeds which.
+///
+/// Implements the one tool in `contracts/mcp-tools.md` §3.14. That contract is authoritative; where
+/// this class and it disagree, the contract is right and this is a bug.
+///
+/// WHY THIS EXISTS (#177). Every other read tool in this family is scoped to ONE host, and so is the
+/// snapshot the engine sends with an investigation. So AI Detective could describe the host it was
+/// asked about in detail and could not see that anything else existed. Measured on a live run: an
+/// upstream `MissingFolder` fault was fixed, 281 accumulated messages flushed through in one burst,
+/// `Cloud API` queued 296 and `queue_buildup` fired — and the Detective, reading only `Cloud API`,
+/// recommended doubling the pool to the maximum of its bounds at 0.85 confidence, on a queue that
+/// drained to zero unaided while it was writing. Its own evidence said "No errors recorded in the
+/// last 60 minutes", which was true of `Cloud API` and false of the production: `EMR Source` had been
+/// erroring every poll for twenty minutes inside that same window.
+///
+/// A host-scoped tool cannot be wrong about that. It can only be silent, and a model reads silence as
+/// absence.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// IRIS ALREADY KNOWS THE ANSWER, AND IT IS NOT IN THE SETTINGS
+///
+/// This tool computes nothing. `Ens.InterfaceMaps.Utils` is the engine behind the Management Portal's
+/// Interface Maps page, and its `EnumeratePaths` query returns one row per end-to-end path with the
+/// columns `Service, Processes, Rules, Transforms, Operation`.
+///
+/// THAT IT RESOLVES RULES IS THE WHOLE REASON TO USE IT rather than reading config here. On this
+/// production the two links are declared in completely different places:
+///
+///   EMR Source -> Lab Router    a `TargetConfigNames` setting on the service
+///   Lab Router -> Cloud API     a `<send target="Cloud API"/>` inside RoutingRule.cls
+///
+/// The second is invisible to anything that reads settings. `Ens.InterfaceMaps.Utils` walks routing
+/// rules, DTLs and BPL diagrams (`findRuleConnections`, `handleSendTag`, `findBPLUse`) to find it. A
+/// hand-rolled topology built from `TargetConfigNames` would have produced a map missing precisely
+/// the edge #177 needs, and it would have looked right.
+///
+/// It also derives the map from the production DEFINITION rather than from runtime state, which is
+/// what makes it usable here at all: an investigation runs when a host is broken, and a dead host is
+/// still in the map.
+///
+/// NO SECOND SOURCE OF TRUTH. Root `CLAUDE.md` §6 makes the `<Item>` set in `Production.cls`
+/// authoritative and forbids restating it; this reads IRIS's own derivation of it, so there is nothing
+/// here to go stale when the production changes. That is the same argument `Tools.Read` makes for
+/// reading `Ens.Config.Item` instead of a copied host list.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// THE QUERY, AND THE TWO SURFACES DELIBERATELY NOT USED
+///
+/// `Ens.InterfaceMaps.Utils` offers three ways in. This uses the SQL query, and the other two were
+/// tried and rejected on evidence:
+///
+///   - `FindAllPaths()` returns each path as ONE STRING delimited by raw control characters --
+///     measured as $c(12), $c(11) and $c(1) at byte offsets in a 122-character path. An undocumented
+///     internal encoding, and #161 is open in this repo about exactly what raw control characters do
+///     to a source file. The SQL query is that same data already parsed into named columns.
+///   - `FindSequentialPath()` takes a JSON "spec" whose shape is not documented anywhere reachable.
+///     Passing it a path string from `FindAllPaths` returns `ERROR #5035 ... 'Parsing error'`. Guessing
+///     at an undocumented request shape would be a version-fragile dependency on an internal.
+///
+/// The query cost 33.7 ms on this production, measured. It walks rules and transforms, so that number
+/// is about three hosts and one path and says nothing about a fifty-host production -- see the
+/// contract's note.
+///
+/// **THE `Processes` COLUMN'S SEPARATOR FOR A CHAIN OF TWO OR MORE PROCESSES IS UNVERIFIED**, and
+/// cannot be verified here: LABDEMO has exactly one business process, so no path in it has two. The
+/// implementation source is not shipped, so it could not be read either. `SplitList` therefore parses
+/// defensively -- any control character, or a comma-space -- and the contract records the gap rather
+/// than implying it was checked. Getting this wrong on a longer chain degrades to a process name that
+/// is not split, i.e. one wrong entry in `upstream`, not a wrong ANSWER about who is upstream of whom.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────
+/// WHAT IT RETURNS, AND WHY `upstream` IS ORDERED
+///
+/// `upstream` and `downstream` are NEAREST FIRST. For `Cloud API` that is `["Lab Router",
+/// "EMR Source"]` -- the host that feeds it, then the one that feeds that. Ordered because the model's
+/// question is "who handed me this work", and an unordered set makes the immediate feeder
+/// indistinguishable from something three hops away. Stated in the payload's own `note` as well, since
+/// an array's order is not self-describing.
+///
+/// A TRUNCATED RESULT SAYS SO. `#MAXPATHS` caps what is returned and `truncated` reports it, because
+/// #165 is open against exactly the opposite choice -- a tool that capped silently and published a
+/// count of the capped list, so a consumer could not tell a small production from a clipped one.
+///
+/// CONFIGURATION ONLY, so §6's data boundary is not at risk here in the way it is for
+/// `GetRecentErrors`: every value is a config item name, a rule class name or a DTL class name. No
+/// message content, no PHI, nothing read from `Ens_Util.Log`. Rule and transform CLASS names are
+/// included because "which transform runs between these two hosts" is diagnostic and is configuration;
+/// their contents are not read.
+Class ProductionGuardian.LabDemo.Tools.Topology Extends %AI.Tool
+{
+
+/// The production these tools report on. Same value as `Tools.Read.#PRODUCTION`, and deliberately NOT
+/// imported from it, for the reason stated there: a tool that silently followed another class's change
+/// would start reporting on a production it was not authorised for.
+Parameter PRODUCTION = "ProductionGuardian.LabDemo.Production";
+
+/// Cap on returned paths. Reported through `truncated` rather than applied silently (#165).
+///
+/// 50 rather than the 25 the findings tool uses: a path is one short row and the whole value of this
+/// tool is seeing the shape of the production, where a clipped map could hide the one branch that
+/// explains the fault. Still bounded, because the return value reaches a metered model.
+Parameter MAXPATHS = 50;
+
+/// Which hosts feed, and are fed by, one interoperability host — the production's interface map.
+///
+/// Use this whenever a finding might have been CAUSED SOMEWHERE ELSE. A queue building on a host that
+/// is keeping up with its own work is the classic case: the work arrived in a burst because something
+/// upstream was stopped and has been fixed, and the queue is draining through rather than growing.
+///
+/// `upstream` and `downstream` are nearest-first: the first entry in `upstream` is the host that hands
+/// work directly to this one. The paths this host sits on are returned whole, with the routing rules
+/// and transforms that connect each hop, so a fault can be traced to the hop that carries it.
+///
+/// Derived from the production's configuration by IRIS's own interface-map utility, which resolves
+/// routing rules and transformations -- not only the `TargetConfigNames` settings. It describes how
+/// the production is WIRED, not what is flowing now: pair it with the activity, event-log and findings
+/// tools to see which of these hosts is actually in trouble.
+///
+/// Pass `host` to place one host in the map, or omit it for every path in the production.
+ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
+{
+    set out = { "host": null, "production": (..#PRODUCTION), "known": false,
+        "upstream": null, "downstream": null, "paths": null,
+        "pathCount": 0, "pathsReturned": 0, "truncated": false,
+        "basis": "Ens.InterfaceMaps.Utils", "note": null }
+    // null when unfiltered, so "the whole production" and "a host whose name is empty" are different
+    // payloads rather than the same one -- `Tools.Findings`'s rule, for its reason.
+    if host '= "" {
+        set out.host = host
+    }
+
+    set paths = [], upstream = [], downstream = []
+    // Sets rather than arrays for the dedupe, keyed by name, with the nearest-first ORDER kept
+    // separately: a host can sit on several paths and must not appear twice.
+    kill seenUp, seenDown
+    set truncated = 0, total = 0
+
+    try {
+        set rs = ##class(%SQL.Statement).%ExecDirect(
+            ,
+            "SELECT Service, Processes, Rules, Transforms, Operation "
+                _ "FROM Ens_InterfaceMaps.Utils_EnumeratePaths(?,?,?,?,?,?)",
+            "",
+            // Every category in, because a filtered map would answer a different question than the
+            // one asked. The shape is the utility's own default.
+            "{""svc"":1,""op"":1,""proc"":1,""rule"":1,""xform"":1}",
+            0,
+            ..#PRODUCTION,
+            "",
+            ""
+        )
+        if rs.%SQLCODE < 0 {
+            set out.note = "the interface map could not be read: SQLCODE " _ rs.%SQLCODE _ " " _ rs.%Message
+            // RETURN, not QUIT: inside a TRY block `quit` exits the BLOCK and refuses an argument
+            // (#1043). `Tools.Findings` carries the same note at the same kind of early exit.
+            return out
+        }
+
+        while rs.%Next() {
+            set total = total + 1
+            if paths.%Size() >= ..#MAXPATHS {
+                set truncated = 1
+                continue
+            }
+
+            set svc = $zstrip(rs.Service, "<>W")
+            set op = $zstrip(rs.Operation, "<>W")
+            set procs = ..SplitList(rs.Processes)
+            set rules = ..SplitList(rs.Rules)
+            set xforms = ..SplitList(rs.Transforms)
+
+            // The hops in flow order, service first. One list, so position and neighbours are read
+            // off the same sequence rather than reasoned about per column -- which is what made the
+            // rule-derived link easy to lose.
+            set hops = []
+            if svc '= "" {
+                do hops.%Push(svc)
+            }
+            set pit = procs.%GetIterator()
+            while pit.%GetNext(.pk, .pv) {
+                do hops.%Push(pv)
+            }
+            if op '= "" {
+                do hops.%Push(op)
+            }
+
+            set position = ""
+            if host '= "" {
+                set at = -1
+                for i = 0:1:hops.%Size() - 1 {
+                    if hops.%Get(i) = host {
+                        set at = i
+                        quit
+                    }
+                }
+                if at < 0 {
+                    // This path does not involve the host asked about. Not returned: the map for one
+                    // host is the paths it sits on, and every other path is noise a model would have
+                    // to filter itself.
+                    continue
+                }
+                set out.known = 1
+                set position = $case(at, 0: "service", (hops.%Size() - 1): "operation", : "process")
+                // NEAREST FIRST in both directions -- walking outwards from the host rather than
+                // along the path, which is the order the docstring promises.
+                for i = at - 1:-1:0 {
+                    set name = hops.%Get(i)
+                    if '$data(seenUp(name)) {
+                        set seenUp(name) = ""
+                        do upstream.%Push(name)
+                    }
+                }
+                for i = at + 1:1:hops.%Size() - 1 {
+                    set name = hops.%Get(i)
+                    if '$data(seenDown(name)) {
+                        set seenDown(name) = ""
+                        do downstream.%Push(name)
+                    }
+                }
+            }
+
+            set entry = { "service": (svc), "processes": (procs), "operation": (op),
+                "rules": (rules), "transforms": (xforms), "hops": (hops) }
+            if position '= "" {
+                set entry.position = position
+            }
+            do paths.%Push(entry)
+        }
+    } catch ex {
+        // The map is a diagnostic aid, so a failure to read it must not take an investigation down.
+        // Reported as a reason rather than thrown, matching every other tool in this family.
+        set out.note = "the interface map could not be read: " _ ex.DisplayString()
+        return out
+    }
+
+    set out.paths = paths
+    set out.pathsReturned = paths.%Size()
+    set out.pathCount = total
+    do out.%Set("truncated", truncated, "boolean")
+    if host '= "" {
+        set out.upstream = upstream
+        set out.downstream = downstream
+        do out.%Set("known", out.known, "boolean")
+    }
+    set out.note = ..Note(host, out.known, paths.%Size(), truncated)
+    quit out
+}
+
+/// The payload's own explanation of what it does and does not assert. Private.
+///
+/// Written into the payload rather than left to the prompt, for `Tools.ChangeLog`'s reason: a model
+/// reads the thing it was handed. The three sentences that matter are the ORDER of the arrays, that a
+/// wiring map is not a statement about current traffic, and -- when the host is not in the map -- that
+/// this is not evidence the host is fine.
+ClassMethod Note(host As %String, known As %Boolean, returned As %Integer, truncated As %Boolean) As %String [ Private ]
+{
+    if (host '= "") && 'known {
+        quit host _ " does not appear in any path of this production's interface map. That may mean "
+            _ "it is not wired to anything, or that it is referenced only in a way the map cannot "
+            _ "resolve -- it is NOT evidence that the host is healthy or that nothing feeds it."
+    }
+    set note = "upstream and downstream are NEAREST FIRST: the first entry in upstream hands work "
+        _ "directly to this host. This describes how the production is WIRED, from its "
+        _ "configuration, not what is flowing through it now -- a host being upstream does not mean "
+        _ "it is currently sending anything."
+    if truncated {
+        set note = note _ " The path list is TRUNCATED at " _ returned _ " of " _ ..#MAXPATHS
+            _ "; pathCount is the true total."
+    }
+    quit note
+}
+
+/// Split one column of the interface-map row into its members. Private.
+///
+/// DEFENSIVE BECAUSE THE SEPARATOR IS UNVERIFIED. See the class comment: LABDEMO has one business
+/// process, so no path here has two, and the query's row-building source is not shipped. What IS
+/// established is that the underlying path encoding uses control characters -- measured as $c(1),
+/// $c(11) and $c(12) -- so those are split on, and a comma-space is split on as well because that is
+/// how the portal renders a list.
+///
+/// Splitting on a bare comma would be worse than not splitting: a config item name may contain one,
+/// and cutting a host name in half would put a host that does not exist into `upstream`. A separator
+/// that turns out to be something else entirely leaves one unsplit name, which is visibly wrong rather
+/// than quietly wrong.
+ClassMethod SplitList(value As %String) As %DynamicArray [ Private ]
+{
+    set out = []
+    if $get(value) = "" {
+        quit out
+    }
+    // Normalise every control character to one delimiter first, so the split below is a single pass
+    // and cannot depend on WHICH control character the utility used.
+    set norm = ""
+    for i = 1:1:$length(value) {
+        set ch = $extract(value, i)
+        set norm = norm _ $select($ascii(ch) < 32: $char(1), 1: ch)
+    }
+    set norm = $replace(norm, ", ", $char(1))
+    for i = 1:1:$length(norm, $char(1)) {
+        set piece = $zstrip($piece(norm, $char(1), i), "<>W")
+        if piece '= "" {
+            do out.%Push(piece)
+        }
+    }
+    quit out
+}
+
+}

--- a/iris/labdemo/Tools/Topology.cls
+++ b/iris/labdemo/Tools/Topology.cls
@@ -49,10 +49,19 @@
 /// `Ens.InterfaceMaps.Utils` offers three ways in. This uses the SQL query, and the other two were
 /// tried and rejected on evidence:
 ///
-///   - `FindAllPaths()` returns each path as ONE STRING delimited by raw control characters --
-///     measured as $c(12), $c(11) and $c(1) at byte offsets in a 122-character path. An undocumented
-///     internal encoding, and #161 is open in this repo about exactly what raw control characters do
-///     to a source file. The SQL query is that same data already parsed into named columns.
+///   - `FindAllPaths()` IS AN INTERNAL METHOD, and says so itself: its dictionary description opens
+///     "Internal method for finding all of the routes through the active production". It returns a
+///     `%Status` and hands the paths back BYREF as `$listbuild` lists --
+///     `$lb(Service,Processes,Rules,DTLs,Operations)`, per that same description. The SQL query is the
+///     same data already parsed into named columns, and is what the portal's own list is built on.
+///
+///     AN EARLIER VERSION OF THIS COMMENT SAID IT RETURNED A CONTROL-CHARACTER-DELIMITED STRING IN AN
+///     UNDOCUMENTED ENCODING. That was wrong (@Ari-Glikman, #186). The $c(12), $c(11) and $c(1) bytes
+///     measured at offsets in the value are `$list` length and type HEADERS, not delimiters: verified
+///     live, `$listvalid` is 1, five elements, `$listget` reads each. Corrected in place rather than
+///     quietly dropped, because that rationale would have told the next reader the richer surface --
+///     it also yields `pCategoryItems` and a `pDeDup` flag -- was undecodable, when its layout is in
+///     the class dictionary. "Internal method" is the firmer reason and needs no decoding claim.
 ///   - `FindSequentialPath()` takes a JSON "spec" whose shape is not documented anywhere reachable.
 ///     Passing it a path string from `FindAllPaths` returns `ERROR #5035 ... 'Parsing error'`. Guessing
 ///     at an undocumented request shape would be a version-fragile dependency on an internal.
@@ -157,12 +166,6 @@ ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
         }
 
         while rs.%Next() {
-            set total = total + 1
-            if paths.%Size() >= ..#MAXPATHS {
-                set truncated = 1
-                continue
-            }
-
             set svc = $zstrip(rs.Service, "<>W")
             set op = $zstrip(rs.Operation, "<>W")
             set procs = ..SplitList(rs.Processes)
@@ -194,13 +197,18 @@ ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
                     }
                 }
                 if at < 0 {
-                    // This path does not involve the host asked about. Not returned: the map for one
-                    // host is the paths it sits on, and every other path is noise a model would have
-                    // to filter itself.
+                    // This path does not involve the host asked about. Not returned, and -- since the
+                    // counter now sits below this -- NOT COUNTED and unable to set `truncated`. Both
+                    // were bugs (@Ari-Glikman, #186): counting above the filter made `pathCount`
+                    // production-wide while `pathsReturned` was host-scoped, so a host on 3 of 60 paths
+                    // published `pathCount: 60, pathsReturned: 3, truncated: false` -- and the only
+                    // reading available to a model is "57 paths were withheld from me", which is #165's
+                    // clipped-versus-small confusion in a subtler form. Invisible on LABDEMO, where one
+                    // path and one matching host collapse all three numbers to 1.
                     continue
                 }
                 set out.known = 1
-                set position = $case(at, 0: "service", (hops.%Size() - 1): "operation", : "process")
+                set position = ..PositionOf(host, svc, op, procs)
                 // NEAREST FIRST in both directions -- walking outwards from the host rather than
                 // along the path, which is the order the docstring promises.
                 for i = at - 1:-1:0 {
@@ -217,6 +225,19 @@ ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
                         do downstream.%Push(name)
                     }
                 }
+            }
+
+            // COUNTED HERE, once the row is known to belong to the answer -- see the `at < 0` note.
+            // `pathCount` is therefore "paths this host sits on", which is what §3.14 defines it
+            // against, and it counts paths the cap withheld so the two numbers can honestly differ.
+            set total = total + 1
+            if paths.%Size() >= ..#MAXPATHS {
+                set truncated = 1
+                // ONLY `paths` IS CAPPED. `upstream` and `downstream` were filled above, for every
+                // matching row, deliberately: they are the answer to "who feeds this host", and
+                // clipping them to honour a display cap on the path list would make the primary answer
+                // wrong to protect the secondary one.
+                continue
             }
 
             set entry = { "service": (svc), "processes": (procs), "operation": (op),
@@ -246,6 +267,39 @@ ClassMethod GetInterfacePath(host As %String = "") As %DynamicObject
     quit out
 }
 
+/// Which role the host plays on one path. Private.
+///
+/// COMPARED AGAINST THE COLUMNS, never inferred from a hop index (@Ari-Glikman, #186). The first
+/// version read `$case(at, 0: "service", last: "operation", : "process")`, and `svc` is only pushed onto
+/// `hops` when the `Service` column is non-empty -- so on any row with an empty service, hop 0 is a
+/// process or an operation and the host was reported as a `service`.
+///
+/// Worth fixing unconditionally rather than after proving the query can emit such a row, which LABDEMO
+/// cannot: `position` is a claim about the host's ROLE that a model repeats in evidence, making it the
+/// one field here that can be confidently WRONG rather than merely absent. Comparing the three columns
+/// costs the same few lines and cannot drift with how `hops` is built.
+ClassMethod PositionOf(host As %String, svc As %String, op As %String, procs As %DynamicArray) As %String [ Private ]
+{
+    if (svc '= "") && (host = svc) {
+        return "service"
+    }
+    if (op '= "") && (host = op) {
+        return "operation"
+    }
+    set it = procs.%GetIterator()
+    while it.%GetNext(.key, .value) {
+        if value = host {
+            // RETURN, not QUIT: inside a WHILE block `quit` exits the loop and would fall through to
+            // the empty answer below.
+            return "process"
+        }
+    }
+    // Reachable only if the caller matched `host` against `hops` and none of the three columns agrees,
+    // which would mean the two disagree about what the path contains. "" omits the field, which is
+    // honest; a guessed role is not.
+    return ""
+}
+
 /// The payload's own explanation of what it does and does not assert. Private.
 ///
 /// Written into the payload rather than left to the prompt, for `Tools.ChangeLog`'s reason: a model
@@ -272,11 +326,15 @@ ClassMethod Note(host As %String, known As %Boolean, returned As %Integer, trunc
 
 /// Split one column of the interface-map row into its members. Private.
 ///
-/// DEFENSIVE BECAUSE THE SEPARATOR IS UNVERIFIED. See the class comment: LABDEMO has one business
-/// process, so no path here has two, and the query's row-building source is not shipped. What IS
-/// established is that the underlying path encoding uses control characters -- measured as $c(1),
-/// $c(11) and $c(12) -- so those are split on, and a comma-space is split on as well because that is
-/// how the portal renders a list.
+/// DEFENSIVE BECAUSE THE SEPARATOR IS UNVERIFIED, AND IT STILL IS. See the class comment: LABDEMO has
+/// one business process, so no path here has two, and the query's row-building source is genuinely not
+/// shipped (`Ens.InterfaceMaps.Utils.1.INT` does not exist on the instance).
+///
+/// The `$list` correction above does NOT settle this, which is worth stating because it looks as though
+/// it might: element 2 of that list is the plain string `Lab Router`, not a nested list, so a chain of
+/// two processes is still a joined value with an unknown separator (@Ari-Glikman, #186, who checked the
+/// same thing). Control characters are split on because a `$list` header byte reaching a column value
+/// would be one, and a comma-space as well because that is how the portal renders a list.
 ///
 /// Splitting on a bare comma would be worse than not splitting: a config item name may contain one,
 /// and cutting a host name in half would put a host that does not exist into `upstream`. A separator

--- a/iris/setup/AIHub.cls
+++ b/iris/setup/AIHub.cls
@@ -377,7 +377,10 @@ ClassMethod CreateRoles() As %Status
 /// Printed on every setup run so the regression is visible at boot rather than in a review.
 ClassMethod ReportTools()
 {
-    // FOURTEEN since the audit log and the findings snapshot became readable, from twelve. `Tools.ChangeLog`
+    // FIFTEEN since the interface map became readable, from fourteen. `Tools.Topology` adds
+    // GetInterfacePath over `Ens.InterfaceMaps.Utils` (mcp-tools.md §3.14) -- one tool and two
+    // `[ Private ]` helpers, read back as exactly one on its first compile. Before that FOURTEEN, from
+    // twelve. `Tools.ChangeLog`
     // adds GetRecentConfigChanges over `%SYS.Audit` and `Tools.Findings` adds GetActiveFindings over the
     // snapshot the engine supplies with a chat request (mcp-tools.md §3.12-3.13) -- one tool each, and
     // seven `[ Private ]` helpers between them that would make it twenty-one if the keyword were dropped.
@@ -399,7 +402,7 @@ ClassMethod ReportTools()
     // Verified rather than assumed: `%IsA("%AI.Tool")` on `Tools.ErrorCatalogue` returns 0, and the
     // count read back as 12 after `Tools.HostRoster` landed with two public methods. Listing either here
     // would call `%Discover()` on a class that has no such method.
-    set expected = 14
+    set expected = 15
     set found = 0
     // EVERY TOOL CLASS IS LISTED HERE, not only registered in Governance. A tool class the count does
     // not cover is a class whose accidental extra method nothing catches at boot -- which is the one
@@ -411,7 +414,7 @@ ClassMethod ReportTools()
     // through a context-free manager), and discovery is about what a class EXPOSES rather than about who
     // is given it. A class left out here because one caller does not want it is a class whose extra
     // public method reaches an LLM with nothing counting it.
-    for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Activity", "ProductionGuardian.LabDemo.Tools.EventLog", "ProductionGuardian.LabDemo.Tools.ChangeLog", "ProductionGuardian.LabDemo.Tools.Findings", "ProductionGuardian.LabDemo.Tools.Resolve" {
+    for class = "ProductionGuardian.LabDemo.Tools.Read", "ProductionGuardian.LabDemo.Tools.Activity", "ProductionGuardian.LabDemo.Tools.EventLog", "ProductionGuardian.LabDemo.Tools.ChangeLog", "ProductionGuardian.LabDemo.Tools.Findings", "ProductionGuardian.LabDemo.Tools.Topology", "ProductionGuardian.LabDemo.Tools.Resolve" {
         if '##class(%Dictionary.CompiledClass).%ExistsId(class) {
             write "3. tools ", class, ": NOT COMPILED", !
             continue

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -185,6 +185,27 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
     metric: projection.metric,
     slope,
     slopeUnit: projection.projection?.slopeUnit ?? 'items/minute',
+    /*
+     * WHICH WAY THE QUEUE IS MOVING, and it is here because `slope` cannot answer it (#177).
+     *
+     * §2.2 says `slope` "may be zero or negative here ... because a queue that is draining is a fact
+     * the agent should see", and the §4 example carries a non-null slope beside
+     * `thresholdCrossed: true`. The implementation does not deliver that: `slope` is read from
+     * `projection.projection`, which Early Warning sets to null for `already_crossed` — i.e. for
+     * every condition this endpoint is ever called about. So the draining fact the contract promises
+     * has never actually reached the agent, and it recommended enlarging a pool on a queue falling
+     * 261 -> 181 because nothing in its input said "falling".
+     *
+     * `recentDirection` is the honest fix available without reopening `earlywarning-api.md` §1.4,
+     * which forbids publishing a bare slope beside a withheld forecast — a direction is not a rate,
+     * so it carries no forecast to mislabel. Sourced from the field #174 added, measured from the
+     * tail of the same fit.
+     *
+     * The `slope`-is-always-null deviation is real and is NOT fixed here: honouring it needs the
+     * window slope published or refitted, which is that contract's decision rather than this
+     * function's. Filed separately.
+     */
+    recentDirection: projection.recentDirection,
     thresholdValue: threshold,
     thresholdCrossed:
       projection.currentValue !== null && threshold !== null


### PR DESCRIPTION
Closes #177. Contract went in separately as #185. Topology source suggested by @tanifgit — IRIS's own Interface Maps feature, which turned out to be fully queryable.

## The defect

Every read tool was scoped to **one host**, and so is the snapshot. Measured: an upstream `MissingFolder` fault was fixed, 281 accumulated messages flushed through at once, `Cloud API` queued 296, and the Detective recommended the **maximum** pool of 8 at 0.85 confidence — on a queue that drained to zero unaided while it answered. Its own evidence read *"No errors recorded in the last 60 minutes"*: true of `Cloud API`, false of the production.

## `Tools.Topology.GetInterfacePath`

Reads `Ens.InterfaceMaps.Utils`, which **resolves routing rules** — the whole reason to use it rather than reading config:

```
EMR Source -> Lab Router     a TargetConfigNames setting
Lab Router -> Cloud API      a <send> inside RoutingRule.cls   <- invisible to settings
```

A hand-built topology would have been missing exactly the edge this exists for, and would have looked correct. Derived from the production *definition*, so it still answers when a host is dead — which is when an investigation runs.

Registered for `"all"` only, the mirror of `FINDINGTOOLS`. **Not given to `"chat"` yet**, and not for lack of use: the chat's capability text and chips enumerate what it can read (#175), so a fifth family there is a copy change in two more places and belongs with that work rather than smuggled in here.

## `trend.recentDirection` — without it the directive pointed at a field that is always null

§2.2 specifies `slope` as *"may be zero or negative here"*, and the engine reads it from Early Warning's `projection` — `null` for `already_crossed`, i.e. every condition this endpoint is called about. So the draining fact the contract promises had **never reached the agent**. The `slope` deviation itself is not fixed here; filed separately.

## Two prompt corrections, both measured rather than reasoned

- **The upstream read is its own `MUST`.** As one clause of a longer sentence, the model called `GetInterfacePath`, correctly named both upstream hosts, and then **never looked at either** — exactly what `iris/CLAUDE.md` §7 predicts about descriptions versus directives.
- **Each upstream host, not the nearest.** With "the nearest" it read `Lab Router` (genuinely clean) and reached the right verdict by the weaker route of "no fault anywhere", never seeing that `EMR Source` two hops up had been in Error for twenty minutes and was fixed three minutes earlier. Same answer, wrong reason.

**Positive evidence only** — `DropPoolFixDuringOutage`'s existing rule applied to the model. A directive about transients must not make the Detective timid about the ordinary sustained rise.

## Verified live, same armed scenario, before and after

| | Before | After |
|---|---|---|
| tool calls | 4 | 6 |
| upstream hosts read | none | both |
| recommendation | `set_pool_size` → 6, conf 0.9 | **`null`** |
| root cause | "pool size 4 is insufficient" | "`EMR Source` … error #5021 … occurred 229 seconds ago and has since ended, the backlog is likely draining through" |
| manual remediation | none | names the real fix (the directory) |

**#108 regression check, same build:** the ordinary rising queue still recommends `1 → 2` at conf 0.9 and still calls the map. That was the thing this change could most easily have broken.

| Check | Result |
|---|---|
| `npm test` (engine) | 415/415 |
| `tsc --noEmit` | clean |
| Boot tool-count guard | **15 discovered, expected 15**, names read back per §7 — `Tools.Topology` exposes exactly one tool, both helpers private |

## Two follow-ups I am filing rather than folding in

- **The sizing input.** `messagesPerSec` is inflated by a drain-through burst, so the Little's-law block is fed a bad rate. You chose to keep this separate, and it stays separate.
- **A `#171`-adjacent observation.** In both of today's runs the model wrote "No recent configuration changes found" in an evidence entry — the claim `BuildGoal` explicitly forbids. The tool behaved correctly (the change was on another host). It may be displacement from the ~25 lines this PR adds nearby, which is a mechanism this very file documents. I have no clean before/after run to attribute it, so I am filing it with the evidence rather than guessing.

**Not merging without a nod** — yesterday's self-review arrangement was explicitly for yesterday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)