### PR TITLE
fix(engine): the ETA was divided by a 300s window fit, so a 50s ramp read as ~20 minutes (#237)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ docker compose exec iris iris session IRIS -U LABDEMO
 ```
 
 ```objectscript
-// Arm: throttles the downstream to ~1s/message and raises inflow, after warming the baseline
-// at zero. Takes about 2 minutes to produce a confirmed finding.
+// Arm: throttles the downstream to ~1s/message and raises inflow, after a 75s settle with nothing
+// armed so Early Warning can project. Takes about 2 minutes to produce a confirmed finding.
 do ##class(ProductionGuardian.LabDemo.Triggers).PoolBottleneck()
 do ##class(ProductionGuardian.LabDemo.Triggers).Status()   // what is armed, and the queue cap
 do ##class(ProductionGuardian.LabDemo.Triggers).Reset()    // undo, including the pool size

--- a/apps/dashboard/src/components/EarlyWarning.tsx
+++ b/apps/dashboard/src/components/EarlyWarning.tsx
@@ -6,14 +6,21 @@
  * §1.4 makes it a boundary condition: a forecast presented as a reading is the same defect class as
  * the coerced `lastActivity` in #58, and it is worse here because the number is about the future.
  *
- * WHAT IT RENDERS, AND THE ONE CASE THAT CHANGED. Measured on the live stack: a projection exists
- * for roughly 100 seconds of a queue_buildup run — from the queue starting to rise until it crosses
- * the threshold. Before that the slope is too flat to fit; after it, `already_crossed`.
+ * WHAT IT RENDERS, AND THE ONE CASE THAT CHANGED. A projection exists from the first rising poll
+ * until the queue crosses the threshold, then `already_crossed`. Measured on the captured
+ * `pool_bottleneck` series (floor 50, crossed 50s after the ramp starts), replayed through the
+ * engine — these are the numbers the strip shows since #237 moved the fit to the 45s tail:
  *
- *     q=9    (not_rising)
- *     q=19   slope=1.5/min  eta=1240s     <- strip appears
- *     q=49   slope=8.6/min  eta=7s
- *     q=58   (already_crossed)            <- strip used to vanish here
+ *     q=0    (not_rising)
+ *     q=4    slope=0.2/min  eta=1062s     <- strip appears, on the FIRST rising poll
+ *     q=17   slope=21.5/min eta=92s
+ *     q=34   slope=48.0/min eta=20s       <- exact: the true crossing is 20s out
+ *     q=47   slope=48.0/min eta=4s
+ *     q=54   (already_crossed)            <- strip used to vanish here
+ *
+ * The eta was ~20x too long and the first four polls declined `beyond_horizon` until #237. Both were
+ * the same divisor: a 300s window fit is ~85% flat-at-zero prefix on a 50s ramp, so least squares
+ * averaged two regimes. Neither the horizon nor this component was wrong.
  *
  * The first version hid `already_crossed` entirely, reasoning that the state is covered by a
  * FINDING and repeating it would be noise. That reasoning is sound and the consequence was not:
@@ -43,6 +50,13 @@
  * shown and then after a while it shows warning/rising. why is there a time that nothing is
  * displayed?" (@Ari-Glikman). The blank is 20s against a forecast that lasts 25s, so the module is
  * absent for nearly half the window it exists for.
+ *
+ * #237 then removed the *cause* — those four polls now carry a projection — but the sentence stays,
+ * and the ordering is the point: this fix was right on its own terms and would still be right if the
+ * engine change were reverted. A reason with no sentence is a blank row whenever it is returned, and
+ * `beyond_horizon` is still returned by a genuinely slow rise. Fixing the display of a state is not
+ * the same as making the state rarer, and a fix that only holds because a state stopped occurring is
+ * not a fix.
  *
  * The reason it was missed three times is that the map was a `Record<string, string>`, which accepts
  * any subset of the reasons in silence. It is now `Record<ProjectionDeclineReason, string | null>`, so
@@ -115,10 +129,13 @@ const REASON_SENTENCES: Record<ProjectionDeclineReason, string | null> = {
   already_crossed: 'Threshold reached — see the finding below',
   /*
    * Rising, but the crossing is further out than the engine's horizon (30 min on the shipped
-   * config), so it declines to name a time. That is a real, transient state in the middle of a ramp
-   * — it is what the first four polls of a queue build look like — and it is exactly when an
-   * operator is watching the card. The rate is not available to say (§1.4, see the header), so this
-   * says the direction and the reason there is no ETA, and nothing it cannot support.
+   * config), so it declines to name a time. The rate is not available to say (§1.4, see the header),
+   * so this says the direction and the reason there is no ETA, and nothing it cannot support.
+   *
+   * NO LONGER THE FIRST FOUR POLLS OF A QUEUE BUILD, which is what this comment said until #237.
+   * That reading was an artefact of the 300s window fit understating a 50s ramp by ~20x; the tail fit
+   * projects from the first rising poll. What reaches here now is a rise that really is slower than
+   * 30 minutes to threshold — a real state, no longer a transient one on the demo path.
    */
   beyond_horizon: 'Rising — a crossing is beyond the projection horizon',
   /*
@@ -154,9 +171,21 @@ const QUIET_REASONS = new Set(['not_rising']);
 /**
  * Seconds to a human span, rounded coarsely on purpose.
  *
- * A least-squares fit over a five-minute window does not support "crosses in 7 minutes 12 seconds",
- * and printing that precision would imply a confidence the arithmetic does not have. Minutes below
- * an hour, hours above it.
+ * A least-squares fit over a 45-second tail (§1.1, as amended by #237) does not support "crosses in
+ * 7 minutes 12 seconds", and printing that precision would imply a confidence the arithmetic does not
+ * have. Minutes below an hour, hours above it.
+ *
+ * The span in that first sentence read "five-minute window" until #237, and the shorter span makes the
+ * argument stronger rather than weaker: a ~9-sample fit is jumpier than a 60-sample one, which is the
+ * cost #237 accepted in exchange for the eta being right. So the coarse rounding is now doing more
+ * work, not less — it absorbs the jitter that would otherwise show as an eta flicking between
+ * neighbouring seconds every poll.
+ *
+ * ONE CONSEQUENCE WORTH KNOWING BEFORE MAKING THIS FINER. Everything under 90s reads "under a minute",
+ * and on the shipped `pool_bottleneck` ramp the last ~30s of the build sits in that bucket, so the
+ * strip stops visibly tightening near the end. That is deliberate: the tightening is carried by the
+ * RATE and by the queue depth beside it, both of which are measurements, and buying a countdown here
+ * would mean printing seconds off a nine-sample fit.
  */
 function horizon(seconds: number): string {
   if (seconds < 90) return 'under a minute';

--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -22,8 +22,10 @@
  *     activating        the request was accepted; the scenario is not in effect yet
  *     activated         the scenario is live
  *
- * `pool_bottleneck` is why. It warms a baseline at zero for ~75 seconds *before* arming anything —
- * that wait is load-bearing, see `Triggers.PoolBottleneck` and #43 — and it runs as a background
+ * `pool_bottleneck` is why. It settles for ~75 seconds with nothing armed *before* arming anything —
+ * that wait is load-bearing, see `Triggers.PoolBottleneck`, which is also where to read why the
+ * reason changed (it was `queue_buildup`'s baseline and #43; it is now Early Warning's fit window,
+ * and the 75s is unchanged either way) — and it runs as a background
  * job, so the arm POST returns in ~0.26s. For over a minute the scenario is in neither of the other
  * two states. Collapsing that into "not activated" invites a second click; collapsing it into
  * "activated" is a claim a presenter notices is false when no queue appears. The dispatcher reports
@@ -247,8 +249,8 @@ export function TriggerRail(): JSX.Element | null {
          * Both notes this system produces are ONE LINE and each answers a question the state word
          * immediately provokes, rather than restating it:
          *
-         *   pool_bottleneck   "Warming the baseline at zero for ~75s before arming, so
-         *                      queue_buildup can fire..."
+         *   pool_bottleneck   "Settling for ~75s with nothing armed, so Early Warning has enough
+         *                      samples to project the crossing..."
          *   reset             "Findings clear within ~10s. A system_alert finding persists until it
          *                      ages out of the proxy's buffer."
          *

--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,72 @@ Every contract change, dated, with the reason. Newest first.
 
 ---
 
+## 2026-09-02 — `earlywarning-api.md` §1.1: `projection.slope` and `secondsToThreshold` are fitted over the 45 s tail, not the 300 s window (#237)
+
+**Behaviour change.** `projectHost` in `services/detection-engine/src/detect/earlywarning.ts` divides by
+`recentSlopePerMinute` instead of `windowSlopePerMinute`, and publishes that same slope. The window fit
+keeps both of its other jobs — it still gates the forecast (§2.2.1's two-fit test is untouched) and it
+still reaches the agent as `trend.slope` (`investigation-api.md` §2.2). One PR with the prose, for the
+same reason as the entry below: the divisor is observable through `slope`, `secondsToThreshold` and
+`beyond_horizon`, so landing one half would leave the ratified contract describing something else.
+
+### What was wrong
+
+§1.1's own argument, one window size too high up. It said a 1800 s fit "systematically understates a
+rise that started two minutes ago — it would hand back a comfortably distant ETA at exactly the moment
+the queue is running away", and then chose 300 s. On the one scenario MVP 2 exists to demonstrate the
+whole ramp is **50 s**, so 300 s is ~85% flat-at-zero prefix and least squares averaged the two regimes.
+
+Replayed against a captured live series (60 idle polls, then the measured `pool_bottleneck` ramp; floor
+50 crossed at t=50 s), against the truth the series itself supplies:
+
+| queued | true | 300 s window | 45 s tail |
+|---|---|---|---|
+| 4 | 50 s | 27600 s → `beyond_horizon` | 1062 s |
+| 14 | 40 s | 4320 s → `beyond_horizon` | 153 s |
+| 24 | 30 s | 1300 s = "~22 min" | 50 s |
+| 34 | 20 s | 418 s = "~7 min" | **20 s** |
+| 37 | 15 s | 269 s = "~4 min" | **15 s** |
+| 47 | 5 s | 41 s | 4 s |
+
+Two reported symptoms, one divisor: four polls of "beyond projection horizon" on a queue 35–50 s from
+crossing, then a countdown in **minutes** on a queue seconds from crossing. Under-warning in the state
+Early Warning exists for.
+
+**Then confirmed live rather than only in replay** — one `pool_bottleneck` arm from a cold engine on the
+containerised stack, the full nine-poll table in §1.1. `beyond_horizon` did not occur at all, a
+projection was published on every rising poll, `slope` converged on 60.4/min against a scenario that
+creates ~1/sec by construction, and the last ETA before the crossing read 2 s against a true ~3 s. The
+replay predicted the fix; the live run is what confirms it, and the two agree except on the first rising
+poll, where the live residual is 863 s rather than 1062 s.
+
+### Why the tail rather than a third span
+
+It is the span §1.5 already calls "now", and §2.2.1's gate already turns on it — so the ETA was being
+divided by a different slope than the one that decided the queue was rising at all. §1.1 now names one
+fit, and `message` is arithmetic a reader can check against the number beside it. This is the same
+amendment `investigation-api.md` §2.2 made to `snapshot.inboundRatePerSec` on 2026-09-01 (#188), on the
+identical reasoning: *"the window slope is the wrong span … the tail fit is the 'now' the definition
+needs."*
+
+### What a consumer must still not assume
+
+**The ETA is jumpier than it was**, and §5 now says so: a 45 s fit moves more between polls than a 300 s
+one. §1.4's "let `secondsToThreshold` jump, never tick it down client-side" was already the rule and is
+now load-bearing rather than cautious. The overstatement is **not** fully removed at the very start of a
+ramp — 1062 s in replay and 863 s live at `queued: 4`, against a true ~43–50 s — because the tail also
+still holds part of the flat
+prefix there; "at this rate" is what covers it, and the number is exact from 20 s out, which is where
+§5's "below ~20 s is inside the pipeline's own latency bound" takes over.
+
+**Two paragraphs were reversed rather than extended.** §1.5's "publishing a magnitude here would put two
+rates in one payload" and §2.2.1's "`slope` is never published for the tail" were both arguments against
+this change, and both are struck with the reason: there is now one published rate. `recentDirection`
+stays a sign, on a narrower and better justification — it is what `already_crossed` rows have instead of
+a slope.
+
+---
+
 ## 2026-09-02 — `earlywarning-api.md` §1.5 / §2.2.1: the tail fit is 15% of the window (45 s), not 40% (120 s) — a draining queue was getting a forecast
 
 **Behaviour change, not documentation.** `RECENT_FIT_FRACTION` in

--- a/contracts/earlywarning-api.md
+++ b/contracts/earlywarning-api.md
@@ -123,16 +123,76 @@ contract violation, a `null` value is not — same rule as `healthscan-api.md` �
 
 ### 1.1 How the slope is fitted
 
-Ordinary least squares of `value` against sample time (in minutes), unweighted, over every sample
-in the **fit window**: the trailing **300 s**, i.e. up to 60 samples at the shipped 5000 ms engine
-poll. `slope` is that line's gradient.
+Ordinary least squares of `value` against sample time (in minutes), unweighted, over the **most
+recent 15% of the fit window**: 45 s, ~9 samples at the shipped 5000 ms engine poll. `slope` is that
+line's gradient, and `secondsToThreshold` is `(threshold.value - currentValue) / slope`.
 
-Three things about that, each a decision rather than an implementation detail:
+**AMENDED 2026-09-02 (#237). `slope` was the fit over the WHOLE 300 s fit window until then**, and the
+bullet immediately below was the argument for it — correct in form and one window size too high up.
+Substituting 300 s for "30 minutes" and 40 s for "two minutes" describes what shipped: on
+`pool_bottleneck`, the one scenario MVP 2 exists to demonstrate, the ramp is a short suffix on a
+flat-at-zero prefix, so least squares averaged the two regimes and understated the rise by ~20x.
+Measured on a captured live series (60 idle polls, then the ramp; floor 50 crossed at t=50 s):
 
-- **The fit window is 300 s, not the 1800 s baseline window.** A 30-minute least-squares fit over
+| queued | true seconds to crossing | ETA over the 300 s window | ETA over the 45 s tail |
+|---|---|---|---|
+| 4 | 50 s | 27600 s → `beyond_horizon` | 1062 s |
+| 7 | 45 s | 12900 s → `beyond_horizon` | 391 s |
+| 14 | 40 s | 4320 s → `beyond_horizon` | 153 s |
+| 17 | 35 s | 2475 s → `beyond_horizon` | 92 s |
+| 24 | 30 s | 1300 s = "~22 min" | 50 s |
+| 27 | 25 s | 812 s = "~14 min" | 36 s |
+| 34 | 20 s | 418 s = "~7 min" | **20 s** |
+| 37 | 15 s | 269 s = "~4 min" | **15 s** |
+| 44 | 10 s | 100 s | 7 s |
+| 47 | 5 s | 41 s | 4 s |
+
+So the panel spent its first four polls saying the crossing was beyond a 30-minute horizon, on a queue
+35 to 50 seconds away from it, and then counted down in **minutes** on a queue seconds away. Both
+were reported from a demo run; both are this one divisor. The tail is exact from 20 s out.
+
+**CONFIRMED LIVE**, not only in replay — one `pool_bottleneck` arm from a cold engine on the
+containerised stack, 2026-09-02, `t` measured from the arm and the floor of 50 crossed at t≈128 s:
+
+| t | queued | `recentDirection` | `slope` | `secondsToThreshold` |
+|---|---|---|---|---|
+| 80 s | 0 | `steady` | — | `not_rising` |
+| 85 s | 4 | `rising` | 3.2 | 863 |
+| 90 s | 11 | `rising` | 11.2 | 209 |
+| 95 s | 14 | `rising` | 16.2 | 134 |
+| 100 s | 21 | `rising` | 25.7 | 68 |
+| 105 s | 24 | `rising` | 34.2 | 46 |
+| 110 s | 35 | `rising` | 55.4 | 17 |
+| 115 s | 39 | `rising` | 59.0 | 12 |
+| 120 s | 46 | `rising` | 60.4 | 4 |
+| 125 s | 49 | `rising` | 59.0 | 2 |
+| 130 s | 56 | `rising` | — | `already_crossed` |
+
+Three properties a consumer may rely on, all visible above: **a projection on every rising poll** and
+no `beyond_horizon` anywhere on this scenario; **`slope` converging on the scenario's actual net
+inflow** (~1/sec = 60/min, which is what `pool_bottleneck` creates by construction — see
+`Triggers.PoolBottleneck`); and **the ETA landing within one poll of the true crossing** over the last
+20 s. The first row is the residual §5 warns about: 863 s against a true ~43 s, because at the first
+rising poll the 45 s tail still holds flat-at-zero samples. It corrects within two polls.
+
+**The tail is the right span rather than merely the shorter one.** §1.5 already defines it as the
+answer to "which way is it moving *now*", and §2.2.1's gate turns on it — so the ETA was being divided
+by a different slope than the one that decided the queue was rising at all. That is the same amendment
+`investigation-api.md` §2.2 made to `snapshot.inboundRatePerSec` on 2026-09-01 (#188), for the same
+reason and against the same alternative: *"the window slope is the wrong span … the tail fit is the
+'now' the definition needs."*
+
+Three things about the fit, each a decision rather than an implementation detail:
+
+- **Neither span is the 1800 s baseline window.** A 30-minute least-squares fit over
   mostly-flat history systematically understates a rise that started two minutes ago — it would
   hand back a comfortably distant ETA at exactly the moment the queue is running away. The whole
-  claim is "at *this* rate", so the fit has to be over the recent rate.
+  claim is "at *this* rate", so the fit has to be over the recent rate. The amendment above is that
+  argument reaching its conclusion: 300 s was still mostly-flat history for a 50 s ramp.
+- **The 300 s window still gates the forecast, it just no longer supplies the number.** §2.2.1's
+  two-fit test is unchanged — both spans must lean up — and `fitSampleCount >= minFitSamples` (12) is
+  still measured against the full window. 9 samples decide the *rate* only once 12 have agreed on the
+  *direction*, which is what keeps a 45 s fit from being a claim with nothing behind it.
 - **It is not `(latest - previous) / interval`.** That is a one-sample difference and it is pure
   noise at this cadence — `window.ts` exposes `latest()` and `previous()` for rate-of-change
   comparisons and they are the wrong input here. It is also not `(last - first) / span`, which
@@ -150,7 +210,7 @@ promising they are the only possible ones.
 
 | Field | Rounded to | Reason |
 |---|---|---|
-| `slope` | 1 decimal | `9.63841...` implies precision a 60-sample fit over a bursty queue does not have |
+| `slope` | 1 decimal | `9.63841...` implies precision a ~9-sample fit over a bursty queue does not have — and since #237 it is the 45 s tail, so this is more true than when it was written against 60 samples |
 | `secondsToThreshold` | whole seconds | same |
 | minutes inside `message` | nearest whole minute | the demo line is "~4 min", and a "~3.96 min" reads as a measurement |
 
@@ -239,11 +299,18 @@ producing one. Published standalone on a warming host, a sign fitted through thr
 a claim with nothing behind it. So `warming` and `insufficient_samples` rows always carry `null`
 here, and a consumer gets a direction exactly when there is a fit worth signing.
 
-**A SIGN, NOT A SECOND SLOPE, and that is §2.2.1's own decision rather than a new one.** That section
-already states that the tail fit "is a sign test confirming an answer the window already grounded in
-`minFitSamples`" and that its slope is deliberately never published. Publishing a magnitude here
-would put two rates in one payload with no way for a reader to know which one `message` was built
-from. So the tail keeps answering exactly one question — *which way* — and this field is that answer.
+**A SIGN, NOT A SECOND SLOPE.** The magnitude of this fit *is* published — as `projection.slope`, since
+#237 (§1.1) — so the field is redundant with it wherever a projection exists. It is kept as a sign
+because that is exactly where a projection does **not** exist: on `already_crossed`, which is the state
+the panel spends most of its life in (see "Why it exists" below), there is no `slope` and the sign is
+the only thing that distinguishes a recovery from a runaway.
+
+**The old reason for it being a sign — that "publishing a magnitude here would put two rates in one
+payload with no way for a reader to know which one `message` was built from" — was retired by #237,
+which removed the second rate.** There is now one published rate, it is this fit, and `message` is
+built from it. The window fit is internal and reaches only the agent, as `trend.slope`
+(`investigation-api.md` §2.2). That is a stronger arrangement than the one that argument was
+protecting: a reader can check the sentence's arithmetic against the number beside it.
 
 **MEASURED, so §1.4 does not apply to it.** It is computed from samples that have already happened,
 which makes it the same kind of value as `currentValue` and `fitSampleCount`, not the same kind as
@@ -361,11 +428,11 @@ answer to *which reason* is unchanged, and what is added is the answer to *which
 
 Two consequences worth stating, because a consumer cannot see them from the reason alone:
 
-- **`slope` is never published for the tail** — the *magnitude*, that is. The tail fit is a sign test
-  confirming an answer the window already grounded in `minFitSamples`; only the window slope is
-  published as a rate. So a positive published `slope` with `projection: null` cannot occur — the
-  decline happens before any projection is built. Its **sign** is published, as `recentDirection`
-  (§1.5), which is a different claim: `rising` is not a rate and cannot be used as one.
+- **`slope` is the tail's magnitude, and the window's is never published** — the reverse of what this
+  bullet said until 2026-09-02 (#237, §1.1). A positive published `slope` with `projection: null` still
+  cannot occur, and for the same reason: the decline happens before any projection is built, so the
+  gate and the divisor being the same fit changes nothing about that invariant. The window fit stays
+  internal and reaches the agent only, as `trend.slope`.
 - **An unfittable tail declines too**, and still as `not_rising`: fewer than two samples has no
   slope, and a tail sharing one timestamp is division by zero. `insufficient_samples` would be the
   wrong reason, since the contract defines that against the published `fitSampleCount` — the full
@@ -460,8 +527,14 @@ the other two (healthscan Q9). The dashboard works with or without the Vite dev 
 ### 4.1 Live projection — the MVP 2 scenario
 
 `Cloud API` at `PoolSize 1` against a ~1s-per-message downstream, so it clears ~1 msg/sec while
-inflow exceeds that. Net queue growth ~9.6/min. Baseline is ~0.4, so `baseline * 5.0` is ~2 and the
-absolute floor of 50 is the live arm.
+inflow exceeds that. Net queue growth ~9.6/min over the 45 s tail (§1.1) — the span `slope` is fitted
+over and the one `secondsToThreshold` is divided by. Baseline is ~0.4, so `baseline * 5.0` is ~2 and
+the absolute floor of 50 is the live arm.
+
+This row sits early in the ramp, where the tail is still catching up: §1.1's live table read `slope`
+11.2 at `queued: 11` and 16.2 at `queued: 14`, so 9.6 at 12 is one poll's worth of jitter below that
+pair rather than a different regime. The slope on this scenario ends up at ~60/min — see that table
+before treating 9.6 as the scenario's rate.
 
 `200` · `X-Healthscan-State: ok`
 
@@ -655,6 +728,12 @@ in `message` is there to say.
 and in the demo it is closer to a step than a ramp. A slope fitted across a step is an artifact of
 where the fit window happens to sit relative to the step, and it will move substantially between
 polls in the seconds after load changes.
+
+**And #237 made that worse on purpose.** A 45 s fit moves more between polls than a 300 s one, so both
+`slope` and `secondsToThreshold` are jumpier than they were — that is the price of the accuracy in
+§1.1's table, and it is the right price, because the smooth number it replaced was wrong by more than
+an order of magnitude at the moment it mattered. It also means the ETA is not a countdown: §1.4's
+"let it jump" rendering rule is load-bearing rather than cautious.
 
 **The target can move as well as the value** — §1.3, whenever `basis` is `baselineMultiplier`.
 

--- a/docs/demo/cue-sheet.md
+++ b/docs/demo/cue-sheet.md
@@ -169,13 +169,61 @@ the most common real-world failure and the hardest to see, because every individ
 | t | What happens |
 |---|---|
 | 0s | Button returns immediately; shows *activating* |
-| **~77s** | Takes effect — measured 77s. It warms a baseline at zero first |
-| ~90s | Queue starts climbing, ~1/sec net |
+| **~77s** | Takes effect — measured 77s. It settles with nothing armed first |
+| ~85s | Queue starts climbing, ~1/sec net — **and Early Warning starts projecting** (§1.2b) |
 | ~2min | First findings confirmed |
 
 > **Do not skip the 77 seconds and do not fill it with silence.** The wait exists for a real reason and
 > it is worth saying out loud: *"it is establishing what normal looks like before I break anything —
 > a baseline learned during a fault is worthless."* That line lands well with a technical audience.
+>
+> It is also worth knowing which reason is the live one, because someone will ask. The wait was
+> originally there to hold `queue_buildup`'s rolling baseline at zero; a **stated** baseline
+> (`referenceBaselines`) replaced that need. What it buys now is Early Warning's minimum fit window —
+> twelve samples at the 5s engine poll, i.e. 60s — which is why the projection in §1.2b is available
+> from the very first poll on which the queue moves. The number did not change; the reason did.
+
+### 1.2b Early Warning projects the crossing before it happens (30s)
+
+**This is the beat that was missing, and it is the one that distinguishes the product from a
+dashboard.** Between the queue starting to move and the first finding there are ~40 seconds in which
+Guardian is saying something no threshold alert can say: *not yet, but shortly, and here is how fast.*
+
+**Measured live on the containerised stack, 2026-09-02, one arm from a cold engine.** `t` is seconds
+from arming; the queue crossed the floor of 50 at t≈128s:
+
+| t | queue | Early Warning shows |
+|---|---|---|
+| 80s | 0 | *"Watching — not trending toward a threshold"* |
+| **85s** | 4 | `queued rising ~3.2/min · projected to cross 50 in ~14 min` |
+| 95s | 14 | `rising ~16.2/min · in ~2 min` |
+| 105s | 24 | `rising ~34.2/min · in under a minute` |
+| 120s | 46 | `rising ~60.4/min · in under a minute` |
+| 130s | 56 | *"Threshold reached — see the finding below"* |
+
+**Say:** *"Look at the rate, not the countdown: 60 messages a minute — one a second — arriving at a
+host that can clear one a second at best. Guardian worked that out from the trend, and it told me
+before the queue was deep enough for any threshold to have fired. That is the difference between a
+monitor and a warning."*
+
+> **Point at the RATE.** `~60.4/min` is a measurement and it converges on exactly the net inflow the
+> scenario creates. The countdown is the softer of the two claims — it is a projection, prefixed `~`
+> on purpose — and everything under 90 seconds is rendered *"under a minute"* rather than as a
+> ticking number, because a nine-sample fit does not support seconds.
+>
+> **The first projection is a large overestimate and say so if asked.** At t=85s it reads ~14 minutes
+> for a crossing that is ~43 seconds away, because at the first rising poll the fit still contains
+> mostly flat-at-zero history. It corrects within two polls. Claiming otherwise is a worse answer
+> than the honest one, and the honest one is the product's own point: the estimate improves as
+> evidence accumulates.
+>
+> **This used to be broken and it is worth knowing what it looked like**, in case you are presenting
+> from an older build. Until #237 the eta was fitted over a 300-second window rather than the recent
+> tail, which on a 50-second ramp is ~85% flat-at-zero prefix — so the rate read ~20× too low, the
+> first four polls said *"a crossing is beyond the projection horizon"* with nothing else on the
+> strip, and the polls after that promised *"~22 min"*, *"~14 min"*, *"~7 min"* for a queue 30, 25
+> and 20 seconds from crossing. If you see either symptom, the engine image predates the fix:
+> `PG_DEMO_TRIGGERS=1 PG_AGENT_MODE=live docker compose up -d --build detection-engine`.
 
 ### 1.3 The findings arrive (60s)
 

--- a/iris/labdemo/REST/TriggerDispatcher.cls
+++ b/iris/labdemo/REST/TriggerDispatcher.cls
@@ -139,10 +139,11 @@ ClassMethod Status() As %Status
 ///   activating      the request landed; the scenario is not in effect yet
 ///   activated       the scenario is in effect
 ///
-/// The middle state is real and observable, not a UI nicety. `PoolBottleneck()` warms the baseline
-/// at zero for 75 seconds BEFORE arming anything -- that wait is load-bearing (see that method, and
-/// #43: a queue forming during warm-up caps the ratio near 2x and `queue_buildup` can then never
-/// fire) -- and it runs as a background job, so the HTTP call returns in ~0.26s. For 75 seconds the
+/// The middle state is real and observable, not a UI nicety. `PoolBottleneck()` settles for 75
+/// seconds with nothing armed BEFORE arming anything -- that wait is load-bearing (see that method
+/// for why, and note the reason has changed once: it was #43's zero baseline, which
+/// `referenceBaselines` made unnecessary, and it is now Early Warning's minimum fit window. The 75s
+/// did not move) -- and it runs as a background job, so the HTTP call returns in ~0.26s. For 75 seconds the
 /// operator has a scenario that was accepted and is doing nothing yet. Reporting that as "not
 /// activated" invites a second click; reporting it as "activated" is a claim the presenter notices
 /// is false when no queue appears.
@@ -239,9 +240,13 @@ ClassMethod Arm() As %Status
         //
         //     POST /labdemo/trigger/arm {"scenario":"pool_bottleneck"}  ->  HTTP 504 in 60.2s
         //
-        // `PoolBottleneck()` waits 75s BEFORE arming anything -- the baseline has to warm at exactly
-        // zero or `queue_buildup` can never fire (see that method's comment, and #43). So the wait is
-        // load-bearing and cannot be shortened, which means the REQUEST has to stop being long.
+        // `PoolBottleneck()` waits 75s BEFORE arming anything. The reason has changed and the wait has
+        // not: it was "the baseline has to warm at exactly zero or `queue_buildup` can never fire"
+        // (#43), which `referenceBaselines` made untrue, and it is now Early Warning's `minFitSamples`
+        // (12) x the 5s engine poll -- see `PoolBottleneck()`'s comment for both halves. Either way the
+        // wait is load-bearing and cannot be shortened, which means the REQUEST has to stop being long.
+        // Worth noting the 504 does not care WHY the wait exists, so this block would have been needed
+        // regardless.
         //
         // Raising timeouts was the wrong fix and I tried it first: nginx 35s -> 180s and the engine
         // at 150s both sat outside a limit neither of them owned, and the symptom was unchanged.
@@ -266,7 +271,7 @@ ClassMethod Arm() As %Status
                 return $$$OK
             }
             write { "armed": (scenario), "ok": true, "pending": true, "log": "",
-                "note": "Warming the baseline at zero for ~75s before arming, so queue_buildup can fire. The armed indicator will appear when it starts." }.%ToJSON()
+                "note": "Settling for ~75s with nothing armed, so Early Warning has enough samples to project the crossing. The throttle and the inflow then go on together and the armed indicator appears." }.%ToJSON()
             return $$$OK
         }
 

--- a/iris/labdemo/Triggers.cls
+++ b/iris/labdemo/Triggers.cls
@@ -312,11 +312,30 @@ ClassMethod SystemAlert(pHost As %String = {..#OPERATION}) As %Status
 /// this value, and #66 established that restoring to a hardcoded number destroys a deployment that
 /// legitimately differs.
 ///
-/// THE BASELINE MUST WARM AT ZERO, WITH NO QUEUE, BEFORE ANYTHING IS ARMED. `pWarmSeconds`
-/// (default 75) waits with both halves OFF so the engine records a genuinely empty queue, and only
-/// then applies the throttle and the rate together.
+/// `pWarmSeconds` (default 75) WAITS WITH BOTH HALVES OFF BEFORE ARMING, AND THE REASON IS NO LONGER
+/// THE ONE THIS COMMENT GAVE. It used to read "THE BASELINE MUST WARM AT ZERO, WITH NO QUEUE" and the
+/// argument below was the justification. That argument is now dead, and the wait is still right:
 ///
-/// WHY, and this comes from the rule rather than from tuning. `queue_buildup` computes:
+///   * DEAD: the `queue_buildup` baseline. `thresholds.json` `referenceBaselines` states
+///     `Cloud API`.`queued = 0`, and `rules/index.ts` resolves the baseline through
+///     `effectiveBaseline()`, which returns the stated reference *instead of* the rolling mean. So
+///     the reference wins from poll 1 and there is no `minBaselineSamples` gate on this path at all.
+///     Whatever the rolling window learns during warm-up is not what the rule divides by. A queue
+///     forming during warm-up can no longer spoil the finding, which is exactly what the two
+///     measurements below were about.
+///
+///   * ALIVE, for a different module: Early Warning's fit. `earlywarning-api.md` §1.1 needs
+///     `minFitSamples` (12) samples before it will project, at the 5s engine poll — 60s on a stack
+///     that has just come up. Below that the endpoint returns `insufficient_samples` and the strip
+///     says "not enough samples yet" over a visibly climbing queue, which is the blank the whole of
+///     #237 was about closing. So 75s is still the right number, with margin, and shortening it
+///     below ~60s reintroduces a defect in a module that did not exist when this wait was written.
+///
+/// Both halves are worth keeping visible: the first because a reader who trusts it will "fix" the
+/// wrong thing, the second because the wait looks like dead weight once you know the first is dead.
+///
+/// THE ORIGINAL ARGUMENT, kept because it is why `referenceBaselines` exists. `queue_buildup`
+/// computes:
 ///
 ///     ratio = baseline > 0 ? depth / baseline : POSITIVE_INFINITY
 ///
@@ -337,13 +356,14 @@ ClassMethod SystemAlert(pHost As %String = {..#OPERATION}) As %Status
 /// passes 50.
 ///
 /// Cloud API idles at queued=0, so an empty warm-up is the natural state rather than something to
-/// engineer. 75s covers minBaselineSamples (12) x the 5s engine poll with margin.
+/// engineer.
 ///
 /// This is the same mechanism that makes ErrorRate() work where a plain disable does not (#43),
 /// stated as a requirement instead of relied on as luck.
 ///
-/// HONEST STATUS: THE MECHANICS ALL WORK, THE FINDING IS NOT YET RELIABLE. Measured on the
-/// containerised stack, each independently:
+/// STATUS, AS OF MVP 2 SHIPPING: THE FINDING IS RELIABLE. The block below recorded the opposite and
+/// is kept as the measurement record, not as current advice — read the correction after it before
+/// acting on any of it. Measured on the containerised stack, each independently:
 ///
 ///   the dispatcher throttle        avgProcessingTime 0.01s -> 1.01s
 ///   the inflow rate override       archive rate 0.53/sec -> 4.13/sec
@@ -361,11 +381,22 @@ ClassMethod SystemAlert(pHost As %String = {..#OPERATION}) As %Status
 /// gate (#43). Getting the baseline to zero requires the queue to be *empty* for the whole warm-up,
 /// and with the HL7 generator running it intermittently is not.
 ///
-/// So do not build the demo script on `queue_buildup` alone yet. `throughput_drop` fires reliably
-/// on this scenario and is a true statement about it. The remaining work is either a warm-up that
-/// guarantees an empty queue (pause the generator during it) or accepting that #25's threshold
-/// rework is the real fix -- and #25 is open precisely because these floors are tuned to LABDEMO's
-/// scale. Recorded here rather than left as a surprise for whoever writes the demo script.
+/// THE CORRECTION: BUILD THE DEMO SCRIPT ON `queue_buildup`. This paragraph said "do not build the
+/// demo script on `queue_buildup` alone yet" and named two candidate fixes. The first of the two
+/// shipped, in a form neither had guessed: not a warm-up that guarantees an empty queue, but a
+/// **stated** baseline that does not have to be learned. `referenceBaselines` removed the dependency
+/// on "what the instance was doing beforehand" entirely — that was the whole diagnosis above, and a
+/// stated normal is immune to it. MVP 2 shipped on 2026-08-20 with `queue_buildup` as the finding the
+/// agent explains and Smart Resolve clears, verified from an empty volume in one `compose up`, and it
+/// is the standing pre-demo check (#108).
+///
+/// `throughput_drop` is no longer the safe alternative it is called above, and in fact went the other
+/// way: it was measured firing on all three hosts at idle with nothing armed, because a post-reset
+/// backlog flush put ~134/sec into a mean baseline. That is why its baseline is a median now
+/// (`ROBUST_METRICS`). Do not fall back to it on the strength of this comment.
+///
+/// #25 remains open, and the second candidate above is still a fair description of it: these floors
+/// are tuned to LABDEMO's scale. It is no longer blocking anything here.
 ///
 /// EXPECT: queue_buildup within ~2 min of the rate rising. dead_host does NOT fire -- the host is
 /// healthy, just outnumbered, which is the point: this is the scenario where the finding needs an
@@ -425,12 +456,14 @@ ClassMethod PoolBottleneck(pDispatcherMs As %Integer = 1000, pRateSecs As %Doubl
         set ^ProductionGuardian.Trigger("PoolWas") = ..GetPoolSize(..#OPERATION)
     }
 
-    // WARM AT ZERO, with nothing armed. Applying the throttle before this wait was the defect:
-    // a queue forms during warm-up, the baseline learns a nonzero value, and the ratio can then
-    // never reach 5x (see the class comment). Both halves go on together AFTER the wait.
+    // SETTLE WITH NOTHING ARMED, so Early Warning has a fit window before the queue moves. The
+    // original reason -- keeping the rolling baseline at zero so `queue_buildup`'s ratio could clear
+    // 5x -- no longer applies: `referenceBaselines` states that baseline now. The surviving reason is
+    // `minFitSamples` (12) x the 5s poll = 60s before the endpoint will project at all. Full argument
+    // in the method comment. Both halves go on together AFTER the wait.
     if pWarmSeconds > 0 {
-        write "  warming the baseline for ", pWarmSeconds, "s with NOTHING armed", !
-        write "    (queue must read 0 so the baseline is 0 -- otherwise the ratio caps near 2x)", !
+        write "  settling for ", pWarmSeconds, "s with NOTHING armed", !
+        write "    (Early Warning needs ~60s of samples before it will project a crossing)", !
         hang pWarmSeconds
     }
     set ^ProductionGuardian.Trigger("DispatcherMs") = pDispatcherMs

--- a/services/detection-engine/src/detect/earlywarning.ts
+++ b/services/detection-engine/src/detect/earlywarning.ts
@@ -505,12 +505,15 @@ export function projectHost(
   // "nothing to see" about a queue that is over its limit.
   if (currentValue >= threshold.value) return decline('already_crossed', threshold);
 
+  // THE WINDOW MUST LEAN UP — a gate, and no longer the rate that is published (#237, below).
+  //
   // Round to 1dp in the units we publish, and test the ROUNDED value: publishing slope 0.0
   // alongside a finite ETA would be a projection the numbers do not support. Reads the fit measured
-  // above rather than repeating it (#187) — one computation, so the rate this endpoint publishes and
+  // above rather than repeating it (#187) — one computation, so the gate this endpoint applies and
   // the rate the investigation carries cannot drift apart.
-  const slopePerMinute = windowSlopePerMinute;
-  if (slopePerMinute === null || slopePerMinute <= 0) return decline('not_rising', threshold);
+  if (windowSlopePerMinute === null || windowSlopePerMinute <= 0) {
+    return decline('not_rising', threshold);
+  }
 
   // RISING NOW, not merely on average across the window. The window slope above describes the
   // window; this asks the same question of its tail, and both must say rising. That one gate covers
@@ -538,6 +541,55 @@ export function projectHost(
   if (recentDirection !== 'rising') {
     return decline('not_rising', threshold);
   }
+
+  /*
+   * THE ETA IS COMPUTED FROM THE TAIL, NOT THE WINDOW (#237, contract §1.1 as amended).
+   *
+   * `secondsToThreshold` used to divide by `windowSlopePerMinute`, and on the one scenario MVP 2
+   * exists to demonstrate that is the wrong span by a factor of ~20. §1.1 already contains the
+   * argument, one window size too high up: *"a 30-minute least-squares fit over mostly-flat history
+   * systematically understates a rise that started two minutes ago — it would hand back a comfortably
+   * distant ETA at exactly the moment the queue is running away."* Substitute 300 s for 30 minutes
+   * and 40 seconds for two minutes and it describes the shipped behaviour.
+   *
+   * The arithmetic, from the live scenario rather than from paper. `pool_bottleneck` warms at zero
+   * and then ramps +5 per 5 s poll, crossing the floor of 50 at 50 s. The window is 60 samples, so
+   * the ramp is a short suffix on a flat-at-zero prefix and least squares averages the two regimes:
+   *
+   *   t=5s   queued   5   window +0.1/min   tail  +3.3/min   true +60/min
+   *   t=25s  queued  25   window +1.4/min   tail +34.5/min   ETA was 1072 s, truly 25 s away
+   *   t=45s  queued  45   window +3.9/min   tail +60.0/min   ETA was   77 s, truly  5 s away
+   *
+   * So the first four polls of the ramp reported `beyond_horizon` (ETA > 1800 s) on a queue 20 to 45
+   * seconds from crossing, and the next five published a countdown reading 18 min, 11 min, 6 min,
+   * 3 min, 77 s. Both symptoms were reported from a demo run and both are this one division.
+   *
+   * WHY THE TAIL IS THE RIGHT SPAN AND NOT MERELY THE SHORTER ONE. `message` says "at this rate", and
+   * §1.5 already defines the tail as the answer to "which way is it moving NOW" — the gate directly
+   * above turns on it. Dividing by a different slope than the one that decided it is rising was the
+   * inconsistency; the published `slope` now names the divisor, so the message is arithmetic a reader
+   * can check. This is the same amendment #188 made to `snapshot.inboundRatePerSec` for the same
+   * reason: "the window slope is the wrong span … the tail fit is the 'now' the definition needs."
+   *
+   * WHY THE WINDOW GATE STAYS. It no longer supplies a number, but "the window leans up as well" is
+   * the false-positive posture MVP §6 asks for, and `fitSampleCount >= minFitSamples` above is what
+   * grounds the tail: 9 samples decide the rate only once 12 have agreed on the direction.
+   *
+   * The gate's obvious cost — a ramp begun while the window still holds a drain gets no forecast —
+   * turns out not to be reachable on this scenario, and `DISCONTINUITY_FRACTION` is why. A second
+   * `pool_bottleneck` inside five minutes leaves a 200-deep plateau and its drain inside the window,
+   * but the drain ends at zero, so the final step is a 100% fall and the truncation above discards
+   * everything before it. Measured: window +1.3/min at the first poll of the second ramp, forecasting
+   * identically to a cold stack. Checked rather than assumed, because the arrangement only works
+   * while the drain reaches zero.
+   *
+   * The cost is a jumpier countdown. A 45 s fit moves more between polls than a 300 s one, and §5's
+   * "it will move substantially between polls in the seconds after load changes" applies more
+   * strongly. That is the right trade for a warning: the previous number was smooth and wrong by more
+   * than an order of magnitude, and §5 already tells a reader not to treat the seconds as time to act.
+   */
+  const slopePerMinute = recentSlopePerMinute;
+  if (slopePerMinute === null || slopePerMinute <= 0) return decline('not_rising', threshold);
 
   const secondsToThreshold = Math.ceil(
     ((threshold.value - currentValue) / slopePerMinute) * 60,

--- a/services/detection-engine/src/detect/triggers.ts
+++ b/services/detection-engine/src/detect/triggers.ts
@@ -43,7 +43,7 @@ export interface TriggerStatus {
   /**
    * Per-scenario **accepted but not yet in effect** state.
    *
-   * A THIRD STATE, not a flag on the second. `pool_bottleneck` warms a baseline at zero for 75s
+   * A THIRD STATE, not a flag on the second. `pool_bottleneck` settles for 75s with nothing armed
    * before it arms anything and runs as a background job, so the arm POST returns in ~0.26s and the
    * scenario is in neither of the other two states for over a minute. Carried through this service
    * rather than re-derived in the dashboard: IRIS owns the witnesses, and a browser inferring
@@ -195,7 +195,7 @@ function parseResult(raw: unknown, scenario: string | null): TriggerResult {
 /**
  * Live trigger caller, over HTTP to the dispatcher in IRIS.
  *
- * ARM'S TIMEOUT IS LARGE ON PURPOSE. `PoolBottleneck()` warms a baseline at zero for 75 seconds
+ * ARM'S TIMEOUT IS LARGE ON PURPOSE. `PoolBottleneck()` settles for 75 seconds with nothing armed
  * before it returns, so a conventional 30s timeout would abort a call that was working and leave
  * the production half-armed with nothing reporting why. Measured: the trigger blocks for ~80s.
  *

--- a/services/detection-engine/test/earlywarning.test.ts
+++ b/services/detection-engine/test/earlywarning.test.ts
@@ -676,27 +676,31 @@ describe('recentDirection — which way it is moving now (§1.5)', () => {
  * constant can be tuned further without editing an assertion — but it FAILS at 0.4 and at 0.2, which
  * is what makes it a regression test rather than a restatement.
  */
+/* Zeros first so the window is warm and the threshold resolves to the absolute floor of 50, then the
+   measured ramp and drain. The trailing zeros are the idle tail after the queue emptied.
+
+   AT MODULE SCOPE because two describes read it — the drain half below and the ramp half after it
+   (#237). A second copy of a captured series is a copied value like any other, and this one carries
+   the flat-at-zero prefix that both fixes turn on. */
+const OBSERVED_DRAIN: readonly number[] = [
+  ...Array.from({ length: 60 }, () => 0),
+  4, 7, 14, 17, 24, 27, 34, 37, 44, 47, 54, 57, 64, 67, 74, 78,
+  69, 61, 50, 42, 30, 22, 10, 2, 0, 0,
+];
+const PEAK_INDEX = OBSERVED_DRAIN.indexOf(78);
+
+/** Every poll's verdict, projecting at each sample in turn as the engine's loop does. */
+function walk(values: readonly number[]) {
+  const cfg = config();
+  const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
+  return values.map((v, i) => {
+    const at = T0 + i * POLL;
+    store.record(HOST, 'queued', v, at);
+    return { index: i, value: v, row: projectHost(HOST, raw(v), store, cfg, at) };
+  });
+}
+
 describe('a draining queue is never forecast to cross (§2.2.1)', () => {
-  /* Zeros first so the window is warm and the threshold resolves to the absolute floor of 50, then the
-     measured ramp and drain. The trailing zeros are the idle tail after the queue emptied. */
-  const OBSERVED_DRAIN: readonly number[] = [
-    ...Array.from({ length: 60 }, () => 0),
-    4, 7, 14, 17, 24, 27, 34, 37, 44, 47, 54, 57, 64, 67, 74, 78,
-    69, 61, 50, 42, 30, 22, 10, 2, 0, 0,
-  ];
-  const PEAK_INDEX = OBSERVED_DRAIN.indexOf(78);
-
-  /** Every poll's verdict, projecting at each sample in turn as the engine's loop does. */
-  function walk(values: readonly number[]) {
-    const cfg = config();
-    const store = new BaselineStore(cfg.baselineWindowSeconds, cfg.minBaselineSamples);
-    return values.map((v, i) => {
-      const at = T0 + i * POLL;
-      store.record(HOST, 'queued', v, at);
-      return { index: i, value: v, row: projectHost(HOST, raw(v), store, cfg, at) };
-    });
-  }
-
   it('publishes no projection at any poll where the measured queue is falling', () => {
     for (const { index, value, row } of walk(OBSERVED_DRAIN)) {
       const previous = OBSERVED_DRAIN[index - 1] ?? value;
@@ -732,6 +736,122 @@ describe('a draining queue is never forecast to cross (§2.2.1)', () => {
     const last = walk(OBSERVED_DRAIN).find(({ value }) => value === 2);
     assert.ok(last !== undefined, 'sanity: the captured drain reaches 2');
     assert.equal(last.row.recentDirection, 'falling');
+  });
+});
+
+/*
+ * THE ETA IS DIVIDED BY THE TAIL FIT, NOT THE WINDOW FIT — #237, contract §1.1 as amended.
+ *
+ * WHY THIS WAS INVISIBLE TO 455 PASSING TESTS, which is the part worth pinning. Every existing
+ * projection fixture is a UNIFORM ramp from zero: `ramp()` above starts at 0 and rises by a constant,
+ * so the window and its tail fit the same line and the two slopes are equal to the decimal. The test
+ * at "one fit, used twice" even asserts that equality. Swapping the divisor therefore changed no
+ * assertion in the suite — the defect lived entirely in the one shape no fixture had, a rising suffix
+ * on a flat prefix, which is the only shape the shipped demo ever produces.
+ *
+ * THE SERIES IS THE SAME CAPTURED ONE the drain tests use, walked over its RAMP half. The queue clears
+ * the floor of 50 at index 70, so the true seconds-to-threshold at index i is `(70 - i) * 5`, which is
+ * what makes accuracy assertable at all rather than only self-consistency.
+ *
+ * Measured on that series, window basis against tail basis:
+ *
+ *   idx   q   true   window ETA        tail ETA
+ *    60   4    50s   27600s  ->  beyond_horizon      1062s
+ *    61   7    45s   12900s  ->  beyond_horizon       391s
+ *    62  14    40s    4320s  ->  beyond_horizon       153s
+ *    63  17    35s    2475s  ->  beyond_horizon        92s
+ *    64  24    30s    1300s  =  "~22 min"              50s
+ *    65  27    25s     812s  =  "~14 min"              36s
+ *    66  34    20s     418s  =   "~7 min"              20s   <- exact
+ *    67  37    15s     269s  =   "~4 min"              15s   <- exact
+ *    68  44    10s     100s                             7s
+ *    69  47     5s      41s                             4s
+ *
+ * Both reported symptoms are in that table: four polls of "beyond projection horizon" on a queue 35 to
+ * 50 seconds from crossing, then a countdown in MINUTES on a queue seconds from crossing.
+ */
+describe('the ETA measures the current rate, not the window average (§1.1, #237)', () => {
+  /* The first poll at or over the floor of 50. Derived rather than written down: past it the answer is
+     `already_crossed` by §2.2's precedence and there is no forecast to be right or wrong about. */
+  const CROSS_INDEX = OBSERVED_DRAIN.findIndex((v) => v >= 50);
+
+  /** The captured ramp, up to but excluding the poll that crosses. */
+  function ramping() {
+    return walk(OBSERVED_DRAIN).filter(
+      ({ index, row }) => index < CROSS_INDEX && row.recentDirection === 'rising',
+    );
+  }
+
+  it('publishes a projection at every rising poll — no beyond_horizon on the shipped ramp', () => {
+    /* THE FIRST REPORTED SYMPTOM. `beyond_horizon` is a sanity bound on the FORECAST, so reaching it
+       on a queue 50 seconds from its threshold was never a statement about the horizon — it was the
+       divisor being ~20x too shallow. Asserted over every rising poll rather than counting them, so
+       it fails on the first one that declines. */
+    for (const { index, value, row } of ramping()) {
+      assert.ok(
+        row.projection !== null,
+        `no forecast at index ${index}, q=${value}, ${(PEAK_INDEX - index) * 5}s from the peak ` +
+          `(reason=${row.projectionUnavailable}, window=${row.windowSlopePerMinute}/min, ` +
+          `tail=${row.recentSlopePerMinute}/min)`,
+      );
+    }
+  });
+
+  it('divides by the tail slope and publishes that same slope', () => {
+    /* The published rate must BE the divisor, or `message` is arithmetic that does not check out. The
+       second assertion is what makes this a regression test rather than a restatement: on this shape
+       the two fits differ by more than an order of magnitude, so equality with the window fit would
+       mean the old divisor is back. */
+    const rows = ramping().filter(({ row }) => row.projection !== null);
+    assert.ok(rows.length >= 8, `expected the ramp to forecast throughout, got ${rows.length}`);
+    for (const { index, row } of rows) {
+      assert.ok(row.projection !== null);
+      assert.equal(row.projection.slope, row.recentSlopePerMinute, `slope basis at index ${index}`);
+      assert.notEqual(
+        row.projection.slope,
+        row.windowSlopePerMinute,
+        `index ${index} fits both spans identically — the fixture has lost its flat prefix`,
+      );
+      // Self-consistency: the ETA is the published slope's own answer, to the rounding §1.2 states.
+      // Narrowed rather than coalesced — a `?? 0` here would still compute a number on a null
+      // threshold and assert nothing, which is the shape of a test that cannot fail.
+      assert.ok(row.threshold !== null && row.currentValue !== null);
+      assert.equal(
+        row.projection.secondsToThreshold,
+        Math.ceil(((row.threshold.value - row.currentValue) / row.projection.slope) * 60),
+      );
+    }
+  });
+
+  it('lands within one poll of the true crossing over the last 20 s of the ramp', () => {
+    /* THE SECOND REPORTED SYMPTOM — "it says X minutes but it passes in seconds". Asserted only over
+       the final 20s, deliberately: earlier in the ramp the TAIL still holds part of the flat prefix
+       too, so 1062s at q=4 is an overstatement this fix does not remove and "at this rate" is what
+       covers it. What must be true is that the number is right by the time it matters. Under the
+       window basis these four polls read 418s, 269s, 100s and 41s against 20s, 15s, 10s and 5s. */
+    for (const { index, row } of ramping()) {
+      const trueSeconds = (CROSS_INDEX - index) * (POLL / 1000);
+      if (trueSeconds > 20) continue;
+      assert.ok(row.projection !== null);
+      const error = Math.abs(row.projection.secondsToThreshold - trueSeconds);
+      assert.ok(
+        error <= POLL / 1000,
+        `index ${index}: forecast ${row.projection.secondsToThreshold}s against a true ${trueSeconds}s`,
+      );
+    }
+  });
+
+  it('still tightens monotonically, which the window basis also did', () => {
+    /* Kept because it is the property a viewer actually reads off the card, and because a shorter fit
+       is noisier — the accuracy above is bought with jitter (§5), and a countdown that went back up
+       would undo the fix's whole point on stage. */
+    const etas = ramping()
+      .map(({ row }) => row.projection?.secondsToThreshold)
+      .filter((e): e is number => e !== undefined);
+    assert.ok(
+      etas.every((e, i) => i === 0 || e <= (etas[i - 1] ?? e)),
+      `the ETA must tighten as the ramp approaches the threshold: ${etas.join(' -> ')}`,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #237.

`projectHost` divided `secondsToThreshold` by `windowSlopePerMinute` — an OLS fit over the whole 300s / 60-sample window. `pool_bottleneck`'s ramp is ~50s, so the window is ~85% flat-at-zero prefix and least squares averaged two regimes, understating the rise by ~20x. Both reported symptoms are that one division: `beyond_horizon` fired because the *ETA* exceeded 1800s, not because the horizon was wrong.

This divides by the 45s tail fit (`RECENT_FIT_FRACTION`, ~9 samples) and publishes that same slope.

## What the window fit still does

Two of its three jobs are unchanged, which is what keeps this a narrow change:

- it still **gates** the forecast — §2.2.1's two-fit test is untouched, and `fitSampleCount >= minFitSamples` (12) is still measured against the full window. Nine samples decide the *rate* only once twelve have agreed on the *direction*.
- it still reaches the agent as `trend.slope` (`investigation-api.md` §2.2).

It no longer supplies the published number.

Reading the fit measured for the gate rather than repeating the computation, so the gate this endpoint applies and the rate the investigation carries cannot drift apart (#187).

## Why the tail, and not a third span

§1.5 already defines the tail as the answer to "which way is it moving *now*", and §2.2.1's gate already turns on it — so the ETA was being divided by a different slope than the one that decided the queue was rising at all. Identical to the amendment #188 made to `snapshot.inboundRatePerSec`, for the same reason and against the same alternative.

**Option B — truncating the window at the discontinuity — was ruled out by arithmetic, not preference.** On a rise-from-flat it leaves fewer than 12 samples until 60s into a ramp that crosses at 50s, so `minFitSamples` would make Early Warning never project on the one scenario MVP 2 exists to demonstrate.

## Confirmed live from a cold engine

Not only in replay. One arm on the containerised stack; floor of 50 crossed at t~128s:

| t | queued | slope | eta |
|---|---|---|---|
| 80s | 0 | - | `not_rising` |
| 85s | 4 | 3.2 | 863 |
| 95s | 14 | 16.2 | 134 |
| 105s | 24 | 34.2 | 46 |
| 115s | 39 | 59.0 | 12 |
| 125s | 49 | 59.0 | 2 |
| 130s | 56 | - | `already_crossed` |

No `beyond_horizon` anywhere. A projection on every rising poll. `slope` converges on 60.4/min against a scenario that creates ~1/sec by construction. Full nine-poll table in the issue and in §1.1.

Before the fix, the same polls read `beyond_horizon` (a blank strip) for the first four, then "~22 min", "~14 min", "~7 min", "~4 min" for a queue 30, 25 and 20 seconds from crossing.

## Why 455 tests missed it

Every existing fixture is a **uniform ramp from zero**, where the window and the tail fit the same line — `test/earlywarning.test.ts` even asserted their equality to the decimal. The defect exists only where the two spans see different regimes, which is every real ramp and no fixture. The new block replays the captured series and asserts against the truth the series itself supplies: a projection at every rising poll, the divisor identity, accuracy within one poll over the last 20s, and monotonic tightening.

`OBSERVED_DRAIN`, `PEAK_INDEX` and `walk()` are hoisted to module scope rather than copied, because a second copy of a captured series is a copied value like any other.

## The warm-up's stated purpose was already dead

Surfaced by the same investigation. `Triggers.PoolBottleneck` said "THE BASELINE MUST WARM AT ZERO ... or `queue_buildup` can never fire (#43)". But `rules/index.ts` resolves that baseline through `effectiveBaseline()`, and `referenceBaselines` states `Cloud API`.`queued = 0` — so the reference wins from poll 1 and the rolling mean is not what the rule divides by. A queue forming during warm-up can no longer spoil the finding, which is exactly what that comment's two measurements were about.

**The wait is still right, for a different reason:** Early Warning's `minFitSamples` (12) x the 5s poll = 60s on a cold stack, so 75s covers it with margin and cutting below ~60s reintroduces `insufficient_samples` over a visibly climbing queue — the blank this PR exists to close. Both halves are recorded, because a reader who trusts the dead one will fix the wrong thing and the wait looks like dead weight once you know it is dead.

Corrected in `Triggers.cls`, `TriggerDispatcher.cls` (including the operator-visible `note`), `triggers.ts`, `TriggerRail.tsx`, `README.md` and the cue sheet.

Also struck `Triggers.cls`'s **"HONEST STATUS: THE FINDING IS NOT YET RELIABLE"** and **"do not build the demo script on `queue_buildup` alone yet"**. Both were false the moment `referenceBaselines` shipped, and MVP 2 shipped *on* `queue_buildup`. That block also named `throughput_drop` as the reliable alternative, which was later measured firing at idle on all three hosts. Kept as the measurement record, bracketed by the correction, rather than deleted.

## Contract

`earlywarning-api.md` §1.1 amended, with §1.2 (rounding), §1.5 (`recentDirection` stays a sign, on a narrower justification), §2.2.1 (bullet reversed), §4.1 and §5 (jitter) reconciled, plus a `CHANGELOG.md` entry. Two paragraphs were arguments *against* this change and are struck with the reason rather than quietly dropped.

## Demo flow

`cue-sheet.md` gains **§1.2b — Early Warning projects the crossing before it happens**: the ~40s beat between the queue moving and the first finding, which the cue sheet did not script at all. That omission is why the defect reached a rehearsal rather than a test.

## Verified

- engine `tsc --noEmit` clean; **459/459** tests pass (455 before, +4)
- `contracts/validate.mjs` — all checks passed (10 samples, 23 accept, 65 reject, 7 capture claims, 22 prose fences)
- dashboard `tsc --noEmit` clean, `validate-architecture.mjs` ok, **image** build succeeds and serves 200 through nginx. Local `npm run build` is blocked by a pre-existing rollup optional-dependency install bug in `node_modules`, unrelated to this change — per `apps/dashboard/CLAUDE.md` §6.1 the image is the build that ships
- live arm + reset on the containerised stack with `agent=live demo-triggers=ON`

## Known residual, documented rather than fixed

At the first rising poll the tail still holds flat-at-zero samples, so the ETA is a large overestimate — 863s live against a true ~43s. It corrects within two polls, "at this rate" is what covers it, and it is exact from 20s out. §5 and the cue sheet both say so out loud, including what a presenter should answer if asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
