### PR TITLE
contracts: a ResolveRequest definition, so the request half of /api/resolve is checkable too (#205 follow-up, files #222)

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,108 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `ResolveRequest`: the request half of `POST /api/resolve` is checkable, and §1.1 turns out to require three things nothing sends
+
+**One new definition, one new captured sample, one existing sample corrected.** No response shape changed.
+
+The entry below added a pass that validates the JSON fences in the prose. It left the four **request**
+payloads in `resolve-api.md` unannotated for a stated reason: no request schema existed to name. This
+closes that, and it is the follow-up that entry named.
+
+### What landed
+
+| File | What changed |
+|---|---|
+| `resolve.schema.json` | new `ResolveRequest` definition; `title` and top-level `description` corrected |
+| `samples/resolve-request.json` | **new** — a live, §1.1-complete `apply` |
+| `samples/resolve-refusal.json` | `requestId: null` → `"rq-contracts-capture-01"`, re-captured as a matched pair |
+| `resolve-api.md` | the four request fences annotated (§1.1, §11.1, §11.2, §11.4) |
+| `validate.mjs` | 1 sample, 3 accepts, 8 rejects |
+
+`action` is the **same cross-schema `$ref`** the response already uses —
+`investigation.schema.json#/definitions/ResolveAction`. §1.2's rule is that `action` is a field-for-field
+copy of the investigation's structured `recommendedAction`, transcribed and never parsed. One definition
+for what the agent recommends, what the caller approves, and what the server reports applying is how that
+rule gets enforced instead of asserted three times.
+
+### The title said "the request half is already covered". It wasn't
+
+The original `description` on this schema read *"The request half is already covered:
+`investigation.schema.json#/definitions/ResolveAction` is the `action` object and `validate.mjs` carries
+must-reject cases for it."* True of `action`, and of nothing else in §1.1 — `mode`, `requestId`, `origin`,
+`precondition`, `requestedBy` were all uncovered. Corrected in place, and recorded here because it is a
+good specimen: a partial check reading as a complete one is the failure mode this whole directory's
+process exists to prevent, and it happened in the sentence describing the check.
+
+### §1.1's asymmetry is now enforced in both directions
+
+> Unknown top-level fields are **ignored**, not rejected. Unknown fields *inside* `action` are
+> **refused** (`malformed_request`).
+
+So `ResolveRequest` is `additionalProperties: true` at the root and inherits `false` inside `action`. That
+looks like an oversight, so there is a **must-accept** case for an unknown top-level key
+(`approvedInTabId`) alongside the must-reject for an unknown key inside `action`. Without the accept case,
+someone tightens the root in good faith and breaks a caller §1.1 promised would work.
+
+### It found the requirement nothing enforces → #222
+
+§1.1 marks `requestId`, `origin` and `origin.findingId` required **for `apply`**. `parseResolveRequest()`
+enforces none of the three, and `apps/dashboard/src/api/liveClient.ts:230` sends
+`{mode, action, origin, requestedBy}` — **no `requestId`, from any call site in the repo**.
+
+So the replay key #220 needs a store for is not being sent either. That is both halves of §6 mechanism 3
+missing, and §6's own sentence is the cost: *"One approval, one audit event."*
+
+The schema encodes **§1.1, not the parser** — a request schema constrains callers, so a lenient server is
+permissive rather than divergent, and encoding the leniency would have deleted the requirement instead of
+recording that it is unenforced:
+
+```json
+"allOf": [{
+  "if":   { "properties": { "mode": { "const": "apply" } }, "required": ["mode"] },
+  "then": { "required": ["requestId", "origin"],
+            "properties": { "origin": { "required": ["findingId"] } } }
+}]
+```
+
+Three of the eight must-reject cases hold exactly that. **#222** carries the fix, its ordering (the
+dashboard has to send a `requestId` before the parser may demand one, or the shipped Approve button
+breaks), and why it is blocked on #220's A/B decision rather than started.
+
+### One sample corrected, one knowingly left wrong
+
+All three captured responses carried `requestId: null`, **two of them on an `apply`** — so the samples
+collectively taught the opposite of what §1.1 requires, and a consumer mocking against them would build a
+UI handling a state the contract says cannot occur. That is the same defect the "Why the samples matter"
+section names about a laundered `requestedBy`, pointing the other way.
+
+- `samples/resolve-refusal.json` was **re-captured from a §1.1-compliant request**, and
+  `samples/resolve-request.json` is that request. `size: 9` is refused by the governed tool before any
+  write, so the pair cost one audit row and moved nothing. Only `requestId` differs from the previous
+  bytes; ids and timestamps stay pinned to the same values, so the diff is one line.
+- `samples/resolve-response.json` — the `applied` capture — is **still a non-compliant apply** with
+  `requestId: null`. Re-capturing it needs a real `set_pool_size` write plus a revert through
+  `Triggers.SetPoolSize` (the governed tool's `2..8` bound cannot restore `PoolSize 1`), and a live
+  production write to fix a sample is the wrong trade. Left as-is, recorded in #222 step 3, to be done
+  when a live apply is happening anyway.
+
+### Consumers
+
+**None.** The dashboard's request already satisfies everything except `requestId`, and nothing validates
+its outgoing body against this schema — `ResolveRequest` is enforced over `samples/` and the prose, not in
+the request path. The one behaviour change this implies is #222's, and #222 is filed rather than started.
+
+`cd contracts && npm run validate` now reports `7 samples, 19 accept, 40 reject, 7 capture claims, 18
+prose fences`, with `resolve-api.md` at `8 annotated, 7 unannotated`.
+
+The 7 that remain there are not annotatable and are not meant to be: five are single-key fragments
+(`"reversal": {...}`, `"refusal": {...}`, `"failure": {...}`, `"confirmation": {...}`, `"audit": {...}`)
+which are not JSON documents at all, and two are deliberately partial response objects showing "the
+load-bearing parts". Wrapping them in braces to make a linter reach them would change how the document
+reads to serve the tool.
+
+---
+
 ## 2026-09-01 — the JSON payloads *inside* the contract prose are validated now, and the first run found two more divergences
 
 **No shape changes to any schema except one optional field, and that field is a bug report.** `samples/`

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -24,6 +24,7 @@ yet" for the twelve days after it was captured (#201).
 | `samples/investigation-response.json` — a **live** `gpt-4o-mini` capture | Dev B | Dev B (dashboard) |
 | `resolve-api.md`, `resolve.schema.json` | Dev B | Dev B (dashboard) |
 | `samples/resolve-response.json`, `resolve-preview.json`, `resolve-refusal.json` — three **live** captures | Dev B | Dev B (dashboard) |
+| `samples/resolve-request.json` — the **live** request that produced the refusal capture | Dev B | Dev B (dashboard) |
 | `mcp-tools.md` | Dev A | Dev B |
 
 **The dashboard consumer is Dev B, not Dev C** — Dev C left on 2026-08-20 and `apps/dashboard/**`
@@ -33,7 +34,7 @@ as recording who owns it now. It does mean the engine↔dashboard rows have the 
 sides, which is the seam the root file's mock-first rule addresses directly: nothing forces a
 contract to be real when one author owns both ends of it.
 
-Two gaps left in that block, noted rather than left to be discovered:
+Three gaps left in that block, noted rather than left to be discovered:
 
 - **neither `investigation.d.ts` nor `resolve.d.ts` exists**, so unlike Health Scan there is no
   TypeScript transcription for a consumer to import — the engine and the dashboard each hand-maintain
@@ -42,6 +43,12 @@ Two gaps left in that block, noted rather than left to be discovered:
   state, and since #205 the validator prints it as `0 annotated` on every run rather than leaving it to
   be noticed. The three worked payloads in its §4 are unchecked by anything but reading — which is
   exactly the position `investigation-api.md` was in for the twelve days of #201
+- **`investigation-api.md` §2.2 has no `InvestigationRequest` definition** (#211). §2.2 states
+  `additionalProperties: false` at *every* level for the object the engine sends the agent, and nothing
+  enforces it — which is why §2.2 drifted in both directions (five fields specified and never sent,
+  three sent and never specified) while §4 stayed honest. `resolve.schema.json` gained its
+  `ResolveRequest` on 2026-09-01; this is the same job for the other endpoint, and it is the half of
+  #211 that keeps #211 fixed
 
 `resolve.schema.json` and the three captures closed the other gap on 2026-09-01 (#202): `POST
 /api/resolve` was the one MVP 2 endpoint nothing validated, which is why five field-level divergences
@@ -118,7 +125,7 @@ cd contracts && npm install && npm run validate
 It checks five things, and the middle two are what make the first mean anything:
 
 - each JSON sample against **one named definition** (`HostsResponse`, `FindingsResponse`,
-  `InvestigationResponse`, `ResolveResponse`)
+  `InvestigationResponse`, `ResolveResponse`, `ResolveRequest`)
 - structural cases that must **pass** — `[]`, sub-second timestamps from any language, and the real
   proxy payloads including their `null`s
 - cases that must **fail** — a retired `Warning` status, an unknown finding type, a hosts array

--- a/contracts/resolve-api.md
+++ b/contracts/resolve-api.md
@@ -62,7 +62,7 @@ they are the same family of thing.
 
 ### 1.1 Request
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveRequest
 {
   "requestId": "rq-6f2c1e",
   "mode": "apply",
@@ -973,7 +973,7 @@ payloads until `samples/` files land.
 
 Request:
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveRequest
 {
   "mode": "dry_run",
   "action": { "type": "set_pool_size", "host": "Cloud API", "size": 4 },
@@ -1020,7 +1020,7 @@ and `action.size`.
 
 Request:
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveRequest
 {
   "requestId": "rq-6f2c1e",
   "mode": "apply",
@@ -1098,7 +1098,7 @@ refusal.
 
 Request (`size: 40`):
 
-```json
+```json validate=resolve.schema.json#/definitions/ResolveRequest
 {
   "requestId": "rq-6f2c22",
   "mode": "apply",

--- a/contracts/resolve.schema.json
+++ b/contracts/resolve.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://production-guardian/contracts/resolve.schema.json",
-  "title": "Production Guardian — Smart Resolve response (MVP 2)",
-  "description": "The response half of `POST /api/resolve`, which had no machine-readable form until #202. The request half is already covered: `investigation.schema.json#/definitions/ResolveAction` is the `action` object and `validate.mjs` carries must-reject cases for it. Every divergence #202 found was invisible because nothing here could disagree with the prose — the only tests over this path pin the implementation while citing '§3 + §7' as their authority. Two of those divergences are open decisions (§4 `after` on a preview, §5 `confirmation.directEvidence` and `clearsWhen`); this schema is deliberately PERMISSIVE at exactly those two points and says so on the fields, so it holds the decided shape without quietly settling the undecided one.",
+  "title": "Production Guardian — Smart Resolve request and response (MVP 2)",
+  "description": "`POST /api/resolve`, which had no machine-readable form at all until #202. The response half landed then; `ResolveRequest` followed after #205's fence pass, which is worth recording because the original text here read 'the request half is already covered' on the strength of `ResolveAction` alone — true of the `action` object and of nothing else in §1.1, and a good example of a partial check reading as a complete one. Every divergence #202 found was invisible because nothing here could disagree with the prose — the only tests over this path pin the implementation while citing '§3 + §7' as their authority. Two of those divergences are open decisions (§4 `after` on a preview, §5 `confirmation.directEvidence` and `clearsWhen`); this schema is deliberately PERMISSIVE at exactly those two points and says so on the fields, so it holds the decided shape without quietly settling the undecided one.",
   "definitions": {
     "PoolShape": {
       "description": "`before` and `after` are the same one-key object. Its own definition rather than two copies, because the pair is read side by side and a schema that let them diverge would be describing a UI bug as legal.",
@@ -88,6 +88,67 @@
         "recordedAt": { "type": ["string", "null"] },
         "source": { "type": ["string", "null"] }
       }
+    },
+    "ResolveRequest": {
+      "description": "The REQUEST half of `POST /api/resolve`, from §1.1. Added after #205's fence pass, because the four request payloads in this contract's prose were the only ones left that nothing could disagree with — and the fence pass had just found two divergences in the four response payloads next to them.\n\nA request schema constrains CALLERS, which is why it encodes §1.1's table rather than `parseResolveRequest()`'s leniency. The server accepts an `apply` with no `requestId` and no `origin`, both of which §1.1 marks required for `apply`; a server accepting more than the contract demands is permissive, not divergent, and tightening it is a behaviour change filed separately (#222). What this definition must not do is quietly restate the leniency as the contract, which would delete the requirement instead of recording that it is unenforced.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["mode", "action"],
+      "properties": {
+        "requestId": {
+          "description": "Required for `apply` — see the `allOf` below. `maxLength` is §1.1's own '≤ 64 chars' and is the only length bound in this file, because this string is the replay key: an unbounded client-generated id keys an in-memory store (§6).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "mode": {
+          "description": "NO DEFAULT, which is why it is in `required`. `parseResolveRequest()`'s comment states the reason from both sides: a missing mode defaulting to `apply` turns a caller's omission into a live production write, and defaulting to `dry_run` makes an approval silently preview while the operator waits for something to happen.",
+          "enum": ["dry_run", "apply"]
+        },
+        "action": {
+          "description": "The same cross-schema `$ref` the response uses, deliberately: §1.2's rule is that `action` is a field-for-field copy of the investigation's structured `recommendedAction`, transcribed and never parsed. One definition for what the agent recommends, what the caller approves, and what the server reports applying is how that rule is enforced rather than asserted. `additionalProperties: false` lives on that definition, which is what makes an unknown key inside `action` a schema failure here.",
+          "$ref": "https://production-guardian/contracts/investigation.schema.json#/definitions/ResolveAction"
+        },
+        "origin": {
+          "description": "Required for `apply`, with `findingId` required inside it — see the `allOf` below. Not decoration: `confirmation.findingId` is `request.origin?.findingId ?? null`, and §7's confirmation contract is 'watch this finding disappear from `GET /api/healthscan/findings`'. An apply with no `origin` therefore returns a confirmation naming nothing to observe, which is schema-legal (`findingId` is nullable there, for the refusal and preview paths) and useless to the caller. `additionalProperties` is left open here rather than closed: §1.1 closes `action` and only `action`, and the asymmetry is stated as deliberate.",
+          "type": "object",
+          "properties": {
+            "findingId": { "type": "string", "minLength": 1 },
+            "investigationId": {
+              "description": "Opaque here on purpose — §1.1 says its shape belongs to `investigation-api.md`. Typed as a string and nothing more, so this file cannot drift from that one.",
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "precondition": {
+          "description": "Optimistic concurrency, and PARSED BUT USED BY NOTHING as shipped — `precondition_failed` is unreachable (#213). Kept in this schema because §1.1 specifies it and a caller sending it is not making a mistake; the gap is that sending it buys no protection today. `minimum: 1` rather than 2: this is the value the approver believed they were changing FROM, and `Cloud API`'s shipped state is `PoolSize 1`, which the governed tool's `2..8` bound can set nothing back to. A precondition floor of 2 would make the one value the demo actually starts from unstateable.",
+          "type": "object",
+          "properties": {
+            "poolSize": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "requestedBy": {
+          "description": "PROVENANCE LABEL ONLY, never used for authorization — §1.1 and §8 both say so, and the captured samples keep their own capture-time label rather than a plausible-looking one to make the point visible. No pattern, no enum: the moment this schema constrains the value, something downstream starts trusting it.",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "description": "§1.1: `requestId` and `origin` are required FOR `apply`, and optional for `dry_run`, which has nothing to replay and nothing to confirm. Expressed as `if/then` rather than by splitting into two definitions, so the four prose fences and any caller can validate against one name — and so a `dry_run` payload cannot accidentally satisfy the stricter half.",
+          "if": {
+            "properties": { "mode": { "const": "apply" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["requestId", "origin"],
+            "properties": {
+              "origin": { "required": ["findingId"] }
+            }
+          }
+        }
+      ]
     },
     "ResolveResponse": {
       "description": "`additionalProperties: false` is the point of this file. Every #202 divergence was a field whose documented shape and shipped shape differed with nothing in between them; a permissive root would accept the next one too.\n\nTimestamps use `healthscan.schema.json`'s pattern rather than `format: date-time`, for the reason stated there: `toISOString()` output and second-precision Z-suffixed output are both legal here and `format` would accept offsets the rest of the contract forbids.",

--- a/contracts/samples/resolve-refusal.json
+++ b/contracts/samples/resolve-refusal.json
@@ -1,6 +1,6 @@
 {
   "resolveId": "res-Cloud-API-1788278400002",
-  "requestId": null,
+  "requestId": "rq-contracts-capture-01",
   "mode": "apply",
   "requestedAt": "2026-09-01T16:00:00Z",
   "outcome": "refused",

--- a/contracts/samples/resolve-request.json
+++ b/contracts/samples/resolve-request.json
@@ -1,0 +1,17 @@
+{
+  "requestId": "rq-contracts-capture-01",
+  "mode": "apply",
+  "action": {
+    "type": "set_pool_size",
+    "host": "Cloud API",
+    "size": 9
+  },
+  "origin": {
+    "findingId": "f-1042",
+    "investigationId": "inv-queue_buildup:Cloud API-1755691200000"
+  },
+  "precondition": {
+    "poolSize": 1
+  },
+  "requestedBy": "contracts/resolve.schema.json capture"
+}

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -130,6 +130,12 @@ const RESOLVE_CASES = [
   { file: 'samples/resolve-response.json', definition: 'ResolveResponse' },
   { file: 'samples/resolve-preview.json', definition: 'ResolveResponse' },
   { file: 'samples/resolve-refusal.json', definition: 'ResolveResponse' },
+  // The request that produced `resolve-refusal.json`, captured as a matched pair. Sent as a
+  // §1.1-COMPLIANT apply -- `requestId` and `origin.findingId` present -- which the original capture
+  // was not: all three responses carried `requestId: null`, two of them on an `apply`, so the samples
+  // collectively taught the opposite of what §1.1 requires. `size: 9` is refused by the governed tool
+  // before any write, so this pair costs one audit row and moves nothing.
+  { file: 'samples/resolve-request.json', definition: 'ResolveRequest' },
 ];
 
 /** A valid `applied` response, mutated per case below so each rejection isolates one field. */
@@ -165,11 +171,43 @@ const RESOLVE_BASE = {
 };
 
 /**
+ * A §1.1-complete `apply` request, mutated per case below. Deliberately not the captured sample:
+ * `RESOLVE_BASE` is not the captured response either, and a base that doubles as a fixture makes a
+ * failing rejection ambiguous between "the schema changed" and "the capture changed".
+ */
+const RESOLVE_REQUEST_BASE = {
+  requestId: 'rq-6f2c1e',
+  mode: 'apply',
+  action: { type: 'set_pool_size', host: 'Cloud API', size: 4 },
+  origin: { findingId: 'f-1042', investigationId: 'inv-8801' },
+  precondition: { poolSize: 1 },
+  requestedBy: 'presenter@laptop',
+};
+
+/**
  * `RESOLVE_BASE` itself, asserted valid. Every rejection below is `RESOLVE_BASE` with one field
  * changed, so a base the schema already refuses would make all six pass while testing nothing.
+ * `RESOLVE_REQUEST_BASE` is here for the same reason, and the two extra accepts after it are
+ * asserting that the request's conditional requireds and its open root are both deliberate.
  */
 const RESOLVE_MUST_ACCEPT = [
   { name: 'the unmutated applied base the rejections are derived from', definition: 'ResolveResponse', data: RESOLVE_BASE },
+  { name: 'the unmutated apply request the request rejections are derived from', definition: 'ResolveRequest', data: RESOLVE_REQUEST_BASE },
+  {
+    // The `if/then` must NOT fire here. §1.1 makes `requestId` and `origin` required for `apply`
+    // only: a dry run has nothing to replay and nothing to confirm.
+    name: 'a dry_run request with no requestId and no origin',
+    definition: 'ResolveRequest',
+    data: { mode: 'dry_run', action: { type: 'set_pool_size', host: 'Cloud API', size: 4 } },
+  },
+  {
+    // §1.1's asymmetry, asserted rather than assumed: unknown keys at the top level are IGNORED,
+    // unknown keys inside `action` are REFUSED. Without this case, `additionalProperties: true` on
+    // the request root reads as an oversight, and someone tightens it and breaks a caller.
+    name: 'an unknown TOP-LEVEL request field — §1.1 ignores these, and only `action` is closed',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, approvedInTabId: 'tab-7' },
+  },
 ];
 
 /**
@@ -222,6 +260,61 @@ const RESOLVE_MUST_REJECT = [
     name: 'an undocumented top-level field — the whole reason this file has additionalProperties: false',
     definition: 'ResolveResponse',
     data: { ...RESOLVE_BASE, resizedAction: { requested: 2, applied: 4 } },
+  },
+
+  // --- requests (§1.1). The first three are the requirement the shipped parser does not enforce
+  // (#222): these cases hold the contract while the server is lenient, which is the point of having
+  // a request schema at all.
+  {
+    name: 'an apply with no requestId — §1.1 requires the replay key for apply, and §6 is built on it',
+    definition: 'ResolveRequest',
+    data: (() => {
+      const { requestId, ...rest } = RESOLVE_REQUEST_BASE;
+      return rest;
+    })(),
+  },
+  {
+    name: 'an apply with no origin — the confirmation would name no finding to watch clear (§7)',
+    definition: 'ResolveRequest',
+    data: (() => {
+      const { origin, ...rest } = RESOLVE_REQUEST_BASE;
+      return rest;
+    })(),
+  },
+  {
+    name: 'an apply whose origin omits findingId — origin present is not the requirement, the id is',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, origin: { investigationId: 'inv-8801' } },
+  },
+  {
+    name: 'an unknown key INSIDE action — §1.1 refuses these, and the shipped parser agrees',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, action: { ...RESOLVE_REQUEST_BASE.action, clamp: true } },
+  },
+  {
+    name: 'no mode — no default exists, because either default is the wrong one to guess',
+    definition: 'ResolveRequest',
+    data: (() => {
+      const { mode, ...rest } = RESOLVE_REQUEST_BASE;
+      return rest;
+    })(),
+  },
+  {
+    // `previewed` is the OUTCOME and `X-Resolve-Outcome: previewed` is the header, so "preview" is
+    // the plausible wrong guess for the mode rather than an arbitrary bad string.
+    name: 'mode "preview" — the outcome is `previewed`, the mode is `dry_run`, and they are not the same word',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, mode: 'preview' },
+  },
+  {
+    name: 'a fractional action.size — §1.1 says integer, and PoolSize 4.5 is not a thing IRIS has',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, action: { ...RESOLVE_REQUEST_BASE.action, size: 4.5 } },
+  },
+  {
+    name: 'a requestId over §1.1\'s 64 characters — it keys an in-memory replay store (§6)',
+    definition: 'ResolveRequest',
+    data: { ...RESOLVE_REQUEST_BASE, requestId: 'rq-'.padEnd(66, 'x') },
   },
 ];
 


### PR DESCRIPTION
The follow-up #221 named. It found #222.

#205's fence pass left the four **request** payloads in `resolve-api.md` unannotated for a stated reason: no request schema existed to name. This closes that.

## The schema's own description was the specimen

It read:

> The request half is already covered: `investigation.schema.json#/definitions/ResolveAction` is the `action` object and `validate.mjs` carries must-reject cases for it.

True of `action`. Untrue of `mode`, `requestId`, `origin`, `precondition` and `requestedBy` — everything else in §1.1. Corrected in place, and called out in the CHANGELOG because a **partial check reading as a complete one** is the exact failure this directory's process exists to prevent, and it happened in the sentence describing the check.

## What landed

| File | Change |
|---|---|
| `resolve.schema.json` | new `ResolveRequest`; `title` and top-level `description` corrected |
| `samples/resolve-request.json` | **new** — a live, §1.1-complete `apply` |
| `samples/resolve-refusal.json` | `requestId: null` → `"rq-contracts-capture-01"`, re-captured as a matched pair (one line) |
| `resolve-api.md` | the four request fences annotated — §1.1, §11.1, §11.2, §11.4 |
| `validate.mjs` | 1 sample, 3 accepts, 8 rejects |
| `README.md`, `CHANGELOG.md` | table row, definition list, gap list, entry |

`action` is the **same cross-schema `$ref` the response already uses**, deliberately. §1.2's rule is that `action` is a field-for-field copy of the investigation's structured `recommendedAction`, transcribed and never parsed — so one definition for *what the agent recommends*, *what the caller approves* and *what the server reports applying* is how that rule gets enforced instead of asserted in three places.

## §1.1's asymmetry, enforced in both directions

> Unknown top-level fields are **ignored**, not rejected. Unknown fields *inside* `action` are **refused** (`malformed_request`).

So `ResolveRequest` is `additionalProperties: **true**` at the root, inheriting `false` inside `action` from `ResolveAction`. An open root looks like an oversight, so there is a **must-accept** case for an unknown top-level key (`approvedInTabId`) sitting next to the must-reject for an unknown key inside `action`. Without the accept case someone tightens the root in good faith and breaks a caller §1.1 promised would work.

## It found the requirement nothing enforces → #222

§1.1 marks three fields required **for `apply`**: `requestId`, `origin`, `origin.findingId`.

`parseResolveRequest()` enforces **none** of them — all three are `if (typeof x === 'string')`. And `apps/dashboard/src/api/liveClient.ts:230` sends:

```ts
await postJson('/resolve', { mode, action, origin, requestedBy: 'dashboard' }, signal)
```

**No `requestId`, from any call site in the repo.** So the replay key #220 needs a store for is not being sent either — both halves of §6 mechanism 3 are missing, and §6's own sentence is the cost: *"One approval, one audit event."*

The schema encodes **§1.1, not the parser**. A request schema constrains *callers*, so a lenient server is permissive rather than divergent; encoding the leniency would have deleted the requirement instead of recording that it is unenforced:

```json
"allOf": [{
  "if":   { "properties": { "mode": { "const": "apply" } }, "required": ["mode"] },
  "then": { "required": ["requestId", "origin"],
            "properties": { "origin": { "required": ["findingId"] } } }
}]
```

**#222** carries the fix and its ordering — the dashboard must send a `requestId` *before* the parser may demand one, or the shipped Approve button breaks — and states why it is blocked on #220's A/B decision rather than started here.

## One sample corrected, one knowingly left wrong

All three captured responses carried `requestId: null`, **two of them on an `apply`**. So the samples collectively taught the opposite of what §1.1 requires, and a consumer mocking against them would handle a state the contract says cannot occur. That is the "Why the samples matter" argument about a laundered `requestedBy`, pointing the other way.

- **`resolve-refusal.json` re-captured** from a §1.1-compliant request, and `samples/resolve-request.json` *is* that request. `size: 9` is refused by the governed tool before any write, so the pair cost **one audit row and moved nothing**. Ids and timestamps stay pinned to their previous values, so the diff is one line.
- **`resolve-response.json` left non-compliant.** Re-capturing an `applied` needs a real `set_pool_size` write plus a revert through `Triggers.SetPoolSize` — the governed tool's `2..8` bound cannot restore `PoolSize 1` — and a live production write to fix a sample is the wrong trade. #222 step 3, for when a live apply is happening anyway.

`origin.findingId` and `origin.investigationId` in the new sample are the **real ids from `samples/investigation-response.json`** (`f-1042`, `inv-queue_buildup:Cloud API-1755691200000`), not invented ones — so the three samples now chain: finding → investigation → resolve request.

## Verification

```
all checks passed (7 samples, 19 accept, 40 reject, 7 capture claims, 18 prose fences)

      8 annotated, 7 unannotated  resolve-api.md
```

**Each of the eight new rejections was confirmed to fail for its intended reason**, not vacuously — a rejection that trips over the wrong field passes while testing nothing, which is why `RESOLVE_REQUEST_BASE` is also a must-accept:

| Case | Actual error |
|---|---|
| apply, no `requestId` | `must have required property 'requestId'`, `must match "then" schema` |
| apply, no `origin` | `must have required property 'origin'`, `must match "then" schema` |
| apply, `origin` without `findingId` | `data/origin must have required property 'findingId'` |
| unknown key inside `action` | `data/action must NOT have additional properties` |
| no `mode` | `must have required property 'mode'` |
| `mode: "preview"` | `data/mode must be equal to one of the allowed values` |
| `action.size: 4.5` | `data/action/size must be integer` |
| `requestId` of 66 chars | `data/requestId must NOT have more than 64 characters` |

The three conditional cases report `must match "then" schema`, which is what confirms the `if/then` fired rather than something else catching them.

The 7 fences still unannotated in `resolve-api.md` are **not annotatable and not meant to be**: five are single-key fragments (`"reversal": {...}`, `"refusal": {...}`, `"failure": {...}`, `"confirmation": {...}`, `"audit": {...}`) which are not JSON documents at all, and two are deliberately partial responses showing "the load-bearing parts". Wrapping them in braces to reach a linter would change how the document reads to serve the tool.

## Consumers

**None.** The dashboard already sends everything except `requestId`, and nothing validates its outgoing body against this schema — `ResolveRequest` is enforced over `samples/` and the prose, not in the request path. The one behaviour change implied is #222's, filed rather than started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
