### PR TITLE
fix(iris): audit a dispatcher guard refusal, which nothing recorded (#196)

### DIFF
--- a/iris/CLAUDE.md
+++ b/iris/CLAUDE.md
@@ -173,9 +173,15 @@ whose empty read is inconclusive rather than a measurement — `GetRecentConfigC
 **Reading the reply cannot tell you which of these happened**, which is why #192 is measured with
 `Audit.Entry` deltas taken around each investigation rather than from `evidence[]`. Uncalled and
 unreported look identical from the response; the audit table adjudicates. Note it has **no
-`requestId`** — correlate by timestamp or ID range. And one tool is still not measurable this way:
-`DropUnsupportedConfigAbsence` sets `droppedEvidence` on the reply, `investigate.ts` discards it, so a
-guard refusal and a model omission are indistinguishable from the API.
+`requestId`** — correlate by timestamp or ID range.
+
+**And a `dropped` row is not a tool call, so counting tool calls from that table now needs a
+`Disposition` filter.** Until #196 the table held only `executed` and `denied` rows and every row was a
+tool call, which is the assumption #192's delta method was built on. It no longer holds: the four
+dispatcher guards write a row apiece, under the guard's own method name. The upside is that
+`DropUnsupportedConfigAbsence` is finally measurable — it used to set `droppedEvidence` on a reply
+`investigate.ts` discards, so a guard refusal and a model omission were byte-identical from the API and
+that tool had to be excluded from #192's table outright.
 
 **Governance is per-`%AI.ToolMgr` and held in memory — there is no setting.** So never construct a
 `%AI.ToolMgr` or call `%AI.Agent.UseToolSet` directly: both give you an ungoverned manager with no
@@ -186,6 +192,15 @@ authorization check, no audit row, and `SetPoolSize` live. Go through
 denial throws before the audit hook. `Tools.AuthPolicy` writes that row itself. Anything that adds a
 new deny path must go through its `Deny()` helper or the refusal leaves no trace — which is the one
 event a security review actually asks about.
+
+**Nor does anything audit a guard that refuses a claim in the reply, so `REST.AgentDispatcher`'s guards
+write their own rows too — a new guard must end with `RecordRefusal()` (#196).** Same shape of hole as
+the sentence above and found the same way: the two writers there are both tool-level and both fire
+*before* the dispatcher inspects the reply, so a guard refusal reached no writer at all. It used to be
+recorded only on a response field whose only consumer discards it, which meant "the AI recommended X
+and we suppressed it" was unreconstructable an instant after the request ended. The row carries the
+model's claim verbatim, because our reason for refusing it is not the same information as the thing
+refused.
 
 **Tool return values reach an external LLM: metrics and configuration only, never message content
 or PHI** (root `CLAUDE.md` §2.1). `Ens_Util.Log` on this instance holds 61,772 rows carrying
@@ -200,7 +215,7 @@ returns PHI, it lands in `Audit.Entry.Result` in plain text.
 | Read tools return real evidence | met — six tools discovered, live values |
 | `set_pool_size` changes the live pool and is reversible | met — a real `1 → 4` against a queue held at its cap, drained to 0, `Reset()` restored pool 1 (#102). Reversal is *recorded* and correct; reversing **through the API** is blocked by #100 |
 | An unauthorized role is refused | met **by the fixture, not by the running system** — see below |
-| Every call appears in the audit log | met for executions and for authorization denials |
+| Every call appears in the audit log | met for executions, for authorization denials, and — since #196 — for the four dispatcher guard refusals |
 | RBAC roles and resources exist from a clean boot | met, and **verified from a real boot** rather than inferred: the four security objects were deleted and `docker compose restart iris` recreated them through step 9. `Audit/` compiled on the way through, including its SQL table, so the recursive load picks up a new subdirectory |
 | A principal can actually *use* the roles | needs `%DB_%DEFAULT` **as well**, from the invocation path — the `Guardian_*` roles stay minimal and grant only `PG_*`. Without it you get `<PROTECT>` before any policy is consulted |
 | LLM credential in the vault | met — `Setup.AIHub.CreateProvider()` provisions the wallet entry and the `AI.LLM.pgdetective` config from `PG_LLM_API_KEY` at boot (#106), verified on a cold-provisioned instance. **No key, no default:** absent, the boot says `SKIPPED` and AI Detective degrades to a labelled `source: "canned"` |

--- a/iris/labdemo/Audit/Entry.cls
+++ b/iris/labdemo/Audit/Entry.cls
@@ -61,6 +61,12 @@ Property Roles As %String(MAXLEN = 512);
 /// `%LogExecution` payload: `call.name` is `"GetPoolSize"`. The contract's catalogue calls the same
 /// tool `get_pool_size`, so anything joining this column to the contract must map, and
 /// `Tools.AuthPolicy.#WRITETOOL` already depends on the method-name form.
+///
+/// ON A `dropped` ROW THIS IS A GUARD, NOT A TOOL -- `DropUnapplicableAction` and its three siblings.
+/// Still an ObjectScript method name, so the column stays one kind of thing and `ByTool` stays useful
+/// for "did this guard ever fire". But it means **counting tool calls from this table must filter on
+/// `Disposition`**, which the `Audit.Entry`-delta method in #192 did not have to do and any repeat of
+/// it now does.
 Property Tool As %String(MAXLEN = 128) [ Required ];
 
 /// The call's arguments as JSON.
@@ -76,9 +82,9 @@ Property Arguments As %String(MAXLEN = "");
 /// record alone rather than from the operator's memory.
 Property Result As %String(MAXLEN = "");
 
-/// `executed` | `denied`.
+/// `executed` | `denied` | `dropped`.
 ///
-/// TWO VALUES BECAUSE THERE ARE TWO WRITERS, and that is forced by the runtime rather than chosen.
+/// ONE VALUE PER WRITER, and each writer exists because the one before it could not see the event.
 /// `%AI.ToolMgr.ExecuteTool` checks authorization, then executes, then audits -- so an authorization
 /// denial THROWS `<%AICore>ToolAccessDenied` at step one and the audit hook is never reached.
 /// Measured, with a deny-all policy registered: 0 audit records written, `%LogExecution` never
@@ -88,13 +94,28 @@ Property Result As %String(MAXLEN = "");
 /// This is why `mcp-tools.md` §5.5 and `resolve-api.md` §8 both overpromise: a tool-level refusal
 /// (our bounds guard returning `outcome: "refused"`) IS audited, because the tool ran; an
 /// authorization refusal is not. The security-relevant one was the one missing.
+///
+/// `dropped` IS THE THIRD, and it arrived the same way (#196). `REST.AgentDispatcher`'s guards refuse
+/// a *claim in the model's reply* -- after every tool has already run and audited -- so neither writer
+/// above can see one, and the refusal used to live only on a response field the engine discards. A
+/// distinct value rather than reusing `denied`: a security review asking "what was refused for lack of
+/// privilege" and a demo review asking "what did we suppress in the narrative" are different
+/// questions, and one disposition answering both makes neither query correct. `refused` was rejected
+/// as the name because the `Disposition` paragraph above already spends it on a *tool-level* refusal
+/// that audits as `executed`; `dropped` is the word this codebase already uses for the event, in the
+/// guards' own method names and in the `droppedAction` / `droppedRemediation` / `droppedEvidence`
+/// fields they set.
 Property Disposition As %String(MAXLEN = 16) [ Required ];
 
-/// Populated on `denied` rows: the reason the authorization policy refused.
+/// Populated on `denied` and `dropped` rows: the reason the refusal happened.
 ///
-/// Names the rule and the missing privilege only. A refusal string crosses the same boundary as any
-/// other tool output (`Tools.AuthPolicy` keeps it free of instance data), and that discipline is
-/// worth preserving in storage too.
+/// On a `denied` row it names the rule and the missing privilege only. A refusal string crosses the
+/// same boundary as any other tool output (`Tools.AuthPolicy` keeps it free of instance data), and
+/// that discipline is worth preserving in storage too.
+///
+/// On a `dropped` row it is the guard's own `reason` token -- `not_whitelisted_host`,
+/// `downstream_unreachable`, `stale_connectivity_claim`, `unsupported_config_absence_claim` -- taken
+/// from the object the guard built rather than restated here, so the two cannot drift.
 Property DenialReason As %String(MAXLEN = 512);
 
 /// Milliseconds, as the runtime reports them.
@@ -134,7 +155,14 @@ Index ByTool On Tool;
 /// did happen -- the worst of both. So this reports "" and the caller records that it could not
 /// write; `resolve-api.md` §8 covers the consequence: `auditId: null`, and for an apply that is
 /// `failed`/`verify` rather than a silent success.
-ClassMethod Record(actor As %String, tool As %String, arguments As %String, result As %String, disposition As %String, durationMs As %Integer = "", statusText As %String = "", denialReason As %String = "") As %String
+/// `publishHandle` OFF MEANS "this row is not the call I just made". The process-private handle below
+/// answers exactly one question -- what did *this* process last execute -- and `Tools.Governance.Invoke`
+/// reads it unconditionally after `ExecuteTool`, including on the path where the tool's own audit write
+/// failed. So a writer whose rows nobody correlates must not touch it, or a `SetPoolSize` whose audit
+/// write failed would report a *guard refusal's* handle as its `auditId`. CSP reuses processes across
+/// requests, so "an investigation and a resolve in the same process" is the ordinary case, not a
+/// contrived one.
+ClassMethod Record(actor As %String, tool As %String, arguments As %String, result As %String, disposition As %String, durationMs As %Integer = "", statusText As %String = "", denialReason As %String = "", publishHandle As %Boolean = 1) As %String
 {
     set entry = ..%New()
     set entry.RecordedAt = ..NowUTC()
@@ -157,7 +185,44 @@ ClassMethod Record(actor As %String, tool As %String, arguments As %String, resu
     // here in a way that "the newest row for this actor and tool" is not -- two investigations
     // running concurrently would read each other's. Dev B's resolve endpoint needs `audit.auditId`
     // for the response and this is how it gets it without a query that can be wrong.
-    set ^||ProductionGuardian.Audit("last") = handle
+    if publishHandle {
+        set ^||ProductionGuardian.Audit("last") = handle
+    }
+    quit handle
+}
+
+/// Write one row for a dispatcher guard that refused a claim in the model's reply. Returns the handle,
+/// or "" if the write failed.
+///
+/// THE THIRD WRITER, and it lives here for the same reason the other two do: `Record` above takes
+/// already-extracted fields precisely so that writers recording different events can share the
+/// storage and nothing else. A guard refusal is a third kind of event -- see `Disposition`.
+///
+/// IT SWALLOWS ITS OWN FAILURE, and the four call sites therefore have no error handling. That is
+/// deliberate and it is `Tools.AuthPolicy.Deny`'s argument applied to a different failure: a refusal
+/// that could not be recorded is still a refusal, and a guard that let an audit-write error propagate
+/// would turn "we suppressed a bad recommendation and could not log it" into a 500 for the whole
+/// investigation -- restoring the bad recommendation's absence *and* losing the diagnosis. Wrapped
+/// here rather than at each call site so a fifth guard cannot forget it, which is the same reasoning
+/// that made `Deny()` the single deny path.
+///
+/// `refused` IS THE MODEL'S OWN CLAIM, verbatim, as it was removed. That is the point of the row --
+/// #196's complaint was that "the AI recommended X and we suppressed it" was not reconstructable, and
+/// `record` alone carries only our reason for the refusal, not the X. It stays inside the instance:
+/// this table is never sent anywhere, unlike a tool return value.
+ClassMethod RecordRefusal(guard As %String, host As %String, refused As %DynamicAbstractObject = "", record As %DynamicObject = "") As %String
+{
+    // Assigned, then quit AFTER the try. `quit <value>` inside a TRY is #1043 "QUIT argument not
+    // allowed" -- inside a block, QUIT means leave the block, so it cannot also carry a return value.
+    set handle = ""
+    try {
+        set arguments = {"host": (host)}
+        set payload = { "refused": (refused), "record": (record) }
+        set why = $select($isobject(record): record.%Get("reason", ""), 1: "")
+        set handle = ..Record($username, guard, arguments.%ToJSON(), payload.%ToJSON(), "dropped", , , why, 0)
+    } catch ex {
+        set handle = ""
+    }
     quit handle
 }
 

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -191,6 +191,10 @@ ClassMethod DropUnapplicableAction(parsed As %DynamicObject) [ Private ]
         quit
     }
 
+    // Captured before the clear, for the audit row: the whole recommendation, not just its `action`,
+    // because a reviewer asking what we suppressed wants the confidence and the rationale that came
+    // with it too.
+    set refused = parsed.recommendedAction
     set parsed.recommendedAction = ""
     // Built before the literal: a concatenation inside a %DynamicObject constructor is #1021
     // "Expected right bracket". Only a parenthesised single expression is accepted there.
@@ -200,6 +204,7 @@ ClassMethod DropUnapplicableAction(parsed As %DynamicObject) [ Private ]
     // filter is indistinguishable from a model that behaved. The engine ignores unknown keys.
     set parsed.droppedAction = { "type": (action.%Get("type", "")), "host": (host),
         "reason": "not_whitelisted_host", "detail": (detail) }
+    do ..RecordRefusal("DropUnapplicableAction", host, refused, parsed.droppedAction)
 }
 
 /// Raise a pool recommendation that is at or below break-even. Private.
@@ -332,10 +337,12 @@ ClassMethod DropPoolFixDuringOutage(parsed As %DynamicObject, host As %String) [
         quit
     }
 
+    set refused = parsed.recommendedAction
     set parsed.recommendedAction = ""
     set detail = "a connectivity error occurred " _ freshest _ "s ago, so more workers would fail faster rather than drain the queue"
     set parsed.droppedAction = { "type": "set_pool_size", "host": (host),
         "reason": "downstream_unreachable", "detail": (detail) }
+    do ..RecordRefusal("DropPoolFixDuringOutage", host, refused, parsed.droppedAction)
 }
 
 /// Age in seconds of the newest CONNECTIVITY error in a get_recent_errors reply, or "". Private.
@@ -427,6 +434,10 @@ ClassMethod DropStaleConnectivityClaim(parsed As %DynamicObject, host As %String
     // Recorded, not silent -- same reasoning as droppedAction. A reviewer needs to see that the
     // model claimed something and that we refused it, or this looks like a model that behaved.
     set parsed.droppedRemediation = { "reason": "stale_connectivity_claim", "detail": (detail) }
+    // `manual` and not `parsed.manualRemediation`, which is now "". This is the one guard whose
+    // response field carries no trace of what was said -- `droppedRemediation` has a reason and a
+    // detail and no summary -- so the audit row is the only place the refused claim survives at all.
+    do ..RecordRefusal("DropStaleConnectivityClaim", host, manual, parsed.droppedRemediation)
 }
 
 /// Strip an evidence entry that reports configuration the audit log cannot report. Private.
@@ -467,11 +478,18 @@ ClassMethod DropStaleConnectivityClaim(parsed As %DynamicObject, host As %String
 /// `evidence` or `rootCause` -- same division as `droppedRemediation`. The dispatcher may refuse a
 /// claim; it may not become a second author of the narrative.
 ///
-/// `droppedEvidence` REACHES THE AUDIT TRAIL AND THIS INSTANCE'S OWN REPLY, NOT THE API. Same reach as
-/// `droppedAction` and `droppedRemediation`, and worth stating rather than assuming: `investigate.ts`
-/// builds its response field by field from a parsed subset, so an extra key here is ignored rather
-/// than rejected -- no contract change, and no route to the dashboard either. Surfacing a refusal in
-/// the UI is a findings-API question and belongs in that contract, not in this class.
+/// `droppedEvidence` REACHES THIS INSTANCE'S OWN REPLY AND NOT THE API. Same reach as `droppedAction`
+/// and `droppedRemediation`, and worth stating rather than assuming: `investigate.ts` builds its
+/// response field by field from a parsed subset, so an extra key here is ignored rather than rejected
+/// -- no contract change, and no route to the dashboard either. Surfacing a refusal in the UI is a
+/// findings-API question and belongs in that contract, not in this class.
+///
+/// The audit trail is reached SEPARATELY, by `RecordRefusal` below, and this comment claimed otherwise
+/// until #196. It said "reaches the audit trail and this instance's own reply" while nothing in
+/// `iris/**` wrote an `Audit.Entry` row for a guard refusal -- the two writers were both tool-level and
+/// both fire before the dispatcher ever sees the reply. So the field's only consumer discarded it and
+/// the refusal outlived nothing. A comment naming a reach the code does not have is worse than no
+/// comment: it sent the person who found this looking for a defect in `investigate.ts`.
 ClassMethod DropUnsupportedConfigAbsence(parsed As %DynamicObject, host As %String) [ Private ]
 {
     set evidence = parsed.%Get("evidence")
@@ -492,12 +510,17 @@ ClassMethod DropUnsupportedConfigAbsence(parsed As %DynamicObject, host As %Stri
     }
 
     set kept = []
+    // The removed entries, kept for the audit row. The response only ever learns HOW MANY were
+    // dropped, so without this the entries themselves are gone the moment the reply is written --
+    // which is the half of #196 that no response field could have fixed.
+    set removed = []
     set dropped = 0
     for i = 0:1:evidence.%Size() - 1 {
         set entry = evidence.%Get(i)
         set tool = $select($isobject(entry): entry.%Get("tool", ""), 1: "")
         if $piece(tool, ".", $length(tool, ".")) = "GetRecentConfigChanges" {
             set dropped = dropped + 1
+            do removed.%Push(entry)
             continue
         }
         do kept.%Push(entry)
@@ -515,6 +538,33 @@ ClassMethod DropUnsupportedConfigAbsence(parsed As %DynamicObject, host As %Stri
             _ ##class(ProductionGuardian.LabDemo.Tools.ChangeLog).#DEFAULTWINDOW _ "h. Rows take tens "
             _ "of seconds to become readable and a setting changed outside the Management Portal is "
             _ "not audited at all, so this cannot rule a change out.") }
+    // THIS ROW IS ALSO A MEASUREMENT FIX, not only a durability one. #192 could not count
+    // `GetRecentConfigChanges` at all, because from the API a guard refusal and a model omission are
+    // byte-identical -- the tool call audits, the evidence entry simply is not there, and nothing said
+    // which happened. A `dropped` row for this guard is what separates the two.
+    do ..RecordRefusal("DropUnsupportedConfigAbsence", host, removed, parsed.droppedEvidence)
+}
+
+/// Persist one guard refusal to the audit trail. Private.
+///
+/// EVERY GUARD ENDS WITH THIS CALL, which is `Tools.AuthPolicy.Deny`'s rule for a different event: a
+/// row written by four separate branches is one a fifth branch will forget. Kept as a one-line
+/// forwarder rather than calling `Audit.Entry` from each guard, so "did this guard record its refusal"
+/// is answerable by reading the last line of each method.
+///
+/// THE STORAGE DECISION IS NOT HERE. `Audit.Entry.RecordRefusal` chooses the disposition, swallows a
+/// failed write, and keeps the refusal out of the process-private handle -- all three matter and all
+/// three are explained there. Nothing in this class needs to know them.
+///
+/// NOT AUDITED: `RaiseUndersizedPool`. It is the one dispatcher method here that changes the model's
+/// recommendation instead of refusing it, so "the AI recommended X and we suppressed it" is not what it
+/// does -- and #196 scoped itself to the four refusals deliberately. Auditing a *modified* value is a
+/// good argument and a separate one, because the row would need a shape these four do not
+/// (`requested` and `applied`, not `refused`), and because an operator approving a raised
+/// recommendation is a different review question from one never shown a refused claim.
+ClassMethod RecordRefusal(guard As %String, host As %String, refused As %DynamicAbstractObject, record As %DynamicObject) [ Private ]
+{
+    do ##class(ProductionGuardian.LabDemo.Audit.Entry).RecordRefusal(guard, host, refused, record)
 }
 
 /// Invoke the governed write tool. Every guard is the tool's, not this class's.


### PR DESCRIPTION
Closes #196.

`AgentDispatcher`'s four guards refuse a claim in the model's reply and record the refusal into `droppedAction` / `droppedRemediation` / `droppedEvidence`. The class comment said those reach *"the audit trail and this instance's own reply"*. Only the second half was true — `investigate.ts` discards them by construction, and **nothing in `iris/**` wrote an `Audit.Entry` row for a guard refusal.** The only two writers are `Tools.AuditPolicy` (a tool executed) and `Tools.AuthPolicy` (a tool was denied), and both fire *before* the dispatcher ever sees the reply.

So a refusal outlived nothing. "The AI recommended X and we suppressed it" was unreconstructable an instant after the request ended — which is the one event a review of an AI acting on a production actually asks about, and which §7 already says in as many words for the analogous authorization case.

## The fix

`Audit.Entry.RecordRefusal()` is the third writer, on the class that exists to be shared storage for writers that see different events. Four decisions worth reviewing:

- **Disposition `dropped`, not `denied`.** "What was refused for lack of privilege" and "what did we suppress in the narrative" are different queries; one value answering both makes neither correct. Not `refused` either — `Disposition`'s own comment already spends that word on a *tool-level* refusal that audits as `executed`. `dropped` is what this codebase already calls the event.
- **It swallows its own write failure**, so the four call sites have no error handling. `AuthPolicy.Deny`'s argument for a different failure: a refusal that could not be recorded is still a refusal, and letting the error propagate turns "we suppressed a bad recommendation and could not log it" into a 500 for the whole investigation — losing the diagnosis too.
- **It does not publish the process-private handle**, hence `Record`'s new `publishHandle` argument. `Tools.Governance.Invoke` reads `LastHandle()` unconditionally after `ExecuteTool`, including where the tool's own audit write failed; CSP reuses processes across requests, so without this a `SetPoolSize` could report a *guard refusal's* handle as its `auditId`.
- **The row carries the model's claim verbatim, as removed.** Our reason for refusing is not the same information as the thing refused — and for `DropStaleConnectivityClaim` the response keeps no trace of what was said at all (`droppedRemediation` has a reason and a detail and no summary). It stays inside the instance; this table is never sent anywhere.

`DropUnsupportedConfigAbsence` also had to start retaining the entries it strips — the response only ever learned *how many* — which is the half of #196 no response field could have fixed.

## Two consequences, recorded in `iris/CLAUDE.md` §7

A new guard must end with `RecordRefusal()`, and **counting tool calls from `Audit.Entry` now needs a `Disposition` filter**, which #192's delta method did not. The upside is the one #196 flagged: `DropUnsupportedConfigAbsence` becomes measurable at all, where #192 had to exclude it because a guard refusal and a model omission were byte-identical from the API.

**No contract change.** Nothing in `contracts/` enumerates the audit disposition and neither the engine nor the dashboard reads it (grepped). The reply shape is untouched — no field added, none removed.

**Not audited, deliberately:** `RaiseUndersizedPool`, which *modifies* the model's recommendation rather than refusing it. It deserves a row on the same argument but in a different shape (`requested`/`applied`), and #196 scoped itself to the four refusals. Noted at the helper rather than silently widened — happy to file it as a follow-up.

## Verified

Both classes compiled clean against the running instance, and the writer was driven directly **inside a transaction that rolls back**, so the audit table gains no fabricated rows — 590 before, 590 after. (Deleting test rows from an audit log afterwards is the thing an audit log exists to prevent, so the rows were never committed in the first place.)

- a refusal row reads back `Disposition=dropped`, `Tool=DropUnapplicableAction`, `DenialReason=not_whitelisted_host`, `Arguments={"host":"EMR Source"}`, and a `Result` carrying the model's whole recommendation alongside our record
- `Describe()` renders it, so the existing audit view shows it with no change
- `LastHandle()` still returned a pre-set sentinel afterwards — the `publishHandle` decision holds
- degenerate inputs (no record, empty claim) return a handle and throw nothing
- the fourth guard's array-shaped claim serializes
- all four call sites present in the compiled `.INT`, plus the forwarder

`$CLASSMETHOD` on a `Private` method is `<PRIVATE METHOD>` — measured — which is why the writer lives on `Audit.Entry` where it can be driven at all, rather than as a private helper on the dispatcher. The guards themselves stay unreachable from a terminal, so **their firing end-to-end is still only observable on a live metered run**; that is not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
