### PR TITLE
fix(dashboard): one tool read under two names because the provider prefix rendered raw

### DIFF
--- a/apps/dashboard/src/components/ActivityChat.tsx
+++ b/apps/dashboard/src/components/ActivityChat.tsx
@@ -37,6 +37,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ChatExchange } from '../hooks/useChat';
+import { toolLabel } from '../lib/format';
 import { IconMessages } from './icons';
 
 export interface ActivityChatProps {
@@ -349,7 +350,7 @@ function ChatAnswer({ answer, onRetry, asking }: ChatAnswerProps): JSX.Element {
                   ) : (
                     <>
                       read from IRIS
-                      <span className="pg-facts__mono"> · {item.tool}</span>
+                      <span className="pg-facts__mono"> · {toolLabel(item.tool)}</span>
                     </>
                   )}
                 </span>

--- a/apps/dashboard/src/components/InvestigationPanel.tsx
+++ b/apps/dashboard/src/components/InvestigationPanel.tsx
@@ -32,7 +32,7 @@
  */
 
 import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
-import { ABSENT } from '../lib/format';
+import { ABSENT, toolLabel } from '../lib/format';
 import { findingMeta, investigationScope } from '../lib/findingMeta';
 
 export interface InvestigationPanelProps {
@@ -213,7 +213,9 @@ export function InvestigationPanel({
                     <span className="pg-evidence__label">{item.label}</span>
                     <span className={`pg-evidence__source pg-evidence__source--${item.source}`}>
                       {SOURCE_LABEL[item.source] ?? item.source}
-                      {item.tool !== null && <span className="pg-facts__mono"> · {item.tool}</span>}
+                      {item.tool !== null && (
+                        <span className="pg-facts__mono"> · {toolLabel(item.tool)}</span>
+                      )}
                     </span>
                   </div>
                   <div className="pg-evidence__detail">{item.detail}</div>

--- a/apps/dashboard/src/lib/format.ts
+++ b/apps/dashboard/src/lib/format.ts
@@ -113,6 +113,25 @@ export function formatComparison(
   return `${sign}${formatDelta(Math.abs(delta))}`;
 }
 
+/**
+ * `functions.GetPoolSize` → `GetPoolSize`. Display only, for `evidence[].tool`.
+ *
+ * The model sometimes echoes OpenAI's tool namespacing back into its own JSON — measured at about
+ * 1 in 20 runs — so one ClassMethod can arrive under two names inside a single investigation and
+ * read as two different tools (#214). `investigation-api.md` §3.2 documents the prefix and says to
+ * "match on a suffix if you must match at all".
+ *
+ * Nothing is validated and nothing is dropped, which is the rest of §3.2: an unprefixed name passes
+ * through byte-for-byte, including one this directory has never heard of. Narrow on purpose — one
+ * known prefix matched exactly, rather than "everything before the last dot", because a tool name is
+ * a ClassMethod name and guessing that a future provider's prefix is dot-delimited is guessing.
+ */
+export function toolLabel(tool: string): string {
+  const stripped = tool.startsWith('functions.') ? tool.slice('functions.'.length) : tool;
+  // A prefix with nothing after it is not a name; show what actually arrived rather than nothing.
+  return stripped.length > 0 ? stripped : tool;
+}
+
 /** `queue_buildup` → `Queue buildup`. Used for finding types the UI doesn't know. */
 export function humanize(value: string): string {
   const spaced = value.replace(/[_-]+/g, ' ').trim();


### PR DESCRIPTION
Closes #214.

## What was wrong

`evidence[].tool` was rendered verbatim. The model echoes OpenAI's tool namespacing back into its own JSON about **1 run in 20** (measured; `AgentDispatcher.cls:460` records the same rate from the other side, which is why `DropStaleConnectivityClaim` matches with `endsWith` rather than equality), so a single investigation could show:

```
Current Pool Size    mcp tool · GetPoolSize
Queue Depth          mcp tool · functions.GetPoolSize
```

Same ClassMethod, presented as two tools — the one thing the label exists to communicate.

## The fix

`toolLabel` in `src/lib/format.ts`, strictly display-side.

`investigation-api.md` §3.2 gives the consumer three rules: render it don't parse it, *"match on a suffix if you must match at all"*, and never validate against a name list or drop an unrecognised bullet. This implements the middle one without breaking the other two — nothing is validated, nothing is dropped, and any unprefixed name (including one this directory has never heard of) passes through byte-for-byte.

Narrow on purpose: one known prefix matched exactly, not "everything before the last dot". A tool name is a ClassMethod name and contains no dots, but guessing that a future provider's prefix is dot-delimited is guessing about someone else's format.

## Both consumers, not just the one the issue names

#214 was written against `InvestigationPanel.tsx`. `ActivityChat.tsx:352` renders the same field from the same agent and had the same defect. Fixing one would leave the two surfaces disagreeing about what a tool is called, which is worse than the bug — an operator who saw `GetPoolSize` in the panel and `functions.GetPoolSize` in chat would reasonably conclude they are different reads.

## Verified

- `tsc --noEmit` — clean
- `node tools/validate-architecture.mjs` — ok (8 labels, 12 paths, no overlaps)
- `node tools/validate-fixtures.mjs` + `validate-fixture-claims.mjs` — all fixtures match the published contract
- `docker compose up -d --build dashboard` — image built, `pg-dashboard` recreated, `:5173` returns 200. Per §6.1 this is the build that ships; `npm run build` cannot run on this host (the `node_modules` tree was installed in the container).

Not verified by an automated test, because there are none in `apps/dashboard/` and adding a runner is out of scope for a display fix. The prefixed input is not reproducible on demand — it appears in roughly 1 live run in 20 — so the check that matters is the string function, and it is a two-branch function with the comment stating both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
