### PR TITLE
fix(iris): GetEventLogTrend fell through its own unknown-host guard (#156)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,31 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `get_event_log_trend` documents `reason`, and one value of it means "the host may not exist"
+
+**No field, type or shape changes** — `reason` has been returnable from this tool since it shipped and
+was simply absent from §3.11's output list. `mcp-tools.md` §3.11 now lists it, and tabulates its two
+values against what they say about `buckets[]`.
+
+The row worth the paragraph is `host existence unverified`, which is **new behaviour in the same PR**
+(#156): the unknown-host guard's existence check tested `%SQLCODE >= 0` inside one `&&` chain, so a
+failed check made the whole condition false and fell through to a complete set of zero-filled buckets.
+This family inverts §2.1's sign — a log count of `0` is a measurement — so those zeros assert that the
+host was quiet, which is precisely the claim the guard exists to prevent for a host name a model
+invented. The fix separates the two tests and publishes `reason` instead of implying an all-clear.
+
+**Documented rather than left internal** because the resulting payload is the one shape in this tool
+that a consumer can read wrongly *while it is entirely correct*: the trend is true of the rows that
+exist, and it still is not evidence that the host does. So the contract now says a populated trend
+carrying that `reason` is not confirmation the host is real.
+
+`reason` and not `error`, per §4: the tool ran and the buckets are readable. That distinction is the
+same one §3.8 already draws between the two words.
+
+#156.
+
+---
+
 ## 2026-09-01 — `evidence[]` is not the record of what was read (documentation only)
 
 **No field, type or shape changes.** `investigation-api.md` §3.2 gains a paragraph stating the limit of

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1375,7 +1375,8 @@ prefix boundary falling on a clean unit is the minute. Looked up in a fixed `$ca
 distinction is how a model asks for 1440 buckets of days. Out of range is refused:
 `{"error":"buckets must be an integer between 1 and 720","sanitised":true}`.
 
-**Output**: `host`, `resolution`, `buckets[]`, `sanitised`, `from`, `to`, `total`.
+**Output**: `host`, `resolution`, `buckets[]`, `sanitised`, `from`, `to`, `total`, and `reason` where it
+applies (below).
 
 `buckets[]`: `start`, `total`, and one count per severity — `assert`, `error`, `warning`, `info`,
 `trace`, `alert`. **All six keys are always present**, so a severity that did not occur reads as `0`
@@ -1401,6 +1402,28 @@ name look identical otherwise:
 { "host": "No Such Host", "resolution": "hours", "buckets": [], "sanitised": true,
   "error": "no event log rows exist for that host under any window -- call GetEventLogSummary to see which hosts have logged" }
 ```
+
+**`reason` says which of this payload's two reads failed, and the buckets stay readable in one of the
+two cases.** §3.8 draws the same line — `reason` instead of buckets when there is nothing to say,
+`error` when nothing could be read — and this tool has two independent queries, so it needs both words:
+
+| `reason` | What ran, what did not | `buckets[]` |
+|---|---|---|
+| `event log unreadable (SQLCODE n)` | the trend query itself failed | empty — there is nothing to publish |
+| `host existence unverified (SQLCODE n)` | the trend was read; the **existence check** before it failed | populated and correct |
+
+The second row is the interesting one and it is why `reason` is documented here rather than left as an
+implementation detail. Zeros in this family are a *measurement* (above), so a zero-filled trend asserts
+that the host was quiet — and for a host name a model invented, that assertion is false. The unknown-host
+`error` exists to stop exactly that. When the check behind it cannot run, the trend is still true of
+whatever rows exist, but nobody can be told whether the host is real, so the payload says so instead of
+implying an all-clear. **A consumer must not read a populated trend carrying this `reason` as
+confirmation that the host exists.**
+
+Before #156 that case silently produced the zero-filled payload with no `reason` at all: the guard's
+condition tested `%SQLCODE >= 0` as part of one `&&` chain, so a failed check made the whole test false
+and fell through to the buckets. Low likelihood, and a wrong answer rather than an absent one when it
+fires.
 
 ```jsonc
 // <- host "(production)", hours, 6. The two empty leading buckets are the point.

--- a/iris/labdemo/Tools/EventLog.cls
+++ b/iris/labdemo/Tools/EventLog.cls
@@ -421,7 +421,22 @@ ClassMethod GetEventLogTrend(host As %String = "", resolution As %String = "hour
     if (host '= "") && (host '= ..#PRODUCTIONSCOPE) {
         set crs = ##class(%SQL.Statement).%ExecDirect(,
             "SELECT COUNT(*) N FROM Ens_Util.Log WHERE %EXACT(ConfigName) = ?", host)
-        if (crs.%SQLCODE >= 0) && crs.%Next() && (crs.%Get("N") = 0) {
+        // A FAILED EXISTENCE CHECK MUST NOT SKIP THE GUARD SILENTLY, which is what one `&&` chain did:
+        // `%SQLCODE < 0` made the whole condition false, execution fell through, and the method
+        // returned a complete set of zero-filled buckets -- the exact payload the paragraph above
+        // exists to prevent, with nothing anywhere saying the check had not run (#156). Every other
+        // query site in this class tests `%SQLCODE < 0` on its own; this was the one that folded it
+        // into a success test.
+        //
+        // `reason` and not `error`, because the trend itself is still perfectly readable -- the caller
+        // just cannot be told whether the host is real. That is §4's distinction between "could not
+        // measure" and "call failed", and `reason` is the field this class already uses for it.
+        //
+        // `'crs.%Next()` is folded in here for `Retention()`'s reason: a `COUNT(*)` returns exactly one
+        // row, so no row at all is a failure wearing a success's SQLCODE.
+        if (crs.%SQLCODE < 0) || 'crs.%Next() {
+            set out.reason = "host existence unverified (SQLCODE " _ crs.%SQLCODE _ ")"
+        } elseif crs.%Get("N") = 0 {
             // NAMES THE TOOL AS THE RUNTIME NAMES IT, which is the METHOD name and not the contract's
             // section title. Measured: `%Discover()` on these classes returns `GetEventLogSummary`,
             // `CompareHostActivity`, `GetRecentErrors` -- PascalCase, no snake_case anywhere -- and


### PR DESCRIPTION
Closes #156.

`GetEventLogTrend`'s unknown-host guard skipped itself when its own existence check failed, and the fallthrough produced the exact payload the guard exists to prevent.

## The defect

`Tools/EventLog.cls` tested the check's success as part of the guard condition:

```objectscript
if (crs.%SQLCODE >= 0) && crs.%Next() && (crs.%Get("N") = 0) {
```

`%SQLCODE < 0` makes the whole condition false, so execution continues and the method returns a complete set of zero-filled buckets. This family **inverts §2.1's sign** — §3.11 says so outright: *"For a log count, `0` means the query ran and the window was covered and nothing was logged."* So a zero-filled trend is a positive assertion that the host was quiet, and for a host name the model invented that assertion is false. It was the only place in the class where a SQL failure was swallowed; `:210`, `:256` and `Retention()` all test `%SQLCODE < 0` on their own.

## The fix

The two tests are separated, and a failed check publishes `reason` rather than falling through:

```objectscript
if (crs.%SQLCODE < 0) || 'crs.%Next() {
    set out.reason = "host existence unverified (SQLCODE " _ crs.%SQLCODE _ ")"
} elseif crs.%Get("N") = 0 {
    ... unchanged refusal ...
}
```

`reason` and not `error` because the trend is still readable — the caller just cannot be told whether the host is real, which is §4's distinction and the word §3.8 already uses for it. `'crs.%Next()` is folded in for `Retention()`'s reason: a `COUNT(*)` that returns no row at all is a failure wearing a success's SQLCODE.

## contracts

**§3.11 never listed `reason`**, though the tool has been able to return it (`event log unreadable`) since it shipped. Added to the output list with both values tabulated against what each says about `buckets[]`, because the new case is the one shape here a consumer can read wrongly *while the payload is entirely correct*: the trend is true of the rows that exist and still is not evidence the host does. The contract now says so explicitly. `contracts/CHANGELOG.md` entry included.

## Verification

Live instance, class loaded and compiled (`Load finished successfully`):

| case | result |
|---|---|
| `Cloud API`, hours, 3 | `buckets=3`, no `reason`, no `error` |
| `No Such Host` | `buckets=0`, unchanged `error`, still refused |
| `(production)`, hours, 3 | `buckets=3`, `total=0`, no `reason` |

The failure branch cannot be reached by argument, so its condition was measured directly against a cursor forced to `%SQLCODE -30`:

```
FAILED CHECK: sqlcode=-30
  old condition (fell through): FALLS THROUGH TO ZERO BUCKETS
  new condition: REASON SET, buckets still published
  reason text would be: host existence unverified (SQLCODE -30)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
