### PR TITLE
fix(detection-engine): the pool was sized from throughput, which measures the throttle and not the load (#188)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,77 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `inboundRatePerSec` is derived from the TAIL slope, not the window slope
+
+**One file, one formula corrected and one field added.** `investigation-api.md` §2.2:
+`snapshot.inboundRatePerSec` was defined as `messagesPerSec + trend.slope/60` and now reads
+`messagesPerSec + trend.recentSlope/60`; `trend` gains `recentSlope`, the signed magnitude whose sign
+has been published as `recentDirection` since #177.
+
+**Additive for `trend`, a genuine semantic change for `inboundRatePerSec`** — the same field name can
+now hold a different number for the same inputs. That is the honest description, and the reason this is
+a contract change rather than an implementation detail. It is nonetheless safe to land in one step,
+because the field had **never been populated by any engine build**: #188 found the only three mentions
+of it in the repo were in this contract. Nothing has consumed it, so nothing changes meaning underneath
+a consumer. The two things that will read it — `AgentDispatcher`'s prompt and `RaiseUndersizedPool` —
+are in the same PR.
+
+#188.
+
+### Why the original formula was wrong
+
+Arrival rate is completions plus the rate the backlog is growing, and **"is growing" has to mean now**.
+The window fit is 300 s. Minutes into a drain it still leans up, so the estimate lands *above* the raw
+completion rate on the one state where completions are already an overstatement.
+
+Measured on the live drain-through transient: `set_pool_size 1 -> 4` applied, `recentDirection`
+reporting `falling`, `messagesPerSec` reading 4 because four workers are clearing a backlog.
+
+| Arrival rate from | Value | Agent's recommendation |
+|---|---|---|
+| `messagesPerSec` alone | 4 | `set_pool_size 4 -> 8` |
+| `+ slope/60`, queue 94 | 4.57 | `set_pool_size 4 -> 6` |
+| `+ recentSlope/60`, queue 108 | **3.82** | **none** |
+
+The two derived rows are separate runs a few polls apart, not the same sample — the transient is short.
+What decides the outcome is which side of `messagesPerSec` each estimate lands on.
+
+So this is not a refinement of the original formula: it moved the number the wrong way. The flagship
+rise is the only scenario that ever exercised it, and there the two spans agree — which is exactly why
+the defect was invisible until #188 required both scenarios be measured.
+
+One caveat on attribution, because the table above would otherwise overclaim. The `none` outcome is
+produced by the corrected estimate **and** a new prompt directive that says to recommend nothing when
+`recentDirection` is `falling` and `inboundRatePerSec` is below `messagesPerSec`. Neither alone is
+sufficient: the directive cannot fire on an estimate that reads 4.57, and the estimate alone leaves the
+sizing formula free to justify a second increase. The contract change is the half that lives here.
+
+The field was ratified in the MVP 2 design, before either scenario existed to measure it against. That
+is not a criticism of the original spec; it is the argument for #188's instruction to re-measure both.
+
+### Why `recentSlope` is published rather than kept internal
+
+The prompt asks the model to state its sizing arithmetic. A term it cannot see is a term it either
+omits or invents — and the field it reaches for instead is `slope`, which is the wrong span. Measured
+under the *previous* prompt, which never named the derived field at all: the model read
+`inboundRatePerSec` off the snapshot JSON anyway and reported "Receiving approximately 4.69 messages
+per second", presenting a derived estimate as an observation. A number the model will use regardless is
+better named and caveated than hidden.
+
+It stays off `earlywarning-api.md` — §1.4's rule that no bare slope accompanies a withheld forecast does
+not distinguish the two spans, and `publishedProjection()`'s whitelist strips both.
+
+### Also corrected
+
+The §2.2 paragraph telling consumers to "treat a `null` `slope` on a crossed threshold as expected" was
+stale: #187 delivered `slope` as specified and did not update the prose. Both slopes are now populated
+on every investigation, and the section says so.
+
+`inboundRatePerSec` is now stated to clamp at `0`. The two terms span different windows, so a steep
+enough drain can put the sum negative; `null` would claim there was no fit.
+
+---
+
 ## 2026-09-01 — a tool for the interface map, and `trend` gains the field that says a queue is draining
 
 **Two files, both additive.** `mcp-tools.md` gains one read tool (§3.14, `get_interface_path`);

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -124,6 +124,7 @@ The engine builds this from its own in-memory state. It is a closed allowlist:
   "trend": {
     "metric": "queued",
     "slope": 124.2,
+    "recentSlope": 124.2,
     "slopeUnit": "items/minute",
     "recentDirection": "rising",
     "thresholdValue": 50,
@@ -177,11 +178,40 @@ The baseline fields are not decoration. For this scenario the load-bearing one i
 without baselines would force the agent to assert that number instead of comparing it.
 
 **`inboundRatePerSec` is derived and must be labelled as such wherever it is shown.** No metric
-measures arrival rate at a host's queue. The engine computes `messagesPerSec + trend.slope/60` —
+measures arrival rate at a host's queue. The engine computes `messagesPerSec + trend.recentSlope/60` —
 completions plus the rate the queue is growing. It is `null` when either term is unavailable,
 **including whenever `trend` is `null`**, rather than falling back to `messagesPerSec` and reading as
 "inflow equals throughput", which is precisely the conclusion the finding contradicts. This is the
 same defect class as the coerced `lastActivity` in #58: a computed value presented as a measurement.
+
+It is **clamped at `0`** rather than reported negative. The two terms are measured over different
+spans, so a queue collapsing faster than the tail's completions were counted can put the sum below
+zero. "Negative messages arriving" is not a reading to hand a model, and `null` would claim there was
+no fit, which would be false.
+
+**It is `recentSlope`, not `slope` — amended 2026-09-01, and this paragraph said `slope` until then.**
+The window fit is the wrong span for a rate *now*. Minutes into a drain it still leans up, so the
+estimate lands **above** the raw completion rate on the one state where completions are already an
+overstatement.
+
+Measured on the live drain-through transient: `set_pool_size 1 → 4` applied, `recentDirection`
+reporting `falling`, and `messagesPerSec` reading `4` because four workers are clearing a backlog.
+
+| Arrival rate from | Value | Agent's recommendation |
+|---|---|---|
+| `messagesPerSec` alone | 4 | `set_pool_size 4 → 8` |
+| `messagesPerSec + slope/60`, queue 94 | 4.57 | `set_pool_size 4 → 6` |
+| `messagesPerSec + recentSlope/60`, queue 108 | **3.82** | **none** |
+
+The two derived rows are separate runs a few polls apart, not the same sample — the transient is short.
+What decides the outcome is which side of `messagesPerSec` each lands on: the window fit puts arrivals
+*above* throughput while the queue is emptying, and the tail fit puts them below. A consumer that keys
+on that comparison gets the right answer from one and the wrong answer from the other.
+
+So the amendment is not a refinement of the original formula — the original formula did not fix the
+case, it moved the number in the wrong direction. The flagship rise, where the two spans agree, is the
+only scenario that ever exercised it. That is what the original spec had no way to notice: the field was
+ratified before either scenario existed to measure it against.
 
 It sits in `snapshot` rather than `trend` because it is a rate *now*, not a forecast — but it is the
 one field in `snapshot` that is not measured, so it is the one field in `snapshot` that carries a
@@ -211,27 +241,38 @@ is a description of a slope now, not a prediction of a crossing.
 |---|---|---|
 | `metric` | string | `HostProjection.metric`. Only `queued` in MVP 2. Open string. |
 | `slope` | number | Same fit and same units as `Projection.slope` — OLS over the trailing 300 s. **May be zero or negative here**, unlike in `earlywarning-api.md`, because a queue that is draining is a fact the agent should see rather than a forecast to withhold. |
-| `slopeUnit` | string | Spelled out, e.g. `items/minute`. Carried so the agent never has to infer the unit. |
+| `recentSlope` | number | The **magnitude** whose sign is `recentDirection` — OLS over the trailing 120 s (the 40 % tail of the fit window, `earlywarning-api.md` §1.5). Same unit as `slope`, and signed for the same reason. Non-null whenever `trend` is non-null. **Added 2026-09-01**; `snapshot.inboundRatePerSec` is derived from it, and the agent is asked to state its sizing arithmetic, so a hidden term would be one it omits or invents. |
+| `slopeUnit` | string | Spelled out, e.g. `items/minute`. Applies to **both** slopes. Carried so the agent never has to infer the unit. |
 | `recentDirection` | string \| **null** | `rising` \| `falling` \| `steady`, from `earlywarning-api.md` §1.5 — the **sign** of the tail fit, measured. `null` when no direction is claimed. **This is the field that says a queue is draining**; see below for why `slope` does not, and for the two conditions §1.5 attaches to it. |
 | `thresholdValue` | number | `Threshold.value` — `max(baseline * 5.0, 50)`. For this scenario the `absoluteFloor` arm of 50 wins, because Cloud API's queue baseline is near zero. |
 | `thresholdCrossed` | boolean | `queued >= thresholdValue`. **Normally `true`** on an investigated finding. Present so the agent never has to infer it from a null ETA. |
 | `secondsToThreshold` | integer \| null | Whole seconds, `> 0`. **`null` whenever `thresholdCrossed` is `true`**, which is the usual case — there is no crossing left to forecast. Never `0`, never negative. |
 
-**`recentDirection` exists because `slope` does not deliver what the row above promises.** `slope` is
-specified here as "may be zero or negative ... because a queue that is draining is a fact the agent
-should see", and the §4 example carries a non-null slope beside `thresholdCrossed: true`. The engine
-does not produce that: it reads `slope` from Early Warning's `projection`, which is `null` for
-`already_crossed` — i.e. for **every** condition this endpoint is ever called about. So the draining
-fact this contract promises has never reached an agent, and the measured consequence was a
-recommendation to enlarge a pool on a queue falling from 261 to 181, because nothing in the input said
-"falling" (#177).
+**`recentDirection` exists because `slope` did not deliver what the row above promises, and the three
+fields are now one story.** `slope` is specified here as "may be zero or negative ... because a queue
+that is draining is a fact the agent should see", and the §4 example carries a non-null slope beside
+`thresholdCrossed: true`. The engine did not produce that: it read `slope` from Early Warning's
+`projection`, which is `null` for `already_crossed` — i.e. for **every** condition this endpoint is
+ever called about. So the draining fact this contract promises reached no agent for the whole of MVP 2,
+and the measured consequence was a recommendation to enlarge a pool on a queue falling from 261 to 181,
+because nothing in the input said "falling" (#177).
 
-`recentDirection` is the part of that fixable without reopening `earlywarning-api.md` §1.4, which
+`recentDirection` was the part of that fixable without reopening `earlywarning-api.md` §1.4, which
 forbids publishing a bare slope beside a withheld forecast. A **direction is not a rate**, so it
 carries no forecast to mislabel — the same argument that lets `kind: 'projection'` stay absent below.
-**The `slope` deviation is not fixed by this change and is tracked separately**: honouring it needs the
-window slope published or refitted, which is that contract's decision rather than this one's. Until
-then, read `recentDirection` and treat a `null` `slope` on a crossed threshold as expected.
+
+**`slope` was then delivered as specified in #187**, by hoisting Early Warning's existing window fit
+above its precedence chain and reading it from an internal field the endpoint's whitelist strips. No
+amendment was needed: §1.4 governs `/api/earlywarning` and this section governs the agent, which is
+the two-contracts-two-consumers split this file already argues for. `recentSlope` was added the same
+way on 2026-09-01. **So all three are now populated on every investigation**, and the paragraph that
+used to tell you to expect a `null` `slope` on a crossed threshold no longer applies.
+
+They are not redundant, and the sizing arithmetic depends on picking the right one: `slope` is the
+five-minute window, `recentSlope` the two-minute tail. A queue that rose for eight minutes and has been
+draining for two has a **positive** `slope` and a **negative** `recentSlope`, which is the state the
+agent most needs to distinguish and the one a single number flattens. Use `slope` for "how did this
+build", `recentSlope` for "what is happening now".
 
 **`recentDirection` ARRIVES WITH §1.5's TWO CONDITIONS, and they bind harder here than there.** That
 section attaches both to the field, and this contract's consumer is a model — the one already measured

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -215,9 +215,24 @@ ClassMethod DropUnapplicableAction(parsed As %DynamicObject) [ Private ]
 /// does not, and the bound that actually protects the production is `Tools.Resolve`'s 2..8, not this.
 ///
 /// THE FLOOR IS BREAK-EVEN PLUS ONE, not a full drain target. Break-even is
-/// `messagesPerSec x avgProcessingTime`; one spare worker is the minimum that makes the backlog
+/// `arrival rate x avgProcessingTime`; one spare worker is the minimum that makes the backlog
 /// shrink at all, and choosing how FAST to drain is a judgement about how much capacity to spend,
 /// which is the model's to make. This guard only refuses the sizes that cannot work.
+///
+/// THE RATE IS `inboundRatePerSec`, NOT `messagesPerSec` (#188). `messagesPerSec` counts messages
+/// COMPLETED, so on a throughput-bound host it measures the throttle rather than the load: the
+/// flagship scenario clears ~1/sec while ~2.9/sec arrive, and break-even from 1 is 1.01 workers,
+/// giving a floor of 3 for a host that needs 4. The guard raised the model's answer and was still
+/// one short of a size that drains -- so it produced the exact outcome its own note describes, an
+/// approved change the operator watches do nothing. Arrival rate is completions plus the rate the
+/// backlog is growing NOW, which the engine derives from the tail fit behind `recentDirection` and
+/// sends as `inboundRatePerSec` (`contracts/investigation-api.md` §2.2, amended 2026-09-01).
+///
+/// It falls back to `messagesPerSec` when that field is null, which the contract forbids for the
+/// FIELD and not for a consumer: null means no usable trend fit, and on a queue that is not moving
+/// the two rates converge anyway. The distinction is that the field must not claim inflow it has
+/// not measured, whereas this guard's job is to refuse an unworkable size with whatever it has. The
+/// `detail` string names which rate was used, so the arithmetic on screen is the arithmetic run.
 ///
 /// SILENT WHEN IT CANNOT COMPUTE. An absent or zero rate, or an unmeasurable processing time, leaves
 /// the recommendation untouched -- a fabricated floor from missing inputs would be the
@@ -235,7 +250,13 @@ ClassMethod RaiseUndersizedPool(parsed As %DynamicObject, snapshot As %DynamicOb
         quit
     }
 
-    set rate = snapshot.%Get("messagesPerSec")
+    // Arrival rate where the engine could derive one, completions otherwise -- see the note above.
+    set rate = snapshot.%Get("inboundRatePerSec")
+    set rateLabel = "msg/sec arriving"
+    if (rate = "") || (+rate <= 0) {
+        set rate = snapshot.%Get("messagesPerSec")
+        set rateLabel = "msg/sec completed"
+    }
     set perMsg = snapshot.%Get("avgProcessingTime")
     // Both must be present AND positive. A zero rate means nothing is arriving, so there is no
     // break-even to compute; a zero service time means the work is free and no pool size is wrong.
@@ -260,7 +281,7 @@ ClassMethod RaiseUndersizedPool(parsed As %DynamicObject, snapshot As %DynamicOb
     // indistinguishable from a model that got it right, and the arithmetic is exactly what a
     // presenter wants to be able to point at.
     set detail = "break-even is " _ $fnumber(breakEven, "", 2) _ " workers ("
-        _ $fnumber(+rate, "", 2) _ " msg/sec x " _ $fnumber(+perMsg, "", 2) _ "s), so "
+        _ $fnumber(+rate, "", 2) _ " " _ rateLabel _ " x " _ $fnumber(+perMsg, "", 2) _ "s), so "
         _ asked _ " would hold the queue steady rather than drain it"
     set parsed.resizedAction = { "requested": (asked), "applied": (floor),
         "reason": "at_or_below_break_even", "detail": (detail) }
@@ -782,18 +803,49 @@ ClassMethod SystemPrompt() As %String [ Private ]
     // The arithmetic is Little's law and every term is already in the snapshot the goal carries, so
     // this needs no new tool:
     //
-    //     workers to keep up   = messagesPerSec x avgProcessingTime
+    //     workers to keep up    = inboundRatePerSec x avgProcessingTime
     //     workers to also drain = enough spare capacity to clear `queued` in a few minutes
+    //
+    // THE RATE IS `inboundRatePerSec`, AND NAMING IT IS THE WHOLE POINT (#188). The block below said
+    // `messagesPerSec`, which counts messages COMPLETED -- on a throughput-bound host that is the
+    // throttle, not the load, so the formula returned the size the host already effectively had.
+    // Measured: ~1/sec completed while ~2.9/sec arrived, break-even 1.01, "needs 2". The example
+    // sentence has always said "arriving", so the prose was right and the formula was not, which is
+    // the worst arrangement -- the model follows the formula. `iris/CLAUDE.md`'s rule about a tool
+    // that is described but never named in a MUST applies to snapshot fields inside a stated
+    // calculation for the same reason: the model uses the term the formula spells out.
     //
     // Stated as an explicit calculation rather than "choose a sensible size", because a model asked
     // for a judgement produces a round number and a model asked for a computation shows its working
     // -- and the working is what a presenter needs to justify the number on screen.
     set p = p _ "SIZE THE POOL FROM THE NUMBERS, never by simply doubling or adding one. Work it out: "
-    set p = p _ "workersToKeepUp = messagesPerSec x avgProcessingTime, which is the pool that merely "
+    set p = p _ "workersToKeepUp = inboundRatePerSec x avgProcessingTime, which is the pool that merely "
     set p = p _ "stops the queue growing -- at that size the backlog NEVER clears. Then add capacity "
     set p = p _ "to drain what is already queued within a few minutes, and round UP. So a host taking "
     set p = p _ "1s per message with 2 arriving per second needs 2 just to break even, and 4 to break "
     set p = p _ "even and drain a backlog at about 2 per second. "
+    set p = p _ "USE inboundRatePerSec AND NOT messagesPerSec FOR THIS. messagesPerSec counts messages "
+    set p = p _ "the host COMPLETED, which is the bottleneck rather than the load on a host that cannot "
+    set p = p _ "keep up, and is an OVERSTATEMENT of the load on a host that is clearing a backlog after "
+    set p = p _ "a fix. Sizing from it is wrong in both directions. inboundRatePerSec is the arrival "
+    set p = p _ "rate: it is DERIVED, not measured -- messagesPerSec plus trend.recentSlope per minute "
+    set p = p _ "divided by 60 -- so call it an estimate when you quote it, and quote trend.recentSlope "
+    set p = p _ "beside it when you show the arithmetic. If it is null there was no usable trend fit; "
+    set p = p _ "then use messagesPerSec, say that you did, and say that it understates the arrival rate "
+    set p = p _ "while a queue is building and overstates it while one is draining. "
+    // A SEPARATE DIRECTIVE FROM THE SIZING FORMULA, because the formula alone is satisfiable by a
+    // second increase. Measured on the live drain-through transient -- pool already 1 -> 4, queue
+    // falling, `recentDirection: falling` present in the payload -- the model recommended `4 -> 8`
+    // sizing from messagesPerSec alone, and still `4 -> 6` once inboundRatePerSec was derived from the
+    // WINDOW slope, because that estimate read 4.57 and so justified its own increase. Both halves now
+    // point the other way, and neither substitutes for the other: the tail-slope estimate stops the
+    // arithmetic being wrong, and this stops correct arithmetic being applied to a queue that needs no
+    // action at all. The directive cannot fire on an estimate that reads above messagesPerSec.
+    set p = p _ "AND IF THE QUEUE IS ALREADY DRAINING, RECOMMEND NOTHING. When trend.recentDirection is "
+    set p = p _ "'falling' and inboundRatePerSec is below messagesPerSec, the host is clearing its "
+    set p = p _ "backlog with the capacity it has: return recommendedAction null and say in rootCause "
+    set p = p _ "that the queue is recovering and how fast, however deep it still is. A depth above the "
+    set p = p _ "threshold is why the finding exists, not evidence that a further change is needed. "
     set p = p _ "State the arithmetic in rootCause or in an evidence entry, including the break-even "
     set p = p _ "figure, so a reader can see why that size and not a smaller one. "
     set p = p _ "If the computed size exceeds the permitted maximum, recommend the maximum and say in "

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -89,6 +89,35 @@ export interface HostProjection {
    * the published rate and the agent's rate would come to disagree — #174's argument for the tail.
    */
   windowSlopePerMinute: number | null;
+  /**
+   * The TAIL fit's slope in `SLOPE_UNIT` — the magnitude whose sign is `recentDirection`.
+   *
+   * **INTERNAL, on the same terms as `windowSlopePerMinute`**, and stripped by the same whitelist for
+   * the same §1.4 reason. Only the sign has ever left this module.
+   *
+   * It is carried because `snapshot.inboundRatePerSec` is derived from it (#188): arrival rate is
+   * completions plus the rate the backlog is growing, and "is growing" has to mean *now*. The window
+   * fit cannot answer that. Measured on the live drain-through transient — `set_pool_size 1 -> 4`
+   * applied, `recentDirection` reporting `falling`, `messagesPerSec` reading 4 because four workers
+   * are clearing a backlog:
+   *
+   *     messagesPerSec alone                 4      -> the model recommended 4 -> 8
+   *     via windowSlopePerMinute (queue 94)  4.57   -> the model recommended 4 -> 6
+   *     via recentSlopePerMinute (queue 108) 3.82   -> the model recommended nothing
+   *
+   * A queue that is emptying must not report arrivals ABOVE its throughput, and the window fit does.
+   * It is right for an ETA, which asks how the whole rise behaves; it is wrong for "what is arriving",
+   * which is a question about the last two minutes. Same distinction #174 drew, applied to a magnitude.
+   * (The two derived rows are separate runs a few polls apart — the transient is short. What decides
+   * the outcome is which side of `messagesPerSec` each lands on.)
+   *
+   * Gated on `minFitSamples` identically to the window fit, but NOT null under identical conditions:
+   * the tail refits over the trailing 120 s, so a poll gap can leave fewer than two samples in it
+   * while the window still holds twelve. This is then null and so is `recentDirection`, which is its
+   * sign. `buildTrend` declines the whole trend object in that case rather than serving a window slope
+   * beside two nulls — see the third arm of its gate.
+   */
+  recentSlopePerMinute: number | null;
 }
 
 /**
@@ -102,7 +131,7 @@ export interface HostProjection {
  */
 export function publishedProjection(
   p: HostProjection,
-): Omit<HostProjection, 'windowSlopePerMinute'> {
+): Omit<HostProjection, 'windowSlopePerMinute' | 'recentSlopePerMinute'> {
   return {
     host: p.host,
     metric: p.metric,
@@ -423,6 +452,7 @@ export function projectHost(
     fitSpanSeconds,
     recentDirection,
     windowSlopePerMinute,
+    recentSlopePerMinute,
   };
 
   const decline = (

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -147,7 +147,11 @@ function isoSeconds(ms: number): string {
  * whatever a future field carries — so every value is named. Adding a field here is a decision, and
  * a decision is the point.
  */
-function buildSnapshot(host: Host, projection: HostProjection | undefined): Record<string, unknown> {
+function buildSnapshot(
+  host: Host,
+  projection: HostProjection | undefined,
+  trend: Record<string, unknown> | null,
+): Record<string, unknown> {
   return {
     host: host.host,
     type: host.type,
@@ -162,7 +166,61 @@ function buildSnapshot(host: Host, projection: HostProjection | undefined): Reco
     // observations. The projection itself is deliberately NOT sent -- see buildTrend.
     thresholdValue: projection?.threshold?.value ?? null,
     thresholdBasis: projection?.threshold?.basis ?? null,
+    inboundRatePerSec: inboundRatePerSec(host, trend),
   };
+}
+
+/**
+ * Arrival rate at the queue — §2.2's one DERIVED field in an otherwise measured object.
+ *
+ * `messagesPerSec` is COMPLETIONS, and on the host this product exists to fix that is the wrong
+ * number: `Cloud API` at `PoolSize 1` against a ~1s downstream reads ~1/sec because ~1/sec is all it
+ * can clear, while ~2.9/sec is arriving. Little's law fed with throughput then says "one worker is
+ * enough" about a host that is 1.9/sec behind — so the sizing arithmetic the agent shows its working
+ * with was systematically undersized on exactly the bound host it was written for (#188).
+ *
+ * Completions plus the rate the queue is growing is the arrival rate. Nothing measures it — no metric
+ * exists — so it is derived, and §2.2 requires it be labelled that way wherever it is shown.
+ * `AgentDispatcher`'s prompt carries that label; this is the only consumer.
+ *
+ * FROM `trend.recentSlope`, NOT `trend.slope`, and §2.2 was amended to say so (CHANGELOG 2026-09-01).
+ * The contract originally specified the window slope, and measuring both scenarios — which #188 was
+ * explicit about requiring — is what found that wrong. Measured on the drain-through transient:
+ * `set_pool_size 1 -> 4` applied, `recentDirection` reporting `falling`, `messagesPerSec` reading 4
+ * because four workers are clearing a backlog.
+ *
+ *     messagesPerSec alone           4      -> the model recommended 4 -> 8
+ *     via `slope`, queue 94          4.57   -> the model recommended 4 -> 6
+ *     via `recentSlope`, queue 108   3.82   -> the model recommended nothing
+ *
+ * "Is growing" has to mean now. A five-minute fit still leaning up two minutes into a drain is the
+ * right answer to the ETA question and the wrong one to this: it pushed the estimate ABOVE the raw
+ * completion rate on an emptying queue — the one state where completions already overstate the load.
+ * (The two derived rows are separate runs a few polls apart; the transient is short. What decides the
+ * outcome is which side of `messagesPerSec` each estimate lands on.)
+ *
+ * NULL RATHER THAN A FALLBACK TO `messagesPerSec`, which the contract states outright and is the
+ * whole point: throughput standing in for inflow reads as "inflow equals throughput", which is
+ * precisely the conclusion a `queue_buildup` finding contradicts. #58's defect class again — a
+ * computed value presented as a measurement.
+ *
+ * DERIVED FROM THE TREND OBJECT, not from the projection a second time, so a present
+ * `inboundRatePerSec` always has a visible `trend.recentSlope` behind it — which is why that
+ * magnitude was added to the contract rather than left internal. §2.2 ties them together in as many
+ * words — null "including whenever `trend` is `null`" — and the alternative is a snapshot implying a
+ * slope the trend declines to show.
+ */
+function inboundRatePerSec(host: Host, trend: Record<string, unknown> | null): number | null {
+  const slope = trend?.['recentSlope'];
+  if (typeof slope !== 'number') return null;
+  // 2dp, in the units the field is named for. The terms are a 1dp rate and a 1dp-per-minute slope, so
+  // an unrounded sum is float noise (`2.9000000000000004`) presented to an LLM as precision.
+  const rate = Math.round((host.messagesPerSec + slope / 60) * 100) / 100;
+  // A NEGATIVE ARRIVAL RATE IS NOT A RATE. The two terms are measured over different spans, so a queue
+  // draining faster than the tail's completions were counted can put the sum below zero -- arithmetic
+  // noise, not a host receiving negative messages. Clamped to 0 rather than nulled: "nothing is
+  // arriving" is the honest reading of it, and null would say "no fit", which is false here.
+  return rate < 0 ? 0 : rate;
 }
 
 /**
@@ -195,9 +253,10 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
    * off `/api/earlywarning`, where §1.4 forbids it; this is the consumer §2.2 published it for.
    */
   const slope = projection.windowSlopePerMinute;
+  const recentSlope = projection.recentSlopePerMinute;
   const threshold = projection.threshold?.value ?? null;
   /*
-   * NULL WHEN EITHER HALF IS MISSING, which §2.2 states as "no usable fit at all — a warming
+   * NULL WHEN ANY PART IS MISSING, which §2.2 states as "no usable fit at all — a warming
    * baseline, or fewer than 12 samples in the fit window": a null threshold is the warming case and
    * a null slope is the sample-count case, so the contract's sentence is exactly this disjunction.
    *
@@ -205,8 +264,17 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
    * so `insufficient_samples` served a trend object whose only real content was a threshold. That
    * threshold is in `snapshot.thresholdValue` too, so nothing is lost by declining here, and the
    * agent gets one meaning for a present `trend` rather than two.
+   *
+   * `recentSlope` IS A THIRD ARM RATHER THAN AN IMPLIED ONE (#188), because the two fits share a
+   * sample-count gate but not their outcome: the tail refits over the trailing 120 s, so a poll gap
+   * -- the engine records nothing while the proxy is unreachable -- can leave one sample inside it
+   * while the 300 s window still holds twelve. The tail fit is then null, and so is `recentDirection`,
+   * which is derived from its sign. Without this arm `trend` would carry a window slope beside two
+   * nulls and a `snapshot.inboundRatePerSec` of null, which is the two-meanings object the `||` above
+   * exists to refuse; §2.2's `recentSlope` row promises "non-null whenever `trend` is non-null", and
+   * this is what makes that true rather than nearly true.
    */
-  if (slope === null || threshold === null) return null;
+  if (slope === null || recentSlope === null || threshold === null) return null;
   return {
     metric: projection.metric,
     slope,
@@ -223,6 +291,17 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
      * distinguish and the one a single number flattens.
      */
     recentDirection: projection.recentDirection,
+    /*
+     * THE TAIL SLOPE'S MAGNITUDE, beside the sign that was already here (#188).
+     *
+     * Added to the contract rather than kept internal because `snapshot.inboundRatePerSec` is derived
+     * from it, and the prompt asks the model to state its arithmetic. A term it cannot see is a term
+     * it either omits or invents — and the field it would reach for instead is `slope`, which is the
+     * wrong span for "what is arriving now" and was measured producing `4 -> 6` on a draining queue.
+     *
+     * Gated with `slope`, so both are non-null whenever this object exists.
+     */
+    recentSlope,
     thresholdValue: threshold,
     // The `threshold !== null` half of this test went with the gate above, which now guarantees it.
     // Leaving it would say a null threshold is reachable here, and a reader would believe it.
@@ -444,12 +523,15 @@ export async function investigate(
   // this investigation makes, which is how a reviewer ties an action back to the reasoning.
   const requestId = `inv-${finding.id}-${started}`;
 
+  // Built first and passed in: `snapshot.inboundRatePerSec` is derived from `trend.recentSlope`, and reading
+  // it off the trend the agent actually receives is what keeps the two from ever disagreeing (#188).
+  const trend = buildTrend(projection);
   const request: InvestigationRequest = {
     requestId,
     requestedAt: isoSeconds(started),
     finding,
-    snapshot: buildSnapshot(host, projection),
-    trend: buildTrend(projection),
+    snapshot: buildSnapshot(host, projection, trend),
+    trend,
   };
 
   let raw: unknown;

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -341,7 +341,7 @@ describe('write-origin allow-list (resolve-api.md §13.2)', () => {
  * calls it. The two are different claims — the route served `snapshot.projections` raw for the whole of
  * MVP 2, so a mapper that works and a mapper that is reached would have looked identical from there.
  *
- * The projection below is a literal on purpose: it carries `windowSlopePerMinute` set, so a route that
+ * The projection below is a literal on purpose: it carries BOTH internal slopes set, so a route that
  * forgot the whitelist publishes a bare slope beside a withheld forecast and this fails.
  */
 describe('/api/earlywarning publishes no bare slope (earlywarning-api.md §1.4)', () => {
@@ -357,9 +357,13 @@ describe('/api/earlywarning publishes no bare slope (earlywarning-api.md §1.4)'
     projection: null,
     projectionUnavailable: 'already_crossed',
     windowSlopePerMinute: 26.6,
+    // Opposite sign to the window on purpose — the live drain-through transient. A route leaking this
+    // one would put "falling 25.6/min" on the panel, which §1.4 forbids for the same reason as the
+    // other: a rate beside a withheld ETA implies the forecast was withheld arbitrarily.
+    recentSlopePerMinute: -25.6,
   };
 
-  it('strips windowSlopePerMinute from the wire payload', async () => {
+  it('strips BOTH internal slopes from the wire payload', async () => {
     snapshot = { hosts: [], findings: [], projections: [PROJECTION], state: 'ok', lastPollAt: Date.now() };
     const res = await fetch(`${base}/api/earlywarning`);
     assert.equal(res.status, 200);
@@ -368,6 +372,7 @@ describe('/api/earlywarning publishes no bare slope (earlywarning-api.md §1.4)'
     const [row] = rows;
     assert.ok(row !== undefined);
     assert.ok(!('windowSlopePerMinute' in row), 'a slope must not reach the panel');
+    assert.ok(!('recentSlopePerMinute' in row), 'nor the tail slope');
     // Nothing else may go missing with it: §1 makes an absent KEY a violation even where the value
     // would be null, so the count is asserted rather than a sampling of fields.
     assert.equal(Object.keys(row).length, 10);

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -732,8 +732,10 @@ describe('windowSlopePerMinute — measured for the agent, never published (§2.
        still imply a rate we declined to state — the thing §1.4 forbids. */
     const p = series(Array.from({ length: 60 }, (_, i) => i * 3));
     assert.ok('windowSlopePerMinute' in p, 'sanity: it is on the internal type');
+    assert.ok('recentSlopePerMinute' in p, 'sanity: so is the tail magnitude');
     const wire = publishedProjection(p);
     assert.ok(!('windowSlopePerMinute' in wire), 'a slope must not reach /api/earlywarning');
+    assert.ok(!('recentSlopePerMinute' in wire), 'nor the tail slope — §1.4 does not distinguish');
     // Every other §1.1 key survives. A whitelist that dropped a published field would be the
     // opposite defect and just as invisible from the stripping assertion alone.
     for (const key of [
@@ -751,5 +753,95 @@ describe('windowSlopePerMinute — measured for the agent, never published (§2.
       assert.ok(key in wire, `publishedProjection dropped ${key}`);
     }
     assert.equal(Object.keys(wire).length, 10, 'an internal field reached the wire shape');
+  });
+});
+
+/*
+ * `recentSlopePerMinute` — the TAIL magnitude, and why it had to be carried (#188).
+ *
+ * The sign has been published as `recentDirection` since #174. The magnitude was thrown away, and
+ * `investigation-api.md` §2.2 defined `snapshot.inboundRatePerSec` — the arrival rate the pool-sizing
+ * arithmetic depends on — as `messagesPerSec + trend.slope/60`, i.e. from the WINDOW fit.
+ *
+ * That is the wrong span, measured rather than argued. Two minutes into a drain the window still
+ * leans up, so the estimate lands ABOVE the raw completion rate on the one state where completions are
+ * already an overstatement: live, `messagesPerSec 4` became `4.69` and the agent recommended `4 -> 8`
+ * on a queue emptying without help. §2.2 was amended to read `trend.recentSlope` and this is the field
+ * behind it.
+ *
+ * INTERNAL on the same terms as the window slope: `earlywarning-api.md` §1.4 does not distinguish
+ * between the two spans, and "falling ~25/min" beside a withheld ETA is exactly what it forbids.
+ */
+describe('recentSlopePerMinute — the tail magnitude, for the agent only (§2.2 amended)', () => {
+  function series(values: readonly number[], cfg = config()) {
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    let at = T0;
+    for (const v of values) {
+      store.record(HOST, 'queued', v, at);
+      at += POLL;
+    }
+    return projectHost(HOST, raw(values.at(-1) ?? 0), store, cfg, at - POLL);
+  }
+
+  /** Rise to just under `peak` in fives, then drain by 3 a poll — the drain-through transient. */
+  function riseThenDrain(peak: number, drainSamples: number): number[] {
+    const values: number[] = [];
+    for (let v = 0; v < peak; v += 5) values.push(v);
+    let v = peak;
+    for (let i = 0; i < drainSamples; i += 1) {
+      v -= 3;
+      values.push(v);
+    }
+    return values;
+  }
+
+  it('DISAGREES IN SIGN with the window fit on the drain-through transient', () => {
+    /* The load-bearing test of the pair. Same series, opposite answers: +26.6/min over five minutes
+       and -25.6/min over the last two. Everything else in this describe is a boundary condition;
+       this is the measurement that says the two fields are not interchangeable. */
+    const p = series(riseThenDrain(150, 20));
+    assert.equal(p.projectionUnavailable, 'already_crossed', 'sanity: the investigated state');
+    assert.equal(p.windowSlopePerMinute, 26.6);
+    assert.equal(p.recentSlopePerMinute, -25.6);
+    assert.equal(p.recentDirection, 'falling', 'and the sign is the one already published');
+  });
+
+  it('agrees with the window fit when the whole series moves one way', () => {
+    // Both spans see the same thing on a pure ramp, which is why the flagship scenario does not
+    // distinguish them and the test above is the one that does.
+    const p = series(Array.from({ length: 40 }, (_, i) => i * 5));
+    assert.equal(p.recentSlopePerMinute, p.windowSlopePerMinute);
+    assert.equal(p.recentSlopePerMinute, 60);
+  });
+
+  it('carries the magnitude behind recentDirection, sign for sign', () => {
+    /* The invariant that keeps the two consistent: they are one measurement, not two. A row saying
+       `falling` beside a positive rate would be a contradiction the agent cannot resolve. */
+    for (const values of [
+      Array.from({ length: 40 }, (_, i) => i * 5),
+      riseThenDrain(150, 20),
+      Array.from({ length: 40 }, () => 80),
+    ]) {
+      const p = series(values);
+      const slope = p.recentSlopePerMinute;
+      assert.ok(slope !== null, 'sanity: fitted');
+      const expected = slope > 0 ? 'rising' : slope < 0 ? 'falling' : 'steady';
+      assert.equal(p.recentDirection, expected, `slope ${slope} vs ${p.recentDirection}`);
+    }
+  });
+
+  it('is null exactly where the window slope is null — one meaning for "no fit"', () => {
+    /* Gated identically on purpose: `investigate()` derives `inboundRatePerSec` from a trend object
+       that exists only when the window slope does, so a tail slope null under a non-null window
+       would silently drop the field with no reason a reader could name. */
+    for (const p of [series([0, 1, 2, 3, 5])]) {
+      assert.equal(p.windowSlopePerMinute, null);
+      assert.equal(p.recentSlopePerMinute, null);
+    }
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    const unmeasurable = projectHost(HOST, raw(null), store, cfg, T0);
+    assert.equal(unmeasurable.windowSlopePerMinute, null);
+    assert.equal(unmeasurable.recentSlopePerMinute, null);
   });
 });

--- a/services/detection-engine/test/investigationTrend.test.ts
+++ b/services/detection-engine/test/investigationTrend.test.ts
@@ -99,7 +99,7 @@ function riseThenDrain(peak: number, drainSamples: number): number[] {
 
 /** Run one investigation and return the request the agent was handed. */
 async function requestFor(projection: HostProjection | undefined) {
-  let captured: { trend: Record<string, unknown> | null } | undefined;
+  let captured: { trend: Record<string, unknown> | null; snapshot: Record<string, unknown> } | undefined;
   await investigate(FINDING, HOST, projection, null, {
     callAgent: async (request) => {
       captured = request;
@@ -190,4 +190,124 @@ test('trend is null while the baseline is warming — the other half of the disj
 test('trend is null when Early Warning produced no projection for the host at all', async () => {
   const { trend } = await requestFor(undefined);
   assert.equal(trend, null);
+});
+
+/*
+ * `snapshot.inboundRatePerSec` and `trend.recentSlope` — §2.2, as amended 2026-09-01 (#188).
+ *
+ * `inboundRatePerSec` was ratified and never implemented, which left pool sizing computed from
+ * `messagesPerSec`. That field counts COMPLETIONS, so on the one finding MVP 2 exists to fix it
+ * measures the throttle rather than the load: a host clearing ~1/sec under ~2.9/sec of arrivals
+ * reports ~1, and `workersToKeepUp = rate x perMsg` then returns the break-even pool that holds the
+ * queue steady instead of draining it.
+ *
+ * THE AMENDMENT IS WHICH SLOPE. §2.2 said `messagesPerSec + trend.slope/60`, and measuring both live
+ * scenarios — which #188 required — showed the window slope is the wrong span. Two minutes into a
+ * drain it still leans up, so it pushed the estimate ABOVE the raw completion rate on the one state
+ * where completions are already an overstatement. The tail fit is the "now" the definition needs, and
+ * its magnitude is published as `trend.recentSlope` so the model can show the arithmetic it is asked
+ * for.
+ *
+ * The fixture below is that transient: window +26.6/min, tail -25.6/min. Opposite signs from the same
+ * series, which is why one number cannot serve both this field and the ETA.
+ */
+
+test('inboundRatePerSec is completions plus the CURRENT growth rate, not the window fit', async () => {
+  const p = project(riseThenDrain(150, 20));
+  const { snapshot, trend } = await requestFor(p);
+  assert.equal(trend?.slope, 26.6, 'sanity: the window fit still leans up');
+  assert.equal(trend?.recentSlope, -25.6, 'sanity: the tail is falling');
+
+  // 4/sec cleared with the backlog shrinking 25.6/min = 3.57/sec arriving. Via `slope` this would be
+  // 4.44 -- above the completion rate, on a queue that is emptying. That was measured recommending
+  // `4 -> 8` live, so it is the case the amendment exists for.
+  assert.equal(snapshot.inboundRatePerSec, 3.57);
+  assert.ok(
+    (snapshot.inboundRatePerSec as number) < (snapshot.messagesPerSec as number),
+    'a draining queue must put arrivals BELOW throughput',
+  );
+  assert.equal(snapshot.messagesPerSec, 4, 'the measured field is unchanged beside it');
+});
+
+test('on a queue that is still rising it is ABOVE throughput', async () => {
+  /* The flagship direction, and the reason the field exists at all: the host is behind, so what is
+     arriving exceeds what it clears. Both spans agree here, which is why the case does not
+     distinguish the two slopes and the test above is the one that does. */
+  const p = project(Array.from({ length: 40 }, (_, i) => i * 5));
+  const { snapshot, trend } = await requestFor(p);
+  assert.equal(trend?.recentSlope, 60);
+  assert.equal(snapshot.inboundRatePerSec, 5);
+  assert.ok((snapshot.inboundRatePerSec as number) > (snapshot.messagesPerSec as number));
+});
+
+test('a steady drain agrees with the window, and both put inbound below throughput', async () => {
+  const values = [150];
+  for (let i = 0; i < 30; i += 1) values.push(150 - (i + 1) * 3);
+  const p = project(values);
+  const { snapshot, trend } = await requestFor(p);
+  assert.equal(trend?.slope, -36);
+  assert.equal(trend?.recentSlope, -36, 'no rise left in the window, so the two coincide');
+  assert.equal(snapshot.inboundRatePerSec, 3.4);
+});
+
+test('it is clamped at zero rather than reporting a negative arrival rate', async () => {
+  /* The two terms are measured over different spans, so a drain steeper than the counted completions
+     can put the sum below zero. "Negative messages arriving" is not a reading a model should be given
+     -- and null would claim there was no fit, which is false. A queue collapsing 60 per poll is well
+     past anything the live scenario produces; the guard is for the arithmetic, not the scenario. */
+  const values = [900];
+  for (let i = 0; i < 14; i += 1) values.push(900 - (i + 1) * 60);
+  const p = project(values);
+  const { snapshot, trend } = await requestFor(p);
+  assert.ok((trend?.recentSlope as number) < -240, 'sanity: steeper than 4/sec of completions');
+  assert.equal(snapshot.inboundRatePerSec, 0);
+});
+
+test('inboundRatePerSec is null whenever trend is null — never a messagesPerSec fallback', async () => {
+  /* §2.2 is explicit that it is null when either term is unavailable, "including whenever `trend` is
+     null", and that it must NOT fall back to `messagesPerSec`. A fallback would not read as missing:
+     it would assert inflow equals throughput, which is the one thing a `queue_buildup` finding says
+     is false, and the consumer is a model that cannot tell a default from a measurement. */
+  for (const projection of [undefined, project([0, 1, 2, 3, 5])]) {
+    const { snapshot, trend } = await requestFor(projection);
+    assert.equal(trend, null, 'sanity: the null-trend case');
+    assert.equal(snapshot.inboundRatePerSec, null);
+    assert.notEqual(snapshot.inboundRatePerSec, snapshot.messagesPerSec);
+  }
+});
+
+test('the key is present even when the value is null — an absent field is a contract violation', async () => {
+  const { snapshot } = await requestFor(undefined);
+  assert.ok('inboundRatePerSec' in snapshot);
+});
+
+test('a poll gap that empties the tail declines the whole trend, not three of its four fields', async () => {
+  /* THE TWO FITS SHARE A SAMPLE-COUNT GATE BUT NOT AN OUTCOME, which is the third arm of buildTrend's
+     gate (#188). Twelve samples inside the 300s window and a 200s gap before the last one leaves ONE
+     sample inside the 120s tail, so the tail fit declines and `recentDirection` — its sign — declines
+     with it. Reachable in operation rather than only on paper: the engine records nothing while the
+     proxy is unreachable, and one sample arrives on recovery.
+
+     Serving `trend` here would hand the agent a window slope beside two nulls and a null
+     `inboundRatePerSec`, which is the two-meanings object the `||` in that gate exists to refuse, and
+     would break §2.2's promise that `recentSlope` is non-null whenever `trend` is. */
+  const cfg = config();
+  const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+  let at = T0;
+  for (let i = 0; i < cfg.earlyWarning.minFitSamples; i += 1) {
+    store.record(HOST_NAME, 'queued', i * 5, at);
+    at += POLL;
+  }
+  at += 200_000; // the gap: no polls landed, so no samples were recorded
+  store.record(HOST_NAME, 'queued', 100, at);
+  const p = projectHost(HOST_NAME, raw(100), store, cfg, at);
+
+  assert.equal(p.fitSampleCount, cfg.earlyWarning.minFitSamples + 1, 'sanity: the window still fits');
+  assert.ok(p.windowSlopePerMinute !== null, 'sanity: the window fit survives the gap');
+  assert.equal(p.recentSlopePerMinute, null, 'one sample in the tail is not a fit');
+  assert.equal(p.recentDirection, null, 'the sign goes with the magnitude');
+
+  const { snapshot, trend } = await requestFor(p);
+  assert.equal(trend, null);
+  assert.equal(snapshot.inboundRatePerSec, null);
 });


### PR DESCRIPTION
Closes #188.

## The defect

`snapshot.inboundRatePerSec` has been in `investigation-api.md` §2.2 since MVP 2 and **no engine build ever populated it** — #188's first step confirmed the only three mentions of the field in the repo were in that contract. So the agent sized the pool from `messagesPerSec`, which counts messages **completed**:

- on a **throughput-bound** host it is the throttle, not the load. The flagship scenario clears ~1/sec while ~2.9/sec arrives, so break-even comes out at 1.01 workers and Little's law says "one is enough" about a host 1.9/sec behind.
- on a host **clearing a backlog** after a fix it overstates the load instead — 4/sec of completions while ~1.7/sec arrives.

Wrong in both directions, on the one piece of arithmetic the Detective shows its working with.

## What changed

| Half | Files |
|---|---|
| The engine derives the field, and `trend` carries the term it is derived from | `detect/investigate.ts`, `detect/earlywarning.ts` |
| The prompt names it in the sizing formula, and `RaiseUndersizedPool` prefers it | `iris/labdemo/REST/AgentDispatcher.cls` |
| §2.2 amended: formula, the new `trend.recentSlope` row, the clamp | `contracts/investigation-api.md`, `contracts/CHANGELOG.md` |

`iris/CLAUDE.md`'s rule that **a tool that is registered and described is not a tool that gets called** applies to a snapshot field inside a stated calculation for the same reason: the model uses the term the formula spells out. Measured under the *old* prompt, which never named the field — the model read `inboundRatePerSec` off the snapshot JSON anyway and reported "Receiving approximately 4.69 messages per second", presenting a derived estimate as an observation. That is an argument for naming and caveating it, not for hiding it.

## Re-measuring both scenarios found a second defect

#188 was explicit that **both** scenarios be re-measured, because they distort `messagesPerSec` in opposite directions and #108's standing check covers only the first. Doing it is what caught this: §2.2 specified `messagesPerSec + trend.slope/60`, and the **window** fit is 300 s, so minutes into a drain it still leans up. The estimate then lands *above* the raw completion rate on the one state where completions are already an overstatement.

| Arrival rate from | Value | Agent's recommendation |
|---|---|---|
| `messagesPerSec` alone | 4 | `set_pool_size 4 -> 8` |
| `+ slope/60`, queue 94 | 4.57 | `set_pool_size 4 -> 6` |
| `+ recentSlope/60`, queue 108 | **3.82** | **none** |

The two derived rows are separate runs a few polls apart, not the same sample — the transient is short. What decides the outcome is which side of `messagesPerSec` each estimate lands on. The `4 -> 8` row is `main`'s behaviour, measured by stashing the `.cls` and recompiling `main`'s dispatcher against the same state, so the first build is an improvement rather than a regression I am reporting as one.

So the fix is the **tail** slope — the fit already computed for `recentDirection`'s sign, now published beside it as `trend.recentSlope`. Computed once, used twice: the arrangement #174 and #187 both landed.

**Attribution, so the table above does not overclaim.** The `none` outcome needs the corrected estimate **and** a new prompt directive ("if the queue is already draining, recommend nothing"). Neither alone is sufficient — the directive cannot fire on an estimate reading 4.57, and the estimate alone leaves the sizing formula free to justify a second increase.

## Contract change, per root `CLAUDE.md` §4

**One PR rather than two, stated rather than assumed.** The change is additive for `trend` and a genuine *semantic* change for `inboundRatePerSec` — the same field name can now hold a different number for the same inputs. It is safe to land in one step because no build has ever populated it, so nothing changes meaning underneath a consumer; and the CHANGELOG entry argues the two halves must land together, since the contract's own formula is what produced `4 -> 6`. Splitting it would land a contract describing a field no build populates, which is the state #188 was filed about. `contracts/CHANGELOG.md` carries the entry and the measurements.

`earlywarning-api.md` is untouched: §1.4 forbids a bare slope beside a withheld forecast and does not distinguish the two spans, so `publishedProjection()` strips both, and `api.test.ts` asserts the wire payload still carries exactly its ten keys.

## Also in here

`trend` now declines when the **tail** fit declines, not only the window fit. The two share a sample-count gate but not an outcome: a poll gap — the engine records nothing while the proxy is unreachable — can leave one sample inside the trailing 120 s while the 300 s window still holds twelve. Without that arm `trend` would carry a window slope beside two nulls and a null `inboundRatePerSec`, and §2.2's promise that `recentSlope` is non-null whenever `trend` is would be nearly true rather than true. Unit-tested; not reachable in the measured scenario.

## Verification

`tsc --noEmit` clean, **439/439** (415 was the floor before #187, 428 after it).

Three live runs, each `state: complete` / `source: agent` / `model: gpt-4o-mini` / `toolCalls: 6`, with every `evidence[]` entry attributed — the `#190` displacement risk re-checked, since this edits `SystemPrompt`:

1. **rising**, queued ~174, `messagesPerSec` 1 -> `set_pool_size 1 -> 4`, "Estimated inbound rate is 2 messages per second"
2. **15 s post-apply**, queued 176, `messagesPerSec` 4, direction still `rising` -> inbound 4.84, `4 -> 6`. **The honest limit of this fix**: at 15 s the 120 s tail genuinely still leans up, so no derivation can know the queue is draining yet.
3. **at `recentDirection: falling`**, queued 108, `messagesPerSec` 4 -> inbound 3.82, **`recommendedAction: null`**, confidence 0.85, `rootCause` describing the recovery and its rate.

Demo triggers reset afterwards; `Cloud API` pool restored to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
