### PR TITLE
feat(dashboard): a dark theme, as a token override and three decouplings

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -435,6 +435,28 @@ Match the brochure and deck, not the concept-demo HTML's generic dark theme. Pal
 
 Note that `--pg-critical` / `--pg-warning` / `--pg-ok` are **darkened** from the brochure's brighter marketing tones so that severity text clears WCAG AA on white. Severity must be legible on a projector at the back of a room.
 
+**The block above is a copy and it has drifted — `tokens.css` is the authority.** It predates the
+layout tokens, the three tokens dark mode needed, and the dark theme itself; treat it as the palette's
+intent, not its contents, and read the file for the values. It is not re-copied here for the same
+reason §8 refuses to restate the latency figures.
+
+**`tokens.css` now has TWO blocks: `:root` and `:root[data-theme='dark']`. A new color or shadow token
+must be added to both** — a token defined only in `:root` silently keeps its light value on a dark
+page, which is the one failure mode this arrangement has, and it does not fail loudly. Geometry, type
+and layout tokens are theme-independent and stay in `:root` alone.
+
+Dark mode is a **token override and nothing else** — see the rationale comment above the dark block,
+which is where the reasoning lives (why there is no `@media (prefers-color-scheme: dark)` here, why
+severity is re-derived rather than reused, and why `--pg-text-strong`, `--pg-rail-hover` and
+`--pg-button-primary-border` exist at all). The rule it implies for component CSS: **a primitive used
+as both ink and a background cannot be themed**, so if you find yourself setting `color:` to a token
+that something else uses as a `background:`, split it into two semantic tokens first.
+
+`src/lib/theme.ts` resolves the theme (stored choice, then the system preference) and is the only place
+that reads `prefers-color-scheme`. The pre-paint script in `index.html` duplicates its storage key
+deliberately — a module script is deferred and would flash the light background — and the two must
+change together.
+
 ### 7.2 Layout
 
 Follow the brochure mockup: a **dark navy left nav rail** (Health Connect context: Home, Dashboard, Productions, Alerts, Messages, Jobs, Settings — only *Dashboard* is active and functional; the rest are inert visual context, and should look inert, not clickable-and-broken), a **white content area** on `--pg-surface-alt`, and a header carrying the shield mark, "Production Guardian — Health Scan", the live/demo pill, last-updated time, and the mode toggle.

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -11,6 +11,36 @@
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath d='M16 2 4 6.5v9.8c0 7.3 5 12.1 12 13.7 7-1.6 12-6.4 12-13.7V6.5L16 2Z' fill='%231B2A4A'/%3E%3Cpath d='M16 7.5 9.5 10v6.3c0 4.6 3 7.7 6.5 8.8V7.5Z' fill='%2300A887'/%3E%3C/svg%3E"
     />
     <title>Production Guardian — Health Scan</title>
+    <!-- Sets the theme BEFORE first paint. It cannot live in `src/lib/theme.ts`,
+         which is where the real definitions are: `main.tsx` is a module and
+         therefore deferred, so applying the attribute from React means a flash of
+         the light page background on every reload in dark mode. A blocking inline
+         script is the only thing that runs early enough.
+
+         IN <head> AND NOT AT THE END OF <body>, which is where it is easier to
+         justify putting it. `vite-plugin-singlefile` inlines the whole bundle and
+         the whole stylesheet into <head> (§6), so a script after `#root` sits
+         ~2.5 MB into the document and after the empty root div — the one place the
+         parser could yield and paint the body background first. Being deferred,
+         the inlined module still runs after this either way.
+
+         So the storage key and the attribute name are duplicated between here and
+         `src/lib/theme.ts`, deliberately, and the two must change together. This
+         copy only ever READS: a value stored by a pre-paint script would be
+         indistinguishable from a choice the operator made. -->
+    <script>
+      try {
+        var stored = localStorage.getItem('pg.theme.v1');
+        var dark =
+          stored === 'dark' ||
+          (stored !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+      } catch (cause) {
+        /* localStorage throws in private-mode Safari and under `file://`, which is
+           how the static fallback build is opened. Light is the correct default,
+           and `useTheme` re-resolves from the media query once React mounts. */
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -47,6 +47,7 @@ import {
   IconShield,
   type IconProps,
 } from './icons';
+import { ThemeToggle } from './ThemeToggle';
 import { TriggerRail } from './TriggerRail';
 
 /** Which top-level view is on screen. */
@@ -226,6 +227,11 @@ export function AppShell({
         </h1>
         <div className="pg-header__actions">
           {headerActions}
+          {/* Rendered here rather than passed in through `headerActions`, which carries what the
+              DATA is — the mode pill, the scenario step, when it last updated. The theme is a
+              property of the display and belongs to the shell that owns the chrome, so `App` does
+              not need to know it exists. */}
+          <ThemeToggle />
           {/* A real link, not a button with an onClick: it navigates to another application, so it
               must be middle-clickable and copyable like any other link. `rel="noreferrer"` alongside
               `noopener` because the portal is a different origin. */}

--- a/apps/dashboard/src/components/ThemeToggle.tsx
+++ b/apps/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+/**
+ * The light/dark control, in the header beside the mode toggle.
+ *
+ * SELF-CONTAINED, and the only component in this app that owns its own state
+ * rather than receiving it as props (§3). That is not an exception being carved
+ * out: the theme has exactly one consumer and it is not React. `useTheme` writes
+ * `data-theme` on <html> and every rule in `app.css` reads its tokens from there,
+ * so threading a `theme` prop down from `App` would move state further from its
+ * only reader and buy nothing. Nothing else re-renders when the theme changes.
+ *
+ * IT SHOWS WHAT THE CLICK WILL DO, not what is currently on — a moon while the
+ * page is light. An icon-only control naming its own state is the ambiguous case
+ * (is the moon a label or a button?), and the accessible name and the tooltip say
+ * the same thing the icon does, so the two can never be read against each other.
+ *
+ * No `aria-pressed` for that reason: this is an action whose label changes, not a
+ * two-state switch with a fixed one. And no transition on the switch, so there is
+ * nothing for `prefers-reduced-motion` to suppress (§7.3) — a theme change is a
+ * repaint of the whole page, and cross-fading every surface at once is the one
+ * animation that reliably looks broken.
+ */
+
+import { useTheme } from '../hooks/useTheme';
+import { IconMoon, IconSun } from './icons';
+
+export function ThemeToggle(): JSX.Element {
+  const { theme, toggle } = useTheme();
+  const target = theme === 'dark' ? 'light' : 'dark';
+  const label = `Switch to the ${target} theme`;
+
+  return (
+    <button
+      type="button"
+      className="pg-button pg-button--icon"
+      onClick={toggle}
+      title={label}
+      aria-label={label}
+    >
+      {theme === 'dark' ? <IconSun size={15} /> : <IconMoon size={15} />}
+    </button>
+  );
+}

--- a/apps/dashboard/src/components/icons.tsx
+++ b/apps/dashboard/src/components/icons.tsx
@@ -293,3 +293,25 @@ export const IconArchitecture: PathIcon = (props) =>
     </>,
     props,
   );
+
+/* ── Theme ────────────────────────────────────────────────────────────────── */
+
+/**
+ * Sun — shown while the dark theme is on, because the button offers the switch
+ * back. THE CENTRE IS FILLED, unlike `IconSettings`, which is a hollow circle
+ * with the same six-spoke perimeter: at 15px those two silhouettes are otherwise
+ * near-identical, and §7.3's rule that shape carries the meaning applies to
+ * chrome as much as to severity.
+ */
+export const IconSun: PathIcon = (props) =>
+  svg(
+    <>
+      <circle cx="12" cy="12" r="4" fill="currentColor" stroke="none" />
+      <path d="M12 2.5v3M12 18.5v3M2.5 12h3M18.5 12h3M5.2 5.2l2.1 2.1M16.7 16.7l2.1 2.1M5.2 18.8l2.1-2.1M16.7 7.3l2.1-2.1" />
+    </>,
+    props,
+  );
+
+/** Crescent — shown while the light theme is on. Unmistakable at any size. */
+export const IconMoon: PathIcon = (props) =>
+  svg(<path d="M20 14.5A8.5 8.5 0 0 1 9.5 4a8.5 8.5 0 1 0 10.5 10.5Z" />, props);

--- a/apps/dashboard/src/hooks/useTheme.ts
+++ b/apps/dashboard/src/hooks/useTheme.ts
@@ -1,0 +1,59 @@
+/**
+ * Light or dark, and the one control that flips it.
+ *
+ * `lib/theme.ts` holds the decision; this holds the React part of it. The
+ * attribute is re-applied from an effect rather than only at startup so the
+ * control works — the pre-paint script in `index.html` sets the initial value and
+ * then never runs again.
+ *
+ * THE DESKTOP PREFERENCE IS FOLLOWED ONLY UNTIL THE OPERATOR CHOOSES. Before the
+ * first click the dashboard tracks `prefers-color-scheme` live, which is what
+ * makes an unattended kiosk match the machine it is on; after it, the choice is
+ * pinned and the listener is dropped. A dashboard that re-darkened itself
+ * mid-demo because the desktop hit its evening schedule would be worse than
+ * either fixed theme.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  applyTheme,
+  readStoredTheme,
+  resolveTheme,
+  storeTheme,
+  watchSystemTheme,
+  type Theme,
+} from '../lib/theme';
+
+export interface ThemeControl {
+  theme: Theme;
+  toggle: () => void;
+}
+
+export function useTheme(): ThemeControl {
+  const [theme, setTheme] = useState<Theme>(() => resolveTheme());
+
+  /* Whether the operator has chosen explicitly. Held as state rather than read
+     from storage inside the effect below, because storage is not reactive and the
+     effect has to re-run at the moment of the first click to unsubscribe. */
+  const [pinned, setPinned] = useState<boolean>(() => readStoredTheme() !== null);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (pinned) return undefined;
+    return watchSystemTheme(setTheme);
+  }, [pinned]);
+
+  const toggle = useCallback((): void => {
+    setTheme((current) => {
+      const next = current === 'dark' ? 'light' : 'dark';
+      storeTheme(next);
+      return next;
+    });
+    setPinned(true);
+  }, []);
+
+  return { theme, toggle };
+}

--- a/apps/dashboard/src/lib/theme.ts
+++ b/apps/dashboard/src/lib/theme.ts
@@ -1,0 +1,78 @@
+/**
+ * Theme preference: resolve it, apply it, remember it.
+ *
+ * The whole theme is a token override in `tokens.css` keyed on `data-theme` on
+ * <html>, so this file's only job is deciding which value that attribute holds.
+ * Nothing else in the app reads the theme — CSS does.
+ *
+ * THE SYSTEM PREFERENCE IS HONOURED HERE AND NOWHERE ELSE. `tokens.css`
+ * deliberately carries no `@media (prefers-color-scheme: dark)` block: two
+ * authorities over one decision disagree the moment an operator on a dark
+ * desktop picks light, and the disagreement would be a theme that flips back on
+ * reload.
+ *
+ * Every storage access is wrapped, matching `api/lastGood.ts`: localStorage
+ * throws in private-mode Safari and can be unavailable under `file://`, which is
+ * exactly how the static fallback build is opened (§6). A forgotten preference
+ * costs one click; an exception here would blank the page.
+ */
+
+export type Theme = 'light' | 'dark';
+
+/**
+ * ALSO READ BY THE PRE-PAINT SCRIPT IN `index.html`, which cannot import from
+ * here — it has to run before the deferred module bundle to avoid a flash of the
+ * light page background on reload. That script and this constant are the one
+ * duplicated fact in this feature and must change together.
+ */
+const KEY = 'pg.theme.v1';
+
+const QUERY = '(prefers-color-scheme: dark)';
+
+/** The operator's explicit choice, or null while they have never made one. */
+export function readStoredTheme(): Theme | null {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    return raw === 'dark' || raw === 'light' ? raw : null;
+  } catch (cause) {
+    console.warn('[theme] could not read the stored preference', cause);
+    return null;
+  }
+}
+
+export function storeTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(KEY, theme);
+  } catch (cause) {
+    // The theme still applies for this session; only its persistence is lost.
+    console.warn('[theme] could not store the preference', cause);
+  }
+}
+
+/** What the desktop asks for. Light when the browser has no opinion. */
+export function systemTheme(): Theme {
+  return window.matchMedia(QUERY).matches ? 'dark' : 'light';
+}
+
+/** An explicit choice wins; otherwise follow the desktop. */
+export function resolveTheme(): Theme {
+  return readStoredTheme() ?? systemTheme();
+}
+
+/**
+ * Calls `listener` when the desktop preference changes, and returns the
+ * unsubscribe. Kept here rather than in the hook so `matchMedia` is named in one
+ * place and the hook stays about React.
+ */
+export function watchSystemTheme(listener: (theme: Theme) => void): () => void {
+  const query = window.matchMedia(QUERY);
+  const onChange = (event: MediaQueryListEvent): void => {
+    listener(event.matches ? 'dark' : 'light');
+  };
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+}
+
+export function applyTheme(theme: Theme): void {
+  document.documentElement.dataset.theme = theme;
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -78,6 +78,12 @@ button {
   padding: var(--pg-space-4) var(--pg-space-3);
   background: var(--pg-navy-900);
   color: var(--pg-text-invert);
+  /* Transparent in the light theme, where navy against a near-white page is
+     already a 14.6:1 seam. In the dark theme every surface is dark and the rail
+     would melt into the content area without it, so the token carries a border
+     colour there instead. Border rather than shadow because the rail is a fixed
+     grid column and `box-sizing: border-box` is global, so it costs no layout. */
+  border-right: 1px solid var(--pg-rail-edge);
 }
 
 .pg-rail__brand {
@@ -114,7 +120,7 @@ button {
 }
 
 .pg-rail__item--active {
-  background: var(--pg-navy-700);
+  background: var(--pg-rail-hover);
   color: var(--pg-text-invert);
   font-weight: 600;
   box-shadow: inset 3px 0 0 var(--pg-teal-500);
@@ -140,7 +146,7 @@ button {
   align-items: baseline;
   gap: var(--pg-space-2);
   font-size: 16px;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-header__divider {
@@ -284,7 +290,7 @@ button {
   margin: 0;
   font-size: 13.5px;
   font-weight: 600;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-banner__detail {
@@ -326,14 +332,17 @@ button {
 
 .pg-toggle__option--active {
   background: var(--pg-surface);
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
   font-weight: 600;
   box-shadow: var(--pg-shadow-card);
 }
 
 .pg-button--primary {
   background: var(--pg-navy-800);
-  border-color: var(--pg-navy-800);
+  /* Same value as the fill in the light theme, so no rim shows. See the token —
+     in the dark theme it is what gives the button an edge against its card, which
+     the fill cannot do without taking the label below AA. */
+  border-color: var(--pg-button-primary-border);
   color: var(--pg-text-invert);
 }
 
@@ -372,7 +381,7 @@ button {
   border-radius: var(--pg-radius);
   font-size: 12.5px;
   font-weight: 500;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
   cursor: pointer;
 }
 
@@ -558,7 +567,7 @@ button {
 
 .pg-metric__value--emphasis {
   font-weight: 600;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-host__footer {
@@ -642,7 +651,7 @@ button {
   gap: var(--pg-space-2);
   font-size: 13px;
   font-weight: 600;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-finding__host {
@@ -738,7 +747,7 @@ button {
   margin: 0;
   font-size: 14px;
   font-weight: 600;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-empty__detail {
@@ -1297,7 +1306,7 @@ button {
 }
 
 .pg-rail__item--action:hover {
-  background: var(--pg-navy-700);
+  background: var(--pg-rail-hover);
   color: var(--pg-text-invert);
 }
 
@@ -1546,7 +1555,7 @@ button {
 }
 
 .pg-rail__item--trigger:hover:not(:disabled) {
-  background: var(--pg-navy-700);
+  background: var(--pg-rail-hover);
   color: var(--pg-text-invert);
 }
 
@@ -1638,7 +1647,7 @@ button {
 
 .pg-button--subtle:hover {
   background: var(--pg-surface-sunk);
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 .pg-chat__intro {
@@ -1667,7 +1676,7 @@ button {
   border-radius: var(--pg-radius-pill);
   font-family: inherit;
   font-size: 0.75rem;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
   text-align: left;
   cursor: pointer;
 }
@@ -2249,7 +2258,7 @@ button {
 
 .pg-button--link:hover {
   background: none;
-  color: var(--pg-navy-800);
+  color: var(--pg-text-strong);
 }
 
 /* The panel animates in with the drawer's own keyframes, so `prefers-reduced-motion` is

--- a/apps/dashboard/src/styles/tokens.css
+++ b/apps/dashboard/src/styles/tokens.css
@@ -1,7 +1,13 @@
-/* Design tokens ONLY. No selectors beyond :root, no component styles.
+/* Design tokens ONLY. No selectors beyond :root and its dark variant at the
+   bottom of this file, no component styles.
    Palette from docs/production-guardian-deck.pptx and docs/Brochure.png. */
 
 :root {
+  /* Light is the brand default and the demo default. Set explicitly so the dark
+     variant can flip it, which is what makes native scrollbars and the settings
+     drawer's number inputs follow the theme -- neither is reachable from CSS. */
+  color-scheme: light;
+
   /* Brand */
   --pg-navy-900: #142138;   /* deepest — nav rail base            */
   --pg-navy-800: #1B2A4A;   /* primary brand navy — headings, rail */
@@ -18,7 +24,30 @@
   --pg-border-soft:  #E8EEF5;
   --pg-text:         #1B2A4A;
   --pg-text-muted:   #6B7280;
-  --pg-text-invert:  #FFFFFF;
+  --pg-text-invert:  #FFFFFF;   /* text ON navy — the rail, the primary button */
+  /* Emphasised text: headings, a finding's type, a metric under emphasis. Its
+     value is `--pg-navy-800` and it is deliberately NOT written as
+     `var(--pg-navy-800)`: the dark theme lightens the navy scale so navy stays a
+     usable *fill*, and a foreground aliased to it would follow it into
+     illegibility. A primitive used as both ink and background cannot be themed,
+     so the two uses get separate tokens. */
+  --pg-text-strong:  #1B2A4A;
+
+  /* The rail is dark in both themes, so it needs its own hover and edge rather
+     than borrowing from the navy scale. In light mode the rail reads as chrome
+     because it is navy against a near-white page (14.6:1); in dark mode nothing
+     separates them, and `--pg-rail-edge` is what puts the seam back. */
+  --pg-rail-hover:   #233A5C;   /* = navy-700, lifted from the rail base */
+  --pg-rail-edge:    transparent;
+
+  /* The primary button's outline. Its value is the fill, so in this theme there is
+     no visible rim — a navy button on a white card is a 14:1 boundary already.
+     It exists for the dark theme, where the two constraints on that button pull
+     apart: white on navy needs 4.5:1 (it is the Smart Resolve approve control, so
+     its label is not negotiable) and the button's edge needs 3:1 against the card,
+     and no single navy satisfies both. The fill keeps the label; the rim keeps the
+     edge. */
+  --pg-button-primary-border: #1B2A4A;
 
   /* Severity — the only semantic colors; never reuse for decoration.
      Darkened from the brochure's marketing tones so severity text clears
@@ -53,4 +82,74 @@
   --pg-content-max: 1600px;
   --pg-drawer-width: 420px;
   --pg-focus-ring: 0 0 0 3px rgb(0 168 135 / 45%);
+}
+
+/* ── Dark theme ──────────────────────────────────────────────────────────────
+   A TOKEN OVERRIDE AND NOTHING ELSE. `app.css` is already free of literal colors
+   (§9), so every rule in it themes itself from here — the only component changes
+   dark mode needed were the two primitives above, which were serving as ink and
+   as fill at the same time.
+
+   KEYED ON THE ATTRIBUTE, WITH NO `@media (prefers-color-scheme: dark)` BLOCK.
+   The system preference is honoured, but in one place: `src/lib/theme.ts`
+   resolves stored-choice-then-system and writes `data-theme` on <html>. A media
+   query here would be a second authority over the same decision, and the two
+   would disagree the moment an operator on a dark desktop picks light.
+
+   Surfaces are navy-derived rather than neutral grey, so the brand still reads
+   dark rather than generic. Separation between page, card and inset is
+   deliberately as slight as the light theme's (1.17:1 here, 1.11:1 there) —
+   cards are told apart by their border and shadow in both themes, which is why
+   `--pg-shadow-*` is re-cast in black below instead of the navy tint that is
+   invisible on a dark page.
+
+   Severity is RE-DERIVED, not reused. The light values are darkened for AA on
+   white (§7.1) and are unreadable on a dark card; these are lifted instead, and
+   each clears 4.5:1 both on `--pg-surface` and on its own tint, the weakest
+   being 6.06:1. That is a stricter bar than the shipped light set actually
+   meets — `--pg-warning` is 3.63:1 on white, not the AA its comment claims —
+   so nothing here regresses contrast. */
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  /* Brand. Navy is a FILL in this theme — the primary button, the architecture
+     diagram's brand nodes — so the scale is lifted to stay distinguishable from
+     the surfaces below it. 900 stays dark because it is still the rail. */
+  --pg-navy-900: #101A2C;
+  --pg-navy-800: #2C4675;
+  --pg-navy-700: #3A5789;   /* primary-button hover: lighter than 800, as in light */
+  --pg-navy-600: #4A6AA0;   /* diagram flow lines — must survive on a dark card */
+  --pg-teal-500: #14C79E;   /* lifted so the accent and the focus ring read on navy */
+  --pg-teal-200: #7FD8C6;
+
+  /* Neutrals */
+  --pg-surface:      #16213A;
+  --pg-surface-alt:  #0B1220;
+  --pg-surface-sunk: #1E2A45;
+  --pg-border:       #2E3E5C;
+  --pg-border-soft:  #22304A;
+  --pg-text:         #E4EBF5;
+  --pg-text-muted:   #9CAABF;
+  --pg-text-invert:  #FFFFFF;   /* still white: still on navy */
+  --pg-text-strong:  #F2F6FB;
+
+  --pg-rail-hover:   #223257;
+  --pg-rail-edge:    #22304A;
+  --pg-button-primary-border: #5C84B8;   /* 4.2:1 against --pg-surface */
+
+  /* Severity */
+  --pg-critical:     #FF8A7A;
+  --pg-critical-bg:  #3A1D1B;
+  --pg-warning:      #E8B04B;
+  --pg-warning-bg:   #33260F;
+  --pg-info:         #7FB6EE;
+  --pg-info-bg:      #14263A;
+  --pg-ok:           #3FD3AE;
+  --pg-ok-bg:        #10302A;
+  --pg-neutral:      #9CAABF;
+  --pg-neutral-bg:   #1E2A45;
+
+  --pg-shadow-card: 0 1px 2px rgb(0 0 0 / 40%), 0 2px 8px rgb(0 0 0 / 28%);
+  --pg-shadow-drawer: -8px 0 24px rgb(0 0 0 / 45%);
+  --pg-focus-ring: 0 0 0 3px rgb(20 199 158 / 55%);
 }


### PR DESCRIPTION
The header gains a light/dark control beside the Demo/Live toggle. `app.css` was already free of literal colours (area §9), so the theme is a second block in `tokens.css` and nothing more — **no component's styling changed to support it.**

## The three decouplings, which were the actual work

A primitive used as both ink and a background cannot be themed. Three were:

| Was | Problem in dark | Now |
|---|---|---|
| `--pg-navy-800` — `color:` at 10 sites **and** the primary button's fill **and** the architecture brand node's fill | dark lifts the navy scale so navy stays a usable *fill*; the 10 foregrounds would follow it into illegibility | `--pg-text-strong` for the ink |
| `--pg-navy-700` — the rail hover **and** the primary button's hover | same scale, two unrelated jobs | `--pg-rail-hover` for the rail |
| the primary button's fill carrying both its label and its edge | white-on-navy needs 4.5:1 (it is the **Smart Resolve approve control**, so its label is not negotiable) and the edge needs 3:1 against its card — **no single navy satisfies both.** Reaching the boundary needs ~`#4A6EA8`, which drops the label to 4.4–5.1 and leaves no room for a lighter hover | fill keeps the label, a new `--pg-button-primary-border` rim keeps the edge. Its value *is* the fill in light mode, so nothing shows there |

`--pg-rail-edge` is the one place the themes are deliberately not at parity: navy against a near-white page is already a 14.6:1 seam, but in dark every surface is dark and the rail melts into the content area (1.08:1). `transparent` in light, a border colour in dark.

## Two decisions worth reviewing

**Severity is re-derived, not reused.** The shipped values are darkened for AA *on white* and are unreadable on a dark card. Each dark severity colour clears 4.5:1 both on `--pg-surface` and on its own tint, weakest 6.06:1 — a stricter bar than the light set actually meets. **Noted while measuring: the shipped light `--pg-warning` (#B8791C) is 3.63:1 on white, not the AA its own comment claims.** Left alone — changing it is a shipped-visuals change, not this PR.

**One authority for the system preference.** `src/lib/theme.ts` resolves stored-choice-then-system; `tokens.css` carries **no** `@media (prefers-color-scheme: dark)` block. Two authorities over one decision would disagree the moment an operator on a dark desktop picks light. The preference is tracked live only until the first click, then pinned — a dashboard that re-darkened itself mid-demo because the desktop hit its evening schedule would be worse than either fixed theme.

**The pre-paint script is a blocking inline classic script in `<head>`**, and both facts are load-bearing: `main.tsx` is a module and therefore deferred, so setting the attribute from React flashes the light background on every reload; and `vite-plugin-singlefile` hoists the whole bundle into `<head>`, so a script after `#root` would sit ~2.5 MB downstream of the empty root div. It only ever *reads* — a value it stored would be indistinguishable from an operator's choice. Its storage key is duplicated with `theme.ts` deliberately, and the doc comments on both sides say so.

No new dependencies. `IconSun` is filled at the centre so it is not `IconSettings` at 15px.

## Verified, not asserted

- `tsc --noEmit` clean · `node tools/validate-architecture.mjs` ok
- **`docker compose up -d --build dashboard`** — the build that ships (§6.1) — and the served bundle checked to contain the dark block, the three new tokens, 12 `--pg-text-strong` uses, 3 `var(--pg-rail-hover)` uses and the toggle's label
- Both themes **rendered headlessly at 1440×1050 from the built single file** with fixture data and read back. Dark is legible throughout; light is unchanged, as it should be — the three new tokens were given the exact values they replaced
- Token audit: nothing undefined, nothing orphaned, every colour and shadow token overridden in dark, and the 15 that are not are all geometry, type and layout

## Accepted, not fixed

The architecture diagram's brand node keeps a 1.71:1 *fill* separation in dark (its white labels are 9.37:1, and a theme-conditional token for a decorative rect is over-engineering), and the brochure PNG stays a light document on a dark page.

Area `CLAUDE.md` §7.1 is amended: `tokens.css` now has two blocks and a new colour token must be added to both. The palette copy in that section is marked as drifted rather than re-copied — same rule §8 applies to the latency figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
