### PR TITLE
feat(contracts): resolve.schema.json + three live captures, so Smart Resolve is machine-checked (#202)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,94 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `resolve.schema.json` + three captured samples: Smart Resolve is machine-checked for the first time
+
+**No shape changes. This adds the missing artefact, not a new field.** `POST /api/resolve` was the
+only MVP 2 endpoint nothing validated — the reason five field-level divergences between
+`resolve-api.md` and the shipped path had to be found by reading the two side by side (#202) rather
+than by CI. Every other contract here has a schema and a captured sample; this one had prose, and
+prose does not fail when it stops being true.
+
+### What landed
+
+| File | What it is |
+|---|---|
+| `resolve.schema.json` | draft-07, `ResolveResponse` plus `PoolShape` / `Reversal` / `Refusal` / `Failure` / `Confirmation` / `Audit`. `additionalProperties: false` throughout |
+| `samples/resolve-response.json` | a live `apply` that moved `Cloud API` 1 → 4 |
+| `samples/resolve-preview.json` | a live `dry_run` |
+| `samples/resolve-refusal.json` | a live `refused` / `out_of_bounds` |
+| `validate.mjs` | 3 samples, 1 accept, 6 must-reject cases wired in |
+
+`action` is a cross-schema `$ref` into `investigation.schema.json#/definitions/ResolveAction` rather
+than a second transcription of it, so the object a consumer approves and the object the server reports
+applying cannot drift apart. `ajv.addSchema` order matters for that and is commented where it matters.
+
+### Three samples, not one, and all three are captures
+
+The shape is outcome-dependent: `confirmation` is an object only on `applied`, `refusal` only on
+`refused`, and `before` / `after` / `reversal` are all null on a refusal. One sample would leave both
+branches a consumer actually has to handle uncovered.
+
+All three come from `POST http://localhost:3002/api/resolve` against the live stack, with only
+`resolveId`, `auditId` and the timestamps pinned — the rule `investigation-response.json` established:
+a hand-written sample proves the schema accepts what its author imagined, a captured one proves it
+accepts what the system emits.
+
+Two details in them are deliberate rather than sloppy:
+
+- **`requestedBy` is left as the capture's own label** (`"contracts/resolve.schema.json capture"`)
+  rather than rewritten to `dashboard`. That is §8's point about the field made visible: it is
+  advisory, caller-supplied, and recorded **next to** the server-resolved `actor`, not in place of it.
+  A sample that laundered it into a plausible value would teach the opposite.
+- **`role: "%All"` in all three is not a placeholder, it is #104.** The dedicated RBAC role that
+  root `CLAUDE.md` §2.1 lists as part of the scope boundary is not the role the demo instance
+  actually runs as, and a sample is where that is hardest to keep quiet.
+
+The preview and the refusal mutate nothing. The `applied` capture did move `Cloud API` from PoolSize 1
+to 4 on the demo instance, and it was restored to 1 afterwards — **not** through `/api/resolve`, which
+bounds at `2..8` and refuses 1 as `out_of_bounds`, but through `Triggers.SetPoolSize`.
+
+### The six rejections are safety properties, not type errors
+
+Four are defects that reached `main` or shapes the schema exists to forbid:
+
+- **`confirmation` on anything that did not apply** — a preview and a `no_change`. The panel renders
+  "will clear within N seconds" from `confirmation !== null && !directEvidence`, so a response that
+  wrote nothing while carrying a `confirmation` promises a clearance for a write that never happened.
+  Expressed as an `if/then`: `outcome !== "applied"` ⇒ `confirmation: null`.
+- **`mode: "dry_run"` with `outcome: "applied"`** — the preview wrote. The second `if/then`.
+- **`audit` absent** — the 2026-08-19 defect, where every response claimed §8 compliance while
+  carrying no attribution at all.
+- **`refusal` as `{code, detail}`** — the field-name drift caught by a human in review on #92 rather
+  than by a test, which is the whole argument for this entry existing.
+- **an undocumented top-level field** — why `additionalProperties: false` is on every object here.
+
+The valid base those five mutate is itself asserted valid, because a base the schema already refused
+would make all six pass while testing nothing.
+
+### Deliberately permissive at exactly two points
+
+**`resolve-api.md` §4 (`after` on a preview) and §5 (`confirmation.directEvidence` / `clearsWhen`) are
+open decisions on #202.** This schema is permissive at exactly those two points **and says so on the
+fields** — `TIGHTEN THIS ONCE §5 IS DECIDED` is in the `description`, where a reader of the schema will
+find it. So it holds the decided shape without quietly settling the undecided one, which is what
+"write the schema first" would otherwise do: whichever form the capture happened to have would become
+the contract by accident, and the decision would be made by a sample rather than by a person.
+
+`refusal.reason` is a `string` and **not** an enum for the same class of reason, spelled out in
+`resolve.ts`: an unrecognised refusal reason must still reach the UI. A schema that rejected a new
+reason would turn "the tool refused for a reason we have not seen" into "the response is malformed".
+
+### Consumers
+
+None change. `resolve-api.md`'s header is updated — it said "no machine-readable artefact yet" — and
+**where that document and the schema disagree about a shape the schema constrains, the schema now
+wins**, the same reversal `investigation-api.md` made after #201. `contracts/README.md` gains the rows.
+`resolve.d.ts` is still genuinely absent, as `investigation.d.ts` is; the engine
+(`src/detect/resolve.ts`) and the dashboard (`src/types/mvp2.ts`) each keep their own transcription.
+
+---
+
 ## 2026-09-01 — `investigation-api.md` §2.4: the scope gate now exists, keyed on type, and refuses `system_alert` separately
 
 **A behaviour change, not a wording one, and it closes the hole the entry below filed as #206.**

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -22,7 +22,8 @@ yet" for the twelve days after it was captured (#201).
 | `earlywarning-api.md` | Dev B | Dev B (dashboard) |
 | `investigation-api.md`, `investigation.schema.json` | Dev B | Dev B (dashboard) |
 | `samples/investigation-response.json` — a **live** `gpt-4o-mini` capture | Dev B | Dev B (dashboard) |
-| `resolve-api.md` | Dev B | Dev B (dashboard) |
+| `resolve-api.md`, `resolve.schema.json` | Dev B | Dev B (dashboard) |
+| `samples/resolve-response.json`, `resolve-preview.json`, `resolve-refusal.json` — three **live** captures | Dev B | Dev B (dashboard) |
 | `mcp-tools.md` | Dev A | Dev B |
 
 **The dashboard consumer is Dev B, not Dev C** — Dev C left on 2026-08-20 and `apps/dashboard/**`
@@ -32,10 +33,16 @@ as recording who owns it now. It does mean the engine↔dashboard rows have the 
 sides, which is the seam the root file's mock-first rule addresses directly: nothing forces a
 contract to be real when one author owns both ends of it.
 
-Two gaps in that block, both noted rather than left to be discovered: **`investigation.d.ts` does not
-exist**, so unlike Health Scan there is no TypeScript transcription for a consumer to import — the
-engine and the dashboard each hand-maintain one. And **`resolve-api.md` has no schema and no sample**,
-so `POST /api/resolve` is the one MVP 2 endpoint nothing validates (#202).
+One gap left in that block, noted rather than left to be discovered: **neither `investigation.d.ts`
+nor `resolve.d.ts` exists**, so unlike Health Scan there is no TypeScript transcription for a consumer
+to import — the engine and the dashboard each hand-maintain one for both shapes.
+
+`resolve.schema.json` and the three captures closed the other gap on 2026-09-01 (#202): `POST
+/api/resolve` was the one MVP 2 endpoint nothing validated, which is why five field-level divergences
+in `resolve-api.md` had to be found by reading rather than by CI. Two points in that schema are
+**deliberately permissive** — `resolve-api.md` §4's `after` on a preview and §5's `confirmation`
+fields are open decisions, and the fields say so in their `description` — so for those two the prose
+is still the only statement of intent, and there isn't one yet.
 
 `samples/alerts.json` and `samples/proxy-response.json` were planned in `CONTRIBUTING.md` §1 and do
 not exist. Both are derivable without inventing anything — a real alerts capture is at
@@ -104,12 +111,18 @@ cd contracts && npm install && npm run validate
 
 It checks four things, and the middle two are what make the first mean anything:
 
-- each JSON sample against **one named definition** (`HostsResponse` / `FindingsResponse`)
+- each JSON sample against **one named definition** (`HostsResponse`, `FindingsResponse`,
+  `InvestigationResponse`, `ResolveResponse`)
 - structural cases that must **pass** — `[]`, sub-second timestamps from any language, and the real
   proxy payloads including their `null`s
 - cases that must **fail** — a retired `Warning` status, an unknown finding type, a hosts array
   served in the findings position, an alerts response in the metrics position, and the engine's
-  current `name`/`messagesErrored` host shape
+  current `name`/`messagesErrored` host shape. For the two MVP 2 shapes these are safety properties
+  rather than only type errors: a `manualRemediation` carrying an approvable `action`, an
+  `appliedBy: "system"` (autonomous remediation, which root `CLAUDE.md` §2.1 forbids), a `dry_run`
+  reporting `outcome: "applied"`, and a `confirmation` on a response that applied nothing — the UI
+  renders "will clear within N seconds" from that object, so a preview carrying one promises a
+  clearance for a write that never happened
 - **claims about `samples/metrics-dump.txt`**, which is Prometheus text and cannot be schema-checked
   at all. Regexes over the label shapes `proxy-api.md` quotes, two of them asserting a label is
   **absent** — `iris_interop_queued` and `iris_interop_messages_errored` carry no `host` label, and

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -28,18 +28,30 @@ ourselves — the write happens in IRIS behind RBAC, and this service is a calle
 what it asked for and what came back." The engine gained orchestration, not authority. Read §9
 before assuming otherwise.
 
-**No machine-readable artefact yet, and that is why this file drifted.** There is no
-`resolve.schema.json` and no `resolve.d.ts`, and no `samples/resolve-*.json`. The JSON in §11 is what
-Dev C mocks against until those land; committing them is a follow-up PR — **still open as #202, which
-is also where five divergences found by diffing this document against the shipped path are recorded.**
-Three of them are corrected here (§2, §7, §8); two are open decisions. Every other MVP 2 contract has a
-schema and a captured sample, so this is the only one where prose is the sole normative form and
-nothing fails when it stops being true. `contracts` CI counts are unchanged by this document, because
-it adds no sample for `validate.mjs` to check. **The counts themselves are deliberately not quoted
-here** — this line carried "15 accept / 19 reject / 7 capture claims" and the reject count had reached
-26, a copied number staling exactly as §3's host lists do. `validate.mjs`'s own output is the count.
-Stated rather than quietly left off the table, the way `README.md` does for the two `samples/`
-files `CONTRIBUTING.md` §1 promised and nobody wrote.
+**Machine-readable: `resolve.schema.json` landed 2026-09-01 and `contracts/validate.mjs` enforces it,
+over three captured samples.** Until then this was the only MVP 2 contract where prose was the sole
+normative form and nothing failed when it stopped being true — which is why five field-level
+divergences from the shipped path went unnoticed until they were found by hand (#202). **Where this
+file and the schema disagree about a shape the schema constrains, the schema wins** — the same
+reversal `investigation-api.md`'s header made after #201.
+
+**Two points are deliberately left un-decided, and the schema says so on the fields rather than
+picking:** §4's `after` on a preview, and §5's `confirmation.directEvidence` / `clearsWhen`. Both are
+open decisions on #202 and both are typed permissively, so the schema holds the decided shape without
+quietly settling the undecided one. A permissive field with `TIGHTEN THIS ONCE …` in its `description`
+is a marker, not an answer; the schema does not become the authority for those two until they are
+tightened. `resolve.d.ts` is still genuinely absent — as `investigation.d.ts` is — so there is no
+TypeScript transcription to check against; the engine (`src/detect/resolve.ts`) and the dashboard
+(`src/types/mvp2.ts`) each carry their own.
+
+**`samples/resolve-response.json`, `resolve-preview.json` and `resolve-refusal.json` are captured from
+the live stack and are the bytes to mock against.** Three rather than one because the shape is
+outcome-dependent: `confirmation` is an object only on `applied`, `refusal` only on `refused`, and
+`before`/`after`/`reversal` are all null on a refusal, so one capture would leave both branches a
+consumer has to handle uncovered. The JSON in §11 stays **illustrative** — read §11 for shape and the
+samples for bytes. **CI counts are deliberately not quoted here** — this paragraph carried
+"15 accept / 19 reject / 7 capture claims" and the reject count had reached 26, a copied number staling
+exactly as §3's host lists do. `validate.mjs`'s own output is the count.
 
 ---
 

--- a/contracts/resolve.schema.json
+++ b/contracts/resolve.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://production-guardian/contracts/resolve.schema.json",
+  "title": "Production Guardian — Smart Resolve response (MVP 2)",
+  "description": "The response half of `POST /api/resolve`, which had no machine-readable form until #202. The request half is already covered: `investigation.schema.json#/definitions/ResolveAction` is the `action` object and `validate.mjs` carries must-reject cases for it. Every divergence #202 found was invisible because nothing here could disagree with the prose — the only tests over this path pin the implementation while citing '§3 + §7' as their authority. Two of those divergences are open decisions (§4 `after` on a preview, §5 `confirmation.directEvidence` and `clearsWhen`); this schema is deliberately PERMISSIVE at exactly those two points and says so on the fields, so it holds the decided shape without quietly settling the undecided one.",
+  "definitions": {
+    "PoolShape": {
+      "description": "`before` and `after` are the same one-key object. Its own definition rather than two copies, because the pair is read side by side and a schema that let them diverge would be describing a UI bug as legal.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["poolSize"],
+      "properties": {
+        "poolSize": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "Reversal": {
+      "description": "The undo target, and §4.1 is explicit that it is a RECORD of what was read rather than a request anybody sends (#114). `capturedFrom` names where the value came from — `live` on the shipped path — which is what distinguishes a measured undo target from an inherited one.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "size", "capturedFrom"],
+      "properties": {
+        "host": { "type": "string", "minLength": 1 },
+        "size": { "type": "integer", "minimum": 1 },
+        "capturedFrom": { "type": "string", "minLength": 1 }
+      }
+    },
+    "Refusal": {
+      "description": "A policy refusal, which is a normal 200 response and not an error. `reason` is a CLOSED set in the prose and is deliberately NOT an enum here, for the reason `resolve.ts` gives for typing it as a string: an unrecognised reason must reach the UI to be rendered verbatim rather than be dropped by a narrow union. Enforcing the closed set here would turn a new refusal code into a schema failure on the one path §5 asks consumers to render blindly.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason", "message", "checkedBy"],
+      "properties": {
+        "reason": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "checkedBy": { "type": "string", "minLength": 1 },
+        "bounds": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["min", "max"],
+          "properties": {
+            "min": { "type": "integer" },
+            "max": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "Failure": {
+      "description": "`liveStateVerified` is the field that matters: a failed write whose live state was NOT verified leaves the operator unable to say whether the change landed, and §5.2 makes that a different disposition from a clean failure.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stage", "message", "liveStateVerified"],
+      "properties": {
+        "stage": { "type": "string", "minLength": 1 },
+        "message": { "type": "string" },
+        "liveStateVerified": { "type": "boolean" }
+      }
+    },
+    "Confirmation": {
+      "description": "Present ONLY on `applied` — the top-level `if/then` enforces that, and it is a safety property rather than tidiness: `InvestigationPanel.tsx` renders its 'will clear within N seconds' line from `confirmation !== null && !directEvidence`, so a confirmation object on a preview makes a dry run promise a clearance. §3's original 'always present, `status: \"not_applicable\"` for everything except applied' rule was the defect (#202); five implementations and two tests already agreed on `null`.\n\nDELIBERATELY PERMISSIVE ON `directEvidence` AND `observeVia`, and on `clearsWhen` being absent — that is #202 §5, an open decision. The prose describes `directEvidence` as a string naming the measurement (`hosts[host=\"Cloud API\"].queued falling`) and `observeVia` as an array; the engine emits a boolean and one string. Both readings validate here on purpose. TIGHTEN THIS ONCE §5 IS DECIDED — a schema that had picked a side would have settled the question by accident.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "findingId", "observeVia", "expectedWithinSeconds", "directEvidence"],
+      "properties": {
+        "status": { "type": "string", "minLength": 1 },
+        "findingId": { "type": ["string", "null"] },
+        "observeVia": {
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1 }
+          ]
+        },
+        "expectedWithinSeconds": { "type": "number", "minimum": 0 },
+        "directEvidence": { "type": ["boolean", "string"] },
+        "clearsWhen": { "type": "string", "minLength": 1 }
+      }
+    },
+    "Audit": {
+      "description": "PRESENT ON EVERY RESPONSE — applies, refusals and previews alike — which is why it is in `required` above and why the whole object is nullable rather than optional. `null` means the record could not be written, and that is a meaningful state: §8's opening line is that the contract does not permit an unattributed write. The field was dropped by the engine for a fortnight while every response still claimed §8 compliance, so 'the key is absent' is the exact defect this entry exists to fail on.\n\n`tool` is the RUNTIME METHOD NAME (`SetPoolSize`), on an apply and on a preview alike, and is not the same string as `action.type` (#202 §1). Typed as a plain string and never pinned to a literal, because §8's field table tells consumers to render it and never compare it — a schema pinning the value would be that comparison, moved.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["auditId", "actor", "role", "requestedBy", "tool", "recordedAt", "source"],
+      "properties": {
+        "auditId": { "type": ["string", "null"] },
+        "actor": { "type": ["string", "null"] },
+        "role": { "type": ["string", "null"] },
+        "requestedBy": { "type": ["string", "null"] },
+        "tool": { "type": ["string", "null"] },
+        "recordedAt": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] }
+      }
+    },
+    "ResolveResponse": {
+      "description": "`additionalProperties: false` is the point of this file. Every #202 divergence was a field whose documented shape and shipped shape differed with nothing in between them; a permissive root would accept the next one too.\n\nTimestamps use `healthscan.schema.json`'s pattern rather than `format: date-time`, for the reason stated there: `toISOString()` output and second-precision Z-suffixed output are both legal here and `format` would accept offsets the rest of the contract forbids.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resolveId",
+        "requestId",
+        "mode",
+        "requestedAt",
+        "outcome",
+        "action",
+        "before",
+        "after",
+        "reversal",
+        "refusal",
+        "failure",
+        "confirmation",
+        "audit",
+        "completedAt"
+      ],
+      "properties": {
+        "resolveId": { "type": "string", "minLength": 1 },
+        "requestId": { "type": ["string", "null"] },
+        "mode": { "enum": ["dry_run", "apply"] },
+        "requestedAt": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$"
+        },
+        "outcome": { "enum": ["previewed", "applied", "no_change", "refused", "failed"] },
+        "action": {
+          "oneOf": [
+            { "$ref": "https://production-guardian/contracts/investigation.schema.json#/definitions/ResolveAction" },
+            { "type": "null" }
+          ]
+        },
+        "before": { "oneOf": [{ "$ref": "#/definitions/PoolShape" }, { "type": "null" }] },
+        "after": {
+          "description": "NULLABLE ON PURPOSE AND ON BOTH SIDES OF AN OPEN DECISION (#202 §4). The prose argues `after` must be `null` on a preview because a predicted number in a field named `after` is a forecast presented as a measurement (#58's defect class); the shipped path returns `{\"poolSize\": 4}` and the dashboard labels it '(would be)' at the only place a human reads it. Both validate until that is decided.",
+          "oneOf": [{ "$ref": "#/definitions/PoolShape" }, { "type": "null" }]
+        },
+        "reversal": { "oneOf": [{ "$ref": "#/definitions/Reversal" }, { "type": "null" }] },
+        "refusal": { "oneOf": [{ "$ref": "#/definitions/Refusal" }, { "type": "null" }] },
+        "failure": { "oneOf": [{ "$ref": "#/definitions/Failure" }, { "type": "null" }] },
+        "confirmation": { "oneOf": [{ "$ref": "#/definitions/Confirmation" }, { "type": "null" }] },
+        "audit": { "oneOf": [{ "$ref": "#/definitions/Audit" }, { "type": "null" }] },
+        "completedAt": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$"
+        }
+      },
+      "allOf": [
+        {
+          "description": "A confirmation exists only for a change that happened. See the Confirmation description — a UI reads its presence as 'this will clear', so a preview carrying one promises a clearance nothing was applied to produce.",
+          "if": { "properties": { "outcome": { "not": { "const": "applied" } } }, "required": ["outcome"] },
+          "then": { "properties": { "confirmation": { "type": "null" } } }
+        },
+        {
+          "description": "A preview cannot report a write. `Tools/Resolve.cls` returns before the write when `dryRun` is set, so this holds structurally rather than by promise — and stating it here is what makes 'the dry run applied something' a schema failure instead of a reading of the audit log.",
+          "if": { "properties": { "mode": { "const": "dry_run" } }, "required": ["mode"] },
+          "then": { "properties": { "outcome": { "not": { "const": "applied" } } } }
+        }
+      ]
+    }
+  }
+}

--- a/contracts/samples/resolve-preview.json
+++ b/contracts/samples/resolve-preview.json
@@ -1,0 +1,36 @@
+{
+  "resolveId": "res-Cloud-API-1788278400001",
+  "requestId": null,
+  "mode": "dry_run",
+  "requestedAt": "2026-09-01T16:00:00Z",
+  "outcome": "previewed",
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 4
+  },
+  "before": {
+    "poolSize": 1
+  },
+  "after": {
+    "poolSize": 4
+  },
+  "reversal": {
+    "host": "Cloud API",
+    "size": 1,
+    "capturedFrom": "live"
+  },
+  "refusal": null,
+  "failure": null,
+  "confirmation": null,
+  "audit": {
+    "auditId": "pg-audit-595",
+    "actor": "SuperUser",
+    "role": "%All",
+    "requestedBy": "contracts/resolve.schema.json capture",
+    "tool": "SetPoolSize",
+    "recordedAt": "2026-09-01T16:00:00Z",
+    "source": "live"
+  },
+  "completedAt": "2026-09-01T16:00:00Z"
+}

--- a/contracts/samples/resolve-refusal.json
+++ b/contracts/samples/resolve-refusal.json
@@ -1,0 +1,36 @@
+{
+  "resolveId": "res-Cloud-API-1788278400002",
+  "requestId": null,
+  "mode": "apply",
+  "requestedAt": "2026-09-01T16:00:00Z",
+  "outcome": "refused",
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 9
+  },
+  "before": null,
+  "after": null,
+  "reversal": null,
+  "refusal": {
+    "reason": "out_of_bounds",
+    "message": "size must be an integer between 2 and 8",
+    "checkedBy": "iris",
+    "bounds": {
+      "min": 2,
+      "max": 8
+    }
+  },
+  "failure": null,
+  "confirmation": null,
+  "audit": {
+    "auditId": "pg-audit-598",
+    "actor": "SuperUser",
+    "role": "%All",
+    "requestedBy": "contracts/resolve.schema.json capture",
+    "tool": "SetPoolSize",
+    "recordedAt": "2026-09-01T16:00:00Z",
+    "source": "live"
+  },
+  "completedAt": "2026-09-01T16:00:00Z"
+}

--- a/contracts/samples/resolve-response.json
+++ b/contracts/samples/resolve-response.json
@@ -1,0 +1,42 @@
+{
+  "resolveId": "res-Cloud-API-1788278400000",
+  "requestId": null,
+  "mode": "apply",
+  "requestedAt": "2026-09-01T16:00:00Z",
+  "outcome": "applied",
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 4
+  },
+  "before": {
+    "poolSize": 1
+  },
+  "after": {
+    "poolSize": 4
+  },
+  "reversal": {
+    "host": "Cloud API",
+    "size": 1,
+    "capturedFrom": "live"
+  },
+  "refusal": null,
+  "failure": null,
+  "confirmation": {
+    "status": "pending",
+    "findingId": "f-3001",
+    "observeVia": "GET /api/healthscan/findings",
+    "expectedWithinSeconds": 120,
+    "directEvidence": false
+  },
+  "audit": {
+    "auditId": "pg-audit-596",
+    "actor": "SuperUser",
+    "role": "%All",
+    "requestedBy": "contracts/resolve.schema.json capture",
+    "tool": "SetPoolSize",
+    "recordedAt": "2026-09-01T16:00:00Z",
+    "source": "live"
+  },
+  "completedAt": "2026-09-01T16:00:00Z"
+}

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -31,6 +31,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const SCHEMA_ID = 'https://production-guardian/contracts/healthscan.schema.json';
 const PROXY_SCHEMA_ID = 'https://production-guardian/contracts/proxy.schema.json';
 const INVESTIGATION_SCHEMA_ID = 'https://production-guardian/contracts/investigation.schema.json';
+const RESOLVE_SCHEMA_ID = 'https://production-guardian/contracts/resolve.schema.json';
 
 /** Each sample is validated against ONE named definition, never "either". */
 const CASES = [
@@ -103,6 +104,124 @@ const INVESTIGATION_MUST_REJECT = [
     name: "action.type 'restart_host' — one action type in MVP 2, enumerated so a second is a decision",
     definition: 'ResolveAction',
     data: { type: 'restart_host', host: 'Cloud API', size: 4 },
+  },
+];
+
+/**
+ * The Smart Resolve response, which had no schema and no sample until #202 — the one MVP 2 contract
+ * nothing machine-checked, and the reason five things in it drifted unnoticed.
+ *
+ * THREE samples rather than one, because the shape is outcome-dependent and one capture cannot
+ * exercise it: `confirmation` is an object only on `applied`, `refusal` only on `refused`, and
+ * `before`/`after`/`reversal` are null on a refusal. A single sample would leave the two branches a
+ * consumer actually has to handle uncovered.
+ *
+ * ALL THREE ARE CAPTURED from `POST http://localhost:3002/api/resolve` against the live stack, with
+ * only `resolveId`, `auditId` and the timestamps pinned — same rule as `investigation-response.json`.
+ * `requestedBy` is left as the capture's own label rather than rewritten to `dashboard`, which is
+ * §8's point about the field made visible: it is advisory, caller-supplied, and recorded NEXT TO the
+ * server-resolved `actor` rather than in place of it.
+ *
+ * The preview and the refusal mutate nothing. The `applied` capture did move `Cloud API` from
+ * PoolSize 1 to 4 on the demo instance, and it was restored afterwards — `role: "%All"` in all three
+ * is not a placeholder, it is #104.
+ */
+const RESOLVE_CASES = [
+  { file: 'samples/resolve-response.json', definition: 'ResolveResponse' },
+  { file: 'samples/resolve-preview.json', definition: 'ResolveResponse' },
+  { file: 'samples/resolve-refusal.json', definition: 'ResolveResponse' },
+];
+
+/** A valid `applied` response, mutated per case below so each rejection isolates one field. */
+const RESOLVE_BASE = {
+  resolveId: 'res-Cloud-API-1788278400000',
+  requestId: null,
+  mode: 'apply',
+  requestedAt: '2026-09-01T16:00:00Z',
+  outcome: 'applied',
+  action: { type: 'set_pool_size', host: 'Cloud API', size: 4 },
+  before: { poolSize: 1 },
+  after: { poolSize: 4 },
+  reversal: { host: 'Cloud API', size: 1, capturedFrom: 'live' },
+  refusal: null,
+  failure: null,
+  confirmation: {
+    status: 'pending',
+    findingId: 'f-3001',
+    observeVia: 'GET /api/healthscan/findings',
+    expectedWithinSeconds: 120,
+    directEvidence: false,
+  },
+  audit: {
+    auditId: 'pg-audit-596',
+    actor: 'SuperUser',
+    role: '%All',
+    requestedBy: 'dashboard',
+    tool: 'SetPoolSize',
+    recordedAt: '2026-09-01T16:00:00Z',
+    source: 'live',
+  },
+  completedAt: '2026-09-01T16:00:00Z',
+};
+
+/**
+ * `RESOLVE_BASE` itself, asserted valid. Every rejection below is `RESOLVE_BASE` with one field
+ * changed, so a base the schema already refuses would make all six pass while testing nothing.
+ */
+const RESOLVE_MUST_ACCEPT = [
+  { name: 'the unmutated applied base the rejections are derived from', definition: 'ResolveResponse', data: RESOLVE_BASE },
+];
+
+/**
+ * Resolve responses that must FAIL. Every one is a defect that reached `main`, or a safety property
+ * that only exists because the shape forbids the alternative.
+ */
+const RESOLVE_MUST_REJECT = [
+  {
+    name: 'confirmation on a preview, as `status: "not_applicable"` — a dry run promising a clearance',
+    definition: 'ResolveResponse',
+    data: {
+      ...RESOLVE_BASE,
+      mode: 'dry_run',
+      outcome: 'previewed',
+      confirmation: { ...RESOLVE_BASE.confirmation, status: 'not_applicable' },
+    },
+  },
+  {
+    name: 'confirmation on `no_change` — nothing moved, so there is nothing to observe clearing',
+    definition: 'ResolveResponse',
+    data: { ...RESOLVE_BASE, outcome: 'no_change' },
+  },
+  {
+    name: 'a dry_run reporting outcome `applied` — the preview wrote',
+    definition: 'ResolveResponse',
+    data: { ...RESOLVE_BASE, mode: 'dry_run' },
+  },
+  {
+    name: 'audit absent — every response claimed §8 compliance while carrying no attribution (2026-08-19)',
+    definition: 'ResolveResponse',
+    data: (() => {
+      const { audit, ...rest } = RESOLVE_BASE;
+      return rest;
+    })(),
+  },
+  {
+    name: 'refusal as {code, detail} — the field-name drift caught in review on #92, not by a test',
+    definition: 'ResolveResponse',
+    data: {
+      ...RESOLVE_BASE,
+      outcome: 'refused',
+      before: null,
+      after: null,
+      reversal: null,
+      confirmation: null,
+      refusal: { code: 'out_of_bounds', detail: 'size must be an integer between 2 and 8' },
+    },
+  },
+  {
+    name: 'an undocumented top-level field — the whole reason this file has additionalProperties: false',
+    definition: 'ResolveResponse',
+    data: { ...RESOLVE_BASE, resizedAction: { requested: 2, applied: 4 } },
   },
 ];
 
@@ -568,6 +687,9 @@ addFormats(ajv);
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'healthscan.schema.json'), 'utf8')));
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'proxy.schema.json'), 'utf8')));
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'investigation.schema.json'), 'utf8')));
+// AFTER investigation.schema.json, which it $refs for `action` rather than transcribing ResolveAction
+// a second time. ajv resolves the cross-schema $ref out of this same instance, so the order matters.
+ajv.addSchema(JSON.parse(readFileSync(join(here, 'resolve.schema.json'), 'utf8')));
 
 const validatorFor = (definition) => {
   const validate = ajv.getSchema(`${SCHEMA_ID}#/definitions/${definition}`);
@@ -584,6 +706,12 @@ const proxyValidatorFor = (definition) => {
 const investigationValidatorFor = (definition) => {
   const validate = ajv.getSchema(`${INVESTIGATION_SCHEMA_ID}#/definitions/${definition}`);
   if (validate === undefined) throw new Error(`no such investigation definition: ${definition}`);
+  return validate;
+};
+
+const resolveValidatorFor = (definition) => {
+  const validate = ajv.getSchema(`${RESOLVE_SCHEMA_ID}#/definitions/${definition}`);
+  if (validate === undefined) throw new Error(`no such resolve definition: ${definition}`);
   return validate;
 };
 
@@ -620,6 +748,25 @@ for (const { name, definition, data } of INVESTIGATION_MUST_REJECT) {
   report(!validate(data), `rejects: ${name}`);
 }
 
+for (const { file, definition } of RESOLVE_CASES) {
+  const validate = resolveValidatorFor(definition);
+  const data = JSON.parse(readFileSync(join(here, file), 'utf8'));
+  report(validate(data), `${file} validates as ${definition}`);
+  if (validate.errors) console.log(JSON.stringify(validate.errors, null, 2));
+}
+
+for (const { name, definition, data } of RESOLVE_MUST_ACCEPT) {
+  const validate = resolveValidatorFor(definition);
+  const ok = validate(data);
+  report(ok, `accepts: ${name}`);
+  if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+}
+
+for (const { name, definition, data } of RESOLVE_MUST_REJECT) {
+  const validate = resolveValidatorFor(definition);
+  report(!validate(data), `rejects: ${name}`);
+}
+
 for (const { name, definition, data } of MUST_REJECT) {
   const validate = validatorFor(definition);
   report(!validate(data), `rejects: ${name}`);
@@ -644,8 +791,10 @@ for (const { name, re } of CAPTURE_CLAIMS) {
 
 console.log(
   failures === 0
-    ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length} samples, ${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length} accept, `
-      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length} reject, ${CAPTURE_CLAIMS.length} capture claims)`
+    ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length + RESOLVE_CASES.length} samples, `
+      + `${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length + RESOLVE_MUST_ACCEPT.length} accept, `
+      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length + RESOLVE_MUST_REJECT.length} reject, `
+      + `${CAPTURE_CLAIMS.length} capture claims)`
     : `\n${failures} check(s) failed`,
 );
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes the durable half of #202: `POST /api/resolve` gets a schema and captured samples, so it stops being the one MVP 2 endpoint nothing validates.

This is step 2 of #202's own proposed order of work, which authorises it independently of the two open decisions — *"so §4 and §5 cannot re-drift while they wait for a decision. This is the durable half."* Step 1 turned out to have already landed in #203.

**No shape changes.** Nothing on the wire moves; this adds the missing artefact.

## What's here

| File | What it is |
|---|---|
| `contracts/resolve.schema.json` | draft-07, `ResolveResponse` + `PoolShape` / `Reversal` / `Refusal` / `Failure` / `Confirmation` / `Audit`, `additionalProperties: false` throughout |
| `contracts/samples/resolve-response.json` | a live `apply` that moved `Cloud API` 1 → 4 |
| `contracts/samples/resolve-preview.json` | a live `dry_run` |
| `contracts/samples/resolve-refusal.json` | a live `refused` / `out_of_bounds` |
| `contracts/validate.mjs` | 3 samples, 1 accept, 6 must-reject wired in |

`action` is a cross-schema `$ref` into `investigation.schema.json#/definitions/ResolveAction` rather than a second transcription of it, so the object a consumer approves and the object the server reports applying cannot drift apart. `ajv.addSchema` ordering matters for that and is commented where it matters.

## Three samples, not one — and all three are captures

The shape is outcome-dependent: `confirmation` is an object only on `applied`, `refusal` only on `refused`, and `before`/`after`/`reversal` are all null on a refusal. One sample leaves both branches a consumer actually has to handle uncovered.

All three come from `POST http://localhost:3002/api/resolve` against the live stack with only `resolveId`, `auditId` and the timestamps pinned — the rule `investigation-response.json` set: a hand-written sample proves the schema accepts what its author imagined, a captured one proves it accepts what the system emits.

Two details are deliberate:

- **`requestedBy` is left as the capture's own label** rather than rewritten to `dashboard`. That is §8's point about the field made visible: it is advisory, caller-supplied, and recorded **next to** the server-resolved `actor` rather than in place of it. A sample that laundered it would teach the opposite.
- **`role: "%All"` in all three is not a placeholder, it is #104.** The dedicated RBAC role root `CLAUDE.md` §2.1 lists as part of the scope boundary is not what the demo instance runs as, and a sample is where that is hardest to keep quiet.

The preview and the refusal mutate nothing. The `applied` capture did move `Cloud API` from PoolSize 1 to 4 on the demo instance, and it was restored to 1 afterwards — **not** through `/api/resolve`, which bounds at `2..8` and refuses 1 as `out_of_bounds`, but through `Triggers.SetPoolSize`. `Cloud API` is verified back at PoolSize 1.

## The six rejections are safety properties, not type errors

- **`confirmation` on anything that did not apply** — a preview, and a `no_change`. `InvestigationPanel.tsx` renders "will clear within N seconds" from `confirmation !== null && !directEvidence`, so a response that wrote nothing while carrying a `confirmation` promises a clearance for a write that never happened. An `if/then`: `outcome !== "applied"` ⇒ `confirmation: null`.
- **`mode: "dry_run"` with `outcome: "applied"`** — the preview wrote. The second `if/then`.
- **`audit` absent** — the 2026-08-19 defect, where every response claimed §8 compliance while carrying no attribution.
- **`refusal` as `{code, detail}`** — the field-name drift caught by a human in review on #92 rather than by a test, which is the argument for this PR in one line.
- **an undocumented top-level field** — why `additionalProperties: false` is on every object here.

The valid base those five mutate is itself asserted valid, because a base the schema already refused would make all six pass while testing nothing.

## Deliberately permissive at exactly two points

**§4 (`after` on a preview) and §5 (`confirmation.directEvidence` / `clearsWhen`) are still open decisions on #202 and this PR does not settle them.** The schema is permissive at exactly those two points **and says so on the fields** — `TIGHTEN THIS ONCE §5 IS DECIDED` is in the `description`, where a reader of the schema finds it. It holds the decided shape without quietly settling the undecided one, which is the failure mode of writing the schema from a capture: whichever form the capture happened to have becomes the contract by accident, and the decision gets made by a sample rather than by a person.

`refusal.reason` is a `string` and **not** an enum for a related reason `resolve.ts` already gives: an unrecognised refusal reason must still reach the UI. A schema that rejected a new reason would turn "the tool refused for a reason we have not seen" into "the response is malformed".

## Docs

- `resolve-api.md`'s header said "no machine-readable artefact yet". It now records the schema, and that **where the document and the schema disagree about a shape the schema constrains, the schema wins** — the same reversal `investigation-api.md` made after #201. It also states which two points the schema deliberately does not decide, so nobody reads the permissiveness as an answer.
- `README.md` gains the rows, and its "cases that must fail" bullet now names the MVP 2 safety properties rather than only the MVP 1 type errors.
- `CHANGELOG.md` entry per root `CLAUDE.md` §4.
- `resolve.d.ts` is still genuinely absent, as `investigation.d.ts` is — noted in both files rather than left to be discovered.

## Verification

`node contracts/validate.mjs` passes — the `contracts — samples vs schema` CI job. Each of the six rejections was additionally confirmed to fail **for its intended reason** rather than incidentally, by printing `ajv.errorsText` per case; the two `if/then` cases fail on `must match "then" schema`, `audit` on `must have required property 'audit'`, `refusal` on its `oneOf`, and the extra field on `must NOT have additional properties`.

Refs #202. Leaves #202 open for §4 and §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
