### PR TITLE
fix(engine): the §2.4 scope gate existed in three paragraphs and no code, so system_alert text reached the LLM

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -568,6 +568,7 @@ export function App(): JSX.Element {
         investigation={
           selected === null ? null : (
             <InvestigationPanel
+              findingType={selected.type}
               investigation={detective.investigation}
               investigating={detective.investigating}
               error={detective.error}

--- a/apps/dashboard/src/components/InvestigationPanel.tsx
+++ b/apps/dashboard/src/components/InvestigationPanel.tsx
@@ -33,8 +33,11 @@
 
 import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
 import { ABSENT } from '../lib/format';
+import { findingMeta, investigationScope } from '../lib/findingMeta';
 
 export interface InvestigationPanelProps {
+  /** The finding's type, for the §2.4 scope check. Only the type is needed, so only it is passed. */
+  findingType: string;
   investigation: InvestigationView | null;
   investigating: boolean;
   error: string | null;
@@ -74,6 +77,7 @@ function confidenceText(confidence: number | null): string {
 }
 
 export function InvestigationPanel({
+  findingType,
   investigation,
   investigating,
   error,
@@ -87,6 +91,39 @@ export function InvestigationPanel({
   const manual = investigation?.manualRemediation ?? null;
   const canned = investigation?.source === 'canned';
   const unavailable = investigation !== null && investigation.rootCause === null;
+  const scope = investigationScope(findingType);
+
+  /*
+   * OUT OF SCOPE RETURNS EARLY rather than wrapping the button in a condition, so `onInvestigate` is
+   * unreachable from this branch at all. Same argument as `manualRemediation` renders from its own
+   * branch below: a control that must not exist should be absent by construction, not disabled by an
+   * `if` somebody can invert later. §2.4 asks the UI not to offer the button; the engine refuses
+   * independently, which is what makes this a UI concern rather than the boundary itself.
+   */
+  if (scope !== 'investigable') {
+    return (
+      <section className="pg-investigate" aria-label="AI Detective and Smart Resolve">
+        <h3 className="pg-investigate__heading">Why is this happening?</h3>
+        <p className="pg-investigate__intro">
+          {scope === 'never_forwarded' ? (
+            <>
+              <strong>System alerts are not investigated.</strong> The text of an alert is written by
+              IRIS and can name the message it was about, so it never leaves the instance — only
+              metrics and configuration do. The alert itself is above, verbatim.
+            </>
+          ) : (
+            <>
+              <strong>
+                No investigation exists for {findingMeta(findingType).label.toLowerCase()} findings
+              </strong>{' '}
+              yet. The AI Detective covers queue buildup on a throughput-bound host and a host that
+              has stopped processing. Nothing is being withheld — this one has not been built.
+            </>
+          )}
+        </p>
+      </section>
+    );
+  }
 
   return (
     <section className="pg-investigate" aria-label="AI Detective and Smart Resolve">

--- a/apps/dashboard/src/lib/findingMeta.ts
+++ b/apps/dashboard/src/lib/findingMeta.ts
@@ -171,3 +171,37 @@ const ABSOLUTE_TYPES: ReadonlySet<string> = new Set<FindingType>([
 export function comparesToBaseline(type: string): boolean {
   return !ABSOLUTE_TYPES.has(type);
 }
+
+/**
+ * Whether an investigation exists for a finding type, and if not, which of the two reasons applies.
+ *
+ * `investigation-api.md` §2.4 tells the consumer not to offer Investigate outside this set, and says
+ * in the same breath that the engine's own check "is the backstop, not the UI's contract" — so this
+ * list is a deliberate duplicate of `INVESTIGABLE_TYPES` in the engine rather than a single source of
+ * truth. Both exist because a hidden button is not a boundary and a served refusal is not a UI.
+ *
+ * THE TWO REASONS ARE KEPT APART because they are different facts about the product, and an operator
+ * acting on them would do different things. `never_forwarded` is a data rule: a `system_alert`'s
+ * message is text IRIS wrote and can name the message an alert was about, so it does not leave the
+ * instance (root `CLAUDE.md` §2.1). `no_scenario` is a coverage gap: nothing is unsafe, there is
+ * simply no investigation built for it yet. Collapsing them into "cannot investigate" would let a
+ * privacy boundary read as an unfinished feature.
+ *
+ * KEYED ON TYPE, NOT ON `(type, host)` as §2.4 words it. Two scenarios ship — queue buildup on a
+ * throughput-bound operation, and a host that has stopped processing — and a host name here would be
+ * this directory tracking `Production.cls`'s config, which §9 forbids outright (#25).
+ *
+ * An unrecognized type gets `no_scenario`, which matches what the engine would answer: its check is
+ * an allowlist, so a type neither side knows is refused by both.
+ */
+export type InvestigationScope = 'investigable' | 'never_forwarded' | 'no_scenario';
+
+const INVESTIGABLE_TYPES: ReadonlySet<string> = new Set<FindingType>([
+  'queue_buildup',
+  'dead_host',
+]);
+
+export function investigationScope(type: string): InvestigationScope {
+  if (type === 'system_alert') return 'never_forwarded';
+  return INVESTIGABLE_TYPES.has(type) ? 'investigable' : 'no_scenario';
+}

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,64 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `investigation-api.md` §2.4: the scope gate now exists, keyed on type, and refuses `system_alert` separately
+
+**A behaviour change, not a wording one, and it closes the hole the entry below filed as #206.**
+`POST /api/investigate` previously accepted **any** finding on **any** host — including a
+`system_alert`, whose `message` is text IRIS wrote into `alerts.log` and which an alert about a failed
+send can use to name the message it failed to send. That string was forwarded verbatim to an external
+LLM. Root `CLAUDE.md` §2.1 makes that a rule rather than a preference: metrics and configuration leave
+the instance, never message content.
+
+### What changed on the wire
+
+| | Accepted |
+|---|---|
+| §2.4, until today | `type === 'queue_buildup'` **and** `host === 'Cloud API'` — asserted in three places in prose, enforced in none |
+| §2.4, now | `type` is `queue_buildup` **or** `dead_host`. No host check. `system_alert` refused by a separate rule checked first |
+
+Everything else is `200` + `state: "unavailable"` + `source: "none"` with a `note`, which is what §5
+already specified for this case. **No consumer of a valid request sees a different response**, and
+nothing in `investigation.schema.json` changes — an out-of-scope refusal is the `unavailable` shape
+that was already schema-valid.
+
+### Two lists, not one, and the order is the point
+
+The boundary refusal (`NEVER_FORWARDED`) is **not derived from** the scope allowlist
+(`INVESTIGABLE_TYPES`) and is checked before it. Until now §2.3's alert-text rule was *implied* by
+§2.4's single accepted shape, so widening scope for a second scenario would have reopened it silently —
+which is exactly how a gate asserted in three paragraphs came to be enforced nowhere. Widening scope
+now cannot widen the boundary. `test/investigationScope.test.ts` pins the two sets as disjoint, and
+every test there asserts **`callAgent` was not called**, because the absence of the outbound call is
+the property that matters rather than the shape of the reply.
+
+### The fix #206 proposed would have broken a shipped scenario
+
+That issue proposed rejecting anything but `(queue_buildup, Cloud API)`. **MVP 3 shipped a second
+scenario** — `dead_host` on a service polling a directory that does not exist
+(`docs/production-guardian-mvp3.md` §2.1/§2.3, with `Triggers.MissingFolder()`, `get_host_settings`
+and `manualRemediation` all built for it) — and §2.4 was never amended when it landed. Enforcing the
+contract as literally written would have refused a scenario the product demonstrates. Two lessons, both
+already in this file's history: a scope table is a contract surface and drifts like any other, and the
+right response to "the code does not match the contract" is to check which one is wrong.
+
+**The host half of the pair is dropped rather than extended.** The concern is the provenance of
+`finding.message`, which is a property of the *type*; the agent's read tools are host-agnostic; and a
+host name compiled into the engine or the panel is either of them tracking `Production.cls`'s config,
+which `apps/dashboard/CLAUDE.md` §9 forbids outright (#25). `mockClient.investigate` already keys its
+own branch on type for that reason (#84).
+
+### Consumers
+
+The panel hides Investigate for the six refused types and **distinguishes the two reasons in its
+copy** — `system_alert` is a data rule, the other five are an unbuilt feature, and collapsing them into
+"cannot investigate" would let a privacy boundary read as a missing feature. That duplicate type list
+in `apps/dashboard/src/lib/findingMeta.ts` is deliberate: §2.4 says the engine's check is the backstop,
+not the UI's contract, because a hidden button is not a boundary.
+
+§4.1 gains the two new `note` shapes; §5 replaces its "no check exists" row with the two refusals; Q3
+no longer promises a host filter or the retired `out_of_scope` failure reason.
+
 ## 2026-09-01 — `investigation-api.md`: `diagnostics` documented a block no build has ever sent
 
 **No wire change.** Every field named here already ships and is already in
@@ -78,6 +136,8 @@ names the issue rather than quietly asserting either side:
 - **§2.4's scope gate does not exist** — no type or host check anywhere, so a `system_alert` finding,
   whose `message` is text IRIS wrote into `alerts.log`, can be forwarded to the external LLM. §2.3
   names that as the hole §2.4 closes, and it does not. **#206**, and the most serious of the three.
+  *Fixed the same day — see the entry above. Left as written because this entry records what that PR
+  found, and the fix turned out not to be the one the issue proposed.*
 - **§4.3's fallback chain has no cache and `canned` is a boot mode, not a fallback**, so nothing ever
   produces `state: "degraded"` and §8.2 is schema-valid but unreachable. **#207**
 - **A cleared `findingId` is a `400`**, not the `200` + `state: "unavailable"` §5 argues for at

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -365,27 +365,43 @@ send can name the message it failed to send. That text is not safe to forward un
 no reliable way to sanitise arbitrary alert prose. So the engine does not accept those findings at
 all.
 
-### 2.4 Only one finding shape is accepted
+### 2.4 Two finding types are accepted, and `system_alert` is refused separately
 
-`POST /api/investigate` accepts a finding where **`type` is `queue_buildup` and `host` is
-`Cloud API`.** Anything else returns `200` with `state: "unavailable"` and a `note` saying so (§5).
+`POST /api/investigate` accepts a finding whose **`type` is `queue_buildup` or `dead_host`**.
+Anything else returns `200` with `state: "unavailable"` and a `note` saying which of the two reasons
+below applies (§5).
 
-> **This gate does not exist in the shipped engine, and reason 2 below is why that matters more than
-> a scope slip.** There is no type or host check in `investigate()`, in `index.ts`, or in the panel,
-> so the Investigate button renders on every finding and the finding is forwarded to the agent
-> verbatim — including a `system_alert` whose `message` is text IRIS wrote into `alerts.log`. That is
-> the one path §2.3 says is closed. **#206**, and it is a code fix rather than a wording fix.
+Two refusals, checked in this order, and **they are deliberately not the same list**:
 
-Two reasons, and both are load-bearing:
+1. **The data boundary.** `system_alert` is never forwarded, whatever else changes. §2.3 is the rule:
+   its `message` is text IRIS wrote into `alerts.log`, an alert about a failed send can name the
+   message it failed to send, and there is no reliable way to sanitise arbitrary alert prose.
+2. **Scope.** The remaining five types are refused because **no investigation exists for them** —
+   nothing about them is unsafe. An endpoint that accepts all eight implies eight investigations
+   exist.
 
-1. **Scope.** MVP 2 is one scenario end to end, not a general capability (root `CLAUDE.md` §2.1).
-   One finding type, one host, one action type. An endpoint that accepts all eight types implies
-   eight investigations exist.
-2. **Safety.** It is what makes §2.3's alert-text hole unreachable rather than merely discouraged.
+Ordering them this way is the point. Until #206 the boundary was *implied* by the accepted set, so
+widening scope would have reopened the alert path silently — which is how the gate came to be asserted
+in three places in prose and none in code. A refusal that is not derived from the scope list cannot be
+widened by widening scope, and `test/investigationScope.test.ts` pins the two lists as disjoint.
 
-The dashboard should not offer the Investigate button for other findings; the check here is the
-backstop, not the UI's contract. When a second scenario lands, widening this set is a contract change
-that must say what it does about `system_alert`.
+**Keyed on `type`, not on `(type, host)`.** This section named `Cloud API` until #206, because MVP 2
+had exactly one host. The host half buys nothing: the concern above is the provenance of
+`finding.message`, which is a property of the type, and the agent's read tools are host-agnostic. A
+host name in the engine or the panel would also be either of them tracking `Production.cls`'s config
+— what `apps/dashboard/CLAUDE.md` §9 forbids outright (#25).
+
+**Two types because two scenarios ship.** `queue_buildup` is MVP 2's throughput-bound operation;
+`dead_host` is MVP 3's service polling a directory that does not exist
+(`docs/production-guardian-mvp3.md` §2.3). This section still said "one finding shape" after the
+second landed, so enforcing it as literally written would have refused a shipped, specified scenario
+— the second thing #206 found, and the reason the fix was not the one that issue proposed.
+
+The dashboard should not offer the Investigate button for these types; the check here is the backstop,
+not the UI's contract. The panel duplicates the type list for that reason, and distinguishes the two
+refusals in its copy — a privacy boundary and an unbuilt feature should not read the same to an
+operator. A third scenario is a contract change to this section, and it must say what it does about
+`system_alert`.
 
 ## 3. The response
 
@@ -767,6 +783,12 @@ shapes, and both are prefixes with the underlying cause appended verbatim:
 |---|---|
 | `agent call failed: <message>` | Anything that stopped the call producing a reply — connection refused, reset, DNS, the 30 s deadline, an error from the agent, an LLM outage or a rate limit. The transport or agent message is appended as-is. |
 | `agent reply did not match the contract` | The agent answered and the payload failed validation (§4.4). |
+| `system_alert findings are not investigated: …` | §2.4's first refusal. **Nothing was sent** — this is decided before the request is built. |
+| `no investigation exists for <type> findings` | §2.4's second refusal. Also decided before anything is sent. |
+
+The last two name the finding **type** and never quote `finding.message`, deliberately: on the
+`system_alert` path the message is the thing that must not travel, and a `note` is rendered in a
+browser.
 
 **Render it, do not parse it.** This table describes what the strings look like today, not a
 vocabulary anything guarantees — the engine builds them by interpolation, so a new cause changes the
@@ -782,9 +804,12 @@ quietly dropped — the enum was the better design and the wrong claim, and re-e
 change with a schema change behind it, not a paragraph. A sixth, `malformed_agent_response`, is the
 second row and loses nothing.
 
-**The remaining two described conditions the engine does not reach at all**, which is a divergence in
-behaviour rather than in field names, so §5 and Q3 now say what actually happens: `finding_not_found`
-is a `400` (#207), and there is no `out_of_scope` check anywhere (#206).
+**The remaining two are the reverse case — a state the engine reaches with no field to name it.**
+`out_of_scope` is now two distinct refusals (§2.4, #206) and `finding_not_found` is a `400` (#207);
+both are divergences in behaviour rather than in field names, so §5 and Q3 say what actually happens
+and the notes above are how a consumer tells them apart. The last two rows of that table are the
+closest thing to the retired enum that ships, and they are prose, which is why §5 asks consumers to
+branch on `state` and `source` instead.
 
 ### 4.2 Timeouts and retries
 
@@ -879,7 +904,8 @@ that is the worst of the available outcomes. Validate the whole object or use no
 | Agent unavailable, no cache | `200`, `state: "unavailable"`, `source: "none"` as shipped. Specified as `200`, `state: "degraded"`, `source: "canned"`; `canned` is a boot-time mode rather than a fallback (§4.3) |
 | Agent unavailable, no cache, no fixture | `200`, `state: "unavailable"`, `source: "none"`, `note` set |
 | Finding cleared between the poll and the click | **`400`** as shipped — `{"error": "bad request: no current finding with id ..."}`. **Specified as `200` + `state: "unavailable"`, and the paragraph below is the argument for it.** The engine deliberately throws instead, on the reasoning that an unknown id is the caller being wrong; the two readings disagree about whether a *race* is a caller defect. #207 |
-| Finding outside §2.4 | **No check exists**, and §2.4 explains why that is a data-boundary hole and not only a scope slip. As shipped, any finding on any host is investigated against the live agent. Specified as `200` + `state: "unavailable"`. #206 |
+| `system_alert` finding | `200`, `state: "unavailable"`, `source: "none"`, `note` naming the type. **Nothing is sent to the agent** — §2.4's first refusal, and the one that closes §2.3's hole. #206 |
+| Finding of any other type outside §2.4 | `200`, `state: "unavailable"`, `source: "none"`, `note: "no investigation exists for <type> findings"`. Also refused before the request is built. #206 |
 | Malformed body — not JSON, no `findingId`, extra keys | `400` + `{"error":"..."}` |
 | Wrong method on the path | `405` |
 | Genuine server fault | `500` + `{"error":"..."}` |
@@ -927,7 +953,7 @@ an answer is an assumption rather than a fact.
 |---|---|---|
 | **Q1** | What does the dashboard send? | `{"findingId": "..."}` and nothing else (§2.1). Not negotiable — it is half the data-boundary argument. |
 | **Q2** | Is it synchronous? How long? | Synchronous. Hard deadline 30 s, so build the panel for a multi-second spinner, not an instant swap. No polling endpoint. |
-| **Q3** | Can I investigate any finding? | **Contractually no** — `queue_buildup` on `Cloud API` only (§2.4), and a consumer should hide the control elsewhere. **But nothing enforces it as shipped:** there is no scope check in the engine and no type gate in the panel, so a click on any finding reaches the live agent. The `200` + `out_of_scope` this row promised until #201 does not exist, and §2.4 records what it lets through. #206 |
+| **Q3** | Can I investigate any finding? | **No — `queue_buildup` or `dead_host`, keyed on type only** (§2.4). Anything else is `200` + `state: "unavailable"` with a `note` naming which of the two refusals applied, and **the agent is not called at all** — the refusal happens before the request is built. A consumer should hide the control for the other six, and distinguish `system_alert` (never forwarded, a data rule) from the rest (no investigation built yet) in its copy. This row promised `queue_buildup` on `Cloud API` and an `out_of_scope` failure reason; the host half is dropped and there is no such enum — see §2.4 and §4.1. #206 |
 | **Q4** | Is `rootCause` safe to render verbatim? | Yes, and it is authoritative — do not summarise or reflow it. Same rule as `Finding.message`. |
 | **Q5** | Is `evidence[]` strings or objects? | Objects. Render `detail` as the bullet; use `source` to mark what was tool-measured versus model-asserted (§3.2). **`tool` is provenance text, not an enum** — it carries the runtime ClassMethod name (`GetPoolSize`), sometimes with a provider prefix (`functions.GetPoolSize`), and never the snake_case titles in `mcp-tools.md` §1. Render it; do not validate it, and do not drop a bullet whose tool you do not recognise (§3.2). |
 | **Q6** | Can I bind the approve button straight to `recommendedAction`? | Yes when `action.type` is `set_pool_size` and `action.size` is within `bounds`. Otherwise disable it and render nothing (§3.3). **Send `recommendedAction.action` to `POST /api/resolve` as `action`, unmodified** — it is already that contract's exact shape, and reshaping it is the failure `resolve-api.md` §1.2 warns about. Applying is that endpoint, not this one. |

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -134,6 +134,46 @@ const TIMEOUT_MS = 30_000;
 /** §3.3. Must match resolve-api.md §3 exactly — an out-of-bounds recommendation is unusable. */
 const BOUNDS = { min: 2, max: 8 } as const;
 
+/**
+ * §2.3's data boundary, as a refusal rather than as a comment about one.
+ *
+ * A `system_alert` finding's `message` is the ONLY finding message this engine does not author: it is
+ * copied out of `alerts.log`, which IRIS wrote, and an alert about a failed send can name the message
+ * it failed to send. There is no reliable way to sanitise arbitrary alert prose, so it is not sent.
+ * Root `CLAUDE.md` §2.1 is the rule this enforces — metrics and configuration leave the instance,
+ * never message content.
+ *
+ * SEPARATE FROM `INVESTIGABLE_TYPES` AND CHECKED FIRST, deliberately. Until now the boundary was
+ * *implied* by §2.4's one accepted shape, so widening the accepted set would have reopened it
+ * silently — which is how the gate came to be asserted in three places in prose and none in code
+ * (#206). A refusal that is not derived from the scope list cannot be widened by widening scope.
+ * `test/investigationScope.test.ts` pins the two lists as disjoint.
+ */
+export const NEVER_FORWARDED: ReadonlySet<Finding['type']> = new Set(['system_alert']);
+
+/**
+ * §2.4. The finding types an investigation exists for.
+ *
+ * TWO SCENARIOS, NOT ONE, because two shipped: `queue_buildup` on a throughput-bound operation is
+ * MVP 2's, and `dead_host` is MVP 3's missing-folder service (spec §2.3 — `Error` is already in
+ * `DEAD_STATUSES`, so that scenario needed no new rule). §2.4 still named only the first, which is
+ * the second thing #206 found: enforcing the contract as literally written would have refused a
+ * shipped, specified scenario.
+ *
+ * KEYED ON TYPE, NOT ON `(type, host)` AS §2.4 SPECIFIES. The host half was in that section because
+ * MVP 2 had exactly one host, and it buys nothing now: the boundary concern is the provenance of
+ * `finding.message`, which is a property of the *type*, and the agent's read tools are host-agnostic.
+ * A host name here would also be this service tracking `Production.cls`'s config — the same argument
+ * `mockClient.investigate` already makes for keying its own branch on type (#84).
+ *
+ * The five remaining types are refused because no investigation exists for them, not because they are
+ * unsafe. An endpoint that accepts all eight implies eight investigations exist.
+ */
+export const INVESTIGABLE_TYPES: ReadonlySet<Finding['type']> = new Set([
+  'queue_buildup',
+  'dead_host',
+]);
+
 function isoSeconds(ms: number): string {
   return `${new Date(Math.round(ms / 1000) * 1000).toISOString().slice(0, 19)}Z`;
 }
@@ -522,6 +562,37 @@ export async function investigate(
   // Deterministic and correlatable: this id appears in the AI Hub audit entries for the tool calls
   // this investigation makes, which is how a reviewer ties an action back to the reasoning.
   const requestId = `inv-${finding.id}-${started}`;
+
+  /*
+   * THE §2.4 GATE, before anything is built and long before anything leaves the process.
+   *
+   * Placed here rather than in `index.ts` so it holds for every caller: the endpoint, a test, and any
+   * future wiring. The panel hides its Investigate button for these types too, but a hidden button is
+   * not a boundary — §2.4 says as much ("the check here is the backstop, not the UI's contract").
+   *
+   * `200` + `unavailable` rather than `400`, per §5's own line: a state is a state, and only a
+   * malformed request is an error. The caller asked a legitimate question and the answer is no.
+   */
+  if (NEVER_FORWARDED.has(finding.type)) {
+    deps.log?.(`investigation ${requestId} refused: ${finding.type} is outside the data boundary`);
+    return unavailable(
+      requestId,
+      finding.id,
+      started,
+      // Names the reason without quoting the finding: the message is the thing that must not travel,
+      // and a note is rendered in a browser.
+      `${finding.type} findings are not investigated: the alert text is IRIS's, not ours to forward`,
+    );
+  }
+  if (!INVESTIGABLE_TYPES.has(finding.type)) {
+    deps.log?.(`investigation ${requestId} refused: no investigation exists for ${finding.type}`);
+    return unavailable(
+      requestId,
+      finding.id,
+      started,
+      `no investigation exists for ${finding.type} findings`,
+    );
+  }
 
   // Built first and passed in: `snapshot.inboundRatePerSec` is derived from `trend.recentSlope`, and reading
   // it off the trend the agent actually receives is what keeps the two from ever disagreeing (#188).

--- a/services/detection-engine/test/investigationScope.test.ts
+++ b/services/detection-engine/test/investigationScope.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The §2.4 scope gate, and the §2.3 data boundary it was supposed to enforce (#206).
+ *
+ * THE ASSERTION THAT MATTERS IS THE ABSENCE OF THE OUTBOUND CALL, not the shape of the response. The
+ * defect was not a wrong payload — it was that `investigate()` had no type check at all, so a
+ * `system_alert` finding, whose `message` is text IRIS wrote into `alerts.log` rather than metric
+ * prose this engine composed, was forwarded verbatim to an external LLM. Root `CLAUDE.md` §2.1 states
+ * that as non-negotiable: metrics and configuration leave the instance, never message content.
+ *
+ * So every test here spies on `callAgent` and asserts it was never invoked. A test that only checked
+ * `state === 'unavailable'` would pass against a version that refused the response *after* making
+ * the call, which is exactly the failure being fixed.
+ *
+ * WHY THE TWO LISTS ARE TESTED FOR DISJOINTNESS. The boundary refusal is deliberately not derived
+ * from the scope allowlist, so that widening scope for a third scenario cannot silently reopen the
+ * alert-text path. That property is invisible in normal use — nothing fails if the two overlap until
+ * a real alert is forwarded — so it is asserted rather than left to the comment that argues for it.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  INVESTIGABLE_TYPES,
+  NEVER_FORWARDED,
+  investigate,
+  type InvestigateDeps,
+} from '../src/detect/investigate.ts';
+import type { Finding, Host } from '../src/types/healthscan.ts';
+
+const HOST: Host = {
+  host: 'Cloud API',
+  type: 'operation',
+  status: 'OK',
+  queued: 90,
+  messagesPerSec: 4,
+  errored: 0,
+  avgProcessingTime: 1.01,
+  avgQueueingTime: 12,
+  lastActivity: '2026-08-31T10:00:00Z',
+};
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    id: 'f-3001',
+    host: 'Cloud API',
+    type: 'queue_buildup',
+    severity: 'critical',
+    currentValue: 90,
+    baselineValue: 0,
+    detectedAt: '2026-08-31T10:00:00Z',
+    message: 'Queue depth 90 is over the floor of 50',
+    ...over,
+  };
+}
+
+/** An agent that records whether it was reached, and fails the test's premise if it is. */
+function spyAgent(): { calls: unknown[]; deps: InvestigateDeps } {
+  const calls: unknown[] = [];
+  return {
+    calls,
+    deps: {
+      callAgent: async (request) => {
+        calls.push(request);
+        return {
+          rootCause: 'this reply should never be reachable in these tests',
+          evidence: [],
+          confidence: 0.9,
+        };
+      },
+      source: 'agent',
+      now: () => Date.parse('2026-08-31T10:00:00Z'),
+    },
+  };
+}
+
+test('a system_alert finding never reaches the agent, and says why', async () => {
+  const { calls, deps } = spyAgent();
+  const res = await investigate(
+    finding({
+      type: 'system_alert',
+      severity: 'info',
+      // The shape of the real hazard: an alert about a failed send, naming what was being sent. This
+      // string is what must not travel, and it is why the note below quotes the TYPE and not it.
+      message: 'Cloud API failed to send message 4417 for patient MRN 90210',
+    }),
+    HOST,
+    undefined,
+    null,
+    deps,
+  );
+
+  // THE POINT OF THE TEST.
+  assert.equal(calls.length, 0, 'the finding was forwarded to the agent');
+
+  assert.equal(res.state, 'unavailable');
+  assert.equal(res.source, 'none');
+  assert.equal(res.rootCause, null);
+  assert.deepEqual(res.evidence, []);
+  assert.equal(res.recommendedAction, null);
+  assert.equal(res.manualRemediation, null);
+  assert.match(res.diagnostics.note ?? '', /not investigated/);
+  // The note is rendered in a browser, so it must not carry the message it refused to send.
+  assert.ok(
+    !(res.diagnostics.note ?? '').includes('MRN'),
+    'the refusal note quoted the finding message',
+  );
+});
+
+test('the five types with no scenario are refused without an agent call', async () => {
+  for (const type of [
+    'stalled_host',
+    'elevated_error_rate',
+    'slow_processing',
+    'growing_queue_wait',
+    'throughput_drop',
+  ] as const) {
+    const { calls, deps } = spyAgent();
+    const res = await investigate(finding({ type }), HOST, undefined, null, deps);
+    assert.equal(calls.length, 0, `${type} was forwarded to the agent`);
+    assert.equal(res.state, 'unavailable', type);
+    // Distinguishable from the boundary refusal, because they are different reasons: no scenario
+    // exists, versus this may not be sent. An operator reading the panel should be able to tell.
+    assert.match(res.diagnostics.note ?? '', /no investigation exists/, type);
+  }
+});
+
+test('the two shipped scenarios are NOT refused', async () => {
+  // The complement, and the half that would catch a gate that refuses everything. Both scenarios are
+  // real: `queue_buildup` on a throughput-bound operation (MVP 2) and `dead_host` on a service
+  // polling a directory that does not exist (MVP 3 §2.3).
+  for (const type of ['queue_buildup', 'dead_host'] as const) {
+    const { calls, deps } = spyAgent();
+    const res = await investigate(finding({ type }), HOST, undefined, null, deps);
+    assert.equal(calls.length, 1, `${type} did not reach the agent`);
+    assert.equal(res.state, 'complete', type);
+  }
+});
+
+test('a refusal is still stamped and correlatable, like any other response', async () => {
+  const { deps } = spyAgent();
+  const res = await investigate(finding({ type: 'system_alert' }), HOST, undefined, null, deps);
+  // `requestId` and `findingId` are what tie a panel state back to a log line, and a refusal is a
+  // response rather than an error — §5 serves 200 with a labelled state.
+  assert.match(res.requestId, /^inv-f-3001-/);
+  assert.equal(res.findingId, 'f-3001');
+  assert.match(res.investigatedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  assert.equal(res.diagnostics.model, null);
+  // Null rather than 0: nothing was measured. Same rule as every other `unavailable` (§8.3).
+  assert.equal(res.diagnostics.toolCalls, null);
+  assert.equal(res.diagnostics.durationMs, null);
+});
+
+test('the refusal is logged, so the gate is visible in operation and not only in a test', async () => {
+  const lines: string[] = [];
+  const { deps } = spyAgent();
+  await investigate(finding({ type: 'system_alert' }), HOST, undefined, null, {
+    ...deps,
+    log: (m) => lines.push(m),
+  });
+  assert.equal(lines.length, 1);
+  assert.match(lines[0] ?? '', /outside the data boundary/);
+});
+
+test('no finding type is both investigable and never-forwarded', () => {
+  // The structural half of the fix: the boundary refusal is checked first and is not derived from the
+  // allowlist, so adding a third scenario cannot reopen the alert path. If a future change puts a
+  // type in both lists, that intent has been lost and this fails rather than the boundary quietly
+  // depending on statement order.
+  for (const type of NEVER_FORWARDED) {
+    assert.ok(!INVESTIGABLE_TYPES.has(type), `${type} is in both lists`);
+  }
+});


### PR DESCRIPTION
Closes #206.

## The defect

`POST /api/investigate` accepted **any** finding on **any** host. §2.4 of `investigation-api.md` said
otherwise in three separate paragraphs and nothing enforced it — not `investigate()`, not `index.ts`,
not the panel, whose Investigate button rendered on every finding.

That is a scope slip on seven of the eight types and a **data-boundary breach on one**. A
`system_alert`'s `message` is copied out of `alerts.log`: IRIS wrote it, and an alert about a failed
send can name the message it failed to send. There is no reliable way to sanitise arbitrary alert
prose, so it was going verbatim to an external model. Root `CLAUDE.md` §2.1 is a rule, not a
preference — metrics and configuration leave the instance, never message content.

## The fix

Two refusals in `investigate()`, before the request is built:

| Checked | List | Reason |
|---|---|---|
| first | `NEVER_FORWARDED` = `system_alert` | §2.3. The data boundary, whatever else changes |
| second | `INVESTIGABLE_TYPES` = `queue_buildup`, `dead_host` | §2.4. No investigation exists for the other five — nothing about them is unsafe |

Both answer `200` + `state: "unavailable"` + `source: "none"` with a `note`, per §5's own line: a state
is a state, and only a malformed request is an error.

**The two lists are separate on purpose and that is the load-bearing part.** Until now the boundary was
*implied* by §2.4's one accepted shape, so widening scope for a third scenario would have reopened the
alert path silently — which is how a gate asserted in three paragraphs came to be enforced in none. A
refusal that is not derived from the scope list cannot be widened by widening scope.

## The fix this issue proposed would have broken a shipped scenario

#206 proposed `type !== 'queue_buildup' || host !== 'Cloud API'`. **MVP 3 ships a second scenario** —
`dead_host` on a service polling a directory that does not exist, specified in
`docs/production-guardian-mvp3.md` §2.1/§2.3 and built (`Triggers.MissingFolder()`,
`get_host_settings`, `manualRemediation`). §2.4 was never amended when it landed, so enforcing the
contract as literally written would have refused something the product demonstrates.

Hence two types — and hence keyed on **type alone**. The host half was in §2.4 because MVP 2 had
exactly one host, and it buys nothing: the concern is the provenance of `finding.message`, which is a
property of the type; the agent's read tools are host-agnostic; and a host name compiled into the
engine or the panel is either of them tracking `Production.cls`'s config, which
`apps/dashboard/CLAUDE.md` §9 forbids outright (#25). `mockClient.investigate` already keys its own
branch on type for that reason (#84).

## Tests

`test/investigationScope.test.ts`, 6 tests. Every one asserts **`callAgent` was not called** — the
absence of the outbound call is the property that matters, not the response shape. A version that
refused *after* calling the agent would pass a `state` check and still have sent the alert text.

Also covered: the two shipped types still reach the agent (a gate that refuses everything would
otherwise pass); the two lists are disjoint; the refusal is logged; the note names the *type* and never
quotes the message, since that string is the thing that must not travel and a note is rendered in a
browser.

Confirmed failing without the gate — removed the two blocks, ran, restored:

```
✖ the refusal is logged, so the gate is visible in operation and not only in a test
  AssertionError: Expected values to be strictly equal: 0 !== 1
```

## UI

The panel hides Investigate for the six refused types, returning early from its own branch so
`onInvestigate` is not in scope there at all — same argument `manualRemediation` already makes below
it: a control that must not exist should be absent by construction, not disabled by an `if` somebody
can invert later.

It **distinguishes the two reasons in its copy.** `system_alert` is a data rule ("the text of an alert
is written by IRIS and can name the message it was about"); the other five are a coverage gap ("nothing
is being withheld — this one has not been built"). Collapsing them into "cannot investigate" would let
a privacy boundary read as an unfinished feature.

The type list in `lib/findingMeta.ts` is a deliberate duplicate of the engine's. §2.4 says the engine's
check is the backstop, not the UI's contract — because a hidden button is not a boundary.

## Contract

`contracts/investigation-api.md` §2.4 rewritten; §4.1 gains the two new `note` shapes; §5's "no check
exists" row is replaced by the two refusals; Q3 drops the host filter and the retired `out_of_scope`
failure reason. `contracts/CHANGELOG.md` entry per `CLAUDE.md` §4. **No schema change** — an
out-of-scope refusal is the `unavailable` shape that was already valid.

**Contract and code in one PR rather than two.** Since #201 this contract states what ships, so landing
either half alone would leave `main` asserting something false about the other.

## Verified

```
services/detection-engine:  npm run typecheck    clean
                            npm test             447 pass / 0 fail   (441 before, 6 new)
contracts:                  node validate.mjs    all checks passed
apps/dashboard:             docker compose up -d --build dashboard   healthy, serving 200
```

`vite build` cannot run on this host — `node_modules` was installed in the container and holds only the
linux rollup binding — so the dashboard was verified the way `apps/dashboard/CLAUDE.md` §6.1 says to:
the image build, which runs `tsc --noEmit && validate-architecture && vite build` inside it. `tsc` was
also run directly on the host and is clean.

**Not verified live:** no `system_alert` or other refused-type finding exists on the running stack right
now, and arming one is not worth a rehearsal cycle for a path that provably never leaves the process.
The `detection-engine` container is deliberately **not** rebuilt in this PR — a bare
`--build detection-engine` drops the demo trigger env, so that rebuild wants doing deliberately after
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
