### PR TITLE
fix(agent): a tool that gets called is not a tool that gets reported (#192)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,27 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `evidence[]` is not the record of what was read (documentation only)
+
+**No field, type or shape changes.** `investigation-api.md` §3.2 gains a paragraph stating the limit of
+the guarantee already there. That section promises the forward direction — a `mcp_tool` bullet means the
+call is in the audit log — and a reader can easily take the converse, that every call produces a bullet.
+It does not, and the gap was measured rather than supposed: `GetInterfacePath` was called on five
+consecutive investigations, audited every time, and reached `evidence[]` in three (#192, @tanifgit).
+
+The paragraph says so, names `diagnostics.toolCalls` as the count of tools used rather than the length of
+the array, and states that the audit log is what adjudicates a disagreement — from the response the two
+cases are indistinguishable.
+
+**Documented rather than silently fixed** because the fix is prompt-side and probabilistic. The same PR
+adds a one-entry-per-tool-call rule to the per-request goal, measured 8 of 8 against 3 of 5 before it,
+which is a real improvement and not a shape the contract can promise. A consumer that needs certainty
+needs the audit log, and that is now written down where a consumer will read it.
+
+#192.
+
+---
+
 ## 2026-09-01 — `inboundRatePerSec` is derived from the TAIL slope, not the window slope
 
 **One file, one formula corrected and one field added.** `investigation-api.md` §2.2:

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -428,6 +428,16 @@ it came from §2.2, so the engine measured it. `llm` means the model asserted it
 right, and it is not evidence in the same sense. Render the distinction; do not flatten these into
 identical bullets.
 
+**The converse does not hold, so do not read `evidence[]` as the record of what was read.** A
+`mcp_tool` bullet proves the call happened; a call that happened need not produce a bullet. The agent
+authors this array, and it was measured reporting one entry per *conclusion* rather than one per call:
+`GetInterfacePath` was called on all of five consecutive investigations, audited every time, and
+appeared in `evidence[]` in three — its answer folded into the upstream-error bullets it fed, which
+also credited those bullets with topology the error tool does not return (#192). The per-request goal
+now requires one entry per call, so the two should agree; when they do not, the audit log is what
+adjudicates, and it is the only thing that can. **The count of tools used is
+`diagnostics.toolCalls`** — that comes from the runtime — not the length of this array.
+
 `evidence: []` with `state: "complete"` is valid and means the agent produced a narrative without
 citing anything. That is a weak investigation, and it should look weak in the UI rather than being
 padded from the snapshot by either side.

--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -159,6 +159,24 @@ the reply stayed schema-valid while claiming the model had reasoned out values i
 tools. State a requirement in the same breath as the instruction it applies to; do not point at
 another part of the prompt.
 
+**And a tool that gets CALLED is not a tool that gets REPORTED.** The corollary, measured on
+`GetInterfacePath` (#192): called on every one of five runs and audited every time, attributed in
+`evidence[]` in three. `BuildGoal`'s attribution clause is a **shaping** rule — what an entry looks
+like *given that one exists* — so folding three readings into one correctly-shaped entry satisfies it
+completely, and the model reports one entry per *conclusion* rather than per call. `GetInterfacePath`
+loses most often because its answer is never a conclusion on its own: it is the input to the upstream
+error reads, so it rides along inside them, and the resulting entry credits topology to
+`get_recent_errors`. So the third thing a new tool needs is **one evidence entry per call**, stated as
+an existence rule and not implied by the attribution rule. And when you state it, carve out any tool
+whose empty read is inconclusive rather than a measurement — `GetRecentConfigChanges` is one, per #190.
+
+**Reading the reply cannot tell you which of these happened**, which is why #192 is measured with
+`Audit.Entry` deltas taken around each investigation rather than from `evidence[]`. Uncalled and
+unreported look identical from the response; the audit table adjudicates. Note it has **no
+`requestId`** — correlate by timestamp or ID range. And one tool is still not measurable this way:
+`DropUnsupportedConfigAbsence` sets `droppedEvidence` on the reply, `investigate.ts` discards it, so a
+guard refusal and a model omission are indistinguishable from the API.
+
 **Governance is per-`%AI.ToolMgr` and held in memory — there is no setting.** So never construct a
 `%AI.ToolMgr` or call `%AI.Agent.UseToolSet` directly: both give you an ungoverned manager with no
 authorization check, no audit row, and `SetPoolSize` live. Go through

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -693,6 +693,25 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "rootCause (string, 2-3 sentences explaining WHY in operator language), "
     set p = p _ "evidence (array of {label, detail, source, tool} where source is ""mcp_tool"" for a value you read with a tool "
     set p = p _ "or ""snapshot"" for one given to you, and tool is the tool name or null), "
+    // A SNAPSHOT-SIDE GRANULARITY RULE BELONGS HERE AND IS DELIBERATELY ABSENT. #192's one-entry-per-call
+    // rule in `BuildGoal` displaces `source: "snapshot"` bullets -- 0 of 8 runs carried one, against 3 of
+    // 5 before it -- so the obvious completion is a sentence here requiring an entry for any given metric
+    // the narrative argues from. Three formulations were measured and every one cost more than it bought:
+    //
+    //   in BuildGoal, as a second paragraph   3 runs: lost GetInterfacePath twice, GetHostSettings once,
+    //                                                 and reported 2 entries for 3 error calls once
+    //   here, as its own sentence             3 runs: lost GetInterfacePath in ALL THREE
+    //   here, plus "both are required"        3 runs: two clean, and one attributed two entries to
+    //                                                 GetProcessingTime -- a REAL registered tool with
+    //                                                 no audit row for that request
+    //
+    // The third is the one that settles it. A fabricated citation is not a smaller version of a missing
+    // one: `investigation-api.md` §3.2 promises that `mcp_tool` means the call is in the audit log, and a
+    // bullet marked tool-measured with nothing behind it is the #189 direction and falsifies the one
+    // guarantee a human approving a write is relying on. Silence about a snapshot number is survivable --
+    // it stays in `rootCause` prose either way. So the trade is refused rather than split, and the
+    // snapshot displacement is tracked as its own defect.
+
     set p = p _ "confidence (number 0-1, your own judgement), "
     set p = p _ "recommendedAction ({action: {type, host, size}, currentValue}) or null, "
     set p = p _ "manualRemediation ({summary, steps, target}) or null. "
@@ -1199,6 +1218,63 @@ ClassMethod BuildGoal(body As %DynamicObject) As %String [ Private ]
     set g = g _ " source ""mcp_tool"" and tool set to the exact tool name you called. Use source"
     set g = g _ " ""snapshot"" only for the metrics given to you above. Never leave source or tool"
     set g = g _ " unset for something you read with a tool."
+
+    // AND ONE ENTRY PER CALL, which the clause above does NOT already require (#192). It is a SHAPING
+    // rule -- it says what an entry looks like given that one exists -- and says nothing about how many
+    // exist. So folding three readings into one correctly-shaped entry satisfies it completely, and the
+    // model does exactly that: it reports one entry per CONCLUSION, not one per call.
+    //
+    // Measured on `6910c1b`, five runs, `Audit.Entry` deltas taken around each. The audit was identical
+    // every run -- GetHostSettings x1, GetInterfacePath x1, GetRecentConfigChanges x1, GetRecentErrors
+    // x3, and `toolCalls: 6` -- while the reply reported:
+    //
+    //     run   GetInterfacePath entry   entries for the 3 error calls
+    //      1    yes                      3
+    //      2    yes                      3
+    //      3    NO                       1
+    //      4    yes                      1
+    //      5    NO                       3
+    //
+    // GetInterfacePath IS THE ONE THAT LOSES, and not by coincidence: its answer is never a conclusion
+    // on its own, it is the INPUT to the upstream reads the MUST above demands. So when those reads
+    // collapse into one "no errors anywhere upstream" statement, the topology rides along inside it. Run
+    // 3's single entry reads `"No errors found for Cloud API, Lab Router, or EMR Source"` attributed to
+    // get_recent_errors -- and which hosts are upstream came from GetInterfacePath, so that is a
+    // MISATTRIBUTION rather than an omission, the #189 direction on the same data.
+    //
+    // Run 4 is why this is stated as granularity rather than as "something suppresses the topology
+    // read": it collapsed the error entries while KEEPING the map attributed, the inverse of 3 and 5.
+    // The two tools vary independently, so no directive is competing with GetInterfacePath specifically.
+    //
+    // A CLEAN READ IS A RESULT, stated because it is the collapsed case: three quiet hosts read as one
+    // fact worth one sentence, and that is the reasonable-sounding move that loses the provenance.
+    //
+    // GetRecentConfigChanges IS CARVED OUT, and the carve-out is load-bearing rather than tidy. "An
+    // empty read is still a result" is exactly the reasoning #190 prohibited for that one tool: it
+    // cannot distinguish "no changes were made" from "changes were made outside the paths it sees", so
+    // an absence claim from it is unsupportable and `DropUnsupportedConfigAbsence` removes it. Without
+    // this sentence the rule below would invite the claim that guard exists to refuse.
+    set g = g _ " ONE EVIDENCE ENTRY PER TOOL CALL, and never one entry for several calls: if you"
+    set g = g _ " called get_recent_errors on three hosts, that is THREE entries, each naming the host"
+    set g = g _ " you asked about. A value one tool returned must never appear in an entry attributed"
+    set g = g _ " to a different tool -- which hosts feed this one came from GetInterfacePath, so it"
+    set g = g _ " belongs in ITS entry and not inside an error entry. A clean read is a result: ""no"
+    set g = g _ " errors on Lab Router in the last 60 minutes"" is evidence and is reported, not"
+    set g = g _ " dropped because nothing was wrong. The one exception is GetRecentConfigChanges,"
+    set g = g _ " where an empty list proves nothing and the prohibition above still stands."
+    // THIS CLAUSE HAS A COST, AND IT IS NOT PAID HERE. It displaces `source: "snapshot"` bullets: with it
+    // in place eight consecutive runs reported five entries each, every one `mcp_tool`, and NOT ONE from
+    // the snapshot, where the baseline runs it replaced carried four or five in three of five. The
+    // numbers are not lost -- they move into `rootCause` prose ("a queue depth of 224 ... an inbound rate
+    // of approximately 2 messages per second") -- but their provenance is, which is this issue's own
+    // defect in the direction the clause does not cover. A block about tool calls, read last, makes the
+    // reply about tool calls.
+    //
+    // THE GOAL'S CLOSING BLOCK HAS A BUDGET, and the three attempts to spend more of it are recorded in
+    // `SystemPrompt` beside the evidence schema, where the fix for that half would go. #190 established
+    // that a long block here outcompetes the system prompt; adding a second paragraph to this one showed
+    // it also outcompetes its own first paragraph. Do not add a third rule here without measuring what
+    // the existing two lose.
     quit g
 }
 


### PR DESCRIPTION
Closes #192.

`GetInterfacePath` is called on every investigation and reaches `evidence[]` in three of five runs. @tanifgit reported it; the measurement below says why, and it is not what either of us guessed.

## The method, because reading the reply cannot answer this

"Never called" and "called but not reported" are indistinguishable from the response, so each run takes an `Audit.Entry` delta around itself. The audit was **identical every run** — `GetHostSettings x1`, `GetInterfacePath x1`, `GetRecentConfigChanges x1`, `GetRecentErrors x3`, and `diagnostics.toolCalls: 6`. All the variance is in what the reply reports.

| run | `GetInterfacePath` entry | entries for the 3 error calls |
|---|---|---|
| 1 | yes | 3 |
| 2 | yes | 3 |
| 3 | **no** | **1** |
| 4 | yes | **1** |
| 5 | **no** | 3 |

## Diagnosis

`BuildGoal`'s closing attribution clause is a **shaping** rule — what an entry looks like *given that one exists*. It says nothing about existence or granularity, so folding three readings into one correctly-shaped entry satisfies it completely, and the model reports one entry per **conclusion** rather than per call.

`GetInterfacePath` loses most often because its answer is never a conclusion on its own: it is the *input* to the upstream error reads the MUST above it demands. When those collapse into one "no errors anywhere upstream" statement, the topology rides along inside it. Run 3's single entry reads `"No errors found for Cloud API, Lab Router, or EMR Source"` attributed to `get_recent_errors` — and which hosts are upstream came from `GetInterfacePath`. That is a **misattribution**, the #189 direction, not merely an omission.

**Run 4 identifies the mechanism as granularity rather than suppression**: it collapsed the error entries while *keeping* the map attributed, the inverse of 3 and 5. The two tools vary independently, so nothing is competing with the topology read specifically — which retires the spillover hypothesis I offered on the issue.

`iris/CLAUDE.md` §7 gains the corollary to its standing rule: **a tool that is called is not a tool that is reported.**

## The fix, and what it measured

One paragraph in `BuildGoal`, as an existence rule rather than a shaping one, with `GetRecentConfigChanges` carved out — "an empty read is still a result" is exactly the reasoning #190 prohibits for that tool, and `DropUnsupportedConfigAbsence` exists to refuse it.

**8 of 8 on the shipped text**, same method, queue in the same 213–300 band as the baseline runs:

```
GetInterfacePath attributed      8/8   (was 3/5)
3 entries for 3 error calls      8/8   (was 3/5)
every reported tool audited      8/8   -- no fabricated citations
unattributed / source llm        0     every run
recommendedAction                1 -> 4 every run
#108's three fields              agent / gpt-4o-mini / toolCalls 6 every run
```

## What it costs, measured and refused rather than hidden

The clause displaces `source: "snapshot"` bullets — **0 of 8**, against 3 of 5 before it. The numbers are not lost; they move into `rootCause` prose ("a queue depth of 224 … an inbound rate of approximately 2 messages per second"). Their provenance is lost, which is this issue's own defect in the direction the clause does not cover.

Three ways to fix that half were measured, and every one cost more than it bought:

| formulation | 3 runs each |
|---|---|
| in `BuildGoal`, as a second paragraph | lost `GetInterfacePath` twice, `GetHostSettings` once, 2 entries for 3 error calls once |
| in `SystemPrompt`, as its own sentence | lost `GetInterfacePath` in all three |
| the same, plus "both are required" | two clean, and one attributed two entries to **`GetProcessingTime` — a real registered tool with no audit row for that request** |

The third settles it. A fabricated citation is not a smaller version of a missing one: §3.2 promises `mcp_tool` means the call is in the audit log, and a bullet marked tool-measured with nothing behind it falsifies the one guarantee a human approving a write relies on. So the trade is refused, both halves of the finding are written into the code where the next person will try the same thing, and the snapshot displacement is filed separately.

The general lesson, recorded in both files: **the goal's closing block has a budget.** #190 showed a long block there outcompetes the system prompt; this shows it also outcompetes its own first paragraph.

## Contract

`contracts/investigation-api.md` §3.2 gains the limit of its own guarantee — a `mcp_tool` bullet proves a call happened, a call need not produce a bullet, the count of tools used is `diagnostics.toolCalls` and not the array length, and the audit log is what adjudicates a disagreement. **No field, type or shape changes**; documented rather than promised, because the fix is prompt-side and probabilistic. `contracts/CHANGELOG.md` entry included.

## Verification

- 439/439 engine tests, including the 17 contract tests that read the file this PR edits (run with the repo root mounted — mounting only the service directory silently drops them and reports `fail 0`)
- `tsc --noEmit` clean
- `AgentDispatcher.cls` compiles clean; the directive verified present in the compiled `.INT` rather than only in the source
- 8 live investigations on the shipped text, `Audit.Entry` delta captured for each
- demo scenario reset afterwards; `armed: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
