### PR TITLE
fix(detection-engine): trend.slope was null on every investigation ever served (#187)

### DIFF
--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -13,6 +13,7 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { EngineSnapshot } from '../detect/engine.ts';
+import { publishedProjection } from '../detect/earlywarning.ts';
 // The off-state payload, imported rather than written out here. It was inlined twice below and
 // gained a third field in #135; two literals that must match a type in another file is the
 // stale-copy shape, and both copies would have been silently short an `activating: {}`.
@@ -342,7 +343,13 @@ export function createFindingsServer(options: ServerOptions): Server {
           // state header could disagree with the first, and a consumer would have no rule for
           // which to believe -- the projections come from the same poll as the findings, so they
           // share its freshness by construction.
-          sendJson(res, 200, snapshot.projections, snapshot.state);
+          //
+          // MAPPED, not served raw: `HostProjection` carries one internal field the contract does not
+          // publish -- the measured window slope, which §1.4 keeps off this endpoint and
+          // `investigation-api.md` §2.2 requires for the agent (#187). `publishedProjection` is a
+          // whitelist, so the endpoint's shape is decided there rather than by whatever the type
+          // happens to hold.
+          sendJson(res, 200, snapshot.projections.map(publishedProjection), snapshot.state);
           return;
         case '/api/hostseries': {
           // `host` IS REQUIRED AND IS A 400, not an empty series. Every other read here answers

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -70,6 +70,51 @@ export interface HostProjection {
   threshold: Threshold | null;
   projection: Projection | null;
   projectionUnavailable: ProjectionUnavailableReason | null;
+  /**
+   * The window fit's slope in `SLOPE_UNIT`, or null when there is no usable fit.
+   *
+   * **INTERNAL. Not part of `earlywarning-api.md`, and `publishedProjection()` strips it** — §1.4
+   * forbids a slope outside `projection` on that endpoint even where we decline to forecast, because
+   * "rising ~0.5/min" next to no ETA implies the forecast we withheld. That rule is not being bent
+   * here: the panel still cannot see this.
+   *
+   * It exists because `investigation-api.md` §2.2 ratifies the opposite decision for the *agent*:
+   * `trend.slope` "may be zero or negative here ... because a queue that is draining is a fact the
+   * agent should see rather than a forecast to withhold". Two contracts, two consumers, and the
+   * difference is deliberate on both sides — a panel renders to an operator who acts on a rate, and
+   * the model has already been measured recommending a bigger pool for a queue falling 261 -> 181
+   * because nothing in its input carried one (#187).
+   *
+   * Sourced from the SAME fit the ETA uses, computed once below. A second derivation of it is how
+   * the published rate and the agent's rate would come to disagree — #174's argument for the tail.
+   */
+  windowSlopePerMinute: number | null;
+}
+
+/**
+ * One projection as `earlywarning-api.md` §1.1 defines it, for the endpoint to serve.
+ *
+ * A WHITELIST rather than a delete, so the wire shape is decided here and an internal field added to
+ * `HostProjection` cannot reach the endpoint by forgetting about it. Publishing a new field becomes a
+ * deliberate edit to this function, which is the right amount of friction for a ratified contract.
+ * Typed as an `Omit` so a renamed field fails to compile rather than silently vanishing from the
+ * payload.
+ */
+export function publishedProjection(
+  p: HostProjection,
+): Omit<HostProjection, 'windowSlopePerMinute'> {
+  return {
+    host: p.host,
+    metric: p.metric,
+    currentValue: p.currentValue,
+    measuredAt: p.measuredAt,
+    fitSampleCount: p.fitSampleCount,
+    fitSpanSeconds: p.fitSpanSeconds,
+    recentDirection: p.recentDirection,
+    threshold: p.threshold,
+    projection: p.projection,
+    projectionUnavailable: p.projectionUnavailable,
+  };
 }
 
 /**
@@ -130,7 +175,16 @@ const DISCONTINUITY_FRACTION = 0.8;
 const RECENT_FIT_FRACTION = 0.4;
 
 const FINDING_TYPE = 'queue_buildup';
-const SLOPE_UNIT = 'items/minute';
+
+/**
+ * The unit of every slope this module produces, published and internal alike.
+ *
+ * Exported because `investigate.ts` labels `windowSlopePerMinute` with it and used to read
+ * `projection.slopeUnit` for that — a field that is null in the one state an investigation happens in
+ * (#187), so it fell back to a second copy of this literal. One constant, so the label cannot say
+ * something the arithmetic does not.
+ */
+export const SLOPE_UNIT = 'items/minute';
 
 /**
  * Least-squares slope in units per MILLISECOND, or null when it cannot be fitted.
@@ -343,6 +397,23 @@ export function projectHost(
           ? 'falling'
           : 'steady';
 
+  /*
+   * THE WINDOW FIT, COMPUTED ONCE AND USED TWICE (#187) — the same arrangement the tail fit above
+   * already has, and for the same reason.
+   *
+   * It used to be computed at step 6, below `already_crossed`, which is exactly the decline a
+   * `queue_buildup` investigation is always requested under. So `trend.slope` was null on every
+   * investigation the product has ever served, and `investigation-api.md` §2.2's stated reason for
+   * carrying a signed slope — a draining queue is a fact the agent should see — was never delivered.
+   *
+   * Hoisting it changes no projection: the ETA path reads this value instead of refitting, and by the
+   * time it does, `fitSampleCount >= minFitSamples` has already been checked, so it is the same
+   * number the same call produced before. Gated identically to the tail so "there is no usable fit"
+   * has one meaning across both.
+   */
+  const windowSlopePerMinute =
+    fitSampleCount >= ew.minFitSamples ? perMinute(fitSlopePerMs(samples)) : null;
+
   const base = {
     host,
     metric: METRIC as string,
@@ -351,6 +422,7 @@ export function projectHost(
     fitSampleCount,
     fitSpanSeconds,
     recentDirection,
+    windowSlopePerMinute,
   };
 
   const decline = (
@@ -376,8 +448,10 @@ export function projectHost(
   if (currentValue >= threshold.value) return decline('already_crossed', threshold);
 
   // Round to 1dp in the units we publish, and test the ROUNDED value: publishing slope 0.0
-  // alongside a finite ETA would be a projection the numbers do not support.
-  const slopePerMinute = perMinute(fitSlopePerMs(samples));
+  // alongside a finite ETA would be a projection the numbers do not support. Reads the fit measured
+  // above rather than repeating it (#187) — one computation, so the rate this endpoint publishes and
+  // the rate the investigation carries cannot drift apart.
+  const slopePerMinute = windowSlopePerMinute;
   if (slopePerMinute === null || slopePerMinute <= 0) return decline('not_rising', threshold);
 
   // RISING NOW, not merely on average across the window. The window slope above describes the

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Finding, Host } from '../types/healthscan.ts';
-import type { HostProjection } from './earlywarning.ts';
+import { SLOPE_UNIT, type HostProjection } from './earlywarning.ts';
 
 /** Where the served content came from. Contract §3.1. */
 export type InvestigationSource = 'agent' | 'cache' | 'canned' | 'none';
@@ -175,35 +175,52 @@ function buildSnapshot(host: Host, projection: HostProjection | undefined): Reco
  *
  * Same field names and units as `earlywarning-api.md`, with the forecast framing dropped:
  * `thresholdCrossed: true` and `secondsToThreshold: null` is the normal case here, not an error.
+ *
+ * `slope` is the measured window fit rather than the projection's copy of it, which is what makes
+ * §2.2's "may be zero or negative here" reachable at all (#187). See below.
  */
 function buildTrend(projection: HostProjection | undefined): Record<string, unknown> | null {
   if (projection === undefined) return null;
-  const slope = projection.projection?.slope ?? null;
+  /*
+   * THE MEASURED WINDOW SLOPE, not `projection.slope` (#187).
+   *
+   * Read from `projection.projection`, this was null on every investigation this endpoint has ever
+   * served: Early Warning sets that object to null for `already_crossed`, which is the state that
+   * made `queue_buildup` fire in the first place. §2.2's argued reason for carrying a signed slope
+   * here -- "a queue that is draining is a fact the agent should see rather than a forecast to
+   * withhold" -- therefore never once reached the agent, and it recommended enlarging a pool on a
+   * queue falling 261 -> 181 because nothing in its input said so.
+   *
+   * `windowSlopePerMinute` is the same fit and the same units, measured before the decline. It stays
+   * off `/api/earlywarning`, where §1.4 forbids it; this is the consumer §2.2 published it for.
+   */
+  const slope = projection.windowSlopePerMinute;
   const threshold = projection.threshold?.value ?? null;
-  if (slope === null && threshold === null) return null;
+  /*
+   * NULL WHEN EITHER HALF IS MISSING, which §2.2 states as "no usable fit at all — a warming
+   * baseline, or fewer than 12 samples in the fit window": a null threshold is the warming case and
+   * a null slope is the sample-count case, so the contract's sentence is exactly this disjunction.
+   *
+   * It was `&&` before, which could only ever be reached because `slope` was unconditionally null --
+   * so `insufficient_samples` served a trend object whose only real content was a threshold. That
+   * threshold is in `snapshot.thresholdValue` too, so nothing is lost by declining here, and the
+   * agent gets one meaning for a present `trend` rather than two.
+   */
+  if (slope === null || threshold === null) return null;
   return {
     metric: projection.metric,
     slope,
-    slopeUnit: projection.projection?.slopeUnit ?? 'items/minute',
+    slopeUnit: SLOPE_UNIT,
     /*
-     * WHICH WAY THE QUEUE IS MOVING, and it is here because `slope` cannot answer it (#177).
+     * WHICH WAY THE QUEUE IS MOVING, and it stays here now that `slope` can also answer it (#177).
      *
-     * §2.2 says `slope` "may be zero or negative here ... because a queue that is draining is a fact
-     * the agent should see", and the §4 example carries a non-null slope beside
-     * `thresholdCrossed: true`. The implementation does not deliver that: `slope` is read from
-     * `projection.projection`, which Early Warning sets to null for `already_crossed` — i.e. for
-     * every condition this endpoint is ever called about. So the draining fact the contract promises
-     * has never actually reached the agent, and it recommended enlarging a pool on a queue falling
-     * 261 -> 181 because nothing in its input said "falling".
-     *
-     * `recentDirection` is the honest fix available without reopening `earlywarning-api.md` §1.4,
-     * which forbids publishing a bare slope beside a withheld forecast — a direction is not a rate,
-     * so it carries no forecast to mislabel. Sourced from the field #174 added, measured from the
-     * tail of the same fit.
-     *
-     * The `slope`-is-always-null deviation is real and is NOT fixed here: honouring it needs the
-     * window slope published or refitted, which is that contract's decision rather than this
-     * function's. Filed separately.
+     * It was added when `slope` was structurally null on every investigation, as the one honest
+     * signal of direction available without reopening `earlywarning-api.md` §1.4. #187 fixed the
+     * slope, so this is no longer the only source — and it is kept because the two are measured over
+     * DIFFERENT spans and disagree usefully: `slope` fits the whole window, `recentDirection` the 40%
+     * tail (#174). A queue that rose for eight minutes and has been draining for two has a positive
+     * `slope` and a `falling` direction, which is exactly the state the agent most needs to
+     * distinguish and the one a single number flattens.
      */
     recentDirection: projection.recentDirection,
     thresholdValue: threshold,

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -224,10 +224,9 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
      */
     recentDirection: projection.recentDirection,
     thresholdValue: threshold,
-    thresholdCrossed:
-      projection.currentValue !== null && threshold !== null
-        ? projection.currentValue >= threshold
-        : null,
+    // The `threshold !== null` half of this test went with the gate above, which now guarantees it.
+    // Leaving it would say a null threshold is reachable here, and a reader would believe it.
+    thresholdCrossed: projection.currentValue !== null ? projection.currentValue >= threshold : null,
     secondsToThreshold: projection.projection?.secondsToThreshold ?? null,
   };
 }

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -10,6 +10,7 @@ import type { AddressInfo } from 'node:net';
 import { after, before, describe, it } from 'node:test';
 import { createFindingsServer } from '../src/api/server.ts';
 import type { EngineSnapshot } from '../src/detect/engine.ts';
+import type { HostProjection } from '../src/detect/earlywarning.ts';
 import type { Finding, Host } from '../src/types/healthscan.ts';
 
 const HOST: Host = {
@@ -330,5 +331,47 @@ describe('write-origin allow-list (resolve-api.md §13.2)', () => {
     });
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+});
+
+/*
+ * §1.4 IS ENFORCED BY THE ROUTE, NOT ONLY BY THE MAPPER (#187).
+ *
+ * `publishedProjection()` is unit-tested in `earlywarning.test.ts`; this asserts the endpoint actually
+ * calls it. The two are different claims — the route served `snapshot.projections` raw for the whole of
+ * MVP 2, so a mapper that works and a mapper that is reached would have looked identical from there.
+ *
+ * The projection below is a literal on purpose: it carries `windowSlopePerMinute` set, so a route that
+ * forgot the whitelist publishes a bare slope beside a withheld forecast and this fails.
+ */
+describe('/api/earlywarning publishes no bare slope (earlywarning-api.md §1.4)', () => {
+  const PROJECTION: HostProjection = {
+    host: 'Cloud API',
+    metric: 'queued',
+    currentValue: 90,
+    measuredAt: '2026-08-31T10:00:00Z',
+    fitSampleCount: 50,
+    fitSpanSeconds: 245,
+    recentDirection: 'falling',
+    threshold: { value: 50, basis: 'absoluteFloor', baselineValue: 0, findingType: 'queue_buildup' },
+    projection: null,
+    projectionUnavailable: 'already_crossed',
+    windowSlopePerMinute: 26.6,
+  };
+
+  it('strips windowSlopePerMinute from the wire payload', async () => {
+    snapshot = { hosts: [], findings: [], projections: [PROJECTION], state: 'ok', lastPollAt: Date.now() };
+    const res = await fetch(`${base}/api/earlywarning`);
+    assert.equal(res.status, 200);
+    const rows = (await res.json()) as Record<string, unknown>[];
+    assert.equal(rows.length, 1);
+    const [row] = rows;
+    assert.ok(row !== undefined);
+    assert.ok(!('windowSlopePerMinute' in row), 'a slope must not reach the panel');
+    // Nothing else may go missing with it: §1 makes an absent KEY a violation even where the value
+    // would be null, so the count is asserted rather than a sampling of fields.
+    assert.equal(Object.keys(row).length, 10);
+    assert.equal(row.projectionUnavailable, 'already_crossed');
+    assert.equal(row.recentDirection, 'falling');
   });
 });

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { BaselineStore } from '../src/baseline/window.ts';
 import { DEFAULT_CONFIG, type ThresholdConfig } from '../src/config/thresholds.ts';
-import { projectHost } from '../src/detect/earlywarning.ts';
+import { projectHost, publishedProjection } from '../src/detect/earlywarning.ts';
 import type { RawHostMetrics } from '../src/detect/rules/types.ts';
 
 const HOST = 'Cloud API';
@@ -653,5 +653,103 @@ describe('recentDirection — which way it is moving now (§1.5)', () => {
     assert.equal(p.projectionUnavailable, 'metric_unmeasurable');
     assert.ok('recentDirection' in p);
     assert.equal(p.recentDirection, null);
+  });
+});
+
+/*
+ * THE DEFECT THIS PINS (#187) is that the window slope was computed at step 6, BELOW the
+ * `already_crossed` decline — which is the state every `queue_buildup` investigation is requested
+ * under. So `investigation-api.md` §2.2's signed slope, argued for on the grounds that "a queue that
+ * is draining is a fact the agent should see rather than a forecast to withhold", was null on every
+ * investigation the product had ever served, and the agent recommended enlarging a pool for a queue
+ * falling 261 -> 181.
+ *
+ * The field is INTERNAL: `publishedProjection()` strips it, because `earlywarning-api.md` §1.4 forbids
+ * a slope outside `projection` on that endpoint even where the forecast is declined. Both halves are
+ * asserted here — measured for the agent, absent for the panel — since either alone would pass against
+ * a wrong implementation.
+ */
+describe('windowSlopePerMinute — measured for the agent, never published (§2.2 / §1.4)', () => {
+  /** Record an arbitrary series at the shipped poll and project at its last sample. */
+  function series(values: readonly number[], cfg = config()) {
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (const v of values) {
+      store.record(HOST, 'queued', v, at);
+      at += POLL;
+    }
+    return projectHost(HOST, raw(values.at(-1) ?? 0), store, cfg, at - POLL);
+  }
+
+  it('is negative for a queue draining above its threshold — the #187 case', () => {
+    /* The exact shape a Smart Resolve apply produces: 150 down to 60 at 3/poll, never below the
+       floor, so `already_crossed` still answers first. Before the fix this was null. */
+    const values = [150];
+    for (let i = 0; i < 30; i += 1) values.push(150 - (i + 1) * 3);
+    const p = series(values);
+    assert.equal(p.projectionUnavailable, 'already_crossed', 'sanity: the investigated state');
+    assert.equal(p.projection, null, 'the forecast is still withheld');
+    assert.ok(p.windowSlopePerMinute !== null, 'the slope is measured anyway');
+    assert.ok(p.windowSlopePerMinute < 0, `expected a falling rate, got ${p.windowSlopePerMinute}`);
+    // 3 per 5s poll downward is -36/min. Asserted numerically, not just by sign: a slope with the
+    // right sign and the wrong magnitude would tell the agent a lie it cannot detect.
+    assert.equal(p.windowSlopePerMinute, -36);
+  });
+
+  it('is positive and EQUAL to projection.slope on the happy path — one fit, used twice', () => {
+    /* The invariant that makes the hoist safe. If these two ever disagree the endpoint publishes one
+       rate and the agent reads another, which is #174's argument for the tail fit. */
+    const p = ramp(20, 2);
+    assert.ok(p.projection !== null, 'sanity: expected a forecast');
+    assert.equal(p.windowSlopePerMinute, p.projection.slope);
+    assert.ok((p.windowSlopePerMinute ?? 0) > 0);
+  });
+
+  it('is measured for a queue rising above its threshold too', () => {
+    // The other direction under the same decline reason — so the agent can tell a queue still
+    // building from one already recovering, which was the pair `recentDirection` was added for.
+    const p = series(Array.from({ length: 60 }, (_, i) => i * 3));
+    assert.equal(p.projectionUnavailable, 'already_crossed');
+    assert.ok((p.windowSlopePerMinute ?? 0) > 0);
+  });
+
+  it('is null below minFitSamples — no rate, rather than one fitted through three points', () => {
+    const p = series([0, 1, 2, 3, 5]);
+    assert.equal(p.projectionUnavailable, 'insufficient_samples');
+    assert.equal(p.windowSlopePerMinute, null);
+  });
+
+  it('is null when the metric is unmeasurable — there is nothing to fit', () => {
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    const p = projectHost(HOST, raw(null), store, cfg, T0);
+    assert.equal(p.projectionUnavailable, 'metric_unmeasurable');
+    assert.equal(p.windowSlopePerMinute, null);
+  });
+
+  it('publishedProjection() strips it and keeps everything else', () => {
+    /* §1.4's regression guard. Asserted with `in` rather than by value, because a `null` field would
+       still imply a rate we declined to state — the thing §1.4 forbids. */
+    const p = series(Array.from({ length: 60 }, (_, i) => i * 3));
+    assert.ok('windowSlopePerMinute' in p, 'sanity: it is on the internal type');
+    const wire = publishedProjection(p);
+    assert.ok(!('windowSlopePerMinute' in wire), 'a slope must not reach /api/earlywarning');
+    // Every other §1.1 key survives. A whitelist that dropped a published field would be the
+    // opposite defect and just as invisible from the stripping assertion alone.
+    for (const key of [
+      'host',
+      'metric',
+      'currentValue',
+      'measuredAt',
+      'fitSampleCount',
+      'fitSpanSeconds',
+      'recentDirection',
+      'threshold',
+      'projection',
+      'projectionUnavailable',
+    ]) {
+      assert.ok(key in wire, `publishedProjection dropped ${key}`);
+    }
+    assert.equal(Object.keys(wire).length, 10, 'an internal field reached the wire shape');
   });
 });

--- a/services/detection-engine/test/investigationTrend.test.ts
+++ b/services/detection-engine/test/investigationTrend.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `trend` on the agent request — contract §2.2, and specifically the slope (#187).
+ *
+ * WHAT MAKES THIS WORTH ITS OWN FILE. §2.2 argues for carrying a *signed* slope to the agent on the
+ * grounds that "a queue that is draining is a fact the agent should see rather than a forecast to
+ * withhold" — the one place in either MVP 2 contract where a bare rate is deliberately allowed,
+ * because the consumer is a model rather than a panel. It was never delivered: `slope` was read from
+ * `projection.projection`, which Early Warning sets to null for `already_crossed`, which is the state
+ * every `queue_buildup` investigation is requested in. So the field was null on every investigation
+ * the product has ever served, and the agent recommended enlarging a pool for a queue falling
+ * 261 -> 181 because nothing in its input said "falling".
+ *
+ * THE TESTS ASSERT THE REQUEST, NOT THE RESPONSE. Nothing in the served payload changes, so a test
+ * that exercised `investigate()` end to end would pass against the defect. The spy captures what
+ * `callAgent` was handed, which is the only place the fix is visible from here.
+ *
+ * Projections come from `projectHost` on a recorded series rather than being hand-written, so these
+ * are the numbers the engine really passes — a literal would test the mapper against itself.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { BaselineStore } from '../src/baseline/window.ts';
+import { DEFAULT_CONFIG, type ThresholdConfig } from '../src/config/thresholds.ts';
+import { projectHost, type HostProjection } from '../src/detect/earlywarning.ts';
+import { investigate } from '../src/detect/investigate.ts';
+import type { RawHostMetrics } from '../src/detect/rules/types.ts';
+import type { Finding, Host } from '../src/types/healthscan.ts';
+
+const HOST_NAME = 'Cloud API';
+const T0 = Date.parse('2026-08-31T10:00:00Z');
+const POLL = 5000;
+
+const HOST: Host = {
+  host: HOST_NAME,
+  type: 'operation',
+  status: 'OK',
+  queued: 90,
+  messagesPerSec: 4,
+  errored: 0,
+  avgProcessingTime: 1.01,
+  avgQueueingTime: 12,
+  lastActivity: '2026-08-31T10:00:00Z',
+};
+
+const FINDING: Finding = {
+  id: 'f-3001',
+  host: HOST_NAME,
+  type: 'queue_buildup',
+  severity: 'critical',
+  currentValue: 90,
+  baselineValue: 0,
+  detectedAt: '2026-08-31T10:00:00Z',
+  message: 'Queue depth 90 is over the floor of 50',
+};
+
+/** The shipped MVP 2 setup: a stated reference baseline of 0 for `queued`. */
+function config(overrides: Partial<ThresholdConfig> = {}): ThresholdConfig {
+  return {
+    ...structuredClone(DEFAULT_CONFIG),
+    referenceBaselines: { [HOST_NAME]: { queued: 0 } },
+    ...overrides,
+  };
+}
+
+function raw(queued: number | null): RawHostMetrics {
+  return {
+    queued,
+    messagesPerSec: 4,
+    errored: 0,
+    avgProcessingTime: 1.01,
+    avgQueueingTime: 12,
+    lastActivityElapsedSeconds: 1,
+  } as RawHostMetrics;
+}
+
+/** Record a series at the shipped poll and project at its last sample. */
+function project(values: readonly number[], cfg = config()): HostProjection {
+  const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+  let at = T0;
+  for (const v of values) {
+    store.record(HOST_NAME, 'queued', v, at);
+    at += POLL;
+  }
+  return projectHost(HOST_NAME, raw(values.at(-1) ?? 0), store, cfg, at - POLL);
+}
+
+/** Rise to just under `peak` in steps of 5, then drain by 3 a poll — an approved fix taking effect. */
+function riseThenDrain(peak: number, drainSamples: number): number[] {
+  const values: number[] = [];
+  for (let v = 0; v < peak; v += 5) values.push(v);
+  let v = peak;
+  for (let i = 0; i < drainSamples; i += 1) {
+    v -= 3;
+    values.push(v);
+  }
+  return values;
+}
+
+/** Run one investigation and return the request the agent was handed. */
+async function requestFor(projection: HostProjection | undefined) {
+  let captured: { trend: Record<string, unknown> | null } | undefined;
+  await investigate(FINDING, HOST, projection, null, {
+    callAgent: async (request) => {
+      captured = request;
+      return {
+        rootCause: 'Cloud API cannot keep up with inbound volume.',
+        evidence: [],
+        confidence: 0.8,
+        recommendedAction: null,
+        manualRemediation: null,
+      };
+    },
+    source: 'canned' as const,
+    now: () => 1_760_000_000_000,
+  });
+  assert.ok(captured !== undefined, 'the agent was never called');
+  return captured;
+}
+
+test('the slope reaches the agent for a crossed queue — the state every investigation runs in', async () => {
+  const p = project(riseThenDrain(150, 20));
+  assert.equal(p.projectionUnavailable, 'already_crossed', 'sanity: the investigated state');
+  assert.equal(p.projection, null, 'sanity: Early Warning withholds the forecast here');
+
+  const { trend } = await requestFor(p);
+  assert.ok(trend !== null, 'trend was null — the #187 defect');
+  assert.equal(trend.slope, p.windowSlopePerMinute);
+  assert.ok(typeof trend.slope === 'number' && trend.slope !== 0);
+  assert.equal(trend.slopeUnit, 'items/minute');
+  assert.equal(trend.thresholdCrossed, true);
+  // §2.2 drops the forecast framing rather than the fields: crossed with no ETA is the normal case.
+  assert.equal(trend.secondsToThreshold, null);
+});
+
+test('a negative slope reaches it too — §2.2s draining fact', async () => {
+  /* The measurement that produced #187: a pool enlargement drains the queue while it stays over the
+     floor, so the reason is still `already_crossed` and the model saw nothing that said "falling". */
+  const values = [150];
+  for (let i = 0; i < 30; i += 1) values.push(150 - (i + 1) * 3);
+  const p = project(values);
+  assert.equal(p.projectionUnavailable, 'already_crossed');
+
+  const { trend } = await requestFor(p);
+  assert.ok(trend !== null);
+  assert.equal(trend.slope, -36, 'a drain of 3 per 5s poll is -36/min');
+  assert.equal(trend.recentDirection, 'falling');
+});
+
+test('slope and recentDirection are allowed to disagree, and that is why both are sent', async () => {
+  /* Measured, not supposed: an eight-minute climb followed by 100 seconds of draining fits a window
+     slope of +26.6/min with a falling tail. One number cannot carry both, and "it built up but is
+     recovering" is the distinction that decides whether a second pool increase is warranted. */
+  const p = project(riseThenDrain(150, 20));
+  const { trend } = await requestFor(p);
+  assert.ok(trend !== null);
+  assert.equal(trend.slope, 26.6);
+  assert.equal(trend.recentDirection, 'falling');
+});
+
+test('trend is null when the fit has too few samples — §2.2s stated null case', async () => {
+  /* "No usable fit at all — a warming baseline, or fewer than 12 samples in the fit window." The gate
+     was `&&`, which only ever passed because `slope` was unconditionally null; it served a trend
+     object whose only real content was a threshold the snapshot already carries. */
+  const p = project([0, 1, 2, 3, 5]);
+  assert.equal(p.projectionUnavailable, 'insufficient_samples');
+  assert.equal(p.windowSlopePerMinute, null);
+
+  const { trend } = await requestFor(p);
+  assert.equal(trend, null);
+});
+
+test('trend is null while the baseline is warming — the other half of the disjunction', async () => {
+  /* A fit exists and a threshold does not. Reachable only with a baseline requirement above
+     `minFitSamples`, which is why it is configured here rather than left to the shipped numbers where
+     the two are both 12 and the cases coincide. */
+  const cfg = config({ referenceBaselines: {}, minBaselineSamples: 40 });
+  const p = project(
+    Array.from({ length: 20 }, (_, i) => i * 3),
+    cfg,
+  );
+  assert.equal(p.projectionUnavailable, 'warming');
+  assert.equal(p.threshold, null);
+  assert.ok(p.windowSlopePerMinute !== null, 'sanity: the fit itself succeeded');
+
+  const { trend } = await requestFor(p);
+  assert.equal(trend, null, 'a slope with no threshold to compare it to is not a trend');
+});
+
+test('trend is null when Early Warning produced no projection for the host at all', async () => {
+  const { trend } = await requestFor(undefined);
+  assert.equal(trend, null);
+});


### PR DESCRIPTION
Closes #187.

## The defect

`investigation-api.md` §2.2 carries a **signed** slope to the agent on purpose:

> May be zero or negative here … because a queue that is draining is a fact the agent should see rather than a forecast to withhold.

It has never been delivered. `buildTrend` read `projection.projection.slope`, and Early Warning sets that object to `null` for `already_crossed` — which is the **only** state a `queue_buildup` investigation is ever requested in. So `trend.slope` was null on every investigation the product has ever served, and the agent recommended enlarging a pool for a queue falling 261 → 181 because nothing in its input said "falling".

## Why this is none of the three options the issue proposed

#187 frames it as a contract decision: publish the slope on `HostProjection` and redraw §1.4, refit inside `buildTrend`, or amend §2.2 to admit null. There is a fourth path that needs **no contract change**, because the two contracts already say the right thing for their own consumer:

| | consumer | rule | after this PR |
|---|---|---|---|
| `earlywarning-api.md` §1.4 | the panel | no slope outside `projection`, *even where we decline to forecast* | unchanged — `publishedProjection()` strips it |
| `investigation-api.md` §2.2 | the model | a signed slope, present whenever there is a usable fit | honoured as ratified |

§1.4's reasoning is not being bent: "a visible *rising ~0.5/min* next to no ETA still implies a forecast we refused to make" is a statement about a **panel**, and the panel still cannot see this field.

## What changed

**The window fit is hoisted, not duplicated.** It already existed as one least-squares fit inside `projectHost` — it was merely computed at step 6, *below* the `already_crossed` decline. It now sits above the precedence chain and lands on `base`, and the ETA path reads it instead of refitting.

- Arithmetically identical on every path that previously reached it: `fitSampleCount >= minFitSamples` is already checked by then, and the rounding and the `<= 0` test are unmoved.
- Same "computed once, used twice" arrangement the tail fit has had since #174, for the same reason — a second derivation is how the published rate and the agent's rate come to disagree.

**`publishedProjection()` is a whitelist, not a delete.** So the wire shape of `/api/earlywarning` is decided in one place and a future internal field cannot reach the endpoint by being forgotten. Typed as `Omit<HostProjection, 'windowSlopePerMinute'>`, so a rename fails to compile rather than silently vanishing from the payload.

**A second, contract-derived fix rides along.** `buildTrend`'s gate was `slope && threshold`, reachable only because `slope` was unconditionally null — so `insufficient_samples` served a trend object whose only real content was a threshold. §2.2 states the null case as *"no usable fit at all — a warming baseline, or fewer than 12 samples in the fit window"*, which is a **disjunction**, so the gate is now `||`. Nothing is lost: `thresholdValue`/`thresholdBasis` are in the snapshot too, and the agent gets one meaning for a present `trend` instead of two.

**`recentDirection` (#177) is kept, and the comment claiming this bug was unfixable there is gone.** The two are measured over different spans and the disagreement is the point — measured, not supposed: a queue that climbed for eight minutes and has drained for 100 seconds fits **+26.6/min over the window with a `falling` tail**. That is exactly the state that decides whether a second pool increase is warranted, and one number flattens it.

**IRIS needs no change.** `AgentDispatcher.BuildGoal` dumps `body.trend.%ToJSON()` wholesale and never names `slope`, so a real value reaches the model without editing the goal — and #190's displacement risk stays untouched.

## Verification

`tsc --noEmit` clean, **428/428 tests** (415 on `main`, 13 new).

The new tests assert the **request handed to `callAgent`**, not the served response — nothing in the response changes, so an end-to-end test would have passed against the defect.

| Test | Pins |
|---|---|
| slope negative on a crossed draining queue | the #187 case, and the magnitude (`-36`/min for a 3-per-poll drain) — a right-signed wrong-magnitude rate is a lie the agent cannot detect |
| `windowSlopePerMinute === projection.slope` on the happy path | the one-fit invariant that makes the hoist safe |
| null below `minFitSamples`, null when unmeasurable | no rate fitted through three points |
| `publishedProjection()` strips it **and keeps the other ten keys** | both directions — a whitelist that dropped a published field is the opposite defect |
| `GET /api/earlywarning` carries no `windowSlopePerMinute` | that the **route** calls the mapper. A mapper that works and a mapper that is reached are different claims; this route served `projections` raw for all of MVP 2 |
| `trend` null for `insufficient_samples` **and** for `warming` | both halves of §2.2's disjunction |

Live end-to-end check against the running stack is in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
