### PR TITLE
feat(contracts): a schema for GET /api/earlywarning, written against live captures rather than the prose

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,107 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-01 — `earlywarning.schema.json`: the last unchecked HTTP contract gets a schema, and the live stack disagrees with two of its three worked examples
+
+**One new schema, three new captured samples, three prose fences annotated.** No shape changed, and
+nothing the engine emits was altered — this describes what already ships (#219).
+
+`GET /api/earlywarning` was the fifth and last HTTP contract in this directory with no machine-readable
+form. The entry below closed the same gap for `POST /api/resolve`; this one finishes the set, so **every
+endpoint documented here now has a schema and at least one live sample.**
+
+### What landed
+
+| File | What changed |
+|---|---|
+| `earlywarning.schema.json` | **new** — `EarlyWarningResponse`, `HostProjection`, `Threshold`, `Projection` |
+| `samples/earlywarning-response.json` | **new** — the live projection, ETA 164 s |
+| `samples/earlywarning-insufficient-samples.json` | **new** — 25 s after engine start, five samples |
+| `samples/earlywarning-crossed.json` | **new** — `already_crossed` at depth 64 |
+| `earlywarning-api.md` | the three §4 fences annotated. **No prose changed** — see below |
+| `validate.mjs` | 3 samples, 14 rejects; the `CONTRACT_MD` comment corrected |
+| `README.md` | table rows, the definition list, and the two places that said this file had no schema |
+
+### The captures came first, and that is the whole reason to read this entry
+
+§1's shape was **not** the source. Six of the seven reason codes were driven out of the running stack
+across one `pool_bottleneck` cycle before a line of schema was written, and the three samples are three
+of those polls byte-for-byte. `disabled` was not captured — it needs `earlyWarning.enabled: false` — and
+is in the enum on the prose's authority alone, which the field's `description` says out loud.
+
+That order was not ceremony. **The captures disagree with two of §4's three worked examples**, and a
+schema written from §4 would have ratified the disagreement:
+
+- **§4.2 names the wrong reason.** Five samples in, 20 s span, `X-Healthscan-State: warming` — the state
+  reproduced exactly. The reason came back `insufficient_samples`, with a **non-null** threshold, not
+  `warming` with `threshold: null`.
+- **§4.3's `baselineValue` climbing 0.4 → 6.1 cannot happen.** It illustrates §1.3's self-inflating
+  rolling mean. `thresholds.json` pins a `referenceBaselines` entry for `queued` on all three reported
+  hosts and `effectiveBaseline()` prefers a reference over the mean, so `baselineValue` is `0` on every
+  host in every capture.
+
+Both have the same root: **`warming` is unreachable for every reported host on the shipped config.** It
+is returned only when `threshold` is null, which needs `effectiveBaseline()` to return null, which a
+reference baseline prevents. §2.3's stronger claim inherits the same defect — *"`X-Healthscan-State:
+warming` implies every entry carries `projection: null` with reason `warming`"* — and the `poll-04`
+capture is a `warming` header over three `insufficient_samples` rows.
+
+**Filed, not encoded, and no prose was corrected here.** Whether §4.2/§4.3/§2.3 should be rewritten or
+the `referenceBaselines` config changed is a product decision — the config is what makes `queue_buildup`
+able to fire on a ramp at all (`services/detection-engine/CLAUDE.md` §5.1) — and a schema is the wrong
+place to settle it. `warming` stays in the enum: the config is hot-reloadable and removing a reference
+baseline makes the state reachable again within one poll.
+
+### What the schema can hold that the prose could not
+
+§1.4 is this contract's central rule and it is **structural**: every computed number lives inside
+`projection`, every observed number outside it. That is enforced by where a field sits, which is exactly
+what a schema checks and a comment cannot. So `additionalProperties: false` on `HostProjection` is
+load-bearing — a top-level `slope` beside a declined forecast is now a validation failure, and §1.4 names
+that case in as many words: *"a visible 'rising ~0.5/min' next to no ETA still implies a forecast we
+refused to make."* The engine's in-memory object really does carry that field; the serialiser dropping it
+was the only thing between it and the wire.
+
+Eight `if/then` pairs encode the invariants the prose states and nothing could check:
+
+| Invariant | Where the prose says it |
+|---|---|
+| `projection` and `projectionUnavailable` are mutually exclusive — exactly one non-null, both directions | §2.1 |
+| a projection implies `recentDirection: "rising"` | §1.5, "the one invariant worth testing" |
+| `warming` / `metric_unmeasurable` ⇒ `threshold: null`; the other four reasons ⇒ non-null | §2.1's table |
+| `metric_unmeasurable` ⇒ `currentValue: null`, and `currentValue: null` ⇒ one of the first two reasons | §2.1 + §2.2's precedence |
+| `fitSampleCount < 2` ⇒ `fitSpanSeconds: 0` | §1 |
+
+Plus `kind: "projection"` as a `const`, `slope` and `secondsToThreshold` strictly positive (§1.4 forbids
+a zero ETA outright), and `message` matched against the substring **"at this rate"** — §1.4 already
+called that hedge "a testable invariant", and now something tests it.
+
+### What it deliberately does not constrain
+
+- **`secondsToThreshold <= 1800`.** The horizon is `thresholds.json` config and hot-reloadable; pinning
+  it would make a config change a contract violation.
+- **`Threshold.baselineValue` pinned to 0.** That is today's config, not the contract. The field stays a
+  plain number so the schema does not fail the moment a reference baseline is removed — which is the
+  change that would make §4.3 true again.
+- **`metric`, `Projection.basis`, `findingType`** stay open strings; only `Threshold.basis` is a closed
+  union, because it names which of two arms of one gate won and a third value would mean the threshold
+  arithmetic changed. §1 tells a consumer meeting an unknown `metric` to label the axis from
+  `slopeUnit`, an instruction that only makes sense if an unknown name can arrive.
+- **the alphabetical sort, and one-entry-per-reported-host.** Draft-07 cannot express either over object
+  items, so both remain §1 prose, checked by the captured samples.
+- **`host` is not `$ref`'d to `healthscan.schema.json`'s `Host.host`.** §1 says they are the same
+  *string*, which is an equal value rather than a shared type. A `$ref` would encode the wrong claim.
+
+### Timestamps are not pinned, unlike the other captured samples
+
+`investigation-response.json` and the resolve captures pin ids and timestamps so the fixtures do not
+move. These three do not, and there is a reason: there are no ids in this payload, and the timestamps are
+load-bearing arithmetic. `projectedCrossingAt` must equal `measuredAt + secondsToThreshold`, which is the
+one cross-field invariant draft-07 cannot express — `17:54:47Z + 164 s = 17:57:31Z` in
+`earlywarning-response.json` is the only check on it, and rewriting the timestamps would delete it.
+
+---
+
 ## 2026-09-01 — `ResolveRequest`: the request half of `POST /api/resolve` is checkable, and §1.1 turns out to require three things nothing sends
 
 **One new definition, one new captured sample, one existing sample corrected.** No response shape changed.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -19,7 +19,8 @@ yet" for the twelve days after it was captured (#201).
 
 | File | Owner | Consumer |
 |---|---|---|
-| `earlywarning-api.md` | Dev B | Dev B (dashboard) |
+| `earlywarning-api.md`, `earlywarning.schema.json` | Dev B | Dev B (dashboard) |
+| `samples/earlywarning-response.json`, `earlywarning-insufficient-samples.json`, `earlywarning-crossed.json` — three **live** captures from one `pool_bottleneck` cycle | Dev B | Dev B (dashboard) |
 | `investigation-api.md`, `investigation.schema.json` | Dev B | Dev B (dashboard) |
 | `samples/investigation-response.json` — a **live** `gpt-4o-mini` capture | Dev B | Dev B (dashboard) |
 | `resolve-api.md`, `resolve.schema.json` | Dev B | Dev B (dashboard) |
@@ -34,15 +35,11 @@ as recording who owns it now. It does mean the engine↔dashboard rows have the 
 sides, which is the seam the root file's mock-first rule addresses directly: nothing forces a
 contract to be real when one author owns both ends of it.
 
-Three gaps left in that block, noted rather than left to be discovered:
+Two gaps left in that block, noted rather than left to be discovered:
 
 - **neither `investigation.d.ts` nor `resolve.d.ts` exists**, so unlike Health Scan there is no
   TypeScript transcription for a consumer to import — the engine and the dashboard each hand-maintain
-  one for both shapes
-- **`earlywarning-api.md` has no schema and no sample** (#219). It is the last MVP 2 endpoint in that
-  state, and since #205 the validator prints it as `0 annotated` on every run rather than leaving it to
-  be noticed. The three worked payloads in its §4 are unchecked by anything but reading — which is
-  exactly the position `investigation-api.md` was in for the twelve days of #201
+  one for both shapes. `earlywarning.d.ts` does not exist either, and for the same reason
 - **`investigation-api.md` §2.2 has no `InvestigationRequest` definition** (#211). §2.2 states
   `additionalProperties: false` at *every* level for the object the engine sends the agent, and nothing
   enforces it — which is why §2.2 drifted in both directions (five fields specified and never sent,
@@ -56,6 +53,18 @@ in `resolve-api.md` had to be found by reading rather than by CI. Two points in 
 **deliberately permissive** — `resolve-api.md` §4's `after` on a preview and §5's `confirmation`
 fields are open decisions, and the fields say so in their `description` — so for those two the prose
 is still the only statement of intent, and there isn't one yet.
+
+`earlywarning.schema.json` and three captures closed the last of them on 2026-09-01 (#219), so **all
+five HTTP contracts now have a schema and at least one live sample.** Two things about that one are
+worth knowing before reading it. First, its central rule is *structural* — `earlywarning-api.md` §1.4
+puts every computed number inside `projection` and every observed one outside it — so
+`additionalProperties: false` is doing the actual work: a top-level `slope` beside a declined forecast
+is now a validation failure, which is the exact case §1.4 names. Second, **the captures were taken
+before the schema was written**, and they disagree with two of the three worked examples in §4:
+`warming` is unreachable on the shipped `referenceBaselines` (§4.2's state comes back as
+`insufficient_samples` with a non-null threshold), and §4.3's climbing `baselineValue` cannot happen
+for the same reason. Both are filed rather than encoded — whether the prose or the config is what
+should change is a product decision, and a schema written from §4 would have settled it by accident.
 
 `samples/alerts.json` and `samples/proxy-response.json` were planned in `CONTRIBUTING.md` §1 and do
 not exist. Both are derivable without inventing anything — a real alerts capture is at
@@ -125,7 +134,7 @@ cd contracts && npm install && npm run validate
 It checks five things, and the middle two are what make the first mean anything:
 
 - each JSON sample against **one named definition** (`HostsResponse`, `FindingsResponse`,
-  `InvestigationResponse`, `ResolveResponse`, `ResolveRequest`)
+  `InvestigationResponse`, `ResolveResponse`, `ResolveRequest`, `EarlyWarningResponse`)
 - structural cases that must **pass** — `[]`, sub-second timestamps from any language, and the real
   proxy payloads including their `null`s
 - cases that must **fail** — a retired `Warning` status, an unknown finding type, a hosts array
@@ -153,8 +162,9 @@ It checks five things, and the middle two are what make the first mean anything:
   Opt-in because most fences here are deliberately *not* whole documents — request bodies, bare
   fragments, error shapes. The compensating rule: every run prints each file's annotated **and**
   unannotated counts, a malformed annotation **fails** rather than skips, and a file that drops to
-  `0 annotated` says so on every CI run. `earlywarning-api.md` is at `0` today because it has no
-  schema (#219); that is the gap being visible rather than absent
+  `0 annotated` says so on every CI run. `earlywarning-api.md` sat at `0` for as long as it had no
+  schema and is at `3 annotated, 0 unannotated` since #219 — the zero was the gap being visible
+  rather than absent, and the count moving is what closing it looks like
 
 **Do not replace this with an `ajv-cli` one-liner.** Three reasons, all learned the hard way on
 PR #3:

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -438,7 +438,7 @@ absolute floor of 50 is the live arm.
 
 `200` · `X-Healthscan-State: ok`
 
-```json
+```json validate=earlywarning.schema.json#/definitions/EarlyWarningResponse
 [
   {
     "host": "Cloud API",
@@ -513,7 +513,7 @@ published; nothing else is.
 
 `200` · `X-Healthscan-State: warming`
 
-```json
+```json validate=earlywarning.schema.json#/definitions/EarlyWarningResponse
 [
   {
     "host": "Cloud API",
@@ -563,7 +563,7 @@ Five samples at a 5000 ms poll is a 20 s span, and the queue *is* rising in this
 
 `200` · `X-Healthscan-State: ok`
 
-```json
+```json validate=earlywarning.schema.json#/definitions/EarlyWarningResponse
 [
   {
     "host": "Cloud API",

--- a/contracts/earlywarning.schema.json
+++ b/contracts/earlywarning.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://production-guardian/contracts/earlywarning.schema.json",
+  "title": "Production Guardian — Early Warning projection (MVP 2)",
+  "description": "`GET /api/earlywarning`, which had no machine-readable shape at all until #219 — the last of the five HTTP contracts in this directory to get one, and the one whose absence was already being printed on every `validate.mjs` run as `0 annotated, 3 unannotated`.\n\nThe reason it needed one is `earlywarning-api.md` §1.4, this contract's own central rule: **every computed number lives inside `projection`, every observed number lives outside it.** That rule is structural — it is enforced by where a field sits, not by a comment — which makes it exactly the kind of rule a schema can hold and prose cannot. `additionalProperties: false` on `HostProjection` is what makes a top-level `slope` a validation failure rather than a code review note, and §1.4 names a top-level slope specifically: *'a visible \"rising ~0.5/min\" next to no ETA still implies a forecast we refused to make.'*\n\nEVERY DEFINITION HERE WAS WRITTEN AGAINST LIVE CAPTURES, not against the prose. Six of the seven reason codes were driven out of the running stack on 2026-09-01 (`disabled` needs `earlyWarning.enabled: false` and was not); the three samples in `samples/` are three of those polls, byte-for-byte. That order was deliberate and it mattered: the captures disagree with two of the three worked examples in the prose, and a schema written from §4 would have ratified the disagreement instead of exposing it. Those divergences are FILED, NOT ENCODED — see the `projectionUnavailable` and `Threshold.baselineValue` descriptions.\n\nWhat this schema deliberately does NOT constrain: `secondsToThreshold <= 1800` (the horizon is `thresholds.json` config and hot-reloadable, so pinning it here would make a config change a contract violation), one-entry-per-reported-host, and the alphabetical sort — the last two are §1 guarantees about the array that draft-07 cannot express over object items.",
+  "definitions": {
+    "Threshold": {
+      "description": "The target a crossing is projected toward: `max(baseline * 5.0, 50)` per §1.3. Non-null exactly when a baseline exists, which is why `warming` is the reason paired with `threshold: null` — no baseline, no target, nothing to project toward.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "basis", "baselineValue", "findingType"],
+      "properties": {
+        "value": { "type": "number" },
+        "basis": {
+          "description": "CLOSED, unlike `metric` and `Projection.basis` below. §1.3 defines it as naming which arm of one two-armed gate won, and the gate has exactly two arms — a third value would mean the threshold arithmetic changed, which is a contract change rather than a new label. The distinction is load-bearing for a consumer: `absoluteFloor` is a fixed target and `baselineMultiplier` is a moving one whose ETA can *increase* while the queue rises (§1.3), so a reader that cannot trust this field cannot know whether a receding countdown is a bug.",
+          "enum": ["absoluteFloor", "baselineMultiplier"]
+        },
+        "baselineValue": {
+          "description": "NEVER NULL — §1.3's 'no baseline, no threshold' in schema form: if this were unknown, `Threshold` itself would be `null`.\n\nIt is `0` on all three hosts in all three captured samples, and that is NOT the rolling mean §1.3 describes. `thresholds.json` `referenceBaselines` pins `queued: 0` for every reported host, and `effectiveBaseline()` returns the reference in preference to the rolling mean whenever one exists, so the self-inflating mean §1.3 warns about is currently unreachable for this metric. §4.3's payload shows `baselineValue` climbing 0.4 -> 6.1 to illustrate exactly that inflation; on the shipped config it cannot. Left as a plain number here rather than pinned to 0: the pinning is config, the field is contract, and a schema that encoded today's config would fail the moment a reference baseline is removed — which is the change that would make §4.3 true again. Filed, not encoded.",
+          "type": "number"
+        },
+        "findingType": {
+          "description": "OPEN string, matching `metric` below and for the same reason: only `queue_buildup` has a projection in MVP 2, and a second finding type gaining one is an addition rather than a redefinition. It is also the key a consumer joins on to find the finding that `already_crossed` tells it to defer to, so an unrecognised value must reach the UI to be looked up rather than be rejected here.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "Projection": {
+      "description": "THE FORECAST, AND EVERY NUMBER IN IT IS COMPUTED. Its own object rather than five fields on `HostProjection`, which is §1.4's whole design: a consumer cannot pick up `secondsToThreshold` without also holding `kind: 'projection'`, so it cannot render a forecast as a measurement by accident. #58 is the defect class — a derived value published in a slot that promised an observed one, where nothing downstream could tell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "basis",
+        "slope",
+        "slopeUnit",
+        "secondsToThreshold",
+        "projectedCrossingAt",
+        "message"
+      ],
+      "properties": {
+        "kind": {
+          "description": "Literal discriminator, and the one field in this file pinned to a value. §1.4: 'a consumer that has this object in hand cannot claim it did not know.' A `const` is how that stops being a promise.",
+          "const": "projection"
+        },
+        "basis": {
+          "description": "OPEN on purpose — `'linear-least-squares'` is the only fit in MVP 2, and a different fitting method is a legitimate future value rather than a contract break. Contrast `Threshold.basis`, which is closed: that one names which of two arms won, this one names an implementation choice a consumer only displays.",
+          "type": "string",
+          "minLength": 1
+        },
+        "slope": {
+          "description": "`exclusiveMinimum: 0` is §1.2's rule made checkable, and it is the rounding that makes it non-trivial: a slope that rounds to `0.0` is declined as `not_rising` rather than published as 'rising ~0.0/min', so a `0` here would mean the publish gate and the rounding disagree. A negative one would mean a draining queue was handed a crossing time.",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "slopeUnit": {
+          "description": "Spelled out ('items/minute') rather than implied, because §1's `metric` is open: a consumer meeting an unknown metric is told to label the axis from this field instead of assuming items.",
+          "type": "string",
+          "minLength": 1
+        },
+        "secondsToThreshold": {
+          "description": "INTEGER AND STRICTLY POSITIVE. §1.4 forbids `0` outright — 'zero reads as a measurement of now', and the honest answer for a crossed threshold is `projection: null` with `already_crossed`. The engine guards this rather than trusting the arithmetic; this is the same guard, on the wire.",
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "projectedCrossingAt": {
+          "description": "`measuredAt + secondsToThreshold`, exactly. Not recomputable from the schema — draft-07 cannot add two sibling fields — so the cross-check lives in the samples, which are captured whole rather than assembled (`17:54:47Z + 164 s = 17:57:31Z` in `earlywarning-response.json`). Pattern rather than `format: date-time`, for `healthscan.schema.json`'s stated reason: `format` would accept the UTC offsets the rest of this contract forbids.",
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$"
+        },
+        "message": {
+          "description": "THE HEDGE IS IN THE PATTERN, and §1.4 already calls it 'a testable invariant': `message` must contain the substring 'at this rate'. This is the one string the dashboard renders verbatim and is told not to reconstruct, so it is the one place the projection's uncertainty is visible to a human — a message that lost the hedge would read as a schedule.",
+          "type": "string",
+          "pattern": "at this rate"
+        }
+      }
+    },
+    "HostProjection": {
+      "description": "One entry per reported host, present whether or not that host has a projection — §3's 'entries are never omitted to signal absence', because a dropped entry leaves a consumer unable to tell 'not projecting' from 'host gone'.\n\n`additionalProperties: false` IS THE POINT OF THIS DEFINITION, and not for tidiness: §1.4 forbids publishing `slope` out here even when a forecast is declined, and the engine's internal shape carries exactly that — `windowSlopePerMinute` and `recentSlopePerMinute` live on the in-memory object and are dropped by the serialiser. This closes the wire against them. All eleven keys are `required`: §1's rule is that a missing key is a contract violation while a `null` value is not, so nullability is spelled as `oneOf … null` throughout rather than as absence.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "metric",
+        "currentValue",
+        "measuredAt",
+        "fitSampleCount",
+        "fitSpanSeconds",
+        "recentDirection",
+        "threshold",
+        "projection",
+        "projectionUnavailable"
+      ],
+      "properties": {
+        "host": {
+          "description": "Exactly equal to some `Host.host` from `healthscan-api.md` — same string, same case. Not enumerated here, and never will be: root CLAUDE.md §6 makes `iris/labdemo/Production.cls` the only authoritative host list, and a copied one is what went stale when `FHIR Transform` was removed.",
+          "type": "string",
+          "minLength": 1
+        },
+        "metric": {
+          "description": "OPEN. Only `'queued'` in MVP 2, and §1 tells a consumer meeting an unknown name to label the axis from `projection.slopeUnit` rather than assume items — an instruction that only makes sense if an unknown name can arrive, so an enum here would contradict the field's own documentation.",
+          "type": "string",
+          "minLength": 1
+        },
+        "currentValue": {
+          "description": "MEASURED. `null` means the metric is not measurable for this host and NEVER means zero — healthscan Q13's rule, and the reason it has its own reason code (`metric_unmeasurable`) rather than being reported as a flat queue.",
+          "type": ["number", "null"]
+        },
+        "measuredAt": {
+          "description": "The engine's poll clock, not the request clock (EW-Q3). That is also how staleness is visible in the body: on `X-Healthscan-State: stale` the payload is last-known and this field does not advance.",
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$"
+        },
+        "fitSampleCount": {
+          "description": "Measured, so present even when `projection` is null — it is the number a reader uses to tell 'we declined' from 'we had nothing'. Integer and non-negative; deliberately NOT bounded below by `minFitSamples`, since every value from 1 upward was captured live during warm-up.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "fitSpanSeconds": {
+          "description": "First to last sample in the fit window. `0` when `fitSampleCount < 2` — see the `allOf` below, where that is enforced rather than described. One sample has no span, and a non-zero span under one sample would be a fabricated duration.",
+          "type": "number",
+          "minimum": 0
+        },
+        "recentDirection": {
+          "description": "MEASURED, which is why it sits out here beside `currentValue` rather than inside `projection` (§1.5). It is the SIGN of the tail fit and never its magnitude — publishing a second rate would put two slopes in one payload with no way to know which one `message` was built from.\n\n`null` is 'no claim', not 'steady': the tail is only signed once the window behind it has cleared `minFitSamples`, so `warming` and `insufficient_samples` rows always carry `null` here. Both captured `insufficient_samples` samples do.",
+          "enum": ["rising", "falling", "steady", null]
+        },
+        "threshold": {
+          "description": "See the `allOf` below: which reasons force this to `null` and which force it non-null is §2.1's table, and it is enforced here because a mock getting it wrong is invisible until Dev B's fixtures disagree with live in ways that look like bugs.",
+          "oneOf": [{ "$ref": "#/definitions/Threshold" }, { "type": "null" }]
+        },
+        "projection": {
+          "oneOf": [{ "$ref": "#/definitions/Projection" }, { "type": "null" }]
+        },
+        "projectionUnavailable": {
+          "description": "The seven reasons of §2.1, CLOSED — and this is the one closed union in this file that constrains behaviour rather than describing it. §2.2 fixes both the set and the precedence between them because a mock that picks a different reason for the same state is the failure mode the whole section exists to prevent. The engine itself refuses to add an eighth: `earlywarning.ts` routes an unfittable tail to `not_rising` with the note that the contract fixes the seven.\n\nSix were captured live on 2026-09-01. `disabled` was not — it requires `earlyWarning.enabled: false` — and is in the enum on the prose's authority alone.\n\n`warming` IS CURRENTLY UNREACHABLE FOR EVERY REPORTED HOST, and that is not encoded here. It is returned only when `threshold` is null, which happens only when `effectiveBaseline()` returns null, which cannot happen while `thresholds.json` pins a `referenceBaselines` entry for `queued` on all three hosts. So the state §4.2 illustrates — 25 s after engine start, no baseline, reason `warming` — came back live as `insufficient_samples` with a non-null threshold, and `samples/earlywarning-insufficient-samples.json` is that poll at the same five samples §4.2 uses. The member stays in the enum: the config is hot-reloadable and removing a reference baseline makes the state reachable again within one poll. Filed, not encoded — whether §4.2 should be corrected or the config changed is a product decision, not a schema one.",
+          "enum": [
+            "disabled",
+            "metric_unmeasurable",
+            "warming",
+            "insufficient_samples",
+            "already_crossed",
+            "not_rising",
+            "beyond_horizon",
+            null
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "description": "THE HEADLINE INVARIANT, half one: no projection means a reason. §2.1 states it as 'both null is a contract violation', and it is the half that fails safe in the wrong direction if unchecked — a consumer seeing `projection: null` with no reason has nothing to render and no way to know why.",
+          "if": { "properties": { "projection": { "type": "null" } }, "required": ["projection"] },
+          "then": { "properties": { "projectionUnavailable": { "type": "string" } } }
+        },
+        {
+          "description": "THE HEADLINE INVARIANT, half two: a projection means NO reason. Both non-null is the more dangerous violation of the pair, because a UI that checks `projectionUnavailable` first would hide a live ETA, and one that checks `projection` first would show it — two consumers of the same bytes disagreeing about whether a queue is about to cross.",
+          "if": {
+            "properties": { "projection": { "type": "object" } },
+            "required": ["projection"]
+          },
+          "then": { "properties": { "projectionUnavailable": { "type": "null" } } }
+        },
+        {
+          "description": "§1.5's 'one invariant worth testing': where a projection exists, `recentDirection` is ALWAYS `rising`. The projection path cannot be reached with a non-positive tail — §2.2.1's gate reads the same measured value this field publishes, so one computation feeds both and they cannot disagree. The converse deliberately does not hold, and is not encoded: `rising` with `projection: null` is normal and means already over the threshold, beyond the horizon, or the defensive decline at the end of §2.2.1.",
+          "if": {
+            "properties": { "projection": { "type": "object" } },
+            "required": ["projection"]
+          },
+          "then": { "properties": { "recentDirection": { "const": "rising" } } }
+        },
+        {
+          "description": "§2.1: `warming` and `metric_unmeasurable` carry NO threshold. Both are the same statement — there is no target to project toward — reached two different ways: no baseline, or no reading to compare to one. `disabled` is excluded from this pair on purpose: §2.1's table says its threshold 'may be non-null', and although the engine passes `null` on that path, encoding the implementation here would narrow the contract to it.",
+          "if": {
+            "properties": {
+              "projectionUnavailable": { "enum": ["warming", "metric_unmeasurable"] }
+            },
+            "required": ["projectionUnavailable"]
+          },
+          "then": { "properties": { "threshold": { "type": "null" } } }
+        },
+        {
+          "description": "§2.1, the other four rows: each of these reasons means 'there IS a target, and here is why we still will not forecast toward it'. A null threshold under any of them would make the reason unreadable — `already_crossed` with nothing to have crossed, `beyond_horizon` with no horizon.",
+          "if": {
+            "properties": {
+              "projectionUnavailable": {
+                "enum": ["insufficient_samples", "already_crossed", "not_rising", "beyond_horizon"]
+              }
+            },
+            "required": ["projectionUnavailable"]
+          },
+          "then": { "properties": { "threshold": { "type": "object" } } }
+        },
+        {
+          "description": "§2.1: `metric_unmeasurable` means `currentValue` is null, by definition — the reason IS the absence of a reading. Stated in this direction as well as the one below because they catch different mistakes: this one catches a mock that pairs the reason with a plausible number, which is precisely the 'null is not zero' error healthscan Q13 exists for.",
+          "if": {
+            "properties": { "projectionUnavailable": { "const": "metric_unmeasurable" } },
+            "required": ["projectionUnavailable"]
+          },
+          "then": { "properties": { "currentValue": { "type": "null" } } }
+        },
+        {
+          "description": "§2.2's PRECEDENCE, in the only form draft-07 can hold it: `metric_unmeasurable` is checked second, so no reason below it in the order can be reported for an unreadable metric. A row with `currentValue: null` and reason `not_rising` claims a queue is flat when nothing was read at all — and it is the shape a fixture written from the §2.1 table alone will produce, because that table lists the reasons without the order.",
+          "if": { "properties": { "currentValue": { "type": "null" } }, "required": ["currentValue"] },
+          "then": {
+            "properties": {
+              "projectionUnavailable": { "enum": ["disabled", "metric_unmeasurable"] }
+            }
+          }
+        },
+        {
+          "description": "§1: `fitSpanSeconds` is 0 when `fitSampleCount < 2`. A span needs two samples to exist; a positive one under a single sample is a fabricated duration, which is the same class of error as #58's fabricated timestamp — well-formed, plausible, and describing history that was never observed. Captured live: `fitSampleCount: 1` came back with `fitSpanSeconds: 0`.",
+          "if": {
+            "properties": { "fitSampleCount": { "maximum": 1 } },
+            "required": ["fitSampleCount"]
+          },
+          "then": { "properties": { "fitSpanSeconds": { "const": 0 } } }
+        }
+      ]
+    },
+    "EarlyWarningResponse": {
+      "description": "The whole response body: a bare array, one entry per reported host, sorted alphabetically by `host` and stable. `[]` is legal and means no hosts yet or the production is stopped — §3 makes it a `200` in every empty case and forbids `404` for an empty result. Note what this cannot say: neither the sort nor the one-entry-per-host guarantee is expressible over object items in draft-07, so both remain prose (§1) checked by the captured samples.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/HostProjection" }
+    }
+  }
+}

--- a/contracts/samples/earlywarning-crossed.json
+++ b/contracts/samples/earlywarning-crossed.json
@@ -1,0 +1,53 @@
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 64,
+    "measuredAt": "2026-09-01T17:55:12Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "rising",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "already_crossed"
+  },
+  {
+    "host": "EMR Source",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:55:12Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "steady",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  },
+  {
+    "host": "Lab Router",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:55:12Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "steady",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  }
+]

--- a/contracts/samples/earlywarning-insufficient-samples.json
+++ b/contracts/samples/earlywarning-insufficient-samples.json
@@ -1,0 +1,53 @@
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:49:31Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "recentDirection": null,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "insufficient_samples"
+  },
+  {
+    "host": "EMR Source",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:49:31Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "recentDirection": null,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "insufficient_samples"
+  },
+  {
+    "host": "Lab Router",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:49:31Z",
+    "fitSampleCount": 5,
+    "fitSpanSeconds": 20,
+    "recentDirection": null,
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "insufficient_samples"
+  }
+]

--- a/contracts/samples/earlywarning-response.json
+++ b/contracts/samples/earlywarning-response.json
@@ -1,0 +1,61 @@
+[
+  {
+    "host": "Cloud API",
+    "metric": "queued",
+    "currentValue": 41,
+    "measuredAt": "2026-09-01T17:54:47Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "rising",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": {
+      "kind": "projection",
+      "basis": "linear-least-squares",
+      "slope": 3.3,
+      "slopeUnit": "items/minute",
+      "secondsToThreshold": 164,
+      "projectedCrossingAt": "2026-09-01T17:57:31Z",
+      "message": "Queue depth 41 rising ~3.3/min; at this rate it crosses 50 in ~3 min."
+    },
+    "projectionUnavailable": null
+  },
+  {
+    "host": "EMR Source",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:54:47Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "steady",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  },
+  {
+    "host": "Lab Router",
+    "metric": "queued",
+    "currentValue": 0,
+    "measuredAt": "2026-09-01T17:54:47Z",
+    "fitSampleCount": 60,
+    "fitSpanSeconds": 295,
+    "recentDirection": "steady",
+    "threshold": {
+      "value": 50,
+      "basis": "absoluteFloor",
+      "baselineValue": 0,
+      "findingType": "queue_buildup"
+    },
+    "projection": null,
+    "projectionUnavailable": "not_rising"
+  }
+]

--- a/contracts/validate.mjs
+++ b/contracts/validate.mjs
@@ -32,6 +32,7 @@ const SCHEMA_ID = 'https://production-guardian/contracts/healthscan.schema.json'
 const PROXY_SCHEMA_ID = 'https://production-guardian/contracts/proxy.schema.json';
 const INVESTIGATION_SCHEMA_ID = 'https://production-guardian/contracts/investigation.schema.json';
 const RESOLVE_SCHEMA_ID = 'https://production-guardian/contracts/resolve.schema.json';
+const EARLYWARNING_SCHEMA_ID = 'https://production-guardian/contracts/earlywarning.schema.json';
 
 /** Each sample is validated against ONE named definition, never "either". */
 const CASES = [
@@ -315,6 +316,153 @@ const RESOLVE_MUST_REJECT = [
     name: 'a requestId over §1.1\'s 64 characters — it keys an in-memory replay store (§6)',
     definition: 'ResolveRequest',
     data: { ...RESOLVE_REQUEST_BASE, requestId: 'rq-'.padEnd(66, 'x') },
+  },
+];
+
+/**
+ * Early Warning, the last of the five HTTP contracts to get a schema (#219).
+ *
+ * THREE samples, and the reason is the same one that made `resolve` need three: the shape is
+ * state-dependent and one poll cannot exercise it. `projection` is an object on exactly one of these
+ * three, `threshold` differs in nothing but the state it belongs to, and `recentDirection` is `null`
+ * on one, `"rising"` on one, `"steady"` on the third.
+ *
+ * ALL THREE ARE CAPTURED, byte-for-byte, from `GET http://localhost:3002/api/earlywarning` across one
+ * `pool_bottleneck` cycle on 2026-09-01 — poll 4 (25 s after engine start), poll 42 (the live
+ * projection, ETA 164 s), poll 46 (12 s later, crossed at 64). NOTHING IS PINNED, unlike the resolve
+ * and investigation samples: there are no ids in this payload, and the timestamps are load-bearing
+ * arithmetic rather than noise — `17:54:47Z + 164 s = 17:57:31Z` is the one cross-field invariant
+ * draft-07 cannot express (`Projection.projectedCrossingAt`), so rewriting them would delete the only
+ * check on it.
+ *
+ * The captures were taken BEFORE the schema was written, in that order and on purpose, and they
+ * disagree with two of the three worked examples in §4. See `earlywarning-insufficient-samples.json`
+ * against §4.2: same five samples, same 20 s span, different reason — `warming` is unreachable on the
+ * shipped `referenceBaselines`. That disagreement is filed, not encoded.
+ */
+const EARLYWARNING_CASES = [
+  { file: 'samples/earlywarning-response.json', definition: 'EarlyWarningResponse' },
+  { file: 'samples/earlywarning-insufficient-samples.json', definition: 'EarlyWarningResponse' },
+  { file: 'samples/earlywarning-crossed.json', definition: 'EarlyWarningResponse' },
+];
+
+/** The projecting `Cloud API` row from `earlywarning-response.json`, to mutate one field at a time. */
+const EW_PROJECTING = JSON.parse(
+  readFileSync(join(here, 'samples/earlywarning-response.json'), 'utf8'),
+)[0];
+
+/** The `already_crossed` `Cloud API` row from `earlywarning-crossed.json`. Same purpose. */
+const EW_DECLINED = JSON.parse(
+  readFileSync(join(here, 'samples/earlywarning-crossed.json'), 'utf8'),
+)[0];
+
+/**
+ * Early Warning rows that must FAIL.
+ *
+ * The first two are #219's own headline: `projection` and `projectionUnavailable` are mutually
+ * exclusive, and BOTH directions are tested because they fail differently. Both non-null makes two
+ * consumers of the same bytes disagree about whether a queue is about to cross; both null leaves one
+ * with nothing to render and no way to know why.
+ *
+ * The rest are each a rule the prose states and nothing could previously check — and every one of
+ * them is a shape a hand-written fixture produces naturally, which is the point. `slope` outside
+ * `projection` is the §1.4 violation the contract names in as many words; a reason paired with the
+ * wrong `threshold` nullability is what a fixture written from §2.1's table without §2.2's order
+ * gives you.
+ */
+const EARLYWARNING_MUST_REJECT = [
+  {
+    name: 'both projection and projectionUnavailable non-null — two consumers, two answers',
+    definition: 'HostProjection',
+    data: { ...EW_PROJECTING, projectionUnavailable: 'beyond_horizon' },
+  },
+  {
+    name: 'both null — no forecast and no reason, which §2.1 calls a contract violation outright',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, projectionUnavailable: null },
+  },
+  {
+    // §1.4, verbatim: "slope is not published outside projection, even when we decline to forecast. A
+    // visible 'rising ~0.5/min' next to no ETA still implies a forecast we refused to make." The
+    // engine's in-memory object really does carry this field, so the serialiser dropping it is the
+    // only thing between it and the wire.
+    name: 'a top-level slope on a declining row — §1.4, and the engine holds this field internally',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, slope: 0.5 },
+  },
+  {
+    name: 'secondsToThreshold 0 for a crossed queue — §1.4: zero reads as a measurement of now',
+    definition: 'HostProjection',
+    data: {
+      ...EW_PROJECTING,
+      projection: { ...EW_PROJECTING.projection, secondsToThreshold: 0 },
+    },
+  },
+  {
+    name: 'a message with the hedge "at this rate" removed — the one string rendered verbatim',
+    definition: 'HostProjection',
+    data: {
+      ...EW_PROJECTING,
+      projection: {
+        ...EW_PROJECTING.projection,
+        message: 'Queue depth 41 rising ~3.3/min; it crosses 50 in ~3 min.',
+      },
+    },
+  },
+  {
+    // §1.5's "one invariant worth testing". `falling` here is not a typo-shaped error: it is what a
+    // fixture author writes for "queue draining after the fix", and the projection path cannot be
+    // reached from it (§2.2.1's tail gate).
+    name: 'a projection with recentDirection "falling" — §2.2.1 cannot reach that path',
+    definition: 'HostProjection',
+    data: { ...EW_PROJECTING, recentDirection: 'falling' },
+  },
+  {
+    name: 'already_crossed with threshold null — nothing to have crossed',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, threshold: null },
+  },
+  {
+    name: 'warming with a non-null threshold — no baseline means no target, §2.1',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, projectionUnavailable: 'warming' },
+  },
+  {
+    // healthscan Q13's "null is not zero" reaching this endpoint: currentValue null is the definition
+    // of metric_unmeasurable, and §2.2 checks it second, so no later reason can be reported for it.
+    name: 'currentValue null reported as not_rising — a flat queue that was never read (§2.2)',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, currentValue: null, projectionUnavailable: 'not_rising' },
+  },
+  {
+    name: 'metric_unmeasurable carrying a reading — the reason IS the absence of one',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, projectionUnavailable: 'metric_unmeasurable', threshold: null },
+  },
+  {
+    name: 'one sample with a 20 s fitSpanSeconds — a span two samples never existed to measure',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, fitSampleCount: 1, fitSpanSeconds: 20 },
+  },
+  {
+    // The unmeasured cousin of the above: `Threshold.basis` is the ONE closed union in this schema,
+    // and `absolute` / `floor` / `absoluteFloor` are the kind of near-miss a mock writes.
+    name: 'threshold.basis "absolute" — a two-armed gate has exactly two arms (§1.3)',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, threshold: { ...EW_DECLINED.threshold, basis: 'absolute' } },
+  },
+  {
+    name: 'an eighth reason code — §2.2 fixes the set, and the engine refuses to add one',
+    definition: 'HostProjection',
+    data: { ...EW_DECLINED, projectionUnavailable: 'draining' },
+  },
+  {
+    name: 'a missing key rather than a null value — §1: null is legal, absent is not',
+    definition: 'HostProjection',
+    data: (() => {
+      const { recentDirection, ...rest } = EW_DECLINED;
+      return rest;
+    })(),
   },
 ];
 
@@ -784,16 +932,17 @@ const CAPTURE_CLAIMS = [
  * artefact — a consumer mocks against it exactly as they mock against `samples/` — and until now
  * nothing could disagree with it.
  *
- * This is **all five HTTP API contracts**, including `earlywarning-api.md`, which has no schema at
- * all — it is listed precisely so its `0 annotated, 3 unannotated` prints on every run instead of
- * being invisible by omission. `GET /api/earlywarning` is the one MVP 2 endpoint with no
- * machine-readable shape (#219).
+ * This is **all five HTTP API contracts**, and `earlywarning-api.md` is the one that shows what the
+ * table was for. It was listed here while it had no schema at all, purely so its `0 annotated, 3
+ * unannotated` printed on every run instead of being invisible by omission — and the zero is what
+ * #219 closed. All three of its §4 payloads are checked now.
  *
- * `mcp-tools.md` is deliberately absent, and not because it lacks a schema — so does earlywarning.
- * It documents MCP tool returns, a different protocol reached through a different boundary, and its
- * thirteen sections of unannotated fences would bury the single conspicuous zero this table exists
- * to show. Its divergences are real and measured (#218 found three in one section); the fix there is
- * a schema for the tool returns, not a line in this array.
+ * `mcp-tools.md` is deliberately absent, and NOT because it lacks a schema — that was the stated
+ * reason while earlywarning also lacked one, and earlywarning is why it was never the real one. It
+ * documents MCP tool returns, a different protocol reached through a different boundary, and its
+ * thirteen sections of unannotated fences would bury the counts this table exists to show. Its
+ * divergences are real and measured (#218 found three in one section); the fix there is a schema for
+ * the tool returns, not a line in this array.
  */
 const CONTRACT_MD = [
   'healthscan-api.md',
@@ -809,6 +958,7 @@ const SCHEMA_IDS_BY_FILE = {
   'proxy.schema.json': PROXY_SCHEMA_ID,
   'investigation.schema.json': INVESTIGATION_SCHEMA_ID,
   'resolve.schema.json': RESOLVE_SCHEMA_ID,
+  'earlywarning.schema.json': EARLYWARNING_SCHEMA_ID,
 };
 
 /**
@@ -860,6 +1010,11 @@ ajv.addSchema(JSON.parse(readFileSync(join(here, 'investigation.schema.json'), '
 // AFTER investigation.schema.json, which it $refs for `action` rather than transcribing ResolveAction
 // a second time. ajv resolves the cross-schema $ref out of this same instance, so the order matters.
 ajv.addSchema(JSON.parse(readFileSync(join(here, 'resolve.schema.json'), 'utf8')));
+// Order-independent, unlike the line above: this one $refs nothing outside itself, on purpose.
+// `host` is not joined to healthscan.schema.json's `Host.host` even though §1 says they are the same
+// string — a $ref would make that a shared *type*, which it is not; it is an equal *value*, and
+// draft-07 cannot express that. Encoding the wrong one is worse than leaving it in prose.
+ajv.addSchema(JSON.parse(readFileSync(join(here, 'earlywarning.schema.json'), 'utf8')));
 
 const validatorFor = (definition) => {
   const validate = ajv.getSchema(`${SCHEMA_ID}#/definitions/${definition}`);
@@ -882,6 +1037,12 @@ const investigationValidatorFor = (definition) => {
 const resolveValidatorFor = (definition) => {
   const validate = ajv.getSchema(`${RESOLVE_SCHEMA_ID}#/definitions/${definition}`);
   if (validate === undefined) throw new Error(`no such resolve definition: ${definition}`);
+  return validate;
+};
+
+const earlywarningValidatorFor = (definition) => {
+  const validate = ajv.getSchema(`${EARLYWARNING_SCHEMA_ID}#/definitions/${definition}`);
+  if (validate === undefined) throw new Error(`no such earlywarning definition: ${definition}`);
   return validate;
 };
 
@@ -934,6 +1095,18 @@ for (const { name, definition, data } of RESOLVE_MUST_ACCEPT) {
 
 for (const { name, definition, data } of RESOLVE_MUST_REJECT) {
   const validate = resolveValidatorFor(definition);
+  report(!validate(data), `rejects: ${name}`);
+}
+
+for (const { file, definition } of EARLYWARNING_CASES) {
+  const validate = earlywarningValidatorFor(definition);
+  const data = JSON.parse(readFileSync(join(here, file), 'utf8'));
+  report(validate(data), `${file} validates as ${definition}`);
+  if (validate.errors) console.log(JSON.stringify(validate.errors, null, 2));
+}
+
+for (const { name, definition, data } of EARLYWARNING_MUST_REJECT) {
+  const validate = earlywarningValidatorFor(definition);
   report(!validate(data), `rejects: ${name}`);
 }
 
@@ -1014,9 +1187,9 @@ for (const { name, re } of CAPTURE_CLAIMS) {
 
 console.log(
   failures === 0
-    ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length + RESOLVE_CASES.length} samples, `
+    ? `\nall checks passed (${CASES.length + INVESTIGATION_CASES.length + RESOLVE_CASES.length + EARLYWARNING_CASES.length} samples, `
       + `${MUST_ACCEPT.length + PROXY_MUST_ACCEPT.length + RESOLVE_MUST_ACCEPT.length} accept, `
-      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length + RESOLVE_MUST_REJECT.length} reject, `
+      + `${MUST_REJECT.length + PROXY_MUST_REJECT.length + INVESTIGATION_MUST_REJECT.length + RESOLVE_MUST_REJECT.length + EARLYWARNING_MUST_REJECT.length} reject, `
       + `${CAPTURE_CLAIMS.length} capture claims, ${fencesChecked} prose fences)`
     : `\n${failures} check(s) failed`,
 );


### PR DESCRIPTION
Closes #219.

`GET /api/earlywarning` was the fifth and last HTTP contract in `contracts/` with no machine-readable form. **All five now have a schema and at least one live sample.**

## The captures came first, and that is the point

#219's stated order was *"capture the three states live rather than inventing them"* first, *"write the schema against the captures"* second. Six of the seven reason codes were driven out of the running stack across one `pool_bottleneck` cycle before a line of schema existed, and the three samples are three of those polls byte-for-byte. `disabled` was not captured — it needs `earlyWarning.enabled: false` — and is in the enum on the prose's authority alone, which the field's `description` says out loud.

That order was not ceremony. **The captures disagree with two of the three worked examples in §4**, and a schema written from §4 would have ratified the disagreement:

| §4 says | Live says |
|---|---|
| §4.2: five samples, 20 s span, reason `warming`, `threshold: null` | same state reproduced exactly — reason `insufficient_samples`, **non-null** threshold |
| §4.3: `baselineValue` climbing 0.4 → 6.1, illustrating §1.3's self-inflating mean | `baselineValue` is `0` on every host in every capture |

Both have one root: **`warming` is unreachable for every reported host on the shipped config.** It is returned only when `threshold` is null, which needs `effectiveBaseline()` to return null, which a `referenceBaselines` entry prevents — and `thresholds.json` pins one for `queued` on all three reported hosts. §2.3's stronger claim inherits the same defect (*"`X-Healthscan-State: warming` implies every entry carries reason `warming`"*); the captured poll is a `warming` header over three `insufficient_samples` rows.

**Filed, not encoded, and no prose was corrected in this PR.** Whether §4.2/§4.3/§2.3 should be rewritten or the config changed is a product decision — the reference baseline is what makes `queue_buildup` able to fire on a ramp at all (`services/detection-engine/CLAUDE.md` §5.1) — and a schema is the wrong place to settle it. `warming` stays in the enum: the config is hot-reloadable, so removing a reference baseline makes the state reachable again within one poll.

## What a schema can hold here that prose could not

§1.4 is this contract's central rule and it is **structural**: every computed number lives inside `projection`, every observed number outside it. That is enforced by where a field sits — exactly what a schema checks and a comment cannot. So `additionalProperties: false` on `HostProjection` is load-bearing rather than tidiness: a top-level `slope` beside a declined forecast is now a validation failure, and §1.4 names that case in as many words —

> `slope` is **not** published outside `projection`, even when we decline to forecast. A visible "rising ~0.5/min" next to no ETA still implies a forecast we refused to make.

The engine's in-memory object really does carry `windowSlopePerMinute` / `recentSlopePerMinute`; the serialiser dropping them was the only thing between them and the wire.

Eight `if/then` pairs encode invariants the prose states and nothing could check:

| Invariant | Prose |
|---|---|
| `projection` and `projectionUnavailable` mutually exclusive — exactly one non-null, **both directions** | §2.1 |
| a projection implies `recentDirection: "rising"` | §1.5, "the one invariant worth testing" |
| `warming` / `metric_unmeasurable` ⇒ `threshold: null`; the other four reasons ⇒ non-null | §2.1's table |
| `metric_unmeasurable` ⇒ `currentValue: null`, and `currentValue: null` ⇒ one of the first two reasons | §2.1 + §2.2's precedence |
| `fitSampleCount < 2` ⇒ `fitSpanSeconds: 0` | §1 |

Plus `kind: "projection"` as a `const`, `slope` and `secondsToThreshold` strictly positive (§1.4 forbids a zero ETA outright), and `message` matched against the substring **"at this rate"** — §1.4 already called that hedge "a testable invariant", and now something tests it.

Fourteen must-reject cases, each verified to fail on the **intended** keyword rather than incidentally. Two of them are #219's headline stated in both directions, because they fail differently: both non-null makes two consumers of the same bytes disagree about whether a queue is about to cross; both null leaves one with nothing to render and no way to know why.

## What it deliberately does not constrain

- **`secondsToThreshold <= 1800`** — the horizon is `thresholds.json` config and hot-reloadable; pinning it would make a config change a contract violation
- **`baselineValue` pinned to 0** — that is today's config, not the contract. Left a plain number so the schema does not fail the moment a reference baseline is removed, which is the change that would make §4.3 true again
- **`metric`, `Projection.basis`, `findingType`** stay open strings. Only `Threshold.basis` is closed, because it names which of two arms of one gate won and a third value would mean the arithmetic changed
- **the alphabetical sort and one-entry-per-host** — draft-07 cannot express either over object items, so both stay prose checked by the samples
- **`host` is not `$ref`'d to `healthscan.schema.json`'s `Host.host`** — §1 says they are the same *string*, which is an equal value rather than a shared type

## Timestamps are not pinned, unlike every other captured sample here

`investigation-response.json` and the resolve captures pin ids and timestamps so the fixtures do not move. These three do not: there are no ids in this payload, and the timestamps are load-bearing arithmetic. `projectedCrossingAt` must equal `measuredAt + secondsToThreshold`, the one cross-field invariant draft-07 cannot express — `17:54:47Z + 164 s = 17:57:31Z` in `earlywarning-response.json` is the only check on it, and rewriting them would delete it.

## Verified

```
contracts $ npm run validate
      2 annotated, 0 unannotated  healthscan-api.md
      3 annotated, 0 unannotated  proxy-api.md
      5 annotated, 4 unannotated  investigation-api.md
      3 annotated, 0 unannotated  earlywarning-api.md      <- was 0 annotated, 3 unannotated
      8 annotated, 7 unannotated  resolve-api.md

all checks passed (10 samples, 19 accept, 54 reject, 7 capture claims, 21 prose fences)
```

```
services/detection-engine $ npm test
ℹ tests 447   ℹ pass 447   ℹ fail 0
```

No engine or dashboard source changed; nothing the product emits was altered. The `CONTRACT_MD` comment in `validate.mjs` that said this file "has no schema at all" is corrected, and so are the two places in `README.md` that said the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
