### PR TITLE
fix(dashboard): two of the six card metrics are averages over completed messages, and nothing said so

### DIFF
--- a/apps/dashboard/src/components/HostCard.tsx
+++ b/apps/dashboard/src/components/HostCard.tsx
@@ -7,6 +7,30 @@
  * in the header — the border alone signalled severity by colour only, which §7.3
  * forbids and which let a green `OK` dot sit unqualified beside three critical
  * findings.
+ *
+ * FOUR OF THE SIX METRICS ARE READINGS OF NOW AND TWO ARE NOT, which the block did not say. Reported
+ * from a `pool_bottleneck` run: "the avg queueing time is non zero when queue is zero, it seems to
+ * show a stale measurement." Both numbers were true and the pair read as a contradiction —
+ * `Avg queueing 24.6 s` directly under `Queued 0`.
+ *
+ * It is not stale and it is not ours. `avgQueueingTime` is `TotalQueueDuration / TotalCount` over the
+ * messages that have COMPLETED, so queue depth now says nothing about how long the messages that just
+ * finished had waited — and right after a pool enlargement the ones completing are precisely those
+ * that waited longest. Measured (#210): IRIS's own `iris_interop_avg_queueing_time` stepped at 61 s,
+ * 60 s and 55 s intervals while the proxy scraped every 2.5 s, so the ~1 minute of lag is upstream of
+ * every component we own. `24.64 s` was on screen for a full minute at `queued: 0`.
+ *
+ * So the fix is a LABEL, not a guard: `(completed)` on both averages says which population the number
+ * covers, which is the fact that dissolves the contradiction. It goes on `Avg processing` too, and
+ * that is the point of putting it on both — labelling only the queueing row would imply the other
+ * average is instantaneous, and it is the same kind of quantity from the same IRIS provider.
+ *
+ * THE ENGINE RULE WAS DELIBERATELY NOT TOUCHED. Suppressing `growing_queue_wait` when `queued === 0`
+ * was the other candidate and was declined (#210): queue depth is sampled instantaneously, so bursty
+ * traffic can read `0` at the poll instant while real waits accumulate, and that trades a
+ * confusing-but-true finding for an occasionally-missed one. The consequence is on the record — the
+ * finding itself can still stand for ~110 s after the queue empties, and its message is the engine's
+ * and rendered verbatim (§2.4).
  */
 
 import type { HostView } from '../types/healthscan';
@@ -116,8 +140,11 @@ export function HostCard({
           value={formatCount(host.errored)}
           emphasis={isPositiveCount(host.errored)}
         />
-        <MetricRow label="Avg processing" value={formatDuration(host.avgProcessingTime)} />
-        <MetricRow label="Avg queueing" value={formatDuration(host.avgQueueingTime)} />
+        {/* `(completed)` scopes the average's population — see the header. Not "(1 min)": the refresh
+            cadence is measured at ~60s but the averaging window itself is not, and a label naming a
+            span we have not measured would be the invented precision §7.3 argues against. */}
+        <MetricRow label="Avg processing (completed)" value={formatDuration(host.avgProcessingTime)} />
+        <MetricRow label="Avg queueing (completed)" value={formatDuration(host.avgQueueingTime)} />
         <MetricRow label="Last activity" value={formatRelative(host.lastActivity, now)} />
       </div>
 

--- a/apps/dashboard/src/components/HostDetail.tsx
+++ b/apps/dashboard/src/components/HostDetail.tsx
@@ -193,33 +193,52 @@ export function HostDetail({
 
         {/* CURRENT VALUES BELOW THE GRAPHS, not above. The graphs are why this panel was opened; the
             numbers are already on the card that opened it, and repeating them first would put a
-            second copy of the card above the thing that is new. */}
-        <dl className="pg-facts">
-          <div className="pg-facts__row">
-            <dt>Queued</dt>
-            <dd className="pg-facts__mono">{formatCount(host.queued)}</dd>
-          </div>
-          <div className="pg-facts__row">
-            <dt>Msg/sec</dt>
-            <dd className="pg-facts__mono">{formatRate(host.messagesPerSec)}</dd>
-          </div>
-          <div className="pg-facts__row">
-            <dt>Errors</dt>
-            <dd className="pg-facts__mono">{formatCount(host.errored)}</dd>
-          </div>
-          <div className="pg-facts__row">
-            <dt>Avg processing</dt>
-            <dd className="pg-facts__mono">{formatDuration(host.avgProcessingTime)}</dd>
-          </div>
-          <div className="pg-facts__row">
-            <dt>Avg queueing</dt>
-            <dd className="pg-facts__mono">{formatDuration(host.avgQueueingTime)}</dd>
-          </div>
-          <div className="pg-facts__row">
-            <dt>Last activity</dt>
-            <dd>{formatRelative(host.lastActivity, now)}</dd>
-          </div>
-        </dl>
+            second copy of the card above the thing that is new.
+
+            WRAPPED WITH ITS NOTE so the two are one flex item: `pg-drawer__body` sets a 24px gap
+            between its children, which would float the note halfway to the next section instead of
+            reading as a qualifier on the list it belongs to. */}
+        <div className="pg-host-detail__facts">
+          <dl className="pg-facts">
+            <div className="pg-facts__row">
+              <dt>Queued</dt>
+              <dd className="pg-facts__mono">{formatCount(host.queued)}</dd>
+            </div>
+            <div className="pg-facts__row">
+              <dt>Msg/sec</dt>
+              <dd className="pg-facts__mono">{formatRate(host.messagesPerSec)}</dd>
+            </div>
+            <div className="pg-facts__row">
+              <dt>Errors</dt>
+              <dd className="pg-facts__mono">{formatCount(host.errored)}</dd>
+            </div>
+            {/* THE SAME `(completed)` AS THE CARD, and here there is width for the sentence behind
+                it. `Avg queueing` beside `Queued` above reads as a contradiction when the queue has
+                just drained — 24.6 s against 0 — and it is not one: see `HostCard`'s header for the
+                measurement (#210). */}
+            <div className="pg-facts__row">
+              <dt>Avg processing (completed)</dt>
+              <dd className="pg-facts__mono">{formatDuration(host.avgProcessingTime)}</dd>
+            </div>
+            <div className="pg-facts__row">
+              <dt>Avg queueing (completed)</dt>
+              <dd className="pg-facts__mono">{formatDuration(host.avgQueueingTime)}</dd>
+            </div>
+            <div className="pg-facts__row">
+              <dt>Last activity</dt>
+              <dd>{formatRelative(host.lastActivity, now)}</dd>
+            </div>
+          </dl>
+
+          {/* Outside the `<dl>` rather than inside the queueing row: it qualifies BOTH averages, and
+              a `<dl>` may only contain `dt`/`dd` groups, so a prose note has no valid home in one. It
+              also keeps the mono font on the value where it belongs — nested in the `dd` it would
+              inherit it and read as data. */}
+          <p className="pg-facts__note">
+            Both averages cover messages that have already <strong>completed</strong>, so they lag the
+            queue depth above and can stay above zero after the queue empties.
+          </p>
+        </div>
 
         {/* Says what the filtered list below the panel is showing, so the filter is never a silent
             state. `findings` is already this host's; the count is the only claim made here, and the

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -961,6 +961,16 @@ button {
   font-size: 11px;
 }
 
+/* Qualifies the facts list above it -- what the two averages are averaged over.
+   Deliberately not `--pg-warning`-toned: it explains a reading, it does not
+   report a problem, and severity colour is reserved for severity (§7.1). */
+.pg-facts__note {
+  margin: 0;
+  color: var(--pg-text-muted);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
 .pg-drawer__note {
   margin: 0;
   padding: var(--pg-space-3);
@@ -2117,6 +2127,15 @@ button {
   font-size: 0.75rem;
   line-height: 1.5;
   color: var(--pg-text-muted);
+}
+
+/* The facts list and the note that qualifies it, as one item in the drawer's
+   flex column -- so the note stays attached to the list instead of taking the
+   24px gap that separates the drawer's sections. */
+.pg-host-detail__facts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pg-space-3);
 }
 
 .pg-host-detail__filtered {

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -282,6 +282,18 @@ backlog in its window, and it will age out rather than being switched off. Which
 the findings disappear when the condition does. No acknowledging, no clearing, no tombstones. If
 it is still listed, it is still true."*
 
+**If someone points at `Avg queueing` while `Queued` reads 0, that pair is honest and you can say
+why.** It is the same fact as the paragraph above, seen on the host card rather than in the findings
+list: the metric is IRIS's average over messages that have **already completed**, so an empty queue
+now says nothing about how long the messages that just finished had waited — and right after the pool
+grows, the ones completing are precisely those that waited longest. Measured (#210): IRIS refreshes
+it about once a minute, so `24.64 s` sat on screen for a full minute at `queued: 0`, and
+`growing_queue_wait` stood for 110s of it. Both average rows are labelled **`(completed)`** for this
+reason, and the host panel spells it out under the values.
+
+**Say:** *"That average is over the messages that already finished — the ones that had been waiting
+longest. The queue behind it is empty."*
+
 > **The board really does reach zero now, and that is new.** Until 2026-08-27 a third finding —
 > `slow_processing`, on the same host — survived this beat forever, because the throttled downstream
 > takes ~1s per message whether one worker or four are waiting on it. Raising `Cloud API`'s


### PR DESCRIPTION
Symptom 3 of the three reported from a `pool_bottleneck` run, and the option you picked on #210:

> the avg queueing time is non zero when queue is zero, it seems to show a stale measurement.

**It is not stale, and it is not ours.** `avgQueueingTime` is `TotalQueueDuration / TotalCount` over the messages that have **completed**, so queue depth *now* says nothing about how long the ones that just finished had waited — and right after a pool enlargement, the messages completing are precisely those that waited longest. Measured (#210): IRIS's own `iris_interop_avg_queueing_time` steps only at **61 / 60 / 55 s** intervals while the proxy scrapes every 2.5 s, so the ~1 minute of lag is upstream of every component we own. `24.64 s` was displayed for a **full minute** at `queued: 0`.

What was actually wrong is that nothing on screen said so. Four of the six card metrics are readings of *now*; two are backward-looking averages, sitting in the same block, in the same type, with no qualifier.

## The change

| | Before | After |
|---|---|---|
| Card | `Avg processing` / `Avg queueing` | `Avg processing (completed)` / `Avg queueing (completed)` |
| Host panel | same two labels | same, plus a note under the values |

Panel note: *"Both averages cover messages that have already **completed**, so they lag the queue depth above and can stay above zero after the queue empties."*

**Both rows, not just queueing.** Labelling only the row that visibly contradicted `Queued` would imply the other average is instantaneous — it isn't; it's the same quantity from the same IRIS provider, and `services/detection-engine/CLAUDE.md` §5.4 already documents it reading 1.01 s before *and* after the fix for that reason.

**`(completed)` rather than `(1 min)`.** The refresh cadence is measured; the *averaging window* is not. #210's 10 s-bucket series came from `Ens_Activity_Data` (the raw table), not from the metric, so it doesn't establish the metric's own window — and a label naming a span nobody measured is exactly the invented precision §7.3 is against. `(completed)` also does more work: it answers the operator's question directly rather than just warning that the number lags.

## What this deliberately does not do

**The engine rule is untouched.** `if (host.queued === 0) return null` on `growing_queue_wait` was the other candidate on #210 and is declined: queue depth is sampled instantaneously, so bursty traffic can read `0` at the poll instant while real waits accumulate, which trades a confusing-but-true finding for an occasionally-missed one.

**So the residual is on the record, in three places** (`HostCard`'s header, the commit, and #210): the *finding* can still stand for ~110 s after the queue empties, and its message — `"Average queue wait 17.2s is 860x baseline"` — is the engine's and is rendered verbatim per §2.4. The card label makes the pair legible; it does not remove the finding. If that turns out to read badly on stage, reopening the guard is a one-line engine change and the reasoning is already written down.

## Also

Cue sheet §2.3 gains the presenter's answer, because the drain beat is exactly where an audience sees the pair: *"That average is over the messages that already finished — the ones that had been waiting longest. The queue behind it is empty."*

## Verification

```
tsc --noEmit                     clean
validate-architecture.mjs        ok (8 labels, 12 paths, no overlaps)
validate-fixtures.mjs            All fixtures match the published contract
validate-fixture-claims.mjs      ok
docker compose up -d --build dashboard   built and started
```

Confirmed in the **shipped bundle**, not just the source (§6.1 — `npm run build` is not the build that ships):

```
$ docker exec pg-dashboard grep -o "Avg [a-z]* (completed)" /usr/share/nginx/html/index.html | sort -u
Avg processing (completed)
Avg queueing (completed)
$ ... grep -o "pg-host-detail__facts{[^}]*}"
pg-host-detail__facts{display:flex;flex-direction:column;gap:var(--pg-space-3)}
```

**Layout, by arithmetic rather than by eye** — I have no browser here, so stating the method: the widest new label is ~156 px at 12.5 px, plus the 12 px row gap and a ~45 px value against ~224 px of inner width at the narrowest 260 px grid track. It fits with ~11 px of slack, and if a narrower value column ever eats that, `.pg-metric`'s flex label wraps to a second line rather than overflowing.

Two structural notes: the panel note is a `<p>` **outside** the `<dl>` (a `<dl>` may only contain `dt`/`dd` groups, and nested in the `dd` it would inherit the mono font and read as data), wrapped with the list in `.pg-host-detail__facts` so it doesn't take the 24 px gap that separates the drawer's sections. `.pg-facts__note` uses `--pg-text-muted`, which is defined in **both** theme blocks, so dark mode needs nothing further.

Closes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
