### PR TITLE
docs(contracts): resolve-api.md described a dry-run path that does not exist (#202)

### DIFF
--- a/apps/dashboard/src/api/mockClient.ts
+++ b/apps/dashboard/src/api/mockClient.ts
@@ -426,14 +426,14 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
           `about a second per message, so it clears roughly 1 message/sec while inbound volume ` +
           `exceeds that. The host itself is healthy — it is outnumbered, not broken.`,
         evidence: [
-          { label: 'Configured pool size', detail: `${host} PoolSize = 1`, source: 'mcp_tool', tool: 'get_pool_size' },
+          { label: 'Configured pool size', detail: `${host} PoolSize = 1`, source: 'mcp_tool', tool: 'GetPoolSize' },
           {
             label: 'Queue depth',
             detail: queued === null ? 'queue depth not measurable' : `${queued} message(s) queued`,
             source: 'snapshot',
             tool: null,
           },
-          { label: 'Downstream latency', detail: 'average processing time ~1s per message', source: 'mcp_tool', tool: 'get_processing_time' },
+          { label: 'Downstream latency', detail: 'average processing time ~1s per message', source: 'mcp_tool', tool: 'GetProcessingTime' },
         ],
         confidence: 0.9,
         recommendedAction: actionable
@@ -477,7 +477,11 @@ export function createMockClient(pinnedScenarioId?: string): MockClient {
         actor: 'demo',
         role: 'Guardian_Resolve',
         requestedBy: 'dashboard',
-        tool: mode === 'apply' ? 'set_pool_size' : 'get_pool_size',
+        // THE RUNTIME'S OWN NAME, and the same one for both modes. A preview goes through the write
+        // tool with `dryRun`, so `Audit.Entry.Tool` reads `SetPoolSize` either way (#202). This used
+        // to branch on `mode` and emit the snake_case wire enum, which meant driving the UI's own
+        // path could never surface the real name -- the defect mock-first exists to prevent.
+        tool: 'SetPoolSize',
         recordedAt: at,
         source: 'mock',
       };

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,60 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `resolve-api.md`: `audit.tool` is `SetPoolSize`, a preview runs the write tool, and `confirmation` is nullable
+
+**One shape change, and it is the document catching up with five shipped implementations.**
+`confirmation` becomes `object | null` — non-null **iff** `outcome` is `applied`. The `status` value
+`not_applicable` is **removed**; it was never emitted by anything.
+
+Three corrections, all found by diffing this document field by field against a live
+`POST /api/resolve` dry-run and against `Audit.Entry`. The other two divergences that diff turned up
+are **not** in this change — they are open decisions in #202, because in both the document's argument
+is the better one and a shipped UI depends on the current behaviour.
+
+### `audit.tool` — §8
+
+`SetPoolSize`, PascalCase, **on a dry-run as well as an apply**. `%EXACT(Tool)` over the whole audit
+table returns `SetPoolSize` and nothing else for this family; `get_pool_size` has never appeared in it
+and, per `mcp-tools.md` §1, was never a callable name — the same defect #155 corrected in
+`investigation-api.md`, one file over.
+
+**`tool` is not the same string as `action.type`.** `action.type` is this contract's wire enum and is
+correctly `set_pool_size`; `tool` is what the runtime stores. The two looking alike is how this drifted,
+so the field row now says so and repeats the existing rule: render it, never compare it to a literal.
+
+### The dry-run non-mutation guarantee — §2
+
+The paragraph claimed the preview path calls a separate read tool and "never calls `set_pool_size`",
+and called non-invocation "a stronger statement than 'it is invoked with a flag that makes it not
+write'". The shipped path is the second thing: the engine POSTs `{host, size, dryRun}` to the one write
+tool, which is why a preview audits as `SetPoolSize` with `{"dryRun":1,…}`.
+
+**The guarantee held throughout** — `Tools/Resolve.cls` runs every guard and then returns before
+`%Save()`, which is as structural as a second tool. But a safety claim that names the wrong mechanism
+cannot be checked by the person it is written for: they go looking for a read tool and find that the
+privileged one ran. §8 now also warns that counting writes needs `Arguments`, not just `Tool`.
+
+### `confirmation: null` — §3, §7, and three §11 samples
+
+The engine, the dashboard's guard and types, both mocks and two tests have shipped `null` since MVP 2.
+The document was the only holdout, so the document moved — and `null` is the safer of the two forms,
+because `InvestigationPanel.tsx` renders its clearance countdown from `confirmation !== null`, so a
+`not_applicable` object would make a preview promise a clearance that is never coming.
+
+### Why all three were invisible
+
+**`resolve-api.md` is the only MVP 2 contract with no schema and no sample** — no `resolve.schema.json`,
+no `samples/resolve-*.json`, so CI's `contracts — samples vs schema` job cannot see it. Its own preamble
+has promised those artefacts as "a follow-up PR" since Day 1. Meanwhile `resolve.test.ts` asserted
+`audit.tool === 'get_pool_size'` **citing §8's table**, and the two mocks fabricated the same name — so
+the contract, the mock and the test all agreed with each other and none of them agreed with the runtime.
+Committing the schema and a captured sample is tracked in #202 and is the durable half of this fix.
+
+#202.
+
+---
+
 ## 2026-09-01 — `evidence[].tool` is provenance text, and this file stopped teaching a name that was never callable
 
 **No field, type or shape changes.** `investigation-api.md` §3.2's four sample values move from

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -28,10 +28,16 @@ ourselves — the write happens in IRIS behind RBAC, and this service is a calle
 what it asked for and what came back." The engine gained orchestration, not authority. Read §9
 before assuming otherwise.
 
-**No machine-readable artefact yet.** There is no `resolve.schema.json` and no `resolve.d.ts`,
-and no `samples/resolve-*.json`. The JSON in §11 is what Dev C mocks against until those land;
-committing them is a follow-up PR. `contracts` CI counts are unchanged by this document
-(15 accept / 19 reject / 7 capture claims) because it adds no sample for `validate.mjs` to check.
+**No machine-readable artefact yet, and that is why this file drifted.** There is no
+`resolve.schema.json` and no `resolve.d.ts`, and no `samples/resolve-*.json`. The JSON in §11 is what
+Dev C mocks against until those land; committing them is a follow-up PR — **still open as #202, which
+is also where five divergences found by diffing this document against the shipped path are recorded.**
+Three of them are corrected here (§2, §7, §8); two are open decisions. Every other MVP 2 contract has a
+schema and a captured sample, so this is the only one where prose is the sole normative form and
+nothing fails when it stops being true. `contracts` CI counts are unchanged by this document, because
+it adds no sample for `validate.mjs` to check. **The counts themselves are deliberately not quoted
+here** — this line carried "15 accept / 19 reject / 7 capture claims" and the reject count had reached
+26, a copied number staling exactly as §3's host lists do. `validate.mjs`'s own output is the count.
 Stated rather than quietly left off the table, the way `README.md` does for the two `samples/`
 files `CONTRIBUTING.md` §1 promised and nobody wrote.
 
@@ -144,7 +150,7 @@ renders from one type rather than from a status code.
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
-    "tool": "set_pool_size",
+    "tool": "SetPoolSize",
     "recordedAt": "2026-08-18T14:06:43Z",
     "source": "live"
   },
@@ -166,14 +172,14 @@ renders from one type rather than from a status code.
 | `reversal` | object \| null | **A record of the prior value, not a request** — `{host, size, capturedFrom}`. `null` unless `outcome` is `applied`. It is not POSTable: `size` is the shipped value and §3 bounds `action.size` at `2..8`. See §4.1. |
 | `refusal` | object \| null | Non-null **iff** `outcome` is `refused`. See §5. |
 | `failure` | object \| null | Non-null **iff** `outcome` is `failed`. See §5.2. |
-| `confirmation` | object | Always present. `status: "not_applicable"` for everything except `applied`. See §7. |
+| `confirmation` | object \| null | Non-null **iff** `outcome` is `applied`. `null` for every other outcome — nothing changed, so there is nothing to watch for. See §7. |
 | `audit` | object | Always present, for every outcome including refusals and dry-runs. See §8. |
 | `requestedAt` / `completedAt` | string | ISO 8601 UTC, `Z`-suffixed, matching `healthscan-api.md`. |
 | `replayed` | boolean | `true` when this is a stored result returned for a repeated `requestId`. See §6. |
 
-Every field is always **present**. `before`, `after`, `reversal`, `refusal` and `failure` may be
-`null`; the others are always objects, strings or booleans. A missing key is a contract
-violation, a `null` value is not — same rule as `healthscan-api.md` §1, for the same reason.
+Every field is always **present**. `before`, `after`, `reversal`, `refusal`, `failure` and
+`confirmation` may be `null`; the others are always objects, strings or booleans. A missing key is a
+contract violation, a `null` value is not — same rule as `healthscan-api.md` §1, for the same reason.
 
 Advisory response header: `X-Resolve-Outcome`, carrying the same string as `outcome`. Advisory
 because the body is authoritative; a consumer may ignore the header entirely.
@@ -214,11 +220,20 @@ default in every serialization path — absent, `null`, `""`, `0`, and `"false"`
 "not a dry run" somewhere between a React state hook and `JSON.parse`. `"apply"` cannot be
 arrived at by accident.
 
-**A `dry_run` mutates nothing.** Guaranteed, and the guarantee is structural rather than
-promised: in `dry_run` the engine calls the **read** tool `get_pool_size` and the whitelist,
-bounds, production and RBAC checks — it never calls `set_pool_size`, so no code path exists that
-could write. The privileged tool is not invoked at all, which is a stronger statement than "it
-is invoked with a flag that makes it not write".
+**A `dry_run` mutates nothing.** Guaranteed, and the guarantee is structural rather than promised:
+`Tools.Resolve` runs the whitelist, bounds, production and RBAC checks and then **returns before the
+write**, `if dryRun { set out.outcome = "previewed" … quit out }` — commented in the class as
+"Guaranteed not to mutate, structurally: this returns before the write." There is no path from the
+preview branch to `%Save()`.
+
+**Corrected 2026-09-01 (#202). This paragraph previously said the dry-run path invokes a separate read
+tool `get_pool_size` and "never calls `set_pool_size`", calling non-invocation "a stronger statement
+than 'it is invoked with a flag that makes it not write'."** The shipped path is the second thing: the
+engine POSTs `{host, size, dryRun}` to the one write tool, which is why a preview audits as
+`SetPoolSize` with `{"dryRun":1,…}` (§8) and why `get_pool_size` appears nowhere in the audit table.
+The guarantee held throughout — an early `quit` before any write is as structural as a second tool —
+but a safety claim that names the wrong mechanism cannot be checked by the person it is written for:
+they go looking for a read tool and find that the privileged one ran.
 
 What a `dry_run` returns:
 
@@ -232,7 +247,7 @@ What a `dry_run` returns:
   `action.size` without a field that pretends to have been observed.
 - `reversal: null` — nothing changed, so there is nothing to reverse. Offering a reversal for a
   no-op invites a "restore" that writes a value nobody measured.
-- `confirmation.status: "not_applicable"`.
+- `confirmation: null` — see §7.
 - `audit` — **present**. Dry-runs are audited too (§8).
 
 RBAC is checked in `dry_run`. A preview that succeeds and an apply that then denies is the worst
@@ -387,7 +402,9 @@ Two further consequences:
 
 - **`before` is measured, never inherited.** It does not come from `precondition.poolSize`, from
   the finding's `currentValue`, or from the investigation payload — all three are claims made
-  earlier by something else. It comes from `get_pool_size` at the moment of the call.
+  earlier by something else. It is read off the live production definition (`+item.PoolSize`)
+  inside the write tool, at the moment of the call — not from a prior read tool's answer, which
+  would be a claim made earlier by something else too.
 - **There is no automatic rollback on failure**, hence `automatic: false`. A failed
   `Ens.Director.UpdateProduction()` may have already `%Save()`d the config, so the live state
   after a failure is genuinely unknown, and a blind rollback write is a second unverified
@@ -466,9 +483,9 @@ absence of `before`/`after`. Same endpoint, same status, same shape. Dev C mocks
 by changing two fields.
 
 The demo depends on this being real rather than cosmetic: MVP 2 §2.2 wants to show that "AI
-Detective can look without having permission to act". The read tools (`get_host_status`,
-`get_queue_depth`, `get_pool_size`, `get_recent_errors`, `get_processing_time`) are granted more
-broadly; only `set_pool_size` needs the privileged role. So an unauthorized caller can still get
+Detective can look without having permission to act". The read tools (`GetHostStatus`,
+`GetQueueDepth`, `GetPoolSize`, `GetRecentErrors`, `GetProcessingTime`) are granted more
+broadly; only the write tool needs the privileged role. So an unauthorized caller can still get
 a full `dry_run` refusal *with* `before` unavailable and a complete investigation — which is the
 point being demonstrated, not a degraded mode.
 
@@ -589,10 +606,19 @@ Therefore `confirmation` **hands the caller the observation path instead of a ve
 }
 ```
 
-| `status` | When |
+| `confirmation` | When |
 |---|---|
-| `pending` | `outcome: "applied"`. The write landed; clearing is now observed elsewhere. |
-| `not_applicable` | Every other outcome. Nothing was changed, so there is nothing to confirm. |
+| `{ "status": "pending", … }` | `outcome: "applied"`, and only then. The write landed; clearing is now observed elsewhere. `pending` is the only value `status` ever takes. |
+| `null` | Every other outcome. Nothing was changed, so there is nothing to confirm. |
+
+**Corrected 2026-09-01 (#202): a non-`applied` outcome carries `null`, not an object with
+`status: "not_applicable"`.** This section, the §3 field table and three §11 samples all promised the
+object form; the engine, the dashboard's guard and types, both mocks and two tests have all shipped
+`null` since MVP 2. The document was the only holdout, so it was the document that moved — and the
+`null` form is also the safer of the two, because a consumer that branches on presence rather than on
+`status` cannot then render a clearance countdown for a preview. A consumer must still not infer
+"nothing happened" from `confirmation: null` alone: `outcome` is the field to branch on, and a `failed`
+apply carries `null` here while having possibly written (§5.2).
 
 `clearsWhen` is authoritative human-readable text (same rule as `Finding.message`).
 `expectedWithinSeconds` is **advisory and explicitly not a promise** — MVP 2 §6 lists "pool
@@ -662,7 +688,7 @@ none."
   "actor": "guardian_resolve",
   "role": "Guardian_Resolve",
   "requestedBy": "presenter@laptop",
-  "tool": "set_pool_size",
+  "tool": "SetPoolSize",
   "recordedAt": "2026-08-18T14:06:43Z",
   "source": "live"
 }
@@ -674,7 +700,7 @@ none."
 | `actor` | **The authenticated IRIS principal, resolved server-side.** The identity the RBAC decision was made about. |
 | `role` | The role that authorized (or, on `not_authorized`, the role that was required). Lets the UI say *what* is missing. |
 | `requestedBy` | The request's advisory label, echoed. Recorded **next to** `actor`, never in place of it. |
-| `tool` | `set_pool_size` on an apply, `get_pool_size` on a dry-run. Which privileged tool was actually invoked, per §2. |
+| `tool` | **The runtime's own method name, `SetPoolSize`** — on an apply *and* on a dry-run, because the preview goes through the same write tool with `dryRun` set (§2). **PascalCase, and not the same string as `action.type`.** `action.type` is this contract's wire enum, `set_pool_size`; `tool` is what `Audit.Entry.Tool` stores, and reading it as a snake_case name is what #202 corrected here. Render it, never compare it to a literal. |
 | `recordedAt` | ISO 8601 UTC. |
 | `source` | `"live"` \| `"mock"`. |
 
@@ -700,8 +726,10 @@ tool lives in IRIS instead of in the engine.
 are audited by design (MVP 2 §2.2: "every MCP tool call, read and write"). And "who was probing
 the production, and when" is part of the same story as "who changed it" — an audit log with a
 hole where the reconnaissance was is a partial account. It is also not optional: the dry-run path
-invokes `get_pool_size` through the same governed tool path, so `%LogExecution` runs for it
-whether or not anyone wanted it to.
+invokes the write tool through the same governed path, so `%LogExecution` runs for it whether or not
+anyone wanted it to — and the row is indistinguishable from an apply except by its arguments,
+`{"dryRun":1,"host":"Cloud API","size":4}`. **A reviewer counting writes must read `Arguments`, not
+just `Tool`.**
 
 **Refusals are audited.** Including `not_authorized`. A denied attempt is the security-relevant
 event in the set — an audit trail that records only what succeeded cannot answer "did anything try
@@ -809,9 +837,10 @@ proven path is proven for a different job.
 - **One dedicated IRIS role gates `set_pool_size`.** Nothing else needs it, and no read tool has
   it. Least privilege, and it is what makes MVP 2 §2.2's demonstration real: AI Detective can
   look and cannot act.
-- **The read tools are granted more broadly** — `get_host_status`, `get_queue_depth`,
-  `get_pool_size`, `get_recent_errors`, `get_processing_time`. The dry-run path uses only
-  `get_pool_size` (§2).
+- **The read tools are granted more broadly** — `GetHostStatus`, `GetQueueDepth`, `GetPoolSize`,
+  `GetRecentErrors`, `GetProcessingTime`. **The dry-run path uses none of them**: it goes through the
+  write tool with `dryRun`, so it needs the privileged role, which is why RBAC is checked in `dry_run`
+  and why a preview is refused for an unauthorized caller (§2).
 - **The role name, its grants, and the tool catalogue belong to `contracts/mcp-tools.md`**, which
   MVP 2 §2.4 makes a separate contract. Dev C must render `audit.role` as an opaque string and
   never compare it to a literal — this contract deliberately does not fix its value, so that
@@ -954,20 +983,13 @@ Response `200`, `X-Resolve-Outcome: previewed`:
   "reversal": null,
   "refusal": null,
   "failure": null,
-  "confirmation": {
-    "status": "not_applicable",
-    "findingId": "f-1042",
-    "clearsWhen": "queue_buildup for Cloud API disappears from GET /api/healthscan/findings",
-    "observeVia": ["GET /api/healthscan/findings", "GET /api/healthscan/hosts"],
-    "expectedWithinSeconds": 60,
-    "directEvidence": "hosts[host=\"Cloud API\"].queued falling"
-  },
+  "confirmation": null,
   "audit": {
     "auditId": "pg-audit-44810",
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": null,
-    "tool": "get_pool_size",
+    "tool": "SetPoolSize",
     "recordedAt": "2026-08-18T14:06:12Z",
     "source": "live"
   },
@@ -977,8 +999,10 @@ Response `200`, `X-Resolve-Outcome: previewed`:
 }
 ```
 
-Note `after: null` and `tool: "get_pool_size"` — the privileged tool was never invoked (§2). The
-UI renders "1 → 4" from `before.poolSize` and `action.size`.
+Note `after: null` and `confirmation: null` — nothing was written, so there is nothing to read back
+and nothing to watch for. `tool` still reads `SetPoolSize`: the write tool ran and returned before
+the write (§2), which is what the audit row records. The UI renders "1 → 4" from `before.poolSize`
+and `action.size`.
 
 ### 11.2 Apply — succeeded, with before and after
 
@@ -1037,13 +1061,13 @@ Same request as §11.2, from a caller without the write role. Response `200`,
     "checkedBy": "iris"
   },
   "failure": null,
-  "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
+  "confirmation": null,
   "audit": {
     "auditId": "pg-audit-44813",
     "actor": "guardian_readonly",
     "role": "Guardian_Resolve",
     "requestedBy": "presenter@laptop",
-    "tool": "set_pool_size",
+    "tool": "SetPoolSize",
     "recordedAt": "2026-08-18T14:07:02Z",
     "source": "live"
   },
@@ -1090,13 +1114,13 @@ Response `200`, `X-Resolve-Outcome: refused`:
     "checkedBy": "engine"
   },
   "failure": null,
-  "confirmation": { "status": "not_applicable", "findingId": "f-1042" },
+  "confirmation": null,
   "audit": {
     "auditId": "pg-audit-44814",
     "actor": "guardian_resolve",
     "role": "Guardian_Resolve",
     "requestedBy": null,
-    "tool": "set_pool_size",
+    "tool": "SetPoolSize",
     "recordedAt": "2026-08-18T14:07:20Z",
     "source": "live"
   },

--- a/iris/labdemo/REST/AgentDispatcher.cls
+++ b/iris/labdemo/REST/AgentDispatcher.cls
@@ -650,10 +650,13 @@ ClassMethod Resolve() As %Status
                     "checkedBy": "iris"
                 },
                 "failure": null,
-                // §3 marks confirmation always present. `not_applicable` rather than null: nothing
-                // was written, so there is no clearance to wait for, and a null would read as
-                // "unknown" to a UI deciding whether to poll.
-                "confirmation": { "status": "not_applicable" },
+                // NULL, and §7 now says so (#202). This emitted `{"status": "not_applicable"}` on the
+                // strength of §3's "always present" -- a value nothing else in the stack has ever
+                // produced, and one the engine discards anyway: `resolve.ts` computes `confirmation`
+                // from `outcome` and never reads this field, so the object form reached no consumer.
+                // The contract moved to `null` because the dashboard branches on presence, not on
+                // `status`, and an object here would make a refusal promise a clearance.
+                "confirmation": null,
                 "audit": (audit)
             }
             write denial.%ToJSON()

--- a/services/detection-engine/src/detect/agents.ts
+++ b/services/detection-engine/src/detect/agents.ts
@@ -97,7 +97,7 @@ export function mockAgent(): InvestigateDeps['callAgent'] {
           label: `${host} pool size`,
           detail: `${host} PoolSize = ${poolSize ?? 1}`,
           source: 'mcp_tool',
-          tool: 'get_pool_size',
+          tool: 'GetPoolSize',
         },
         {
           label: 'Queue depth',
@@ -111,7 +111,7 @@ export function mockAgent(): InvestigateDeps['callAgent'] {
           label: 'Downstream latency',
           detail: `average processing time ${snapshot['avgProcessingTime'] ?? '~1'}s per message`,
           source: 'mcp_tool',
-          tool: 'get_processing_time',
+          tool: 'GetProcessingTime',
         },
         {
           label: 'Queue slope',
@@ -204,7 +204,10 @@ export function mockResolveTool(initialPoolSize = 1): ResolveDeps['callTool'] {
       auditId: `mock-audit-${auditSeq}`,
       actor: 'mock',
       role: 'Guardian_Resolve',
-      tool: dryRun ? 'get_pool_size' : 'set_pool_size',
+      // The runtime's name, and the SAME on a preview: `liveResolveTool` POSTs `{host, size, dryRun}`
+      // to the one write tool, so a dry-run audits as `SetPoolSize` too (#202, measured). Branching
+      // on `dryRun` here fabricated a `get_pool_size` that was never a callable name.
+      tool: 'SetPoolSize',
       recordedAt: '2026-08-19T00:00:00Z',
       source: 'mock',
     };
@@ -269,19 +272,19 @@ export function mockMissingFolderAgent(): InvestigateDeps['callAgent'] {
           label: 'Host status',
           detail: `${host} is in Error`,
           source: 'mcp_tool',
-          tool: 'get_host_status',
+          tool: 'GetHostStatus',
         },
         {
           label: 'Recent errors',
           detail: '#5021 — a configured directory or file path does not exist',
           source: 'mcp_tool',
-          tool: 'get_recent_errors',
+          tool: 'GetRecentErrors',
         },
         {
           label: 'Configured path',
           detail: `FilePath = ${configuredPath}`,
           source: 'mcp_tool',
-          tool: 'get_host_settings',
+          tool: 'GetHostSettings',
         },
       ],
       confidence: 0.95,

--- a/services/detection-engine/test/resolve.test.ts
+++ b/services/detection-engine/test/resolve.test.ts
@@ -367,7 +367,7 @@ const AUDIT = {
   auditId: 'pg-audit-42',
   actor: 'pg_service',
   role: 'Guardian_Resolve',
-  tool: 'set_pool_size',
+  tool: 'SetPoolSize',
   recordedAt: '2026-08-19T11:00:00Z',
   source: 'live',
 };
@@ -464,6 +464,10 @@ test('mockResolveTool emits an audit block marked source mock', async () => {
   // actions into one row.
   const second = await resolve({ mode: 'dry_run', action: { ...ACTION, size: 8 } }, deps);
   assert.notEqual(second.audit?.auditId, res.audit?.auditId);
-  // tool reflects what was actually invoked -- get_pool_size on a dry-run, per §8's table.
-  assert.equal(second.audit?.tool, 'get_pool_size');
+  // tool reflects what was actually invoked, and a dry-run invokes the WRITE tool with `dryRun`, so
+  // it is `SetPoolSize` in both modes (#202). This line asserted `get_pool_size` on a dry-run and
+  // cited §8's table for it -- a test pinning a name the runtime never had, which is why the
+  // divergence survived: the mock, the contract and the test all agreed with each other.
+  assert.equal(second.audit?.tool, 'SetPoolSize');
+  assert.equal(res.audit?.tool, 'SetPoolSize');
 });


### PR DESCRIPTION
Fixes the three unambiguous halves of #202. **No behaviour change** — every code edit is a mock, a test fixture, or a dead field.

| # | Was | Is | Evidence |
|---|---|---|---|
| §8 `audit.tool` | `set_pool_size` on apply, `get_pool_size` on dry-run | **`SetPoolSize` on both** | `%EXACT(Tool)` over `Audit.Entry` returns `SetPoolSize` ×17 and no snake_case row ever; live `pg-audit-594` |
| §2 dry-run guarantee | "calls the read tool `get_pool_size` … never calls `set_pool_size`" | the write tool runs with `dryRun` and **returns before `%Save()`** | `agents.ts` `liveResolveTool` POSTs `{host,size,dryRun}`; row 116 = `{"dryRun":1,…}` under `SetPoolSize` |
| §3/§7 `confirmation` | "Always present", `status: "not_applicable"` | **`object \| null`**, non-null iff `applied` | `resolve.ts:353`, `mvp2Guards.ts:312`, `types/mvp2.ts:200`, both mocks, `mvp2-contract-drift.test.ts:105`, `resolve.test.ts:151` |

`action.type` is **unchanged** and stays `set_pool_size` — it is this contract's wire enum, enforced by `ResolveAction` in `investigation.schema.json`. The two strings looking alike is how `tool` drifted, so the field row now says so explicitly.

### Code touched, and why each is not a behaviour change

- `agents.ts:207` and `mockClient.ts:480` fabricated `tool: dryRun ? 'get_pool_size' : 'set_pool_size'`. A mock that encodes the contract's fiction is the one thing mock-first cannot catch — driving the UI's own path could never surface the real name. Mock **evidence** tool names move to PascalCase too (`GetPoolSize`, `GetHostStatus`, …), matching `samples/investigation-response.json`, which has carried the runtime forms from a live capture all along.
- `resolve.test.ts:468` asserted `audit.tool === 'get_pool_size'` **citing §8's table**. That is why this survived: contract, mock and test all agreed with each other.
- `AgentDispatcher.cls`'s RBAC-denial branch emitted `{"status":"not_applicable"}` on the strength of §3's "always present". `resolve.ts` recomputes `confirmation` from `outcome` and never reads the field, so it reached no consumer; it now emits `null` and the comment records why. Recompiled against the running instance to confirm.

### Left out deliberately — the two decisions in #202

`after` on a preview (contract says `null`, engine forwards `{"poolSize":4}`, dashboard labels it `(would be)`) and `confirmation.directEvidence` / `clearsWhen` (contract: a string naming `hosts[].queued`; engine: a boolean). In both, the document's argument is the better one and a shipped UI depends on the current behaviour, so they are calls to make, not drift to erase.

### Verified

- `services/detection-engine`: `npm run typecheck` clean; **439 pass / 0 fail** (node:22 container, repo root mounted — local node is 20.18.2 and cannot strip types)
- `apps/dashboard`: `docker compose build dashboard` succeeds, which runs `tsc --noEmit`, `validate-architecture.mjs` and `vite build` inside the image (§6.1 — `npm run build` on a host is not the gate)
- `contracts/validate.mjs`: all checks pass. It does not and cannot see this file, which is the root cause section of #202 — the stale `19 reject` count in the preamble (actual: 26) is removed rather than corrected
- `AgentDispatcher.cls` compiles in the live container

`contracts/CHANGELOG.md` entry included, per root `CLAUDE.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)