### PR TITLE
contracts: validate the JSON payloads inside the contract prose, not just samples/ (#205)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,90 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — the JSON payloads *inside* the contract prose are validated now, and the first run found two more divergences
+
+**No shape changes to any schema except one optional field, and that field is a bug report.** `samples/`
+was the only thing `validate.mjs` checked. The divergences kept turning up somewhere else: all three §8
+payloads in `investigation-api.md` were schema-invalid for twelve days (#201), five more shipped in
+`resolve-api.md` (#202). A fenced payload in a ratified contract is a published artefact — a consumer
+mocks against it exactly as they mock against `samples/` — and nothing could disagree with it. #205.
+
+### The convention
+
+The annotation rides in the CommonMark info string, after the language:
+
+````
+```json validate=resolve.schema.json#/definitions/ResolveResponse
+````
+
+GitHub renders the block as `json` regardless, so nothing about how these files read changes. Ten
+payloads across four files are annotated today:
+
+| File | Annotated | Unannotated |
+|---|---|---|
+| `healthscan-api.md` | 2 | 0 |
+| `proxy-api.md` | 3 | 0 |
+| `investigation-api.md` | 5 | 4 |
+| `earlywarning-api.md` | **0** | 3 |
+| `resolve-api.md` | 4 | 11 |
+
+**Opt-in, and the counts are the price of that.** Most fences in these files are deliberately not whole
+documents — a bare `"reversal": {...}` fragment, a request body for an endpoint whose request has no
+schema, an `{"error": "..."}` shape — and requiring `validate=none` on each would add noise to five
+files to catch a mistake in one. But an unannotated fence is invisible, which is the hole this exists to
+close, so every run prints both counts per file and a file that drops to `0 annotated` says so.
+
+`earlywarning-api.md` is that zero, permanently until someone acts: it is the last MVP 2 endpoint with
+no schema, so there is nothing for an annotation to name. Filed as **#219**. It is listed in
+`CONTRACT_MD` rather than omitted precisely so the gap prints.
+
+`mcp-tools.md` is deliberately out, and not for lack of a schema — so does earlywarning. It documents
+MCP tool returns, a different protocol through a different boundary, and thirteen sections of
+unannotated fences would bury the one conspicuous zero the table exists to show. Its divergences are
+real and measured (#218), and the fix there is a schema for the tool returns.
+
+**A malformed annotation fails rather than skips.** An unknown schema file, an unknown definition name,
+a shape that isn't `<schema.json>#/definitions/<Definition>`, or unparseable JSON — all `fail`. The
+whole point is that an unchecked payload must not be able to look checked, and a typo in a definition
+name is the cheapest way for one to.
+
+### It found two divergences on its first real run
+
+All four `ResolveResponse` payloads in `resolve-api.md` failed, on `additionalProperties`, for two
+independent reasons:
+
+- **`replayed`** — §1.3's field table types it as a plain required `boolean`, §6 builds a whole replay
+  contract on it, and §11's R5 cites it as one of three mechanisms answering "what happens if I click
+  Approve twice?". **Nothing emits it.** `resolve.ts` accepts and echoes `requestId` and has no store,
+  no window, and no `replayed`; it does not even require `requestId` on an `apply`, so §7's
+  `malformed_request` row for that does not fire either. So mechanism 3 of three does not exist — the
+  double-click is harmless (mechanisms 1 and 2 are real) but mints a second audit row for one human
+  decision, on the screen the demo ends on. It is now **permitted and not required** in
+  `resolve.schema.json`, with the reasoning on the field: requiring it would fail the shipped path,
+  dropping it would fail the ratified contract. That is an unimplemented feature rather than a shape
+  question, filed as **#220** with the A/B decision stated and deliberately not taken.
+- **`before.readAt` / `after.readAt`** — present in five prose payloads, absent from §1.3's field table,
+  absent from `resolve.ts`, absent from all three captures. **Removed from the prose** as unratified
+  cruft: `PoolShape` is `{poolSize}` and nothing else, in the schema and in the code. Recorded here
+  rather than only in a diff because there is a second reading worth reconsidering deliberately — that
+  `readAt` documents *when* the pool size was read, which is the timestamp an optimistic-concurrency
+  story around `precondition.poolSize` would want. If that is the intent, it comes back as a field
+  table row and a schema property, not as a payload key nobody declared.
+
+Both were invisible for as long as the payloads existed. That is the argument for the whole pass, and
+it is #84's argument applied to a fenced block rather than to a copied number.
+
+### Consumers
+
+None. No schema loosened, no field required, no sample changed. The four `resolve-api.md` payloads a
+consumer might have mocked against are now *closer* to the shipped shape by five keys. The engine and
+the dashboard are unaffected.
+
+`cd contracts && npm run validate` now reports `6 samples, 16 accept, 32 reject, 7 capture claims,
+14 prose fences`.
+
+---
+
 ## 2026-09-01 — `resolve.schema.json` + three captured samples: Smart Resolve is machine-checked for the first time
 
 **No shape changes. This adds the missing artefact, not a new field.** `POST /api/resolve` was the

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -33,9 +33,15 @@ as recording who owns it now. It does mean the engine↔dashboard rows have the 
 sides, which is the seam the root file's mock-first rule addresses directly: nothing forces a
 contract to be real when one author owns both ends of it.
 
-One gap left in that block, noted rather than left to be discovered: **neither `investigation.d.ts`
-nor `resolve.d.ts` exists**, so unlike Health Scan there is no TypeScript transcription for a consumer
-to import — the engine and the dashboard each hand-maintain one for both shapes.
+Two gaps left in that block, noted rather than left to be discovered:
+
+- **neither `investigation.d.ts` nor `resolve.d.ts` exists**, so unlike Health Scan there is no
+  TypeScript transcription for a consumer to import — the engine and the dashboard each hand-maintain
+  one for both shapes
+- **`earlywarning-api.md` has no schema and no sample** (#219). It is the last MVP 2 endpoint in that
+  state, and since #205 the validator prints it as `0 annotated` on every run rather than leaving it to
+  be noticed. The three worked payloads in its §4 are unchecked by anything but reading — which is
+  exactly the position `investigation-api.md` was in for the twelve days of #201
 
 `resolve.schema.json` and the three captures closed the other gap on 2026-09-01 (#202): `POST
 /api/resolve` was the one MVP 2 endpoint nothing validated, which is why five field-level divergences
@@ -109,7 +115,7 @@ the shared fixtures disagree, CI says so — rather than the Day-5 rehearsal.
 cd contracts && npm install && npm run validate
 ```
 
-It checks four things, and the middle two are what make the first mean anything:
+It checks five things, and the middle two are what make the first mean anything:
 
 - each JSON sample against **one named definition** (`HostsResponse`, `FindingsResponse`,
   `InvestigationResponse`, `ResolveResponse`)
@@ -128,6 +134,20 @@ It checks four things, and the middle two are what make the first mean anything:
   **absent** — `iris_interop_queued` and `iris_interop_messages_errored` carry no `host` label, and
   an assertion that something is missing is the only way a future capture silently gaining it gets
   noticed
+- **the JSON payloads fenced inside the `*-api.md` prose** (#205), which used to be the one published
+  artefact nothing could disagree with — and where #201's twelve days of invalid payloads and #202's
+  five divergences both lived. Opt-in via the CommonMark info string, so nothing about how the files
+  read changes:
+
+  ````
+  ```json validate=resolve.schema.json#/definitions/ResolveResponse
+  ````
+
+  Opt-in because most fences here are deliberately *not* whole documents — request bodies, bare
+  fragments, error shapes. The compensating rule: every run prints each file's annotated **and**
+  unannotated counts, a malformed annotation **fails** rather than skips, and a file that drops to
+  `0 annotated` says so on every CI run. `earlywarning-api.md` is at `0` today because it has no
+  schema (#219); that is the gap being visible rather than absent
 
 **Do not replace this with an `ajv-cli` one-liner.** Three reasons, all learned the hard way on
 PR #3:

--- a/contracts/healthscan-api.md
+++ b/contracts/healthscan-api.md
@@ -15,7 +15,7 @@ bytes* Dev C mocks against.
 
 Current state of every interoperability host in the monitored production.
 
-```json
+```json validate=healthscan.schema.json#/definitions/HostsResponse
 [
   {
     "host": "Lab Router",
@@ -56,7 +56,7 @@ filtered out. For LABDEMO that means exactly three: EMR Source, Lab Router, Clou
 
 Currently-active findings. One entry per ongoing condition, not per occurrence.
 
-```json
+```json validate=healthscan.schema.json#/definitions/FindingsResponse
 [
   {
     "id": "f-1042",

--- a/contracts/investigation-api.md
+++ b/contracts/investigation-api.md
@@ -438,7 +438,7 @@ the investigation were measured.
 
 ### 3.2 `evidence[]`
 
-```json
+```json validate=investigation.schema.json#/definitions/EvidenceItem
 {
   "label": "Cloud API pool size",
   "detail": "Cloud API PoolSize = 1",
@@ -501,7 +501,7 @@ padded from the snapshot by either side.
 
 ### 3.3 `recommendedAction` is a structured object, never prose
 
-```json
+```json validate=investigation.schema.json#/definitions/RecommendedAction
 {
   "action": {
     "type": "set_pool_size",
@@ -996,7 +996,7 @@ until #201**, each with the same four errors in `diagnostics`. They are hand-che
 
 `POST /api/investigate` → `200`, `X-Investigation-State: complete`
 
-```json
+```json validate=investigation.schema.json#/definitions/InvestigationResponse
 {
   "requestId": "inv-8a31f0",
   "findingId": "f-1041",
@@ -1085,7 +1085,7 @@ should still exercise them — but do not read this block as something the runni
 
 `200`, `X-Investigation-State: degraded`
 
-```json
+```json validate=investigation.schema.json#/definitions/InvestigationResponse
 {
   "requestId": "inv-8a3204",
   "findingId": "f-1041",
@@ -1145,7 +1145,7 @@ enum.
 
 `200`, `X-Investigation-State: unavailable`
 
-```json
+```json validate=investigation.schema.json#/definitions/InvestigationResponse
 {
   "requestId": "inv-8a3299",
   "findingId": "f-1041",

--- a/contracts/proxy-api.md
+++ b/contracts/proxy-api.md
@@ -62,7 +62,7 @@ documents what the proxy *does* today, not an intent. Where the code and Dev B's
 The latest metric snapshot. One entry per interoperability host IRIS reported, plus per-production
 scalars and diagnostics.
 
-```json
+```json validate=proxy.schema.json#/definitions/MetricsResponse
 {
   "hosts": [
     {
@@ -253,7 +253,7 @@ reads host state and counts rows. It performs no remediation and changes no prod
 
 `/api/monitor/alerts`, forwarded.
 
-```json
+```json validate=proxy.schema.json#/definitions/AlertsResponse
 {
   "alerts": [
     {
@@ -320,7 +320,7 @@ payload is pinned by one, obtained by accident on a first-ever read. A consumer 
 
 ## 3. `GET /proxy/health`
 
-```json
+```json validate=proxy.schema.json#/definitions/HealthResponse
 {
   "status": "ok",
   "uptime": 3.7539876,

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -133,15 +133,15 @@ the prose-parsing failure with extra steps.
 `200` in every case the request was understood. One shape for all five outcomes, so Dev C
 renders from one type rather than from a status code.
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveResponse
 {
   "resolveId": "rs-19f3",
   "requestId": "rq-6f2c1e",
   "mode": "apply",
   "outcome": "applied",
   "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
-  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
-  "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
+  "before": { "poolSize": 1 },
+  "after":  { "poolSize": 4 },
   "reversal": {
     "host": "Cloud API",
     "size": 1,
@@ -983,14 +983,14 @@ Request:
 
 Response `200`, `X-Resolve-Outcome: previewed`:
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveResponse
 {
   "resolveId": "rs-19f2",
   "requestId": null,
   "mode": "dry_run",
   "outcome": "previewed",
   "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
-  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:12Z" },
+  "before": { "poolSize": 1 },
   "after": null,
   "reversal": null,
   "refusal": null,
@@ -1037,8 +1037,8 @@ load-bearing parts:
 ```json
 {
   "outcome": "applied",
-  "before": { "poolSize": 1, "readAt": "2026-08-18T14:06:41Z" },
-  "after":  { "poolSize": 4, "readAt": "2026-08-18T14:06:43Z" },
+  "before": { "poolSize": 1 },
+  "after":  { "poolSize": 4 },
   "reversal": {
     "host": "Cloud API",
     "size": 1,
@@ -1057,7 +1057,7 @@ load-bearing parts:
 Same request as §11.2, from a caller without the write role. Response `200`,
 `X-Resolve-Outcome: refused`:
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveResponse
 {
   "resolveId": "rs-19f4",
   "requestId": "rq-6f2c1e",
@@ -1109,14 +1109,14 @@ Request (`size: 40`):
 
 Response `200`, `X-Resolve-Outcome: refused`:
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveResponse
 {
   "resolveId": "rs-19f5",
   "requestId": "rq-6f2c22",
   "mode": "apply",
   "outcome": "refused",
   "action": { "type": "set_pool_size", "host": "Cloud API", "size": 40 },
-  "before": { "poolSize": 1, "readAt": "2026-08-18T14:07:20Z" },
+  "before": { "poolSize": 1 },
   "after": null,
   "reversal": null,
   "refusal": {

--- a/contracts/resolve.schema.json
+++ b/contracts/resolve.schema.json
@@ -137,6 +137,10 @@
         "completedAt": {
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$"
+        },
+        "replayed": {
+          "description": "OPTIONAL, AND IT SHOULD NOT BE. §1.3's field table types this as a plain `boolean` with no null and no absence, and §6 builds a whole replay contract on it — a repeated `requestId` returns the stored result with `replayed: true` rather than re-calling the tool, which is one of the three mechanisms §11's R5 cites for 'what happens if I click Approve twice'. NOTHING EMITS IT: absent from `resolve.ts`, from the dashboard's types, and from all three live captures in `samples/`. So it is permitted here and not required, which is the only honest option — requiring it would fail the shipped path and dropping it would fail the ratified contract. That is an unimplemented feature rather than a shape question, tracked as #220; tighten this to required once the replay store exists, or drop the field if #220 decides the other way.",
+          "type": "boolean"
         }
       },
       "allOf": [

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -682,6 +682,83 @@ const CAPTURE_CLAIMS = [
   { name: 'messages_errored carries NO host label (§6.3)', re: /^iris_interop_messages_errored\{id="LABDEMO",production="LABDEMO\.Production"\} 0$/m },
 ];
 
+/**
+ * The `*-api.md` files whose fenced payloads are checked (#205).
+ *
+ * `samples/` was the only thing validated here, and the divergences kept living somewhere else: all
+ * three §8 payloads in `investigation-api.md` were schema-invalid for twelve days (#201), and five
+ * more shipped in `resolve-api.md` (#202). A fenced block in a ratified contract is a published
+ * artefact — a consumer mocks against it exactly as they mock against `samples/` — and until now
+ * nothing could disagree with it.
+ *
+ * This is **all five HTTP API contracts**, including `earlywarning-api.md`, which has no schema at
+ * all — it is listed precisely so its `0 annotated, 3 unannotated` prints on every run instead of
+ * being invisible by omission. `GET /api/earlywarning` is the one MVP 2 endpoint with no
+ * machine-readable shape (#219).
+ *
+ * `mcp-tools.md` is deliberately absent, and not because it lacks a schema — so does earlywarning.
+ * It documents MCP tool returns, a different protocol reached through a different boundary, and its
+ * thirteen sections of unannotated fences would bury the single conspicuous zero this table exists
+ * to show. Its divergences are real and measured (#218 found three in one section); the fix there is
+ * a schema for the tool returns, not a line in this array.
+ */
+const CONTRACT_MD = [
+  'healthscan-api.md',
+  'proxy-api.md',
+  'investigation-api.md',
+  'earlywarning-api.md',
+  'resolve-api.md',
+];
+
+/** Schema filename as written in a fence annotation -> the `$id` ajv knows it by. */
+const SCHEMA_IDS_BY_FILE = {
+  'healthscan.schema.json': SCHEMA_ID,
+  'proxy.schema.json': PROXY_SCHEMA_ID,
+  'investigation.schema.json': INVESTIGATION_SCHEMA_ID,
+  'resolve.schema.json': RESOLVE_SCHEMA_ID,
+};
+
+/**
+ * Pull every ```json fence out of a markdown file, annotated or not.
+ *
+ * The annotation rides in the CommonMark info string, after the language:
+ *
+ *     ```json validate=resolve.schema.json#/definitions/ResolveResponse
+ *
+ * GitHub renders the block as `json` regardless, so nothing about how these files read changes.
+ *
+ * OPT-IN, and the counts below are the price of that. Most fences in these files are deliberately
+ * not whole documents — a bare `"reversal": {...}` fragment, a request body for an endpoint whose
+ * request has no schema, an `{"error": "..."}` shape — and requiring `validate=none` on each would
+ * add noise to five files to catch a mistake in one. The risk is the opposite one: an unannotated
+ * fence is invisible, which is the hole this exists to close. So every file reports its annotated
+ * and unannotated counts, and a file that drops to `0 annotated` says so on every CI run.
+ */
+function jsonFences(file) {
+  const lines = readFileSync(join(here, file), 'utf8').split(/\r?\n/);
+  const fences = [];
+  let i = 0;
+  while (i < lines.length) {
+    const opener = /^```json(?:\s+(.*))?$/.exec(lines[i].trimEnd());
+    if (opener === null) {
+      i += 1;
+      continue;
+    }
+    const bodyStart = i + 1;
+    let j = bodyStart;
+    while (j < lines.length && lines[j].trimEnd() !== '```') j += 1;
+    fences.push({
+      // 1-indexed, and pointing at the opener rather than the body: that is the line a reader
+      // clicks, and the line a `file:line` in CI output has to match.
+      line: i + 1,
+      info: (opener[1] ?? '').trim(),
+      body: lines.slice(bodyStart, j).join('\n'),
+    });
+    i = j + 1;
+  }
+  return fences;
+}
+
 const ajv = new Ajv({ strict: false, allErrors: true });
 addFormats(ajv);
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'healthscan.schema.json'), 'utf8')));
@@ -784,6 +861,59 @@ for (const { name, definition, data } of PROXY_MUST_REJECT) {
   report(!validate(data), `proxy rejects: ${name}`);
 }
 
+// The fenced payloads in the contract prose (#205). Annotated fences are validated; unannotated
+// ones are counted and reported, never silently dropped.
+let fencesChecked = 0;
+const fenceCounts = [];
+for (const file of CONTRACT_MD) {
+  const fences = jsonFences(file);
+  let annotated = 0;
+  for (const { line, info, body } of fences) {
+    const at = `${file}:${line}`;
+    const spec = /(?:^|\s)validate=(\S+)/.exec(info);
+    if (spec === null) continue;
+    annotated += 1;
+    fencesChecked += 1;
+
+    // A malformed annotation FAILS rather than skipping. The whole point is that an unchecked
+    // payload must not be able to look checked, and a typo in the definition name is the cheapest
+    // way for one to.
+    const ref = /^([^#]+)#\/definitions\/(.+)$/.exec(spec[1]);
+    if (ref === null) {
+      report(false, `${at}: annotation is not <schema.json>#/definitions/<Definition>`);
+      continue;
+    }
+    const [, schemaFile, definition] = ref;
+    const schemaId = SCHEMA_IDS_BY_FILE[schemaFile];
+    if (schemaId === undefined) {
+      report(false, `${at}: no such schema file: ${schemaFile}`);
+      continue;
+    }
+    const validate = ajv.getSchema(`${schemaId}#/definitions/${definition}`);
+    if (validate === undefined) {
+      report(false, `${at}: no such definition: ${schemaFile}#/definitions/${definition}`);
+      continue;
+    }
+
+    let data;
+    try {
+      data = JSON.parse(body);
+    } catch (err) {
+      report(false, `${at}: not parseable JSON — ${err.message}`);
+      continue;
+    }
+    const ok = validate(data);
+    report(ok, `${at} validates as ${definition}`);
+    if (!ok) console.log(`      ${ajv.errorsText(validate.errors)}`);
+  }
+  fenceCounts.push({ file, annotated, unannotated: fences.length - annotated });
+}
+console.log('\njson fences in the contract prose (unannotated are NOT validated):');
+for (const { file, annotated, unannotated } of fenceCounts) {
+  console.log(`      ${annotated} annotated, ${unannotated} unannotated  ${file}`);
+}
+console.log('');
+
 const capture = readFileSync(join(here, 'samples/metrics-dump.txt'), 'utf8');
 for (const { name, re } of CAPTURE_CLAIMS) {
   report(re.test(capture), `metrics-dump.txt: ${name}`);
@@ -794,7 +924,7 @@ console.log(
     ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length + RESOLVE_CASES.length} samples, `
       + `${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length + RESOLVE_MUST_ACCEPT.length} accept, `
       + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length + RESOLVE_MUST_REJECT.length} reject, `
-      + `${CAPTURE_CLAIMS.length} capture claims)`
+      + `${CAPTURE_CLAIMS.length} capture claims, ${fencesChecked} prose fences)`
     : `\n${failures} check(s) failed`,
 );
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #205. Also files #219 and #220, both found by running it.

## The hole

`samples/` was the only thing `contracts/validate.mjs` checked. The divergences kept living somewhere else:

- all three §8 payloads in `investigation-api.md` were schema-invalid for twelve days — #201
- five more shipped in `resolve-api.md` — #202

A fenced payload in a ratified contract is a **published artefact**. A consumer mocks against it exactly as they mock against `samples/`, and until now nothing could disagree with it.

## The convention

The annotation rides in the CommonMark info string, after the language:

````
```json validate=resolve.schema.json#/definitions/ResolveResponse
````

GitHub renders the block as `json` regardless, so nothing about how these files read changes. Ten payloads annotated across four files:

| File | Annotated | Unannotated |
|---|---|---|
| `healthscan-api.md` | 2 | 0 |
| `proxy-api.md` | 3 | 0 |
| `investigation-api.md` | 5 | 4 |
| `earlywarning-api.md` | **0** | 3 |
| `resolve-api.md` | 4 | 11 |

**Opt-in, and the counts are the price.** #205 left this open and leaned this way; I took it as an engineering-convention call rather than a product one. Most fences in these files are deliberately *not* whole documents — a bare `"reversal": {...}`, a request body for an endpoint whose request has no schema, an `{"error": "..."}` shape — and requiring `validate=none` on each would add noise to five files to catch a mistake in one.

The risk with opt-in is the opposite one: an unannotated fence is *invisible*, which is the hole this exists to close. Three things pay for it:

1. every run prints each file's **annotated and unannotated** counts, per file
2. a **malformed annotation fails rather than skips** — unknown schema file, unknown definition name, an annotation that isn't `<schema.json>#/definitions/<Definition>`, or unparseable JSON. An unchecked payload must not be able to *look* checked, and a typo in a definition name is the cheapest way for one to
3. a file that drops to `0 annotated` says so on every CI run

`earlywarning-api.md` is that zero, and permanently so until someone acts: it is the last MVP 2 endpoint with **no schema at all**, so there is nothing for an annotation to name. Filed as **#219**. It is in `CONTRACT_MD` rather than omitted precisely so the gap prints instead of being invisible by absence.

`mcp-tools.md` is deliberately out — and *not* for lack of a schema, since neither has earlywarning. It documents MCP tool returns, a different protocol through a different boundary, and thirteen sections of unannotated fences would bury the single conspicuous zero the table exists to show. Its divergences are real and measured (#218 found three in one section); the fix there is a schema for the tool returns, not a line in this array.

## It found two divergences on its first real run

All four `ResolveResponse` payloads in `resolve-api.md` failed on `additionalProperties`, for two independent reasons. Both were diagnosed by reading `resolve.ts` and `Tools/Resolve.cls`, not by guessing which side to change.

### `replayed` — a documented feature that does not exist → #220

§1.3's field table types it as a plain **required** `boolean`. §6 mechanism 3 builds a whole replay contract on it. §11's R5 — the demo answer to *"what happens if I click Approve twice?"* — cites it as one of three mechanisms.

`services/detection-engine/src/detect/resolve.ts` accepts and echoes `requestId` and that is all: no store, no window, no `replayed`, and it does not even *require* `requestId` on an `apply`, so §7's `malformed_request` row for that does not fire either. Mechanism 3 of three does not exist. The double-click is *harmless* — mechanisms 1 and 2 are real and load-bearing — but it mints a second audit row for one human decision, on the screen the demo ends on.

It is now **permitted and not required** in `resolve.schema.json`, with the reasoning on the field:

> requiring it would fail the shipped path and dropping it would fail the ratified contract

Both alternatives are wrong, and a third — leaving it out under `additionalProperties: false` — is how this got found. That is an unimplemented feature rather than a shape question, so it is **#220**, with the A/B decision (build the store vs. cut §6 mechanism 3) stated, a lean given, and deliberately not taken here.

### `before.readAt` / `after.readAt` — removed as unratified

In five prose payloads. Absent from §1.3's field table, from `resolve.ts`, and from all three live captures in `samples/`. `PoolShape` is `{poolSize}` and nothing else, in the schema and in the code.

Removed from the prose. Recorded in the CHANGELOG rather than only in a diff because there is a **second reading worth reconsidering deliberately**: `readAt` could be documenting *when* the pool size was read, which is the timestamp an optimistic-concurrency story around `precondition.poolSize` would want. If that is the intent it comes back as a field-table row and a schema property — not as a payload key nobody declared.

## Verification

`cd contracts && npm run validate` — green:

```
all checks passed (6 samples, 16 accept, 32 reject, 7 capture claims, 14 prose fences)

json fences in the contract prose (unannotated are NOT validated):
      2 annotated, 0 unannotated  healthscan-api.md
      3 annotated, 0 unannotated  proxy-api.md
      5 annotated, 4 unannotated  investigation-api.md
      0 annotated, 3 unannotated  earlywarning-api.md
      4 annotated, 11 unannotated  resolve-api.md
```

A green check that cannot fail is the thing this PR exists to prevent, so **all four failure modes were driven and each was confirmed to exit `1`**, then reverted:

| Mutation | Output |
|---|---|
| definition renamed to `Nope` | `FAIL proxy-api.md:323: no such definition: proxy.schema.json#/definitions/Nope` |
| schema file renamed to `nope.schema.json` | `FAIL proxy-api.md:323: no such schema file: nope.schema.json` |
| annotation shortened to `validate=HealthResponse` | `FAIL proxy-api.md:323: annotation is not <schema.json>#/definitions/<Definition>` |
| stray key added inside an annotated fence | `FAIL resolve-api.md:136 validates as ResolveResponse` / `data must NOT have additional properties` |
| body made unparseable | `FAIL resolve-api.md:136: not parseable JSON — Unexpected token 'o'` |

The first attempt at the fourth case mutated line 67 — a *request* fence, unannotated — and correctly did nothing. Repeated against the annotated fence at `:136`, it failed as it should.

## Consumers

**None.** No schema loosened, no field required, no sample changed. The four `resolve-api.md` payloads a consumer might have mocked against are five keys *closer* to the shipped shape than they were. The engine and the dashboard are untouched by this PR.

## Files

| File | Change |
|---|---|
| `contracts/validate.mjs` | `CONTRACT_MD`, `SCHEMA_IDS_BY_FILE`, `jsonFences()`, the execution pass, per-file counts, `14 prose fences` in the summary |
| `contracts/resolve.schema.json` | `replayed` as an optional boolean, with the #220 reasoning on the field |
| `contracts/resolve-api.md` | 4 fences annotated; 5 `readAt` keys removed |
| `contracts/healthscan-api.md`, `proxy-api.md`, `investigation-api.md` | 10 fence annotations total, no payload edits |
| `contracts/README.md` | "checks five things", the fence bullet, and the `.d.ts` gap paragraph now names #219 too |
| `contracts/CHANGELOG.md` | new top entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
