### PR TITLE
fix(detection-engine): the two reset routes refused a bodyless request — the one thing their comments said must not happen

### DIFF
--- a/services/detection-engine/CLAUDE.md
+++ b/services/detection-engine/CLAUDE.md
@@ -163,7 +163,26 @@ Non-negotiable behaviours:
 
 **A reference baseline exempts a host+metric.** `thresholds.json` `referenceBaselines` states a
 normal that does not move; where one exists it wins over the rolling mean, and self-inflation
-cannot occur for that pair. Currently only `Cloud API` / `queued`, set to `0`.
+cannot occur for that pair. **Nine pairs since 2026-08-23** — all three reported hosts ×
+`queued`, `avgQueueingTime`, `avgProcessingTime` — not the single `Cloud API` / `queued` entry this
+line claimed until 2026-09-01. `thresholds.json`'s `_comment_referenceBaselines_extended` carries
+the values and the reason: the one pair covered `queue_buildup`'s ramp and left every other
+comparative metric self-inflating, which showed up live as `growing_queue_wait` going CRITICAL and
+then falling back to WARNING while the wait was still growing. Read the values there rather than
+here — a copied list is what went stale in the first place.
+
+Two consequences of the extension worth knowing before shrinking it back:
+
+- **`queued: 0` on `Cloud API` is what makes `queue_buildup` able to fire on a ramp at all.** The
+  `2n/(n+1)` closed form below is why. Removing an entry reopens a measured defect, not a
+  theoretical one.
+- **It makes Early Warning's `warming` state unreachable** for every host the endpoint reports, since
+  `effectiveBaseline()` returns the reference *instead of* the rolling mean and so is non-null on the
+  first poll — `insufficient_samples` covers the whole warm-up instead. `_comment_referenceBaselines`
+  predicted this ("skips the warm-up wait … a side effect rather than a feature") without following it
+  through to the contract, so `earlywarning-api.md` §4.2 still documents `warming` at the instant the
+  live stack returns `insufficient_samples`. Filed as #228; whether the prose or the config changes is
+  the open question there.
 
 **`messagesPerSec` is exempt everywhere, because its baseline is a MEDIAN, not a mean.**
 `ROBUST_METRICS` in `baseline/window.ts` carries the full argument and the measurements; the short

--- a/services/detection-engine/src/api/server.ts
+++ b/services/detection-engine/src/api/server.ts
@@ -135,6 +135,37 @@ const POST_PATHS = new Set([
 ]);
 
 /**
+ * POST routes whose body is discarded without being read.
+ *
+ * BOTH HANDLERS ALREADY CLAIMED THIS and neither got it: they take a zero-argument callback, so the
+ * body was never looked at -- but every POST went through `readJsonBody` first, so an ABSENT body
+ * was refused with `400 bad request: empty body` before the handler was reached. Measured on the
+ * live stack while the queue was climbing:
+ *
+ *     curl -XPOST -H 'Origin: http://localhost:5173' localhost:3002/api/demo/reset
+ *     -> HTTP 400  {"error":"bad request: empty body"}
+ *
+ * That is exactly the case the comments below say must not happen. It stayed hidden because every
+ * caller in the repo sends `{}` -- `liveClient.ts` posts an empty object, and `docs/demo/cue-sheet.md`
+ * spells out `-d '{}'` in all four of its reset commands -- so the workaround was written into the
+ * callers instead of the defect being noticed. An operator typing the obvious command gets the 400,
+ * during the one operation that exists to recover from the others.
+ *
+ * MALFORMED, NOT JUST EMPTY. These routes now skip parsing entirely rather than tolerating `''` and
+ * still rejecting `{`: "must not be refusable on a malformed request" is the stated property, and
+ * unparseable JSON is the malformed case. There is nothing to be strict about -- no field of the
+ * body reaches any code path, so refusing it buys no safety and costs the recovery path.
+ *
+ * NOT A GENERAL POLICY. Only these two. `/api/investigate` and `/api/resolve` are strict about their
+ * bodies on purpose (see `readFindingId`), and this set is deliberately a whitelist so adding a
+ * route to it is a visible decision.
+ */
+const BODYLESS_POST_PATHS = new Set([
+  '/api/demo/reset',
+  '/api/settings/thresholds/reset',
+]);
+
+/**
  * Origins permitted to POST — the fix for `resolve-api.md` §13.2's confused deputy.
  *
  * THE PROBLEM, MEASURED rather than reasoned about. `Access-Control-Allow-Origin: *` on a write
@@ -260,7 +291,9 @@ export function createFindingsServer(options: ServerOptions): Server {
               : path === '/api/settings/thresholds/reset'
                 ? // Takes no body, ignored rather than validated -- the same reasoning as
                   // /api/demo/reset below: reset recovers from every other operation and must not
-                  // be refusable on a malformed request.
+                  // be refusable on a malformed request. Enforced by BODYLESS_POST_PATHS, not by
+                  // this callback taking no argument -- that is the distinction this comment got
+                  // wrong for as long as it existed.
                   options.resetSettings === undefined
                   ? undefined
                   : async () => options.resetSettings!()
@@ -269,7 +302,8 @@ export function createFindingsServer(options: ServerOptions): Server {
             : path === '/api/demo/reset'
               ? // Takes no body. Ignoring it rather than validating an empty object: reset is the
                 // operation that recovers from every other one, and it must not be refusable on a
-                // malformed request.
+                // malformed request. See BODYLESS_POST_PATHS -- ignoring the body is that set's job,
+                // and until it existed the request never reached here without one.
                 options.resetTriggers === undefined
                 ? undefined
                 : async () => options.resetTriggers!()
@@ -303,9 +337,11 @@ export function createFindingsServer(options: ServerOptions): Server {
         return;
       }
 
-      readJsonBody(req)
-        .then(async (body) => {
-          const result = await handler(body);
+      // The body is drained either way; whether it is PARSED is the route's decision.
+      const bodyless = BODYLESS_POST_PATHS.has(path);
+      drainBody(req)
+        .then(async (raw) => {
+          const result = await handler(bodyless ? undefined : parseJsonBody(raw));
           sendJson(res, 200, result, options.snapshot().state);
         })
         .catch((err: unknown) => {
@@ -471,7 +507,17 @@ function sendJson(
  * larger is a mistake or an attack, and an uncapped read is an unbounded allocation on a public
  * port. Rejecting is the honest response rather than buffering whatever arrives.
  */
-async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+/**
+ * Drain the request body to a string, capped.
+ *
+ * SPLIT FROM PARSING so the two bodyless routes can be drained without being judged. The cap stays
+ * on this side of the split for both: it is a resource guard, not validation, and a route that
+ * ignores its body still must not buffer 100 MB of it.
+ *
+ * The stream is drained even when the content is discarded -- an undrained request can leave the
+ * socket unusable for keep-alive, which would turn "reset ignores the body" into a hang.
+ */
+async function drainBody(req: IncomingMessage): Promise<string> {
   const MAX = 64 * 1024;
   const chunks: Buffer[] = [];
   let size = 0;
@@ -481,7 +527,10 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
     if (size > MAX) throw new Error('bad request: body exceeds 64 KB');
     chunks.push(buf);
   }
-  const raw = Buffer.concat(chunks).toString('utf8');
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseJsonBody(raw: string): unknown {
   if (raw.trim() === '') throw new Error('bad request: empty body');
   try {
     return JSON.parse(raw);

--- a/services/detection-engine/test/api.test.ts
+++ b/services/detection-engine/test/api.test.ts
@@ -380,3 +380,142 @@ describe('/api/earlywarning publishes no bare slope (earlywarning-api.md §1.4)'
     assert.equal(row.recentDirection, 'falling');
   });
 });
+
+/*
+ * THE TWO RESET ROUTES TAKE NO BODY, and until 2026-09-01 both refused a request without one.
+ *
+ * Their handler comments have said "takes no body, ignored rather than validated -- reset recovers
+ * from every other operation and must not be refusable on a malformed request" since they were
+ * written, and the callbacks genuinely take no argument. But every POST went through the body reader
+ * first, so an absent body was a `400 bad request: empty body` before any handler ran:
+ *
+ *     curl -XPOST -H 'Origin: http://localhost:5173' localhost:3002/api/demo/reset
+ *     -> HTTP 400  {"error":"bad request: empty body"}
+ *
+ * No test caught it because no test asked. Every caller in the repo sends `{}` -- `liveClient.ts`
+ * posts an empty object and `docs/demo/cue-sheet.md` spells out `-d '{}'` in all four reset commands
+ * -- so the workaround lived in the callers and the route was never exercised the obvious way. That
+ * is the shape worth remembering: a property asserted in a comment, contradicted two hundred lines
+ * below it, with the callers papering over the difference.
+ *
+ * Both routes are covered here rather than one, because they shared the defect for the same reason
+ * and a fix that reached only `/api/demo/reset` would look complete.
+ */
+describe('the reset routes are not refusable (BODYLESS_POST_PATHS)', () => {
+  let resets = 0;
+  const withResets = createFindingsServer({
+    port: 0,
+    snapshot: () => snapshot,
+    log: () => {},
+    resetTriggers: async () => {
+      resets += 1;
+      return { outcome: 'reset', armed: [] };
+    },
+    resetSettings: () => {
+      resets += 1;
+      return { outcome: 'reset' };
+    },
+    // Wired so the "unchanged" test below has a real strict route to POST to. Without it that
+    // route answers 503 before the body is read, and the assertion would pass without testing
+    // anything -- which is how this whole class of defect stayed invisible.
+    applySettings: (body: unknown) => ({ outcome: 'applied', echo: body }),
+  });
+  let resetBase = '';
+
+  before(async () => {
+    await new Promise<void>((done) => withResets.listen(0, done));
+    resetBase = `http://127.0.0.1:${(withResets.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((done) => withResets.close(() => done()));
+  });
+
+  const PATHS = ['/api/demo/reset', '/api/settings/thresholds/reset'];
+
+  // No `body`, no `Content-Type` -- exactly what `curl -XPOST <url>` sends, which is what an operator
+  // types when the queue is climbing and the cue sheet is not open.
+  it('accepts a request with NO body at all', async () => {
+    for (const path of PATHS) {
+      const before = resets;
+      const res = await fetch(`${resetBase}${path}`, { method: 'POST' });
+      assert.equal(res.status, 200, `${path} must not refuse a bodyless POST`);
+      assert.equal((await res.json() as { outcome: string }).outcome, 'reset');
+      assert.equal(resets, before + 1, `${path} must actually reset, not just answer 200`);
+    }
+  });
+
+  it('accepts MALFORMED JSON too — that is the stated property, not just "empty"', async () => {
+    // "Must not be refusable on a malformed request" is what the comments claim, and unparseable
+    // JSON is the malformed case. Tolerating `''` while still rejecting `{` would satisfy the letter
+    // of the empty-body fix and leave the property untrue.
+    for (const path of PATHS) {
+      const res = await fetch(`${resetBase}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{ this is not json',
+      });
+      assert.equal(res.status, 200, `${path} must discard a malformed body rather than judge it`);
+    }
+  });
+
+  it('still accepts the `{}` every existing caller sends', async () => {
+    // The regression direction. `liveClient.ts` and the cue sheet both post `{}`; a fix that made
+    // the bodyless case work by rejecting a body would break the shipped dashboard control.
+    for (const path of PATHS) {
+      const res = await fetch(`${resetBase}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      assert.equal(res.status, 200, `${path} must keep working for the callers that send {}`);
+    }
+  });
+
+  it('the origin allow-list and the body cap still apply', async () => {
+    // Bodyless does not mean unguarded. The origin check runs before routing, and the 64 KB cap is a
+    // resource guard rather than validation -- a route that ignores its body still must not buffer
+    // an unbounded one.
+    for (const path of PATHS) {
+      const foreign = await fetch(`${resetBase}${path}`, {
+        method: 'POST',
+        headers: { Origin: 'https://evil.example.com' },
+      });
+      assert.equal(foreign.status, 403, `${path} must still refuse a foreign origin`);
+
+      const huge = await fetch(`${resetBase}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'x'.repeat(65 * 1024),
+      });
+      assert.equal(huge.status, 400, `${path} must still cap the body`);
+      assert.match((await huge.json() as { error: string }).error, /exceeds 64 KB/);
+    }
+  });
+
+  it('the strict routes are UNCHANGED — this is a whitelist, not a policy', async () => {
+    // The settings WRITE sits one path segment away from the settings RESET, so it is the route a
+    // too-broad match would have caught. It must still refuse a bodyless POST: there is no sensible
+    // "apply nothing", and silently applying `undefined` is worse than a 400.
+    const bodyless = await fetch(`${resetBase}/api/settings/thresholds`, { method: 'POST' });
+    assert.equal(bodyless.status, 400, 'the settings write must still require a body');
+    assert.match((await bodyless.json() as { error: string }).error, /empty body/);
+
+    const malformed = await fetch(`${resetBase}/api/settings/thresholds`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ nope',
+    });
+    assert.equal(malformed.status, 400, 'and must still refuse unparseable JSON');
+    assert.match((await malformed.json() as { error: string }).error, /not valid JSON/);
+
+    // With a real body it goes through, so the two assertions above are about the body and not about
+    // the route being broken.
+    const ok = await fetch(`${resetBase}/api/settings/thresholds`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"values":{}}',
+    });
+    assert.equal(ok.status, 200);
+  });
+});


### PR DESCRIPTION
Two independent fixes found while writing `earlywarning.schema.json` (#219), both inside `services/detection-engine/**`.

## 1. `POST /api/demo/reset` and `POST /api/settings/thresholds/reset` refused a request with no body

Both take no body, and both handler comments have said so since they were written:

> Takes no body. Ignoring it rather than validating an empty object: reset is the operation that recovers from every other one, and it must not be refusable on a malformed request.

The callbacks do take no argument. But every POST went through `readJsonBody` before routing reached the handler, so an **absent** body was refused two hundred lines above the comment claiming it could not be. Reproduced on the running stack against the shipped image, both routes:

```
curl -XPOST -H 'Origin: http://localhost:5173' localhost:3002/api/demo/reset
-> HTTP 400  {"error":"bad request: empty body"}

curl -XPOST -H 'Origin: http://localhost:5173' localhost:3002/api/settings/thresholds/reset
-> HTTP 400  {"error":"bad request: empty body"}
```

**Why it stayed invisible: every caller in the repo sends `{}`.** `apps/dashboard/src/api/liveClient.ts:283` posts an empty object, and `docs/demo/cue-sheet.md` spells out `-d '{}'` in all four of its reset commands. The workaround was written into the callers instead of the defect being noticed, so no test ever asked the question — the operator who types the obvious command is the only one who meets it, during the operation that exists to recover from the others.

**The fix.** `readJsonBody` splits in two: `drainBody` (the 64 KB cap — a resource guard rather than validation, so it stays on every route) and `parseJsonBody` (which the two reset routes skip). Malformed JSON is discarded too, not only an empty body: *"must not be refusable on a malformed request"* is the stated property and `{` is the malformed case, and no field of these bodies reaches any code path, so refusing one buys no safety and costs the recovery path. The stream is still drained when the content is discarded — an undrained request can leave the socket unusable for keep-alive, which would turn "reset ignores the body" into a hang.

`BODYLESS_POST_PATHS` is **a whitelist of two, not a default.** `/api/investigate` and `/api/resolve` are strict on purpose (`readFindingId` is the structural half of the data boundary), and `/api/settings/thresholds` — one path segment from the reset it pairs with, so the route a too-broad match would have caught — must still refuse an empty body rather than apply `undefined`.

**Five tests.** Two fail without the change, verified by reverting `src/` alone and re-running (`pass 29 / fail 2`). Three pin the regression directions a narrower fix would break: `{}` keeps working, the origin allow-list and the body cap still apply, and the settings write still requires a parseable body. That last one wires `applySettings` deliberately — against an unwired route it answers 503 *before* the body is read, and the assertion would have passed without testing anything, which is the same shape as the defect itself.

## 2. `CLAUDE.md` §5.1 said there was one reference baseline; there are nine

`referenceBaselines` went from one pair to nine on 2026-08-23 (three hosts × `queued`, `avgQueueingTime`, `avgProcessingTime`) and §5.1 kept reading *"Currently only `Cloud API` / `queued`, set to `0`."* Not cosmetic: that is the sentence that makes the blast radius of shrinking the set look nine times smaller than it is.

Points at `thresholds.json`'s `_comment_referenceBaselines_extended` for the values rather than copying them, per root `CLAUDE.md` §6 — a copied list is what went stale in the first place. Records the two consequences a reader needs before touching the set: `queued: 0` on `Cloud API` is what makes `queue_buildup` able to fire on a ramp at all, and the extension is what makes Early Warning's `warming` state unreachable for every reported host. The second is #228 and stays open there; only the count is corrected here.

## Verification

- engine suite **452/452** (447 was the floor on `main`; the five new tests are the difference)
- `tsc --noEmit` clean
- the pre-fix 400 reproduced on the live stack, and **nothing was reset by doing so** — a refused request changes no state, so the demo stack's current condition is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)