### PR TITLE
ci: a NUL byte suppresses review of a whole file, so sweep for it (#161)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,54 @@
 Dockerfile text eol=lf
 *.ini text eol=lf
 *.conf text eol=lf
+
+# ---------------------------------------------------------------------------
+# Keep source diffs renderable even if a NUL byte gets into a file (#161).
+#
+# Git classifies any file with a NUL in its first 8000 bytes as binary and shows
+# `Bin 21868 -> 27238 bytes` instead of a diff. That happened to mockClient.ts, and it
+# hid a one-line disagreement between two adjacent functions across two PRs (#140, #144)
+# -- demo-mode host graphs had never worked and no reviewer could have seen why.
+#
+# `diff` is the attribute that fixes it, and `text` is NOT -- measured, because the obvious
+# guess is wrong:
+#
+#     *.ts text  ->  bad.ts | Bin 37 -> 46 bytes      (still unreviewable)
+#     *.ts diff  ->  bad.ts | 1 +                     (renders)
+#
+# `text` governs end-of-line normalisation; `diff` governs whether git diffs it as text.
+# Both are wanted here, for two different failures, so both are set:
+#   - `diff` keeps review working. Defence in depth behind the CI sweep in ci.yml, which
+#     rejects the NUL outright -- this only matters for the window before CI runs, and for
+#     anyone reading history that already contains one.
+#   - `text` makes normalisation independent of each developer's core.autocrlf, and applies
+#     it even to a file git would otherwise write off as binary. That is the second-order
+#     cost #161 records: autocrlf skips presumed-binary files, so mockClient.ts quietly
+#     accumulated 616 CRLF endings, and removing the NUL then produced a 616-line diff that
+#     had to be split into its own commit to keep a 3-line fix reviewable.
+#
+# No `eol=` on purpose. These are read by editors and toolchains on the host, not by a
+# shebang inside a container, so the checkout convention stays the platform default -- that
+# is what the four rules above exist to override, and only for files that need it.
+*.ts text diff
+*.tsx text diff
+*.js text diff
+*.mjs text diff
+*.cls text diff
+*.json text diff
+*.css text diff
+*.html text diff
+*.md text diff
+*.yml text diff
+*.py text diff
+
+# The genuinely binary files, declared rather than detected. All five are `docs/` source
+# material, which root CLAUDE.md §3 makes read-only, so this list changes about never.
+#
+# It is load-bearing for CI, not decoration: the NUL sweep skips exactly the files whose
+# `diff` attribute is unset, so this is what tells it "these NULs are legitimate". Adding a
+# real binary therefore means adding a line here, in a reviewed PR -- and a new file type
+# nobody declared gets swept, which is the direction that fails safe.
+*.png binary
+*.pptx binary
+*.docx binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,3 +370,77 @@ jobs:
           if [ "$RAN" -eq 0 ]; then
             echo "npm test reported zero tests — the glob matched nothing"; exit 1
           fi
+
+  # The only job here with no area guard, because the failure it catches is not confined to
+  # a directory. Cheap: a checkout and one git command, no toolchain.
+  #
+  # A NUL byte in a tracked file makes git classify it binary and print `Bin 21868 -> 27238
+  # bytes` in place of every diff of it, on the command line and on GitHub. Nothing else
+  # breaks — it compiles, tests pass, CI is green — and the only casualty is human review.
+  # #157 found a one-line disagreement between two adjacent functions that survived two PRs
+  # inside that blind spot (#140 introduced the NUL, #144 changed 5,370 bytes behind it):
+  # demo-mode host graphs served empty series for every host and had never worked.
+  #
+  # NUL specifically, and not "control characters" as #161's title has it, because NUL is the
+  # only one with this effect — measured, not assumed: a file containing \x01\x02\x08 diffs
+  # normally (`1 +`). Rejecting all control characters would reject things that cost nothing.
+  no-nul-bytes:
+    name: hygiene — no NUL bytes in tracked text files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # THE OBVIOUS ONE-LINER IS SILENTLY BROKEN, which is the only reason this is not one.
+      # Both plausible spellings fail, in opposite directions, and both look like a working
+      # check from the log. Verified on a scratch repo holding one NUL file and one clean file:
+      #
+      #   git grep -lIP '\x00'   ->  (nothing), exit 1   WRONG — misses it, reads as clean
+      #   git grep -lP  '\x00'   ->  bad.ts,    exit 0   correct
+      #   git grep -l $'\x00'    ->  BOTH files, exit 0  WRONG — false positive on everything
+      #
+      # `-I` means "skip binary files", and a NUL is exactly what makes git call a file binary,
+      # so -I excludes the only files that can match. It exits 1 like a clean run, so the
+      # `|| true` form filed on #161 would have been green forever. And the pattern must stay
+      # the literal four characters `\x00` for git's PCRE to expand: bash cannot hold a NUL in
+      # an argument, so $'\x00' collapses to the empty pattern, which matches every file.
+      - name: Sweep tracked files for NUL bytes
+        run: |
+          # git grep exits 0 = matches, 1 = no matches, >1 = git itself failed — e.g. a git
+          # built without PCRE, where -P is unavailable. Treating >1 as clean is how this
+          # check would come to pass without running, which is the failure mode every other
+          # guard in this file exists to prevent.
+          set +e
+          candidates=$(git grep -lP '\x00' -- .)
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "::error::git grep -P exited $status — the NUL sweep did not run, so this is not a pass"
+            exit 1
+          fi
+          # Genuinely binary files legitimately contain NULs. They are DECLARED `binary` in
+          # .gitattributes, which unsets `diff`, and that attribute is what is consulted here
+          # rather than a path list — a second copy of "which files are binary" is a thing that
+          # goes stale, and this repo has been bitten by a hardcoded list three times (#14, #92).
+          # An undeclared file type resolves to `unspecified` and IS swept: a type nobody has
+          # classified is the case to fail on, not the case to wave through.
+          #
+          # ONE `check-attr` invocation over the whole list via --stdin, not one per file. The
+          # per-file loop was written first and is unusable: ~250 tracked files means ~500
+          # process spawns, which did not finish in two minutes locally. `comm -23` over sorted
+          # lists to subtract, the same idiom the iris-compile copy step above uses for the
+          # same job, rather than `grep -vf` whose "no lines matched" exit 1 would need a
+          # `|| true` that also swallows a real grep failure.
+          declared=$(git ls-files | git check-attr --stdin diff | sed -n 's/: diff: unset$//p' | sort)
+          offenders=$(comm -23 <(printf '%s\n' "$candidates" | sed '/^$/d' | sort) <(printf '%s\n' "$declared" | sed '/^$/d'))
+          if [ -n "$offenders" ]; then
+            echo "::error::NUL byte in tracked text file(s) — git diffs these as binary, so every future change to them is unreviewable:"
+            printf '%s\n' "$offenders" | sed 's/^/  /'
+            echo "If a control character is genuinely wanted as a separator, write it as the escape \\u0000 — byte-identical at runtime and the file stays diffable. Both legitimate uses in this repo do that already: seriesKey in apps/dashboard/src/api/mockClient.ts and SEP in services/detection-engine/src/baseline/window.ts, both because a space is legal in a host name."
+            echo "If the file is a real binary, declare it in .gitattributes instead."
+            exit 1
+          fi
+          # Prints the denominator, like the fence counts in contracts/validate.mjs and the
+          # executed-test counts above: "found none" and "looked at nothing" are the same log
+          # line otherwise.
+          tracked=$(git ls-files | wc -l)
+          skipped=$(printf '%s\n' "$declared" | sed '/^$/d' | wc -l)
+          echo "$tracked tracked files, $skipped declared binary in .gitattributes and skipped — no NUL bytes in the other $((tracked - skipped))"


### PR DESCRIPTION
`apps/dashboard/src/api/mockClient.ts` held a literal NUL, so git classified it
binary and rendered every diff of it as `Bin 21868 -> 27238 bytes`. #140
introduced the character and #144 changed 5,370 further bytes behind it; neither
was reviewable, and what survived in the blind spot was a one-line disagreement
between two adjacent functions that meant demo-mode host graphs had never worked
(#157). Nothing errors in that state: it compiles, tests pass, CI is green, and
the only casualty is human review.

Two layers, and BOTH differ from the fix sketched on #161, because both plausible
spellings turn out to be wrong:

1. `.github/workflows/ci.yml` — a repo-wide sweep. The filed one-liner,
   `git grep -lIP '\x00'`, finds NOTHING: `-I` means "skip binary files" and a
   NUL is precisely what makes git call a file binary, so `-I` excludes the only
   files that can match. It exits 1 like a clean run, so with the `|| true` it
   would have been green forever. Dropping `-I` is correct; a shell-expanded
   `$'\x00'` is the opposite error, collapsing to the empty pattern that matches
   every file. Both read as a working check from the log.

2. `.gitattributes` — `diff` on the source extensions, NOT `text`. Measured on a
   scratch repo, because the obvious guess is wrong:

       *.ts text  ->  bad.ts | Bin 37 -> 46 bytes   (still unreviewable)
       *.ts diff  ->  bad.ts | 1 +                  (renders)

   `text` governs end-of-line normalisation, `diff` governs diff treatment. Both
   are set, for two different failures: `diff` keeps review working if a NUL ever
   lands again, and `text` makes normalisation independent of core.autocrlf even
   for a file git presumes binary — which is the second-order cost #161 records,
   where mockClient.ts silently accumulated 616 CRLF endings and removing the NUL
   then produced a 616-line diff that had to be split out to keep a 3-line fix
   reviewable.

Scoped to NUL rather than to control characters generally, despite #161's title:
NUL is the only one with this effect. A file containing \x01\x02\x08 diffs
normally, so rejecting the class would reject things that cost nothing.

The five genuinely binary files (docs/ png, pptx, docx) are DECLARED `binary`
rather than excluded by path, and the sweep consults that attribute — a second
copy of "which files are binary" is what went stale in #14 and #92. An
undeclared type resolves to `unspecified` and IS swept, so a new file type
nobody classified fails rather than slips through.

Verified locally against the extracted step body, all six paths:
  - real repo, unmodified          PASS, "256 tracked files, 5 declared binary
                                   and skipped", 2.35s
  - NUL in a declared-text .ts     FAIL, names the file
  - NUL in an undeclared .txt      FAIL  (the fail-safe direction)
  - NUL in a declared .png         PASS  (legitimate)
  - the sanctioned \u0000 escape   PASS
  - git grep -P itself failing     FAIL, "the sweep did not run, so this is not
                                   a pass" — not silently clean

Also measured: all 224 files newly declared `text` are already stored `i/lf`, so
there is no renormalisation churn, and the first per-file `git check-attr` loop
was replaced with one `--stdin` invocation after it failed to finish in two
minutes (~500 process spawns).

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)