### PR TITLE
fix(chat): get_active_findings capped at 25 without saying so (#165)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,57 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `mcp-tools.md` §3.13: `get_active_findings` capped at 25 in silence — `total` and `truncated`
+
+**Two fields added to `get_active_findings`, and one field added to the request that feeds it.**
+`total` (integer | null) is how many findings **exist**; `truncated` (boolean | null) says whether it
+differs from `count`. On the request the engine now also sends `findingsTotal`. Nothing is removed and
+no existing field changes meaning, so a consumer reading only `count` still reads what it read before —
+it just no longer has to assume that number is the answer.
+
+### What was wrong
+
+`count` was the size of the list **after** the cap, and three separate caps of 25 could clip it: the
+engine's slice, the stash on receipt, and the tool's own. A clipped payload was byte-identical to a
+complete one, so the model stated `count` as the number of open findings. §3.13 mentioned no cap at all
+— a consumer implementing from this contract could not know findings were droppable.
+
+The section already goes to real trouble over `count: 0` meaning four different things. This was the
+same failure pointing the other way and **more** likely to fire, because findings multiply exactly when
+a production is in trouble, which is when someone asks how many there are (@tanifgit, #165).
+
+### The shape follows §3.14 rather than inventing one
+
+`get_interface_path` already solved this for itself — `pathsReturned` / `pathCount` / `truncated` — and
+its own section named #165 as the open defect that made it state the rule. So this is that rule applied,
+including the part #186 had to learn the hard way: **`total` is scoped to the same filter as `count`**,
+never to the production, because "3 of 31 shown" about a host with three findings is a worse answer than
+no total at all.
+
+That scoping makes one case genuinely unknowable, and it is reported as `null` rather than guessed: a
+filtered call against an already-clipped list cannot know how many of the withheld findings were on that
+host. `truncated` still answers `true` there — that some were dropped is known even when how many of
+yours is not — and the `note` refuses the all-clear rather than saying "no open findings on `Cloud API`".
+`truncated` is tested **before** `count: 0` for that reason, which the section now states.
+
+All three fields are `null`, never `false` or `0`, on any payload where no snapshot was read. §2.1's
+rule, applied to a boolean and to a count instead of to a metric.
+
+### Why the cap's justification is also gone
+
+The same sentence appeared in all three cap comments: eight finding types across three hosts is 24, one
+under 25, so the cap could not clip a real production. Findings are keyed `(host, type)`, so the ceiling
+is `hosts × 8` — a **host count** compiled into a justification, which #25 and #34 forbid, and wrong at
+four hosts. #165 filed it as the same defect for the same reason it filed the silence: the 25 is two
+independent literals across the language boundary, so raising one silently drops findings at the other.
+That is now observable instead of invisible.
+
+Pinned by `Test.FindingsTruncation` (`iris/test/`, hand-run, 27 assertions), which was checked against
+two mutations rather than assumed to catch them — including one that shows #165's own reading of the
+filter/cap order was not quite what the code does. The class comment records the difference.
+
+---
+
 ## 2026-09-01 — `resolve-api.md`: `audit.tool` is `SetPoolSize`, a preview runs the write tool, and `confirmation` is nullable
 
 **One shape change, and it is the document catching up with five shipped implementations.**

--- a/contracts/mcp-tools.md
+++ b/contracts/mcp-tools.md
@@ -1643,8 +1643,13 @@ was compared against.
 
 **Input**: `host` (optional — omit for the whole production).
 
-**Output**: `host`, `supplied`, `count`, `findings[]`, `asOf`, `state`, `sanitised`, and `note` or
-`reason` where they apply.
+**Output**: `host`, `supplied`, `count`, `total`, `truncated`, `findings[]`, `asOf`, `state`,
+`sanitised`, and `note` or `reason` where they apply.
+
+`count` is how many findings came back. `total` is how many **exist** — see the cap section below —
+and `truncated` says whether they differ. All three are `null` on any payload where no snapshot was
+read (`supplied: false`, or an unparseable one): `truncated: false` there would assert that a list
+nobody read is complete, which §2.1 forbids for a boolean exactly as it forbids `0` for a metric.
 
 `findings[]`: the eight `healthscan.d.ts` `Finding` keys — `id`, `host`, `type`, `severity`,
 `currentValue`, `baselineValue`, `detectedAt`, `message`. **Allowlisted and copied key by key**, so a
@@ -1661,8 +1666,9 @@ dashboard showing it in red two panels away.
 #### The findings are SUPPLIED WITH THE REQUEST, not queried
 
 Findings are computed by the detection engine on `:3002`, outside this instance. The engine sends them
-in the body of its `POST /labdemo/chat/ask` (`findings`, `findingsAsOf`, `findingsState`);
-`REST.ChatDispatcher` stashes them in a process-private global on entry and this tool republishes them.
+in the body of its `POST /labdemo/chat/ask` (`findings`, `findingsAsOf`, `findingsState`,
+`findingsTotal`); `REST.ChatDispatcher` stashes them in a process-private global on entry and this tool
+republishes them.
 
 Chosen over an IRIS→engine callback because the engine already holds the snapshot in the process making
 the request, and a callback needs an engine URL inside the IRIS container — the class of configuration
@@ -1695,10 +1701,42 @@ ambiguous between the four rows above, and the reassuring reading is available w
 doing anything wrong — which is the same failure as `supplied: false` wearing the shape of a successful
 answer. §2.1 governs: an unmeasurable value is not a small one, and here the "value" is a list.
 
+#### The list is capped at 25, and the cap is reported — `truncated`, with `total` scoped to the filter
+
+**Three caps, none of them silent.** The engine slices to `MAX_FINDINGS` before sending (keeps the
+request small), `ChatDispatcher.StashFindings` caps on receipt (bounds the global), and this tool caps
+what it republishes (bounds the model's context). All three are 25. Each is defensible and until #165
+all three were mute: `count` was the post-cap size, so a clipped payload was byte-identical to a
+complete one and a model reading it stated 25 as the number of open findings. Findings multiply exactly
+when a production is in trouble, which is when that question gets asked.
+
+`findingsTotal` on the request is what makes the difference knowable. It is the array's length **before
+the engine's own slice** — the last point at which the true number exists — and the stash keeps it
+beside the array. Absent (an older engine build, a hand-rolled POST), the stash falls back to the length
+that arrived, and a declared total *below* what arrived is rejected rather than believed.
+
+**`total` is scoped to the same filter as `count`**, which is §3.14's rule for `pathCount` and for the
+reason #186 gives there: a total describing the production while the list describes one host reads as
+"3 of 31 shown" about a host with three findings. That scoping is why one case is genuinely unknowable:
+
+| Call | `total` | `truncated` |
+|---|---|---|
+| unfiltered | exact — the engine's pre-slice length, so `count < total` catches a clip at **either** stage | `count < total` |
+| `host` given, nothing dropped upstream | exact — every finding that exists was available to filter | `count < total` |
+| `host` given, list already clipped | **`null`** — the withheld findings were dropped before any host was applied, so how many were on *this* host cannot be known here | **`true`** — that some were dropped is known even when how many of yours is not |
+
+The third row is the one that changes an answer. `count: 0` on it means "none on this host **among the
+ones I can see**", so `note` says so and does **not** say "no open findings on `Cloud API`" — the
+`truncated` branch is tested before the `count: 0` branch for exactly that reason. Read it as a fifth
+row of the table above: a clipped filtered list is a fourth way an empty list is not an all-clear.
+
+`Test.FindingsTruncation` in `iris/test/` pins all of it, including that the `host` filter is applied
+**before** the cap. Hand-run; `iris/CLAUDE.md` says why `iris/test/` is not compiled at boot.
+
 ```jsonc
 // <- host "Cloud API"
 {
-  "host": "Cloud API", "supplied": true, "count": 1,
+  "host": "Cloud API", "supplied": true, "count": 1, "total": 1, "truncated": false,
   "findings": [
     { "id": "cloud-api-queue-buildup", "host": "Cloud API", "type": "queue_buildup",
       "severity": "critical", "currentValue": 486, "baselineValue": 0,
@@ -1706,6 +1744,16 @@ answer. §2.1 governs: an unmeasurable value is not a small one, and here the "v
       "message": "Queue depth 486 is 32x baseline" }
   ],
   "asOf": "2026-08-30T09:39:50Z", "state": "ok", "sanitised": true
+}
+```
+
+```jsonc
+// <- no host, on a production with more open findings than the cap
+{
+  "host": null, "supplied": true, "count": 25, "total": 31, "truncated": true,
+  "findings": [ /* 25 of them */ ],
+  "asOf": "2026-08-30T09:39:50Z", "state": "ok", "sanitised": true,
+  "note": "this list is INCOMPLETE: 25 of 31 open findings on this production are shown, and the rest were dropped by a size cap before this tool could read them -- state 31 as the number of open findings and say that only 25 of them are described here"
 }
 ```
 
@@ -1804,9 +1852,11 @@ map instead of a metric.
 
 `#MAXPATHS` is 50. `pathsReturned` is what came back, `pathCount` is the true total **of paths this
 host sits on** — including any the cap withheld — and `truncated` says whether they differ. Stated
-because the opposite choice is an open defect elsewhere in this contract (#165): a tool that capped
+because the opposite choice **was** a defect elsewhere in this contract (#165): a tool that capped
 silently and published a count of the *capped* list, leaving a consumer unable to tell a small
-production from a clipped one.
+production from a clipped one. §3.13 now follows this section — `total` and `truncated`, with `total`
+scoped to the filter for the reason two paragraphs down. Kept in the past tense rather than deleted,
+because this rule is the reason that one was fixed to this shape instead of a new one.
 
 **Both counts are scoped to the host asked about**, never to the production. Spelled out because "the
 true total" alone reads just as naturally as production-wide, and that is the reading the first

--- a/iris/labdemo/REST/ChatDispatcher.cls
+++ b/iris/labdemo/REST/ChatDispatcher.cls
@@ -368,8 +368,15 @@ ClassMethod Ask() As %Status
 /// NOT TRUSTED FOR SIZE. The array arrives over HTTP from another service, and a process-private
 /// global node holds a bounded string, so the element count is capped HERE as well as in the tool.
 /// Two caps rather than one, deliberately: this one protects the global, the tool's protects the
-/// model's context, and the engine's own protects the request. Eight finding types across three hosts
-/// is 24 at the ceiling, so none of the three can clip a real production.
+/// model's context, and the engine's own protects the request.
+///
+/// AND A CAP MUST LEAVE A RECORD OF WHAT IT DROPPED, which none of the three did until #165. This
+/// comment used to close by arguing that eight finding types across three hosts is 24, one under the
+/// cap, so none of them could clip a real production — a host COUNT inside a justification, and wrong
+/// the moment a fourth host is reported, because findings are keyed `(host, type)` and the ceiling is
+/// `hosts × 8`. So `total` is stashed next to the array: the engine's declared pre-slice length where
+/// it sent one, and the length that arrived here where it did not. `Tools.Findings` compares it to
+/// what it republishes and answers `truncated` from the difference.
 ClassMethod StashFindings(body As %DynamicObject) [ Private ]
 {
     if '$isobject(body) {
@@ -392,6 +399,22 @@ ClassMethod StashFindings(body As %DynamicObject) [ Private ]
     }
 
     set ^||PGGuardian("chat", "findings") = capped.%ToJSON()
+    // How many findings EXIST, as against how many are in the node above.
+    //
+    // The engine's own figure is preferred because it is the only one taken before any cap: it slices
+    // to `MAX_FINDINGS` before sending, so `findings.%Size()` here is already the clipped length and
+    // would under-report. A body with no `findingsTotal` (an older engine build, or a hand-rolled
+    // POST) falls back to what arrived, which is the most this class can honestly claim.
+    //
+    // AND A DECLARED TOTAL BELOW WHAT ARRIVED IS REJECTED rather than stored. It cannot be true, and
+    // believing it would make `truncated` read false on a clipped list -- the one wrong answer this
+    // field exists to prevent. Same direction as every other guard here: distrust the wire for size.
+    set declared = body.%Get("findingsTotal")
+    set total = findings.%Size()
+    if (declared '= ""), ($isvalidnum(declared)), (declared > total) {
+        set total = declared \ 1
+    }
+    set ^||PGGuardian("chat", "total") = total
     // The instant the engine measured them, so the model can say "as of" rather than implying the
     // reading is from the moment it is speaking. Absent is "" rather than a substituted `$ztimestamp`:
     // stamping it here would be this class inventing a measurement time for another service's reading.
@@ -746,6 +769,16 @@ ClassMethod SystemPrompt() As %String [ Private ]
     set p = p _ "fire, so nothing has been measured; ""stale"" means the list is the last one it could "
     set p = p _ "compute and may be out of date. Report either as such. Only ""ok"" with count: 0 "
     set p = p _ "supports ""no open findings"". "
+    // AND `count` IS NOT THE NUMBER OF FINDINGS WHEN THE LIST WAS CAPPED (#165). The third member of
+    // this set, and the one whose reassuring reading is the *arithmetic* rather than the emptiness:
+    // the payload of a clipped list is byte-shaped exactly like a complete one, so a model with no
+    // instruction states `count` as a fact. Told here as well as in `note` because the two paragraphs
+    // above establish that this tool's numbers need reading rather than quoting, and leaving the third
+    // case out of the prompt would make it the one a model handles by resemblance.
+    set p = p _ "When it returns truncated: true the list is NOT all of them and count is NOT the "
+    set p = p _ "number of open findings: if total is a number, report total as the count and say only "
+    set p = p _ "some are described; if total is null, say the number is at least count and that more "
+    set p = p _ "may exist, and do not call the host or the production clear on a truncated list. "
 
     set p = p _ "GetActivityCoverage lists which hosts have recorded activity and how far back the "
     set p = p _ "data goes -- call it first when you do not already know a host name or a date range. "

--- a/iris/labdemo/Tools/Findings.cls
+++ b/iris/labdemo/Tools/Findings.cls
@@ -86,8 +86,13 @@ Parameter HANDOFF = "findings";
 ///
 /// A cap the ENGINE also applies before sending (see `detect/chat.ts`), so this is the second of two
 /// and deliberately so: the engine's cap keeps the request small and this one keeps a hand-rolled
-/// POST from filling the model's context. Eight finding types across three hosts is 24 at the absolute
-/// ceiling, so 25 cannot clip a real production.
+/// POST from filling the model's context.
+///
+/// NEITHER CAP MAY BE SILENT, which both were until #165. The justification here used to be that eight
+/// finding types across three hosts is 24, one under the cap, so 25 could not clip a real production.
+/// That is a host COUNT written into a reason — the thing #25 and #34 forbid — and findings are keyed
+/// `(host, type)`, so the true ceiling is `hosts × 8` and a fourth reported host puts it at 32. The
+/// `total` and `truncated` fields below are what make a cap that DOES bite say so.
 Parameter MAXFINDINGS = 25;
 
 /// The `Finding` keys this tool will republish, from `contracts/healthscan.d.ts`.
@@ -117,8 +122,11 @@ Parameter FINDINGKEYS = {$listbuild(
 /// Pass `host` to narrow to one interoperability host, or omit it for the whole production.
 ClassMethod GetActiveFindings(host As %String = "") As %DynamicObject
 {
-    set out = { "host": null, "supplied": false, "count": null, "findings": null,
-        "asOf": null, "state": null, "sanitised": true }
+    // `count`, `total` and `truncated` all start null and stay null on every path that returns without
+    // reading a snapshot. `truncated: false` there would assert that a list nobody read is complete,
+    // which is §2.1's rule applied to a boolean: an unmeasurable value is not a small one.
+    set out = { "host": null, "supplied": false, "count": null, "total": null, "truncated": null,
+        "findings": null, "asOf": null, "state": null, "sanitised": true }
     // null when unfiltered, so "every host" and "a host whose name is the empty string" are
     // different payloads rather than the same one.
     if host '= "" {
@@ -150,21 +158,67 @@ ClassMethod GetActiveFindings(host As %String = "") As %DynamicObject
     // and the reason `count: 0` is not self-explanatory. See the note below.
     set out.state = $get(^||PGGuardian("chat", "state"), "")
     set findings = []
+    set matched = 0
     set iter = raw.%GetIterator()
     while iter.%GetNext(.index, .finding) {
         if '$isobject(finding) {
             continue
         }
+        // FILTER FIRST. The cap below tests `findings.%Size()`, which counts pushed MATCHES, so a
+        // non-matching finding does not consume cap budget wherever these two blocks sit -- #165 reads
+        // this as "capping first would return the first 25 of the production and then filter them",
+        // and that is not what these lines do. It IS what a cap on the ITERATION would do, so the
+        // order still carries the property: cap the filtered set, never the array.
         if (host '= "") && (finding.%Get("host") '= host) {
             continue
         }
+        // AFTER THE FILTER, and this is the line that would break quietly. `matched` sizes the filtered
+        // set; counted one line up instead it would size the production, and then `total` would answer
+        // about every host while `count` answered about one -- "3 of 31 shown" for a host with three
+        // findings, which is exactly the mis-scoping #186 fixed in `get_interface_path`. Pinned in
+        // `Test.FindingsTruncation`, which was checked against that mutation rather than assumed to
+        // catch it.
+        set matched = matched + 1
+        // `continue` rather than `quit`: the loop keeps counting past the cap, which is the only way
+        // `truncated` can be computed rather than guessed.
         if findings.%Size() >= ..#MAXFINDINGS {
-            quit
+            continue
         }
         do findings.%Push(..Republish(finding))
     }
     set out.findings = findings
     set out.count = findings.%Size()
+
+    // HOW MANY EXIST, AS AGAINST HOW MANY CAME BACK — and where that is unknowable, null rather than
+    // the number we happen to have (#165).
+    //
+    // `total` is scoped to the SAME filter as `count`, which is `get_interface_path`'s rule for
+    // `pathCount` and for the reason #186 gives there: a total describing the production while the
+    // list describes one host reads as "22 of 31 shown" about a host with four findings.
+    //
+    // The three cases, and only the third is null:
+    //
+    //   unfiltered            the stashed total is the engine's own pre-slice length, so it is exact
+    //                         and `count < total` catches a clip at EITHER stage
+    //   filtered, full stash  every finding that exists is in the stash, so the matches are all of
+    //                         them and `matched` is exact
+    //   filtered, clipped     the withheld findings were dropped before this method saw a host, so
+    //                         how many of them were on this one is not knowable here. `truncated`
+    //                         still answers, because "some were dropped" is known even when "how
+    //                         many of yours" is not
+    set stashTotal = $get(^||PGGuardian("chat", "total"), "")
+    if '$isvalidnum(stashTotal) {
+        // Absent or unreadable: the stash is all we know of, so treat it as whole. Only reachable
+        // from a node this build did not write, since `Ask()` kills the subtree on entry.
+        set stashTotal = raw.%Size()
+    }
+    set stashClipped = (stashTotal > raw.%Size())
+    if host = "" {
+        set out.total = stashTotal
+    } elseif 'stashClipped {
+        set out.total = matched
+    }
+    do out.%Set("truncated", $select(out.total = "": 1, 1: out.count < out.total), "boolean")
     // Said in the payload because the model cannot otherwise tell an unfiltered empty list from a
     // filtered one, and "no findings on Cloud API" and "no findings anywhere" support different
     // answers.
@@ -176,8 +230,29 @@ ClassMethod GetActiveFindings(host As %String = "") As %DynamicObject
     // list is the last one the engine could compute, which is old rather than wrong. Neither is
     // inferable from the array, so the tool says which it is rather than leaving the emptiness to
     // speak for itself.
-    if out.count = 0 {
-        set scope = $select(host = "": " on this production", 1: " on " _ host)
+    set scope = $select(host = "": " on this production", 1: " on " _ host)
+    if out.truncated {
+        // TESTED BEFORE `count = 0`, and the order is the correctness argument. A filtered call whose
+        // matches were all dropped upstream returns `count: 0`, and the plain note below would answer
+        // it with "no open findings on Cloud API at the instant this question was asked" — a false
+        // all-clear composed from a list nobody could see, which is the same defect as `supplied:
+        // false` wearing the shape of a successful answer.
+        //
+        // Phrased as an instruction rather than a fact for the reason the notes below are: the failure
+        // is not the model missing a flag, it is the model reporting `count` as the number of issues.
+        if out.total '= "" {
+            set out.note = "this list is INCOMPLETE: " _ out.count _ " of " _ out.total _
+                " open findings" _ scope _ " are shown, and the rest were dropped by a size cap " _
+                "before this tool could read them -- state " _ out.total _ " as the number of open " _
+                "findings and say that only " _ out.count _ " of them are described here"
+        } else {
+            set out.note = "this list is INCOMPLETE and the true number is NOT KNOWN here: the " _
+                "findings supplied with this question were capped across the whole production " _
+                "before they could be narrowed to " _ host _ ", so there may be open findings on " _
+                host _ " that are absent from this list -- treat " _ out.count _ " as a lower bound " _
+                "and never as a count, and do not conclude that " _ host _ " is clear"
+        }
+    } elseif out.count = 0 {
         if out.state = "warming" {
             set out.note = "the detection engine is still warming up, so its comparative rules are " _
                 "SILENT and no findings can be reported yet" _ scope _ " -- this is not evidence " _

--- a/iris/test/FindingsTruncation.cls
+++ b/iris/test/FindingsTruncation.cls
@@ -1,0 +1,261 @@
+/// Proof that `get_active_findings` filters BEFORE it truncates, and says so when it truncates.
+///
+/// WHY THIS IS PINNED RATHER THAN COMMENTED. #165 closes by naming the property this class exists for:
+/// `GetActiveFindings` applies the `host` filter before the cap, which is the correct order, and
+/// *"swapping them would still return plausible output and would be easy to miss in review"*. That is
+/// the failure class this repository keeps meeting — a wrong answer wearing the shape of a right one —
+/// and a comment does not fail when someone reorders two lines.
+///
+/// IT ALSO PINS THE FIELDS #165 ADDED. `count` was the post-cap size with nothing saying so, so a
+/// clipped list and a complete one were byte-identical; `total` and `truncated` are what tell them
+/// apart, and each of the states below is one a model would otherwise report as a fact.
+///
+/// WHAT THE MUTATION ACTUALLY SHOWED, because it was run rather than assumed and it corrects #165's
+/// own reading. Swapping the filter block and the cap block leaves `count` correct: the cap tests
+/// `findings.%Size()`, which counts pushed MATCHES, so a non-matching finding never consumes cap budget
+/// and the "first 25 of the production, then filtered" outcome the issue describes does not arise from
+/// that swap. What the swap breaks is `matched` — counted before the filter it sizes the production
+/// while `count` sizes the host, and `FilterBeforeCap` fails on `total` and `truncated` rather than on
+/// the count. Both properties are covered here: `count: 2` on an array whose first 28 elements are
+/// another host is what would fail if the cap were ever moved onto the ITERATION, and the total
+/// assertions are what fail if the two blocks trade places. Written down because a test justified by a
+/// failure it does not actually catch is the same defect as a contract justified by a runtime it does
+/// not match (#202).
+///
+/// THE INPUT IS SYNTHETIC AND DELIBERATELY LARGER THAN THIS PRODUCTION CAN PRODUCE. Host names and
+/// finding types are the real ones (`iris/labdemo/Production.cls`, `contracts/healthscan.d.ts`), but
+/// the arrays here run to 30 elements and findings are keyed `(host, type)`, so three reported hosts
+/// across eight types cannot exceed 24. That is the point rather than a liberty taken: the cap under
+/// test is the one whose justification in three separate comments *was* "24 is the ceiling, so 25
+/// cannot clip", which is a host count compiled into a reason (#25, #34) and wrong at four hosts. A
+/// fixture that stayed under the ceiling could not exercise the branch. Nothing here is served to a
+/// dashboard, an LLM or an API — it is an argument to one method.
+///
+/// NO PRIVILEGE, NO USER, NO NETWORK, NO METERED CALL, unlike `Test.GovernanceProof`: the tool reads a
+/// process-private global and this class writes it, so the whole proof is local and repeatable. It is
+/// still hand-run rather than compiled at boot, because `iris/CLAUDE.md` keeps `iris/test/` out of what
+/// the deploy ships and one cheap fixture is not a reason to change that.
+///
+/// ```
+/// do $system.OBJ.LoadDir("/pg-src/test/", "ck", .errors, 1)
+/// write ##class(ProductionGuardian.Test.FindingsTruncation).Prove()
+/// ```
+Class ProductionGuardian.Test.FindingsTruncation
+{
+
+/// The eight real finding types, cycled so the fixture does not carry 30 copies of one classification.
+Parameter TYPES = {$listbuild(
+    "queue_buildup",
+    "growing_queue_wait",
+    "slow_processing",
+    "elevated_error_rate",
+    "throughput_drop",
+    "dead_host",
+    "stalled_host",
+    "system_alert")};
+
+/// Run every case. Returns 1 only if all of them pass.
+ClassMethod Prove() As %Boolean
+{
+    write "get_active_findings -- filter order and truncation reporting (#165)", !
+    write "=================================================================", !, !
+
+    set ok = 1
+    set ok = ..FilterBeforeCap() && ok
+    set ok = ..LocalCapIsReported() && ok
+    set ok = ..UpstreamClipIsReported() && ok
+    set ok = ..CompleteListIsNotFlagged() && ok
+    set ok = ..FilteredClipIsNotAnAllClear() && ok
+    set ok = ..AbsentTotalReadsAsWhole() && ok
+    set ok = ..NoSnapshotReportsNeither() && ok
+
+    kill ^||PGGuardian("chat")
+    write !, $select(ok: "PASS -- all cases", 1: "FAIL -- see above"), !
+    quit ok
+}
+
+/// THE HEADLINE. 28 findings on one host, then 2 on another, and the second host is the one asked
+/// about — so every assertion here is about a number that must describe `Cloud API` and not the array
+/// it was found in. Measured against the block swap and against a cap moved onto the iteration; see
+/// the class comment for which assertion catches which.
+ClassMethod FilterBeforeCap() As %Boolean [ Private ]
+{
+    do ..Stash(..Repeat("Lab Router", 28) _ "," _ ..Repeat("Cloud API", 2), 30)
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings("Cloud API")
+    set ok = ..Check("filtered count is the matches, not the page", out.count, 2)
+    set ok = ..Check("both returned findings are the host asked about", ..HostsOf(out),
+        "Cloud API/Cloud API") && ok
+    // Nothing matching was withheld and the stash was whole, so the filtered total is exact.
+    set ok = ..Check("filtered total is exact", ..Shape(out, "total"), "number:2") && ok
+    set ok = ..Check("not reported as truncated", ..Shape(out, "truncated"), "boolean:0") && ok
+    quit ok
+}
+
+/// The cap in THIS method biting, with nothing dropped upstream. Unreachable while both caps are 25 —
+/// `ChatDispatcher.StashFindings` cannot hand over more than the tool will return — and that is
+/// precisely #165's other half: raise one literal and the other starts dropping. It must not drop
+/// silently when it does.
+ClassMethod LocalCapIsReported() As %Boolean [ Private ]
+{
+    do ..Stash(..Repeat("Cloud API", 30), 30)
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings()
+    set ok = ..Check("count is the cap", out.count, 25)
+    set ok = ..Check("total is what exists", ..Shape(out, "total"), "number:30") && ok
+    set ok = ..Check("truncated", ..Shape(out, "truncated"), "boolean:1") && ok
+    set ok = ..Check("note states the true number", ''(out.note [ "25 of 30"), 1) && ok
+    quit ok
+}
+
+/// A clip that happened BEFORE this instance saw the list — the engine's own `MAX_FINDINGS` slice. The
+/// stash holds 25 and `total` says 40, which is the only reason the difference is knowable at all.
+ClassMethod UpstreamClipIsReported() As %Boolean [ Private ]
+{
+    do ..Stash(..Repeat("Cloud API", 25), 40)
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings()
+    set ok = ..Check("count is what arrived", out.count, 25)
+    set ok = ..Check("total is what the engine measured", ..Shape(out, "total"), "number:40") && ok
+    set ok = ..Check("truncated", ..Shape(out, "truncated"), "boolean:1") && ok
+    set ok = ..Check("note states the true number", ''(out.note [ "25 of 40"), 1) && ok
+    quit ok
+}
+
+/// THE NEGATIVE CASE, and the one that keeps the flag worth reading. A `truncated` that is true often
+/// enough is a field a model learns to ignore, so a complete list must come back clean and carry no
+/// note at all — `note` exists for "this number does not speak for itself", and here it does.
+ClassMethod CompleteListIsNotFlagged() As %Boolean [ Private ]
+{
+    do ..Stash("EMR Source,Lab Router,Cloud API", 3)
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings()
+    set ok = ..Check("count", out.count, 3)
+    set ok = ..Check("total equals count", ..Shape(out, "total"), "number:3") && ok
+    set ok = ..Check("not truncated", ..Shape(out, "truncated"), "boolean:0") && ok
+    set ok = ..Check("no note on a complete list", out.%IsDefined("note"), 0) && ok
+    quit ok
+}
+
+/// THE CASE THE `count: 0` NOTE WOULD HAVE ANSWERED WRONGLY, and the reason `truncated` is tested
+/// first in the method. The stash was clipped across the whole production before a host could be
+/// applied, so how many of the withheld findings were on this host is not knowable here — `total` is
+/// null rather than 0, and the note must not say "no open findings on Cloud API".
+ClassMethod FilteredClipIsNotAnAllClear() As %Boolean [ Private ]
+{
+    do ..Stash(..Repeat("Lab Router", 5), 40)
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings("Cloud API")
+    set ok = ..Check("count", out.count, 0)
+    set ok = ..Check("total is null, not zero", ..Shape(out, "total"), "null:") && ok
+    set ok = ..Check("truncated", ..Shape(out, "truncated"), "boolean:1") && ok
+    set ok = ..Check("note refuses the all-clear", ''(out.note [ "do not conclude"), 1) && ok
+    set ok = ..Check("note does not claim no open findings",
+        ''(out.note [ "no open findings"), 0) && ok
+    quit ok
+}
+
+/// A stash written without a `total` node. Only reachable from a build that predates #165, and it must
+/// degrade to "as far as I know, whole" rather than to a null total on every call — the field is worth
+/// nothing if the common case reads unknown.
+ClassMethod AbsentTotalReadsAsWhole() As %Boolean [ Private ]
+{
+    do ..Stash("Cloud API,Lab Router", "")
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings()
+    set ok = ..Check("total falls back to what was stashed", ..Shape(out, "total"), "number:2")
+    set ok = ..Check("not truncated", ..Shape(out, "truncated"), "boolean:0") && ok
+    quit ok
+}
+
+/// `supplied: false` — no snapshot reached the request. `truncated: false` here would assert that a
+/// list nobody read is complete, so both fields stay null: `mcp-tools.md` §2.1's rule, applied to a
+/// boolean and to a count rather than to a metric.
+ClassMethod NoSnapshotReportsNeither() As %Boolean [ Private ]
+{
+    kill ^||PGGuardian("chat")
+    set out = ##class(ProductionGuardian.LabDemo.Tools.Findings).GetActiveFindings()
+    set ok = ..Check("supplied is false", ..Shape(out, "supplied"), "boolean:0")
+    set ok = ..Check("count is null", ..Shape(out, "count"), "null:") && ok
+    set ok = ..Check("total is null", ..Shape(out, "total"), "null:") && ok
+    set ok = ..Check("truncated is null, not false", ..Shape(out, "truncated"), "null:") && ok
+    quit ok
+}
+
+/// Write the handoff `REST.ChatDispatcher.StashFindings` writes, one finding per host in `hostList`.
+///
+/// `total` is passed separately and can be larger than the array, because that combination is exactly
+/// what a clip upstream looks like on arrival: the node holds what fitted and `total` holds what
+/// existed. Passing "" omits the node.
+ClassMethod Stash(hostList As %String, total As %String) [ Private ]
+{
+    kill ^||PGGuardian("chat")
+    set types = ..#TYPES
+    set arr = []
+    for i = 1:1:$length(hostList, ",") {
+        do arr.%Push({
+            "id": ("fixture-" _ i),
+            "host": ($piece(hostList, ",", i)),
+            "type": ($list(types, (i # $listlength(types)) + 1)),
+            "severity": "critical",
+            "currentValue": 1,
+            "baselineValue": 0,
+            "detectedAt": "2026-09-01T00:00:00Z",
+            "message": "synthetic fixture finding -- Test.FindingsTruncation"
+        })
+    }
+    set ^||PGGuardian("chat", "findings") = arr.%ToJSON()
+    set ^||PGGuardian("chat", "asOf") = "2026-09-01T00:00:00Z"
+    // `ok` throughout, so no case here can pass by way of the `warming` or `stale` note.
+    set ^||PGGuardian("chat", "state") = "ok"
+    if total '= "" {
+        set ^||PGGuardian("chat", "total") = total
+    }
+}
+
+/// `hostList` fragment repeating one host `n` times.
+ClassMethod Repeat(host As %String, n As %Integer) As %String [ Private ]
+{
+    set out = ""
+    for i = 1:1:n {
+        set out = out _ $select(i = 1: "", 1: ",") _ host
+    }
+    quit out
+}
+
+/// The hosts of the returned findings, slash-separated.
+///
+/// ITERATED RATHER THAN INDEXED, because the first version read `%Get(0).host _ "/" _ %Get(1).host` and
+/// the cap-on-iteration mutation returned an empty array, so the assertion died with `<INVALID OREF>`
+/// and took the remaining six cases with it. A fixture that crashes instead of failing reports less
+/// than one that fails, and the run it crashed on is the run that mattered.
+ClassMethod HostsOf(out As %DynamicObject) As %String [ Private ]
+{
+    set hosts = ""
+    if '$isobject(out.findings) {
+        quit ""
+    }
+    set iter = out.findings.%GetIterator()
+    while iter.%GetNext(.index, .finding) {
+        set hosts = hosts _ $select(hosts = "": "", 1: "/") _ finding.%Get("host")
+    }
+    quit hosts
+}
+
+/// One field as `type:value`.
+///
+/// TYPE AND VALUE TOGETHER, because the distinction this whole change rests on is `null` versus
+/// `false`, and both read as "" through `%Get`. Comparing the value alone would let a null pass a test
+/// written for false, which is the one assertion that must not be loose here.
+ClassMethod Shape(out As %DynamicObject, field As %String) As %String [ Private ]
+{
+    quit out.%GetTypeOf(field) _ ":" _ out.%Get(field)
+}
+
+/// Report one assertion.
+ClassMethod Check(label As %String, actual As %String, expected As %String) As %Boolean [ Private ]
+{
+    set ok = (actual = expected)
+    write $select(ok: "  PASS  ", 1: "  FAIL  "), label
+    if 'ok {
+        write " -- expected '", expected, "', got '", actual, "'"
+    }
+    write !
+    quit ok
+}
+
+}

--- a/services/detection-engine/src/detect/chat.ts
+++ b/services/detection-engine/src/detect/chat.ts
@@ -138,6 +138,20 @@ interface ChatAgentRequest extends ChatRequest {
    * this and the chat prompt is told what each means.
    */
   findingsState: HealthScanState;
+  /**
+   * How many findings the snapshot held BEFORE `MAX_FINDINGS` clipped it — `null` when no snapshot
+   * was read at all.
+   *
+   * THIS IS THE ONLY PLACE THE TRUE LENGTH IS KNOWN. Everything downstream sees the sliced array:
+   * IRIS receives at most `MAX_FINDINGS` elements and `Tools.Findings` republishes what it receives,
+   * so without this field `count: 25` and a complete list of 25 are byte-identical and the model
+   * states the capped number as a fact (#165). Sending it costs one integer and is what lets the
+   * tool answer `truncated`.
+   *
+   * `null` rather than `0` for an absent supplier, for the same reason `findingsState` is `warming`
+   * there: nothing was measured, and a total of zero is a measurement.
+   */
+  findingsTotal: number | null;
 }
 
 /** The slice of `EngineSnapshot` this module needs, so a test can supply one without an engine. */
@@ -188,8 +202,14 @@ const MAX_HISTORY = 6;
  *
  * THE FIRST OF TWO CAPS ON PURPOSE, like the question-length cap above and for the same reason in
  * reverse: this one keeps the request small, and IRIS's keeps a hand-rolled POST from filling the
- * model's context. Eight finding types across three reported hosts is 24 at the absolute ceiling, so
- * 25 cannot clip a real production — which is why a cap here needs no accompanying "truncated" flag.
+ * model's context.
+ *
+ * IT DOES NEED AN ACCOMPANYING SIGNAL, and until #165 it had none. This comment used to argue it
+ * could not clip a real production — eight finding types across three reported hosts is 24, one
+ * under the cap — which is a host COUNT compiled into a justification, the thing #25/#34 forbid in
+ * `src/`. Findings are keyed `(host, type)`, so the ceiling is `hosts × 8` and moves the moment a
+ * production has four hosts. `findingsTotal` is sent alongside the slice so the far side can say it
+ * was clipped instead of publishing the capped number as the answer.
  */
 const MAX_FINDINGS = 25;
 
@@ -353,6 +373,9 @@ export async function chat(request: ChatRequest, deps: ChatDeps): Promise<ChatRe
         : isoSeconds(snapshot.lastPollAt),
     /* No supplier means no measurement, which is what `warming` says. See `ChatDeps.findings`. */
     findingsState: snapshot === undefined ? 'warming' : snapshot.state,
+    /* Read off the SAME `snapshot` const as the slice above, so the total and the array it describes
+       cannot come from different polls. */
+    findingsTotal: snapshot === undefined ? null : snapshot.findings.length,
   };
 
   let raw: unknown;

--- a/services/detection-engine/test/chat.test.ts
+++ b/services/detection-engine/test/chat.test.ts
@@ -312,10 +312,11 @@ describe('chat', () => {
     assert.equal(seen['findingsState'], 'stale');
   });
 
-  it('caps the findings it sends', async () => {
-    // The cap is the FIRST of two, the second being `Tools.Findings.#MAXFINDINGS`. Eight types
-    // across three hosts is 24 at the ceiling, so this cannot clip a real production -- it bounds a
-    // malformed snapshot, not a busy one.
+  it('caps the findings it sends, and declares the true length it capped', async () => {
+    // The cap is the FIRST of two, the second being `Tools.Findings.#MAXFINDINGS`. This used to
+    // assert only the slice, with a comment saying 24 was the ceiling so it could not clip a real
+    // production -- a host count in a justification (#165, and #25's shape). `findingsTotal` is the
+    // half that matters: without it the far side cannot tell 25 of 40 from a complete 25.
     const seen = await outbound({
       findings: () => ({
         findings: Array.from({ length: 40 }, (_, i) => finding({ id: `f-${i}` })) as never,
@@ -324,6 +325,21 @@ describe('chat', () => {
       }),
     });
     assert.equal((seen['findings'] as unknown[]).length, 25);
+    assert.equal(seen['findingsTotal'], 40);
+  });
+
+  it('sends findingsTotal equal to the array when nothing was clipped', async () => {
+    const seen = await outbound({
+      findings: () => ({ findings: [finding()] as never, lastPollAt: 1, state: 'ok' }),
+    });
+    assert.equal(seen['findingsTotal'], 1);
+  });
+
+  it('sends a null total rather than zero when no supplier is wired', async () => {
+    // Same argument as `findingsState: 'warming'` two tests up: zero findings measured and no
+    // measurement taken are different claims, and the tool must not report the second as the first.
+    const seen = await outbound();
+    assert.equal(seen['findingsTotal'], null);
   });
 
   it('ignores findings a caller puts in the request body', async () => {


### PR DESCRIPTION
Closes #165.

`get_active_findings` published `count` as the size of the list **after** a cap, and three caps of 25 could clip it — the engine's slice, `StashFindings` on receipt, and the tool's own. A clipped payload was byte-identical to a complete one, so the model stated `count` as the number of open findings, and §3.13 mentioned no cap at all.

## What changed

**`total` and `truncated` on the tool output**, plus **`findingsTotal` on the request**. Nothing is removed and no existing field changes meaning.

The shape follows §3.14 (`pathCount` / `pathsReturned` / `truncated`) rather than inventing one — that section already named #165 as the open defect that made it state the rule. Including #186's lesson: **`total` is scoped to the same filter as `count`**, never to the production.

That scoping makes one case genuinely unknowable, reported as `null` rather than guessed:

| Call | `total` | `truncated` |
|---|---|---|
| unfiltered | exact — the engine's pre-slice length | `count < total` |
| `host` given, nothing dropped upstream | exact | `count < total` |
| `host` given, list already clipped | **`null`** | **`true`** |

The third row is the one that changes an answer. `count: 0` there means "none on this host among the ones I can see", so `truncated` is tested **before** the `count: 0` branch and the note refuses the all-clear instead of saying "no open findings on `Cloud API`". All three fields are `null` — never `false`/`0` — where no snapshot was read (§2.1 applied to a boolean).

Also gone: the justification all three cap comments shared — *"eight finding types across three hosts is 24, so 25 cannot clip a real production"*. Findings are keyed `(host, type)`, so the ceiling is `hosts × 8`; that is a host count compiled into a reason, which #25/#34 forbid, and wrong at four hosts. #165 filed it alongside the silence because the 25 is two independent literals across the language boundary — raise one and the other drops findings. Now observable.

The chat system prompt gets the third paragraph in the set that already tells the model how to read `supplied: false` and `count: 0`.

## The test, and a correction to the issue

`iris/test/FindingsTruncation.cls` — hand-run, 27 assertions, no privilege/user/network/metered call. It pins the filter-before-cap order #165 asked for, and each of the states above.

**It was checked against two mutations rather than assumed to catch them, and one result corrects the issue's own reading.** Swapping the filter block and the cap block leaves `count` correct: the cap tests `findings.%Size()`, which counts pushed *matches*, so a non-matching finding never consumes cap budget and the "first 25 of the production, then filtered" outcome does not arise from that swap. What it breaks is the *scoping* — `matched` counted before the filter sizes the production while `count` sizes the host — so `FilterBeforeCap` fails on `total`/`truncated`. The "returns 0 findings" outcome does arise from a cap moved onto the **iteration**, which the `count: 2` assertion catches (measured: `expected '2', got '0'`). Both are covered; the comments now say which catches which rather than repeating the issue's framing.

That run also found the fixture aborting with `<INVALID OREF>` instead of failing, taking six cases with it — fixed, because a fixture that crashes reports less than one that fails.

## Verified

- engine `tsc --noEmit` clean; **441 pass / 83 suites / 0 fail** (node:22 container, repo root mounted)
- `contracts/validate.mjs` — all checks passed (3 samples, 15 accept, 26 reject, 7 capture claims)
- `Tools/Findings.cls` and `REST/ChatDispatcher.cls` both compile in the live container
- `Test.FindingsTruncation.Prove()` → **PASS, all cases** (27/27)
- no `apps/dashboard/**` change, so nothing to rebuild there

Self-reviewed and merged under the standing full-ownership arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)