### PR TITLE
fix(engine): the tail fit lagged 60s, so a draining queue got a forecast of a crossing that was never coming

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,55 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-02 — `earlywarning-api.md` §1.5 / §2.2.1: the tail fit is 15% of the window (45 s), not 40% (120 s) — a draining queue was getting a forecast
+
+**Behaviour change, not documentation.** `RECENT_FIT_FRACTION` in
+`services/detection-engine/src/detect/earlywarning.ts` goes `0.4 -> 0.15`, and the contract prose that
+stated the old length changes with it. Both are in one PR on purpose: the tail length is observable
+through `recentDirection` and through *when* a projection is withheld, so a merge that landed one
+without the other would leave the ratified contract describing something the engine does not do.
+
+### What was wrong
+
+The tail fit gates the projection (§2.2.1) and, since #174, is also published as `recentDirection`
+(§1.5). A least-squares fit lags a turnover by roughly half its length, so the 120 s tail lagged ~60 s.
+Measured on the live stack — `pool_bottleneck`, approved `set_pool_size 1 -> 4`, queue 78 -> 0 in 50 s
+at the shipped 5 s engine poll — the panel was wrong for 40 s of a 50 s recovery:
+
+| Polls | Queue | Published | Wrong because |
+|---|---|---|---|
+| 3 (15 s) | 69, 61, 50 | `already_crossed`, `recentDirection: rising` | the queue was falling |
+| 5 (25 s) | 42 -> 2 | `slope: 13.0`, `secondsToThreshold` **growing** 37 -> 93 -> 131 -> 192 -> 243 s | a forecast of a crossing that was never coming |
+
+The second row is the serious half and is a §1.2 / §1.4 violation in substance: a projection published
+about a condition that was already being fixed. Once a draining queue falls back **under** its
+threshold, `already_crossed` no longer answers first and the direction gate is the only thing left.
+
+### Why 0.15
+
+Replaying the captured series against each candidate: `0.4` -> 40 s wrong; `0.2` -> 20 s, one bogus
+forecast poll surviving; **`0.15` -> 15 s, no bogus forecast**; `0.1` -> 10 s, none. Neither 0.15 nor
+0.1 shortens the genuine forecast window by a single poll, so this costs no coverage; 0.15 keeps the
+larger sample margin (9 samples at the shipped poll, against a tail minimum of 2).
+
+**The old justification was retired by measurement, not by opinion.** It held that a 120 s tail was
+needed so "one bursty poll cannot flip its sign". Tested on a rising queue with jitter of ±0, ±3, ±6
+and ±10 items per poll, tails of 120 s, 60 s, 45 s and 30 s withheld **exactly the same number of
+forecasts**. There was no flap to trade the 60 s of lag against.
+
+### What a consumer must still not assume
+
+`recentDirection` still lags, now by ~20 s rather than ~60 s, and §1.5's rule is unchanged: it supports
+a "coming down" claim and never a "recovered" one. The **residual 15 s** above — a queue draining while
+still at or above its threshold, reported as `rising` — is *not* closed by this change and is called out
+in both §1.5 and §2.2.1. Closing it needs a retreat-from-peak test rather than a shorter fit, which is
+a new mechanism and deliberately out of this change.
+
+No schema change: `earlywarning.schema.json` never encoded the tail length, and no field's type,
+nullability or range moves. `recentDirection` keeps the same three values and the same `null` rule.
+
+---
+
 ## 2026-09-01 — `mcp-tools.md` §3.6: the `set_pool_size` output table described a tool that never shipped — six of nine fields did not exist
 
 **#218 items 2 and 3. Documentation only — `Tools/Resolve.cls` is unchanged, and it was never the

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -58,8 +58,8 @@ export interface HostProjection {
   /** Seconds from the first to the last sample in the fit window. 0 when fitSampleCount < 2. */
   fitSpanSeconds: number;
   /**
-   * Which way the metric is moving RIGHT NOW: the sign of the tail fit (§2.2.1's most
-   * recent 40%). MEASURED, not forecast — it describes the recent past, never the
+   * Which way the metric is moving RIGHT NOW: the sign of the tail fit (§2.2.1's
+   * tail). MEASURED, not forecast — it describes the recent past, never the
    * future. null when the tail cannot be fitted. See §1.5.
    */
   recentDirection: RecentDirection | null;
@@ -222,8 +222,8 @@ Re-render from the served number on each poll and let it jump.
 
 ### 1.5 `recentDirection` — which way it is moving now, and why it is a sign rather than a slope
 
-`recentDirection` is the **sign of the tail fit**: the same most-recent-40% fit §2.2.1 already runs,
-reported rather than only tested.
+`recentDirection` is the **sign of the tail fit**: the same tail fit §2.2.1 already runs, reported
+rather than only tested. §2.2.1 states the tail length; it is not restated here.
 
 | Value | Means |
 |---|---|
@@ -263,17 +263,27 @@ direction the whole time and published nothing that let a reader tell.
 does **not** hold: `rising` with `projection: null` is normal and means over the threshold already,
 beyond the horizon, or the defensive decline at the end of §2.2.1.
 
-**It LAGS a turn, by design, and a consumer must not read it as instantaneous.** The tail is a
-120 s least-squares fit, so the sign changes only once enough of the tail has turned — not on the
-first sample that moves the other way. Measured on the live stack: a queue peaked at 151 and began
-draining immediately; `recentDirection` reported `rising` for a further **~35 seconds** and 46
-messages of real drain before flipping to `falling`.
+**It LAGS a turn, and a consumer must not read it as instantaneous.** The tail is a least-squares fit,
+so its sign changes only once enough of the tail has turned — not on the first sample that moves the
+other way — and the lag is roughly **half the tail length** (§2.2.1). At the shipped tail that is
+~20 s. On a queue depth series captured live — peaked at 78, drained to 0 in 50 s after an approved
+`set_pool_size 1 -> 4` — the shipped fit replayed over it reports `rising` for a further **15 seconds**
+and 28 messages of real drain (78 -> 50) before flipping to `falling`. The series is measured; the
+direction sequence at this tail length is a deterministic replay of that series, since the live run
+that produced it was still on the 120 s tail.
 
-That is the intended trade and the same one §2.2.1 already makes for the gate — the 40% tail is
-chosen so "one bursty poll cannot flip its sign". A field that reacted within a poll would flap on
-every jitter, and a flapping direction beside a critical finding is worse than a slow one. So it
-answers "which way has this been going" rather than "which way did it move just now", and **a
-consumer must not build a "recovered" claim on it** — only a "coming down" one.
+**The tail was shortened from 120 s to 45 s for this field's sake** (see §2.2.1, and the engine's
+`RECENT_FIT_FRACTION` for the full measurement). At 120 s the lag was ~60 s, measured at ~35 s on one
+run and 40 s on another, and the trade was previously defended here on the grounds that the longer
+tail meant "one bursty poll cannot flip its sign". **That defence did not survive being measured**: on
+a rising queue with jitter of ±0, ±3, ±6 and ±10 items per poll, a 120 s, 60 s, 45 s and 30 s tail
+withheld exactly the same number of forecasts. There was no flap to trade against, and the 60 s lag
+was buying nothing.
+
+What the lag still costs, and what a consumer must therefore not do: a queue that has turned over
+reports `rising` for its first few polls of decline. So this field answers "which way has this been
+going" rather than "which way did it move just now", and **a consumer must not build a "recovered"
+claim on it** — only a "coming down" one. `null` likewise is not "steady".
 
 **Rendering requirement for Dev C:** where a reason is rendered for a crossed threshold, the
 direction must distinguish recovering from still-rising. `null` is not "steady" — it means unknown,
@@ -296,7 +306,7 @@ Never invent a number here; there is a reason code for every case instead.
 | `warming` | No rolling baseline yet, so **no threshold exists to project toward**. Fewer than `minBaselineSamples` (12) in the 1800 s baseline window | `null` | `—`, plus the warming affordance |
 | `insufficient_samples` | Baseline is warm, but the 300 s fit window holds fewer than **12** samples — a newly appeared host, or a gap in polling | non-null | `—` |
 | `already_crossed` | `currentValue >= threshold.value`. There is no time remaining to forecast; the `queue_buildup` finding is the thing to render | non-null | defer to the finding, **and read `recentDirection`** — a crossed queue that is `falling` is recovering, and must not read the same as one that is `rising` (§1.5) |
-| `not_rising` | **Either** fit is `<= 0` after rounding to 1 decimal — the 300 s window, **or its most recent 40%**. Flat, draining, levelled off, or turned over — nothing is approaching anything. See §2.2.1 | non-null | nothing, or a neutral "steady" |
+| `not_rising` | **Either** fit is `<= 0` after rounding to 1 decimal — the 300 s window, **or its tail**. Flat, draining, levelled off, or turned over — nothing is approaching anything. See §2.2.1 | non-null | nothing, or a neutral "steady" |
 | `beyond_horizon` | Rising, but the projected crossing is more than **1800 s** away | non-null | nothing |
 
 **The horizon is 1800 s because that is the baseline window.** Do not project further forward than
@@ -327,7 +337,7 @@ Otherwise: project.
 
 **A single slope over the 300 s window describes the WINDOW, not the present**, and
 `"rising ~N/min"` is a claim about the present. So step 6 fits twice and declines unless **both**
-fits are positive: once over the whole window, once over its **most recent 40%** (120 s, ~24 samples
+fits are positive: once over the whole window, once over its **most recent 15%** (45 s, ~9 samples
 at the shipped 5 s poll). Reported from a live run:
 
 > the early warning sometimes comes up when the queue pool is being drained, because it takes a
@@ -368,7 +378,24 @@ declines rather than publishing it. That state would mean the arithmetic disagre
 `secondsToThreshold: 0` is exactly the "zero reads as a measurement of now" case §1.4 forbids. A consumer needs no special handling: it is the same reason
 code with the same `null` projection.
 
-**The 40% is not configurable, deliberately.** ADR 0003 governs the numbers that decide what fires;
+**THE TAIL WAS 40% (120 s) UNTIL 2026-09-02, AND A DRAIN GOT A FORECAST BECAUSE OF IT.** The lag of a
+least-squares fit is roughly half its length, so a 120 s tail took ~60 s to change sign — and once a
+draining queue falls back **under** its threshold, this gate is the only thing between it and a
+published projection. Measured on the live stack (`pool_bottleneck`, approved `set_pool_size 1 -> 4`,
+queue 78 -> 0 in 50 s): five consecutive polls published `slope: 13.0` with `secondsToThreshold`
+*growing* 37 -> 93 -> 131 -> 192 -> 243 s, i.e. a forecast of a crossing that was never coming, while
+the fix worked. That is precisely what §1.2 and §1.4 exist to prevent, so the tail was shortened to
+the shortest length that costs nothing measured. Replaying the captured series: 40% left 25 s of
+bogus forecast, 20% left one poll of it, **15% and 10% left none**, and neither 15% nor 10% shortened
+the genuine forecast window by a single poll. The engine's `RECENT_FIT_FRACTION` carries the full
+comparison and the jitter experiment that retired the old justification.
+
+**A residual remains and is not closed by this change**: while the draining queue is still *at or
+above* its threshold, `already_crossed` answers first and the direction is the lagging tail, so ~15 s
+of a real cool-down still reads as `rising` (§1.5). Closing that needs a different mechanism — a
+retreat-from-peak test rather than a shorter fit — and is deliberately not in this change.
+
+**The fraction is not configurable, deliberately.** ADR 0003 governs the numbers that decide what fires;
 this one says how much of the series the word "now" covers, which is the definition of "rising"
 rather than a threshold for it. A fraction rather than a duration for two reasons: it can never be
 set longer than the window it is a tail of, and it inherits the existing

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -112,7 +112,7 @@ export interface HostProjection {
    * the outcome is which side of `messagesPerSec` each lands on.)
    *
    * Gated on `minFitSamples` identically to the window fit, but NOT null under identical conditions:
-   * the tail refits over the trailing 120 s, so a poll gap can leave fewer than two samples in it
+   * the tail refits over the trailing 45 s, so a poll gap can leave fewer than two samples in it
    * while the window still holds twelve. This is then null and so is `recentDirection`, which is its
    * sign. `buildTrend` declines the whole trend object in that case rather than serving a window slope
    * beside two nulls — see the third arm of its gate.
@@ -189,19 +189,47 @@ const DISCONTINUITY_FRACTION = 0.8;
  *     a fraction moves with the window and can never invert.
  *   - it inherits the reachability invariant instead of needing its own. `thresholds.json` already
  *     requires `fitWindowSeconds / poll > minFitSamples` so a projection is structurally possible
- *     (#64's failure mode); at the shipped 300s/5s that is 60 samples, of which the tail is 24. A
+ *     (#64's failure mode); at the shipped 300s/5s that is 60 samples, of which the tail is 9. A
  *     separate configurable duration would need that check duplicated, and an unreachable value
  *     would silence the module with no error — which is exactly what the existing check exists to
  *     prevent.
  *
- * 0.4 rather than something shorter: at the shipped poll the tail is 24 samples, enough that one
- * bursty poll cannot flip its sign, where the last 30s (6 samples) of a queue that drains and refills
- * would flap between projecting and not. Rather than something longer: at 0.8 the tail is nearly the
- * window and would just re-answer the same question. Note the drain only reaches this code once the
- * queue is UNDER the threshold — above it, `already_crossed` answers first — so the tail does not
- * need to react within a poll or two of the fix landing.
+ * WHY 0.15, AND WHY IT WAS 0.4. A least-squares fit lags a turnover by roughly half its length, so the
+ * tail length IS the lag. At 0.4 the tail was 120s and the lag ~60s, and the comment here argued that
+ * was harmless: "the drain only reaches this code once the queue is UNDER the threshold — above it,
+ * `already_crossed` answers first — so the tail does not need to react within a poll or two of the fix
+ * landing." That was true when written and #174 falsified it, by giving `recentDirection` a second job:
+ * it is now published on every row and picks the `already_crossed` sentence, so an operator reads the
+ * lagging tail directly.
+ *
+ * Measured on the live stack (`pool_bottleneck`, approved `set_pool_size 1 -> 4`, engine polls at 5s),
+ * the queue drained 78 -> 0 in 50s and the panel was wrong for 40s of it:
+ *
+ *     q= 69, 61, 50   "threshold reached and STILL RISING"      <- 15s, lagging tail, queue falling
+ *     q= 42 .. 2      "rising ~13.0/min, crossing in 37s"       <- 25s, and the eta GREW 37 -> 243s
+ *
+ * The second block is the serious half. Once the queue falls back under the threshold the direction
+ * gate is the only thing between a draining queue and a published forecast, and a 120s tail still said
+ * rising — so the module projected a crossing that was never coming, five polls running, while the fix
+ * worked. §1.2 and §1.4 exist to stop exactly that.
+ *
+ * 0.15 (45s, 9 samples) rather than 0.4 because it is the shortest tail that costs nothing measured.
+ * Replaying the observed series: 0.4 -> 40s wrong; 0.2 -> 20s, one bogus forecast poll left; 0.15 ->
+ * 15s, none; 0.1 -> 10s, none. Neither 0.15 nor 0.1 shortens the forecast window by a single poll, so
+ * the shorter tail buys correctness without buying silence, and 0.15 keeps the larger sample margin.
+ *
+ * Rather than shorter still: the tail is what makes "rising" mean *now*, and below ~9 samples it stops
+ * being a fit and starts being a difference. The old comment's objection to a short tail — that a queue
+ * which drains and refills would flap between projecting and not — was tested rather than reasoned
+ * about, on a +3/poll rise with jitter of ±0/±3/±6/±10 items, and 0.4, 0.2, 0.15 and 0.1 withheld
+ * exactly the same number of forecasts. It is not a cost this series can show.
+ *
+ * The residual 15s is three polls at q=69,61,50, all at or above the threshold of 50 — a queue that is
+ * genuinely still critical, described as rising when it is falling. §1.5 warns consumers the field
+ * lags, so this is within what the contract promises rather than a second defect; closing it needs a
+ * different mechanism (a retreat-from-peak test), filed separately rather than bundled here.
  */
-const RECENT_FIT_FRACTION = 0.4;
+const RECENT_FIT_FRACTION = 0.15;
 
 const FINDING_TYPE = 'queue_buildup';
 

--- a/services/detection-engine/src/detect/investigate.ts
+++ b/services/detection-engine/src/detect/investigate.ts
@@ -306,7 +306,7 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
    * agent gets one meaning for a present `trend` rather than two.
    *
    * `recentSlope` IS A THIRD ARM RATHER THAN AN IMPLIED ONE (#188), because the two fits share a
-   * sample-count gate but not their outcome: the tail refits over the trailing 120 s, so a poll gap
+   * sample-count gate but not their outcome: the tail refits over the trailing 45 s, so a poll gap
    * -- the engine records nothing while the proxy is unreachable -- can leave one sample inside it
    * while the 300 s window still holds twelve. The tail fit is then null, and so is `recentDirection`,
    * which is derived from its sign. Without this arm `trend` would carry a window slope beside two
@@ -325,7 +325,7 @@ function buildTrend(projection: HostProjection | undefined): Record<string, unkn
      * It was added when `slope` was structurally null on every investigation, as the one honest
      * signal of direction available without reopening `earlywarning-api.md` §1.4. #187 fixed the
      * slope, so this is no longer the only source — and it is kept because the two are measured over
-     * DIFFERENT spans and disagree usefully: `slope` fits the whole window, `recentDirection` the 40%
+     * DIFFERENT spans and disagree usefully: `slope` fits the whole window, `recentDirection` its short
      * tail (#174). A queue that rose for eight minutes and has been draining for two has a positive
      * `slope` and a `falling` direction, which is exactly the state the agent most needs to
      * distinguish and the one a single number flattens.

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -656,6 +656,85 @@ describe('recentDirection — which way it is moving now (§1.5)', () => {
   });
 });
 
+/**
+ * NO FORECAST WHILE THE APPROVED FIX IS WORKING — the tail length, pinned against the series it was
+ * chosen on.
+ *
+ * THE DEFECT THIS PINS is not a wrong number but a **false claim about the future**. The tail fit gates
+ * the projection, a least-squares fit lags a turnover by roughly half its length, and at the old
+ * `RECENT_FIT_FRACTION = 0.4` the tail was 120s. Once a draining queue falls back UNDER its threshold,
+ * `already_crossed` no longer answers first and that lagging tail is the only gate left — so the engine
+ * published five consecutive polls of `slope: 13.0` with `secondsToThreshold` *growing* 37 -> 243s,
+ * forecasting a crossing that was never coming, while Smart Resolve's own fix drained the queue.
+ * `earlywarning-api.md` §1.2 and §1.4 exist to prevent exactly that.
+ *
+ * The series below is CAPTURED, not composed: `pool_bottleneck` on the live stack at the shipped 5s
+ * engine poll, an approved `set_pool_size 1 -> 4`, queue 78 -> 0 in 50s. It is used because a shape
+ * invented to fail would not have shown that 0.2 still leaves one bad poll and 0.15 leaves none.
+ *
+ * Asserted as "no projection at any draining poll" rather than against a specific fraction, so the
+ * constant can be tuned further without editing an assertion — but it FAILS at 0.4 and at 0.2, which
+ * is what makes it a regression test rather than a restatement.
+ */
+describe('a draining queue is never forecast to cross (§2.2.1)', () => {
+  /* Zeros first so the window is warm and the threshold resolves to the absolute floor of 50, then the
+     measured ramp and drain. The trailing zeros are the idle tail after the queue emptied. */
+  const OBSERVED_DRAIN: readonly number[] = [
+    ...Array.from({ length: 60 }, () => 0),
+    4, 7, 14, 17, 24, 27, 34, 37, 44, 47, 54, 57, 64, 67, 74, 78,
+    69, 61, 50, 42, 30, 22, 10, 2, 0, 0,
+  ];
+  const PEAK_INDEX = OBSERVED_DRAIN.indexOf(78);
+
+  /** Every poll's verdict, projecting at each sample in turn as the engine's loop does. */
+  function walk(values: readonly number[]) {
+    const cfg = config();
+    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+    return values.map((v, i) => {
+      const at = T0 + i * POLL;
+      store.record(HOST, 'queued', v, at);
+      return { index: i, value: v, row: projectHost(HOST, raw(v), store, cfg, at) };
+    });
+  }
+
+  it('publishes no projection at any poll where the measured queue is falling', () => {
+    for (const { index, value, row } of walk(OBSERVED_DRAIN)) {
+      const previous = OBSERVED_DRAIN[index - 1] ?? value;
+      if (index <= PEAK_INDEX || value >= previous) continue;
+      assert.equal(
+        row.projection,
+        null,
+        `forecast published at q=${value} while draining from ${previous} ` +
+          `(reason=${row.projectionUnavailable}, dir=${row.recentDirection})`,
+      );
+    }
+  });
+
+  it('still forecasts the genuine ramp — the shorter tail costs no coverage', () => {
+    /* The other half of the pair. A tail short enough to kill every drain forecast could also kill the
+       real one, and then the module would be "correct" by being silent. The ramp must still produce a
+       forecast, and it must still be the accelerating one the demo shows. */
+    const forecasts = walk(OBSERVED_DRAIN)
+      .filter(({ index }) => index < PEAK_INDEX)
+      .map(({ row }) => row.projection)
+      .filter((p): p is NonNullable<typeof p> => p !== null);
+    assert.ok(forecasts.length >= 5, `expected the ramp to forecast, got ${forecasts.length} polls`);
+    const etas = forecasts.map((p) => p.secondsToThreshold);
+    assert.ok(
+      etas.every((e, i) => i === 0 || e <= (etas[i - 1] ?? e)),
+      `the ETA must tighten as the ramp approaches the threshold: ${etas.join(' -> ')}`,
+    );
+  });
+
+  it('reports falling, not rising, once the drain is under way', () => {
+    /* The direction half of the same fix. This is the field an operator reads on a crossed threshold
+       (§1.5), and it lags by design — so this asserts the LAST drain poll, not the first. */
+    const last = walk(OBSERVED_DRAIN).find(({ value }) => value === 2);
+    assert.ok(last !== undefined, 'sanity: the captured drain reaches 2');
+    assert.equal(last.row.recentDirection, 'falling');
+  });
+});
+
 /*
  * THE DEFECT THIS PINS (#187) is that the window slope was computed at step 6, BELOW the
  * `already_crossed` decline — which is the state every `queue_buildup` investigation is requested
@@ -797,12 +876,18 @@ describe('recentSlopePerMinute — the tail magnitude, for the agent only (§2.2
 
   it('DISAGREES IN SIGN with the window fit on the drain-through transient', () => {
     /* The load-bearing test of the pair. Same series, opposite answers: +26.6/min over five minutes
-       and -25.6/min over the last two. Everything else in this describe is a boundary condition;
-       this is the measurement that says the two fields are not interchangeable. */
+       and -36/min over the last 45s. Everything else in this describe is a boundary condition;
+       this is the measurement that says the two fields are not interchangeable.
+
+       The tail magnitude was -25.6 until 2026-09-02, when `RECENT_FIT_FRACTION` went 0.4 -> 0.15 to
+       stop a draining queue getting a forecast. A shorter tail on a monotonic drain is necessarily
+       STEEPER, not merely different, so the direction of this move is a check on that change rather
+       than a number to re-pin blindly: -36 is the drain's actual rate (20 per 5s poll less the fit's
+       smoothing), where -25.6 was it averaged with the tail end of the rise. */
     const p = series(riseThenDrain(150, 20));
     assert.equal(p.projectionUnavailable, 'already_crossed', 'sanity: the investigated state');
     assert.equal(p.windowSlopePerMinute, 26.6);
-    assert.equal(p.recentSlopePerMinute, -25.6);
+    assert.equal(p.recentSlopePerMinute, -36);
     assert.equal(p.recentDirection, 'falling', 'and the sign is the one already published');
   });
 

--- a/services/detection-engine/test/investigationTrend.test.ts
+++ b/services/detection-engine/test/investigationTrend.test.ts
@@ -208,20 +208,25 @@ test('trend is null when Early Warning produced no projection for the host at al
  * its magnitude is published as `trend.recentSlope` so the model can show the arithmetic it is asked
  * for.
  *
- * The fixture below is that transient: window +26.6/min, tail -25.6/min. Opposite signs from the same
+ * The fixture below is that transient: window +26.6/min, tail -36/min. Opposite signs from the same
  * series, which is why one number cannot serve both this field and the ETA.
+ *
+ * The tail read -25.6 until 2026-09-02 and the shape of the argument is unchanged. `RECENT_FIT_FRACTION`
+ * went 0.4 -> 0.15 so a draining queue stops getting a forecast, and a shorter tail on a drain is
+ * steeper — which moves this estimate FURTHER below the completion rate, i.e. further in the direction
+ * the amendment wanted. The invariant asserted below, not the constant, is what this test protects.
  */
 
 test('inboundRatePerSec is completions plus the CURRENT growth rate, not the window fit', async () => {
   const p = project(riseThenDrain(150, 20));
   const { snapshot, trend } = await requestFor(p);
   assert.equal(trend?.slope, 26.6, 'sanity: the window fit still leans up');
-  assert.equal(trend?.recentSlope, -25.6, 'sanity: the tail is falling');
+  assert.equal(trend?.recentSlope, -36, 'sanity: the tail is falling');
 
-  // 4/sec cleared with the backlog shrinking 25.6/min = 3.57/sec arriving. Via `slope` this would be
+  // 4/sec cleared with the backlog shrinking 36/min = 3.4/sec arriving. Via `slope` this would be
   // 4.44 -- above the completion rate, on a queue that is emptying. That was measured recommending
   // `4 -> 8` live, so it is the case the amendment exists for.
-  assert.equal(snapshot.inboundRatePerSec, 3.57);
+  assert.equal(snapshot.inboundRatePerSec, 3.4);
   assert.ok(
     (snapshot.inboundRatePerSec as number) < (snapshot.messagesPerSec as number),
     'a draining queue must put arrivals BELOW throughput',


### PR DESCRIPTION
Symptom 2 of three reported from a `pool_bottleneck` demo run:

> when fixing, on the way down I still see early warning **rising**, though it is for very slight period of time (when queue is decreasing).

Confirmed. The reported part is the smaller half of what was actually wrong.

## What was published while the fix worked

Live stack, `pool_bottleneck`, approved `set_pool_size 1 -> 4`, queue 78 → 0 in 50 s, engine polling at 5 s:

| Polls | Queue | Published | Why wrong |
|---|---|---|---|
| 3 (15 s) | 69, 61, 50 | `already_crossed`, `recentDirection: rising` → *"Threshold reached and still rising"* | the queue was falling |
| 5 (25 s) | 42 → 2 | `slope: 13.0`, `secondsToThreshold` **growing** 37 → 93 → 131 → 192 → 243 s | **a forecast of a crossing that was never coming** |

The second row is the serious one and it is what the report only glimpsed. **Once a draining queue falls back under its threshold, `already_crossed` stops answering first and the tail-fit direction gate is the only thing between it and a published projection.** So the module spent five consecutive polls telling an operator a threshold crossing was approaching — with a *receding* ETA, which is itself the tell — while Smart Resolve's own approved fix was emptying the queue. `earlywarning-api.md` §1.2 and §1.4 exist precisely to prevent a projection like that.

## Root cause

A least-squares fit lags a turnover by roughly **half its length**. `RECENT_FIT_FRACTION = 0.4` of the 300 s window is a 120 s tail, so the sign took ~60 s to turn.

That was not an oversight — the constant's comment argued it was safe:

> Note the drain only reaches this code once the queue is UNDER the threshold — above it, `already_crossed` answers first — so the tail does not need to react within a poll or two of the fix landing.

**True when written, and #174 falsified it.** #174 gave `recentDirection` a second, operator-facing job: it is published on every row and selects the `already_crossed` sentence. So the lagging tail became something an operator reads directly, and the "above the threshold nothing depends on it" premise stopped holding.

## Why 0.15, measured rather than picked

Replaying the captured live series against each candidate:

| Tail | Polls wrong during drain | Bogus forecasts | Genuine forecast window |
|---|---|---|---|
| **0.4** (120 s, shipped) | 8 → 40 s | 5 polls | unchanged |
| 0.2 (60 s) | 4 → 20 s | 1 poll | unchanged |
| **0.15 (45 s) ← this PR** | 3 → 15 s | **0** | unchanged |
| 0.1 (30 s) | 2 → 10 s | 0 | unchanged |

0.15 kills the serious half outright at no cost in coverage, and keeps the larger sample margin over 0.1 (9 samples at the shipped poll, against a tail minimum of 2).

**The old justification was retired by measurement, not by preference.** It held that 120 s was needed so "one bursty poll cannot flip its sign". Tested on a +3/poll rise with jitter of ±0, ±3, ±6 and ±10 items per poll, tails of 120/60/45/30 s withheld **exactly the same number of forecasts**. There was no flap to trade 60 s of lag against.

## Why the contract edit is in the same PR

The tail length is observable — through `recentDirection` and through *when* a projection is withheld. Landing the engine change alone would leave the ratified contract describing behaviour the engine no longer has, for however long the second PR took. §1.5 and §2.2.1 change with the constant, `CHANGELOG.md` records it.

**No schema change.** The tail length was never encoded in `earlywarning.schema.json`; no field's type, nullability or range moves, and `recentDirection` keeps the same three values and the same `null` rule.

## What this does NOT fix

The **15 s residual** — a queue draining while still *at or above* its threshold, where `already_crossed` answers first and the direction is the lagging tail. Still reads "still rising" for three polls.

Not bundled, on purpose. The candidate that closes it (a retreat-from-peak test) scored 0 s wrong on this series but **reintroduces #142's defect class**: `sinceLastDiscontinuity` only truncates on a >80 % fall, so a drain that stops above zero leaves a stale peak in the window, and a genuine new ramp from that trough would be reported `falling` for up to 45–300 s. Trading 15 s of wrong text for a possibly-suppressed warning is the wrong direction, so it is **#232** with three options for you to pick from. Called out explicitly in §1.5, §2.2.1 and the constant's comment so it reads as a known bound rather than an oversight.

## Verification

```
typecheck  clean
tests      ℹ tests 455   ℹ pass 455   ℹ fail 0     (floor 452 + 3 new)
```

The new test block is a real regression test, not a restatement — **it fails at 0.4 and at 0.2**:

```
▶ a draining queue is never forecast to cross (§2.2.1)     [at RECENT_FIT_FRACTION = 0.4]
  ✖ publishes no projection at any poll where the measured queue is falling
  ✔ still forecasts the genuine ramp — the shorter tail costs no coverage
  ✖ reports falling, not rising, once the drain is under way
```

The middle test is the guard against over-correcting: a tail short enough to kill every drain forecast could also kill the real one, and then the module would be "correct" by being silent. It asserts the ramp still forecasts and that the ETA still *tightens*.

The series in it is captured, not composed, because a shape invented to fail would not have shown that 0.2 still leaves one bad poll.

**Two existing tests re-pinned**, both asserting the tail magnitude at the old length (`-25.6` → `-36`). A shorter tail on a monotonic drain is necessarily steeper, so the direction of the move is itself a check on the change; the invariants both tests protect (opposite signs from one series; arrivals below throughput on a draining queue) are unchanged, and for `inboundRatePerSec` the new value moves *further* in the direction #188's amendment wanted. Both carry a comment saying why the number moved.

**Live re-run** after `docker compose up -d --build detection-engine` with `DEMO_TRIGGERS`/`AGENT_MODE` preserved:

```
t=151s q=71  already_crossed  dir=rising     <- peak
t=156s q=69  already_crossed  dir=rising  }
t=161s q=57  already_crossed  dir=rising  }  the documented 15s residual, all >= 50
t=166s q=52  already_crossed  dir=rising  }
t=171s q=40  not_rising       dir=falling    <- first poll under 50: no forecast
t=176s q=32  not_rising       dir=falling
```

Zero bogus forecast polls, and `dir` flips at the exact poll the queue crosses back under 50 — matching the replay poll for poll. Stack reset clean afterwards (pool restored to 1, `findings=none`). Audit row `pg-audit-611` for the governed write; no LLM call, so no metered cost.

## Not in this PR

- Symptom 1 (blank Early Warning row mid-ramp) — #234, dashboard
- Symptom 3 (`avgQueueingTime` non-zero at `queued: 0`) — a product decision, measured evidence added to #210
- #232 — the 15 s residual, three options, needs a decision
- #233 — `projection.crossesAt` always null

🤖 Generated with [Claude Code](https://claude.com/claude-code)
