### PR TITLE
fix(dashboard): beyond_horizon had no sentence, so Early Warning went blank mid-ramp

### DIFF
--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -34,7 +34,25 @@
  * healthy host, and a row saying "no projection available" on every card would make the grid
  * unreadable for information nobody needs. `warming` and `insufficient_samples` render because they
  * mean "ask again shortly" rather than "nothing is coming". `not_rising` renders too — see
- * `SHOWN_REASONS` for why that changed, and why it is the only one that earns an icon.
+ * `REASON_SENTENCES` for why that changed, and why it is the only one that earns an icon.
+ *
+ * AND `beyond_horizon` RENDERS, WHICH IS THE THIRD TIME THIS FILE HAS LEARNED THE SAME THING. It had
+ * no entry in the sentence map, so the row vanished for the 20 seconds it is returned — measured on
+ * the live stack, `pool_bottleneck`, engine polls at `q=4,7,14,17`: the queue is *visibly climbing*
+ * and the panel is blank, between "Watching" and the forecast. Reported as "the early warning is not
+ * shown and then after a while it shows warning/rising. why is there a time that nothing is
+ * displayed?" (@Ari-Glikman). The blank is 20s against a forecast that lasts 25s, so the module is
+ * absent for nearly half the window it exists for.
+ *
+ * The reason it was missed three times is that the map was a `Record<string, string>`, which accepts
+ * any subset of the reasons in silence. It is now `Record<ProjectionDeclineReason, string | null>`, so
+ * a reason with no sentence is a **compile error** and choosing silence has to be written down as an
+ * explicit `null`. Same move as `validate-architecture.mjs`'s header describes for coordinates: a
+ * missing one was made impossible rather than documented.
+ *
+ * Note the engine does NOT publish the slope on this row — `earlywarning-api.md` §1.4 forbids a slope
+ * outside `projection`, and a decline has no `projection` — so the sentence is qualitative. The rate
+ * is withheld by the contract, not lost.
  *
  * ONE REASON CARRIES AN ICON, AND ONLY ONE. `not_rising` is the sole state whose whole content is
  * reassurance, so a tick makes it readable at a glance instead of as a line of grey text among five
@@ -47,19 +65,13 @@
  * `svg()` wrapper; the sentence beside it stays the authoritative statement (§7.3).
  */
 
-import type { HostProjectionView, RecentDirection } from '../types/mvp2';
+import type { HostProjectionView, ProjectionDeclineReason, RecentDirection } from '../types/mvp2';
 import { IconWatching } from './icons';
 
 export interface EarlyWarningProps {
   projection: HostProjectionView | null;
 }
 
-/**
- * The reasons worth a row, and what each says.
- *
- * `already_crossed` is the one that earns its place by NOT being a forecast: it marks the module as
- * present and watching after the window has closed. The other two mean "ask again shortly".
- */
 /**
  * `already_crossed`, by which way the queue is actually moving (§1.5, #174).
  *
@@ -83,10 +95,32 @@ const CROSSED_BY_DIRECTION: Record<RecentDirection, string> = {
   steady: 'Threshold reached — holding steady; see the finding below',
 };
 
-const SHOWN_REASONS: Record<string, string> = {
+/**
+ * Every decline reason's sentence, or `null` for the two that stay silent.
+ *
+ * TOTAL OVER THE UNION, which is the whole point. This was `Record<string, string>` holding only the
+ * reasons that speak, and a partial map of a closed union is a blank row waiting to happen — it
+ * happened three times (see the file header). Now `tsc` fails when `ProjectionDeclineReason` gains a
+ * member, and choosing silence means writing `null` next to it rather than leaving it out.
+ *
+ * `disabled` and `metric_unmeasurable` are the two nulls, and they are steady states on a host nothing
+ * is happening to: Early Warning is off, or the host reports no `queued` at all (contract Q13 — null
+ * is "not measurable", never zero). A row per card saying so is noise on every poll forever.
+ */
+const REASON_SENTENCES: Record<ProjectionDeclineReason, string | null> = {
+  disabled: null,
+  metric_unmeasurable: null,
   warming: 'Baseline still warming — no projection yet',
   insufficient_samples: 'Not enough samples yet for a projection',
   already_crossed: 'Threshold reached — see the finding below',
+  /*
+   * Rising, but the crossing is further out than the engine's horizon (30 min on the shipped
+   * config), so it declines to name a time. That is a real, transient state in the middle of a ramp
+   * — it is what the first four polls of a queue build look like — and it is exactly when an
+   * operator is watching the card. The rate is not available to say (§1.4, see the header), so this
+   * says the direction and the reason there is no ETA, and nothing it cannot support.
+   */
+  beyond_horizon: 'Rising — a crossing is beyond the projection horizon',
   /*
    * `not_rising` was silent, and that made the module INVISIBLE on a healthy production — which is
    * every demo before a trigger is armed, and is what "I don't see the early warning" meant
@@ -139,16 +173,18 @@ export function EarlyWarning({ projection }: EarlyWarningProps): JSX.Element | n
 
   if (forecast === null) {
     /* `already_crossed` is the one reason whose sentence depends on a second field, so it is resolved
-       here rather than by widening SHOWN_REASONS into a nested map that three other reasons would
+       here rather than by widening REASON_SENTENCES into a nested map that the other reasons would
        carry a null key for. */
     const direction = projection.recentDirection;
     const shown =
       reason === 'already_crossed' && direction !== null
         ? CROSSED_BY_DIRECTION[direction]
         : reason === null
-          ? undefined
-          : SHOWN_REASONS[reason];
-    if (shown === undefined) return null;
+          ? null
+          : REASON_SENTENCES[reason];
+    /* Null covers both "the engine declined for no stated reason" and the two reasons that are
+       deliberately silent. Neither renders, and REASON_SENTENCES is where the second is argued. */
+    if (shown === null) return null;
     /* `already_crossed` reads as spent rather than pending -- it is not waiting for anything, it is
        reporting that the thing it was watching for has happened. The other two are genuinely
        "not yet", so they keep the muted pending styling. */


### PR DESCRIPTION
Symptom 1 of three reported from a `pool_bottleneck` demo run:

> the early warning is not shown and then after a while it shows warning/rising. **why is there a time that nothing is displayed?**

Confirmed, root-caused, and fixed. Dashboard only — no contract change is possible or needed.

## What the operator saw

Measured on the live stack, engine polling at 5 s:

```
q=0             "Watching — not trending toward a threshold"
q=4,7,14,17     (nothing at all)                              <- 20s blank, queue climbing
q=24            "queued rising ~1.2/min · projected to cross 50 in ~22 min"
q=54            "Threshold reached and still rising"
```

The forecast-with-an-ETA state lasts ~25 s on this scenario. **The blank was 20 s**, so the module was invisible for nearly half the window it exists for — during the part of the ramp an operator is most likely to be looking at the card.

## Root cause

Those four polls return `projectionUnavailable: 'beyond_horizon'` — genuinely rising, but the projected crossing is further out than the 30 min horizon, so the engine declines to name a time. `beyond_horizon` had **no entry in `SHOWN_REASONS`**, so `SHOWN_REASONS[reason]` was `undefined` and the component hit `if (shown === undefined) return null`.

The row's own type doc already stated the rule this violated: *"Rendering the reason rather than hiding the row is the point … a blank space means neither."*

## Why the fix has to be here

`contracts/earlywarning.schema.json` makes `Projection.secondsToThreshold` **required** and `exclusiveMinimum: 0`, and `earlywarning-api.md` §1.4 forbids a slope outside `projection`. So the engine has no way to publish "rising ~1.2/min, crossing beyond the horizon" — the rate is withheld by the contract, not lost. Only the panel can say it, and only qualitatively, which is why the new sentence names the direction and the reason there is no ETA and nothing more.

(The `eta === null` branch further down the component is dead code written against an imagined engine that could do this. Left alone — `mvp2Guards.ts` reaches it defensively.)

## The structural half — this was the third instance

`already_crossed` was hidden and had to be given a sentence. `not_rising` was hidden and had to be given a sentence. Now `beyond_horizon`. Same defect, three times, and the cause is the type:

```ts
const SHOWN_REASONS: Record<string, string> = { ... }   // accepts any subset, silently
```

A partial map over a closed union is a blank row waiting to happen. It is now:

```ts
const REASON_SENTENCES: Record<ProjectionDeclineReason, string | null> = {
  disabled: null,              // steady state on a host nothing is happening to
  metric_unmeasurable: null,   // ditto — contract Q13
  ...
};
```

Total over the union, so **a new decline reason fails `tsc` until someone decides**, and deciding to stay silent means writing `null` with the argument beside it rather than leaving the key out. Same move `tools/validate-architecture.mjs` describes for coordinates: make the omission impossible instead of documenting it.

The bail-out now rejects `null` as well as `undefined`, so deliberate silence and "no reason given" take the same path.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `validate-architecture.mjs` | `ok (8 labels and 12 paths, no overlaps, all within the viewBox)` |
| `validate-fixtures.mjs` | all 8 fixtures match the published contract |
| Image build (§6.1) | `docker compose up -d --build dashboard` succeeded; sentence confirmed present in `/usr/share/nginx/html/index.html` |
| Live re-run | `beyond_horizon` at `q=7` now renders instead of blanking |

Note the host `vite build` cannot run in this checkout at all — `node_modules` is a Linux install (POSIX symlinks in `.bin`, missing rollup native binary) — so verification went through the image, which installs its own deps and is the build that ships anyway.

## Not in this PR

- Symptom 2 (Early Warning says "rising" on the way down) — separate PR, engine + contract
- Symptom 3 (`avgQueueingTime` non-zero at `queued: 0`) — a product decision, evidence added to #210
- #233 — `projection.crossesAt` is always null, found while reading the guard for this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
