### PR TITLE
feat(dashboard): drag-resizable panels, and the triggers and evidence collapse

### DIFF
--- a/apps/dashboard/src/components/AppShell.tsx
+++ b/apps/dashboard/src/components/AppShell.tsx
@@ -47,8 +47,10 @@ import {
   IconShield,
   type IconProps,
 } from './icons';
+import { ResizeHandle } from './ResizeHandle';
 import { ThemeToggle } from './ThemeToggle';
 import { TriggerRail } from './TriggerRail';
+import { useResizable } from '../hooks/useResizable';
 
 /** Which top-level view is on screen. */
 export type View = 'dashboard' | 'brochure' | 'architecture';
@@ -137,6 +139,16 @@ export function AppShell({
   settingsOpen,
   children,
 }: AppShellProps): JSX.Element {
+  /* Drives `--pg-rail-width`, which `.pg-shell`'s grid column reads — see `useResizable`. Owned here
+     rather than by the rail's contents because the rail is not the element that is sized; the shell
+     is, and this is the component that renders both. */
+  const rail = useResizable({
+    variable: '--pg-rail-width',
+    storageKey: 'pg.railWidth.v1',
+    edge: 'end',
+    label: 'Navigation rail width',
+  });
+
   return (
     <div className="pg-shell">
       <nav className="pg-rail" aria-label="Health Connect">
@@ -211,6 +223,12 @@ export function AppShell({
             rail so an audience reads the product's own navigation first and the demo scaffolding
             after it, and so its absence leaves the rail visually unchanged. */}
         <TriggerRail />
+
+        {/* Last of all, and absolutely positioned on the rail's own right edge — so it tracks the
+            column whatever the rail contains, including the demo triggers being off. Hidden under
+            1100px, where the media query pins the rail to an icon strip and a drag would appear to
+            do nothing. */}
+        <ResizeHandle {...rail} className="pg-resize--rail" />
       </nav>
 
       <header className="pg-header">

--- a/apps/dashboard/src/components/DrawerResizeHandle.tsx
+++ b/apps/dashboard/src/components/DrawerResizeHandle.tsx
@@ -1,0 +1,28 @@
+/**
+ * The right-hand drawer's resize handle, options and all.
+ *
+ * A WRAPPER BECAUSE THERE ARE THREE CALL SITES. `FindingDetail`, `HostDetail` and `ThresholdSettings`
+ * are the three panels that render `.pg-drawer`, they are mutually exclusive by construction (see
+ * `App.tsx`), and they share `--pg-drawer-width` — so whichever is open must resize the same thing to
+ * the same remembered value. Three copies of the same `useResizable` options is three chances for one
+ * of them to name a different storage key and quietly stop agreeing. The rail has one call site and
+ * so calls the hook directly in `AppShell`.
+ *
+ * `edge: 'start'` — the handle sits on the drawer's LEFT edge, so dragging right narrows it. Dragging
+ * right always moves the separator right; which side gains is a consequence of which side the panel
+ * is on.
+ */
+
+import { ResizeHandle } from './ResizeHandle';
+import { useResizable } from '../hooks/useResizable';
+
+export function DrawerResizeHandle(): JSX.Element | null {
+  const drawer = useResizable({
+    variable: '--pg-drawer-width',
+    storageKey: 'pg.drawerWidth.v1',
+    edge: 'start',
+    label: 'Panel width',
+  });
+
+  return <ResizeHandle {...drawer} className="pg-resize--drawer" />;
+}

--- a/apps/dashboard/src/components/FindingDetail.tsx
+++ b/apps/dashboard/src/components/FindingDetail.tsx
@@ -34,6 +34,7 @@ import {
   formatRate,
   formatRelative,
 } from '../lib/format';
+import { DrawerResizeHandle } from './DrawerResizeHandle';
 import { SeverityBadge } from './SeverityBadge';
 import { IconClose } from './icons';
 
@@ -117,6 +118,11 @@ export function FindingDetail({
       aria-modal="false"
       aria-labelledby="pg-drawer-title"
     >
+      {/* First child, on the drawer's own left edge, so it tracks the real rendered width — including
+          the `min(…, 60vw)` narrowing under 1100px, which a handle positioned from the viewport
+          would not. */}
+      <DrawerResizeHandle />
+
       <header className="pg-drawer__header">
         <div className="pg-drawer__heading">
           <SeverityBadge severity={finding.severity} />

--- a/apps/dashboard/src/components/HostDetail.tsx
+++ b/apps/dashboard/src/components/HostDetail.tsx
@@ -36,6 +36,7 @@ import { useEffect } from 'react';
 import type { FindingView, HostView, Severity } from '../types/healthscan';
 import type { HostSeriesView } from '../types/hostseries';
 import { formatCount, formatDuration, formatRate, formatRelative } from '../lib/format';
+import { DrawerResizeHandle } from './DrawerResizeHandle';
 import { MetricChart } from './MetricChart';
 import { SeverityBadge } from './SeverityBadge';
 import { StatusDot } from './StatusDot';
@@ -118,6 +119,9 @@ export function HostDetail({
       aria-modal="false"
       aria-labelledby="pg-host-drawer-title"
     >
+      {/* One width for all three right-edge panels — see `DrawerResizeHandle`. */}
+      <DrawerResizeHandle />
+
       <header className="pg-drawer__header">
         <div className="pg-drawer__heading">
           <h2 id="pg-host-drawer-title" className="pg-drawer__title">

--- a/apps/dashboard/src/components/InvestigationPanel.tsx
+++ b/apps/dashboard/src/components/InvestigationPanel.tsx
@@ -31,9 +31,17 @@
  * be explicit for the same reason: nothing about a write should be inferred.
  */
 
+import { useState } from 'react';
 import type { InvestigationView, ResolveActionView, ResolveMode, ResolveView } from '../types/mvp2';
 import { ABSENT, toolLabel } from '../lib/format';
 import { findingMeta, investigationScope } from '../lib/findingMeta';
+import { IconChevronRight } from './icons';
+
+/**
+ * `aria-controls` needs an id, and the three right-edge panels are mutually exclusive by construction
+ * (see `App.tsx`), so at most one of these lists is in the document at a time.
+ */
+const EVIDENCE_ID = 'pg-evidence-list';
 
 export interface InvestigationPanelProps {
   /** The finding's type, for the §2.4 scope check. Only the type is needed, so only it is passed. */
@@ -92,6 +100,32 @@ export function InvestigationPanel({
   const canned = investigation?.source === 'canned';
   const unavailable = investigation !== null && investigation.rootCause === null;
   const scope = investigationScope(findingType);
+
+  /*
+   * THE EVIDENCE LIST, COLLAPSED BY DEFAULT (@Ari-Glikman, 2026-09-02: "when retracted one should be
+   * able to see the suggested fix but not the evidence").
+   *
+   * COLLAPSED IS THE INITIAL STATE, and that is the load-bearing half of the request rather than a
+   * default picked for tidiness. The evidence sits BETWEEN the root cause and the recommended action
+   * in this panel — deliberately, because it is what the recommendation rests on — and four to six
+   * bullets is enough to push Approve below the fold of a 420px drawer. An expand-by-default toggle
+   * would leave that complaint exactly where it was.
+   *
+   * WHAT MUST NOT BE HIDEABLE IS PROVENANCE, so two things stay outside the collapse: the badge row
+   * above (live-vs-canned, model, tool count, confidence) is never collapsed, and the closed toggle
+   * states how many bullets exist and how many were READ FROM IRIS rather than asserted. Point 3 of
+   * this file's header is that provenance is part of the evidence; a disclosure that hid the count
+   * silently would let a canned narrative and a governed one look identical while closed, which is
+   * the same defect class as point 1.
+   *
+   * NOT PERSISTED, and reset by the drawer closing rather than by anything here — this component
+   * unmounts with it (`App.tsx` clears the selection), so the next finding starts collapsed too. A
+   * remembered "expanded" would mean the fix is below the fold again for whoever opens the dashboard
+   * next, which is the state this exists to avoid.
+   */
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+  const evidence = investigation?.evidence ?? [];
+  const measured = evidence.filter((item) => item.source === 'mcp_tool').length;
 
   /*
    * OUT OF SCOPE RETURNS EARLY rather than wrapping the button in a condition, so `onInvestigate` is
@@ -205,23 +239,52 @@ export function InvestigationPanel({
             <p className="pg-investigate__rootcause">{investigation.rootCause}</p>
           )}
 
-          {investigation.evidence.length > 0 && (
-            <ul className="pg-evidence">
-              {investigation.evidence.map((item, index) => (
-                <li key={`${item.label}-${index}`} className="pg-evidence__item">
-                  <div className="pg-evidence__head">
-                    <span className="pg-evidence__label">{item.label}</span>
-                    <span className={`pg-evidence__source pg-evidence__source--${item.source}`}>
-                      {SOURCE_LABEL[item.source] ?? item.source}
-                      {item.tool !== null && (
-                        <span className="pg-facts__mono"> · {toolLabel(item.tool)}</span>
-                      )}
-                    </span>
-                  </div>
-                  <div className="pg-evidence__detail">{item.detail}</div>
-                </li>
-              ))}
-            </ul>
+          {evidence.length > 0 && (
+            <>
+              <button
+                type="button"
+                className="pg-disclose"
+                aria-expanded={evidenceOpen}
+                aria-controls={EVIDENCE_ID}
+                onClick={() => setEvidenceOpen((prev) => !prev)}
+              >
+                {/* Rotated by a class rather than an `[aria-expanded]` selector, so it cannot pick
+                    up an expandable control added to this panel later. */}
+                <IconChevronRight
+                  size={14}
+                  className={`pg-disclose__chevron${
+                    evidenceOpen ? ' pg-disclose__chevron--open' : ''
+                  }`}
+                />
+                Evidence
+                {/* The count and its provenance, stated on the CLOSED control — see the comment on
+                    `evidenceOpen`. `measured` is the `mcp_tool` entries: read from the live
+                    production by a governed tool, as opposed to asserted by the model. */}
+                <span className="pg-disclose__count">
+                  {evidence.length} item{evidence.length === 1 ? '' : 's'}
+                  {measured > 0 && <> · {measured} read from IRIS</>}
+                </span>
+              </button>
+
+              {/* `hidden` rather than unmounted, so the list is not rebuilt on every toggle and the
+                  button's `aria-controls` always points at something that exists. */}
+              <ul className="pg-evidence" id={EVIDENCE_ID} hidden={!evidenceOpen}>
+                {evidence.map((item, index) => (
+                  <li key={`${item.label}-${index}`} className="pg-evidence__item">
+                    <div className="pg-evidence__head">
+                      <span className="pg-evidence__label">{item.label}</span>
+                      <span className={`pg-evidence__source pg-evidence__source--${item.source}`}>
+                        {SOURCE_LABEL[item.source] ?? item.source}
+                        {item.tool !== null && (
+                          <span className="pg-facts__mono"> · {toolLabel(item.tool)}</span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="pg-evidence__detail">{item.detail}</div>
+                  </li>
+                ))}
+              </ul>
+            </>
           )}
 
           {manual !== null && (

--- a/apps/dashboard/src/components/ResizeHandle.tsx
+++ b/apps/dashboard/src/components/ResizeHandle.tsx
@@ -1,0 +1,67 @@
+/**
+ * The grab strip on a resizable panel's edge.
+ *
+ * PRESENTATIONAL AND STATELESS — every decision is in `hooks/useResizable.ts`, and this file exists
+ * so the rail and the drawer cannot end up with different affordances or different keyboard support.
+ * Spread the hook's return into it: `<ResizeHandle {...rail} className="pg-resize--rail" />`.
+ *
+ * A `separator`, NOT A `<button>`, which is the one exception to §7.3's "real `<button>` for anything
+ * clickable". This is the ARIA window-splitter pattern: a focusable separator carrying
+ * `aria-valuenow/min/max`, so assistive technology reads out a position rather than announcing a
+ * press. A button would announce the wrong thing and would have no way to report the width.
+ *
+ * WIDER THAN IT LOOKS. The visible mark is a 2px line; the target is 10px, because a 1px seam is not
+ * a pointer target on a laptop trackpad. The extra width sits inside the panel's own padding, so it
+ * covers nothing clickable — see the rule in `app.css`.
+ *
+ * RENDERS NOTHING WHEN THE HOOK IS DISABLED, i.e. when a bound token could not be read. A handle that
+ * is present and inert is worse than an absent one: it invites a drag and then reports nothing.
+ */
+
+import type { Resizable } from '../hooks/useResizable';
+
+export interface ResizeHandleProps extends Resizable {
+  /** Positioning modifier — which edge of which panel. Geometry only; behaviour is the hook's. */
+  className: string;
+}
+
+export function ResizeHandle({
+  className,
+  enabled,
+  width,
+  min,
+  max,
+  label,
+  dragging,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onLostPointerCapture,
+  onKeyDown,
+  onDoubleClick,
+}: ResizeHandleProps): JSX.Element | null {
+  if (!enabled) return null;
+
+  return (
+    <div
+      className={`pg-resize ${className}${dragging ? ' pg-resize--dragging' : ''}`}
+      role="separator"
+      /* The separator itself is vertical; `separator`'s ARIA default is horizontal. */
+      aria-orientation="vertical"
+      aria-label={label}
+      aria-valuenow={width}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      /* Says how it works, since the control carries no visible text. Both halves matter: nobody
+         discovers the keyboard path, and nobody discovers the reset without being told. */
+      title={`${label} — drag, or focus it and use the arrow keys. Double-click to reset.`}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onLostPointerCapture={onLostPointerCapture}
+      onKeyDown={onKeyDown}
+      onDoubleClick={onDoubleClick}
+    />
+  );
+}

--- a/apps/dashboard/src/components/ThresholdSettings.tsx
+++ b/apps/dashboard/src/components/ThresholdSettings.tsx
@@ -24,6 +24,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { SettingFieldView, ThresholdSettingsView } from '../types/settings';
+import { DrawerResizeHandle } from './DrawerResizeHandle';
 import { IconClose, IconRestart, IconSettings } from './icons';
 
 export interface ThresholdSettingsProps {
@@ -125,6 +126,9 @@ export function ThresholdSettings({
       aria-modal="false"
       aria-labelledby="pg-settings-title"
     >
+      {/* One width for all three right-edge panels — see `DrawerResizeHandle`. */}
+      <DrawerResizeHandle />
+
       <header className="pg-drawer__header">
         <div className="pg-drawer__heading">
           <h2 id="pg-settings-title" className="pg-drawer__title">

--- a/apps/dashboard/src/components/TriggerRail.tsx
+++ b/apps/dashboard/src/components/TriggerRail.tsx
@@ -41,7 +41,14 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { IconAlert } from './icons';
+import { IconAlert, IconChevronRight } from './icons';
+
+/**
+ * `aria-controls` needs an id, and one instance of this component exists in the app — it is rendered
+ * once by `AppShell`. A constant rather than `useId`, so the relationship is greppable from the CSS
+ * and from the markup.
+ */
+const LIST_ID = 'pg-trigger-list';
 
 /** One scenario, exactly as the server describes it. */
 export interface TriggerScenario {
@@ -153,6 +160,25 @@ export function TriggerRail(): JSX.Element | null {
    * mis-attribution is plausible enough to be believed (@Ari-Glikman, from driving the live UI).
    */
   const [messages, setMessages] = useState<Record<string, TriggerMessage>>({});
+  /**
+   * The scenario list, COLLAPSED BY DEFAULT (@Ari-Glikman, 2026-09-02).
+   *
+   * This replaces the distance that used to do the same job. The list was pinned to the bottom of the
+   * rail so an audience would read the product's own navigation first; it now sits directly under the
+   * Thresholds group, and collapsing it is what keeps four buttons that break a production on purpose
+   * from being the largest thing in the rail. Collapsed is the stronger separation of the two: absent
+   * beats merely lower down.
+   *
+   * WHAT COLLAPSING MUST NOT HIDE IS STATE, which is why the summary below exists. `pool_bottleneck`
+   * reads "trigger activating…" for about 75 seconds — the longest wait in the demo and the whole
+   * reason the middle phase exists (#135) — and a collapsed rail that said nothing about it would
+   * re-create, one layer up, exactly the defect the three-phase rail was built to fix.
+   *
+   * NOT PERSISTED, unlike the panel widths. A remembered "expanded" would put the scaffolding back on
+   * screen for whoever opens the dashboard next, which is the state this change exists to avoid; and
+   * a presenter who wants it open is one click away, mid-demo, with the rail in front of them.
+   */
+  const [open, setOpen] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -368,70 +394,121 @@ export function TriggerRail(): JSX.Element | null {
     void post('/reset', {}, RESET_KEY);
   };
 
+  /*
+   * WHAT THE COLLAPSED HEADING SAYS ABOUT A LIVE SCENARIO.
+   *
+   * `activating` WINS OVER `activated` when both are present, because it is the one that describes a
+   * wait somebody is currently sitting through. Counted rather than named: the phase word is the fact
+   * that matters, and a scenario name at 11px in a 208px rail is not readable from the back of a room
+   * anyway — the label is one click away in the list itself.
+   *
+   * Recomputed from `phaseOf`, so it cannot disagree with the buttons below it.
+   */
+  const phases = state.scenarios.map((s) => phaseOf(s.id));
+  const activating = phases.filter((p) => p === 'activating').length;
+  const activated = phases.filter((p) => p === 'activated').length;
+  const summary =
+    activating > 0
+      ? { phase: 'activating' as const, count: activating }
+      : activated > 0
+        ? { phase: 'activated' as const, count: activated }
+        : null;
+
   return (
     <div className="pg-triggers">
-      <span className="pg-rail__brand pg-rail__brand--triggers">
+      {/* The heading IS the disclosure. A separate toggle beside it would be a second control for one
+          thing in a rail this narrow, and the heading is already the whole width of the group. */}
+      <button
+        type="button"
+        className="pg-rail__brand pg-rail__brand--triggers pg-triggers__toggle"
+        aria-expanded={open}
+        aria-controls={LIST_ID}
+        onClick={() => setOpen((prev) => !prev)}
+      >
         <IconAlert size={14} />
-        Demo triggers
-      </span>
-      <p className="pg-triggers__caption">These break the production on purpose.</p>
+        <span className="pg-triggers__toggle-label">Demo triggers</span>
+        {/* Only while collapsed: expanded, every button states its own phase, and repeating it here
+            would be two authorities on one fact. */}
+        {!open && summary !== null && (
+          <span className="pg-triggers__summary">
+            {/* Shape as well as colour, the same pair the buttons use (§7.3). */}
+            <span
+              className={`pg-rail__trigger-dot pg-rail__trigger-dot--${summary.phase}`}
+              aria-hidden="true"
+            />
+            {summary.count} {summary.phase}
+          </span>
+        )}
+        <IconChevronRight
+          size={14}
+          className={`pg-triggers__chevron${open ? ' pg-triggers__chevron--open' : ''}`}
+        />
+      </button>
 
-      <ul className="pg-rail__list">
-        {state.scenarios.map((s) => {
-          const phase = phaseOf(s.id);
-          return (
-            <li key={s.id} className="pg-triggers__row">
-              <button
-                type="button"
-                className={`pg-rail__item pg-rail__item--trigger pg-rail__item--${phase}`}
-                /* NOT `disabled`. A trigger that will refuse stays focusable and clickable so the
-                   refusal can explain itself in the slot below — see `onArm`. `aria-disabled` is what
-                   tells assistive technology the control will not act, which `disabled` would say at
-                   the cost of making the explanation unreachable by keyboard. */
-                aria-disabled={phase !== 'idle' || busy !== null}
-                onClick={() => onArm(s)}
-                title={`${s.detail}\n\nFires: ${s.findings}`}
-              >
-                <span className="pg-rail__trigger-label">
-                  {s.label}
-                  {/* Shape as well as words: a filled disc for activated, a hollow ring for
-                      activating. State is never carried by colour alone (§7.3), and these two are
-                      told apart by silhouette at the back of a room where amber and teal may not
-                      be. */}
-                  {phase !== 'idle' && (
-                    <span
-                      className={`pg-rail__trigger-dot pg-rail__trigger-dot--${phase}`}
-                      aria-hidden="true"
-                    />
+      {/* HIDDEN RATHER THAN UNMOUNTED. Each row carries a `role="status"` slot that has to be in the
+          document before its text changes or the change is not announced (see `TriggerNote`), and
+          unmounting the list would rebuild those regions on every expand. `hidden` is `display: none`,
+          so it is out of the layout and out of the accessibility tree either way. */}
+      <div id={LIST_ID} hidden={!open}>
+        <p className="pg-triggers__caption">These break the production on purpose.</p>
+
+        <ul className="pg-rail__list">
+          {state.scenarios.map((s) => {
+            const phase = phaseOf(s.id);
+            return (
+              <li key={s.id} className="pg-triggers__row">
+                <button
+                  type="button"
+                  className={`pg-rail__item pg-rail__item--trigger pg-rail__item--${phase}`}
+                  /* NOT `disabled`. A trigger that will refuse stays focusable and clickable so the
+                     refusal can explain itself in the slot below — see `onArm`. `aria-disabled` is what
+                     tells assistive technology the control will not act, which `disabled` would say at
+                     the cost of making the explanation unreachable by keyboard. */
+                  aria-disabled={phase !== 'idle' || busy !== null}
+                  onClick={() => onArm(s)}
+                  title={`${s.detail}\n\nFires: ${s.findings}`}
+                >
+                  <span className="pg-rail__trigger-label">
+                    {s.label}
+                    {/* Shape as well as words: a filled disc for activated, a hollow ring for
+                        activating. State is never carried by colour alone (§7.3), and these two are
+                        told apart by silhouette at the back of a room where amber and teal may not
+                        be. */}
+                    {phase !== 'idle' && (
+                      <span
+                        className={`pg-rail__trigger-dot pg-rail__trigger-dot--${phase}`}
+                        aria-hidden="true"
+                      />
+                    )}
+                  </span>
+                  {/* Words, not a spinner: pool_bottleneck warms a baseline for 75 seconds and a
+                      spinner that long reads as a hang. The word the operator now sees is "activated"
+                      rather than "armed" — same state, plainer language. */}
+                  {phase === 'activating' && (
+                    <span className="pg-rail__trigger-state">trigger activating…</span>
                   )}
-                </span>
-                {/* Words, not a spinner: pool_bottleneck warms a baseline for 75 seconds and a
-                    spinner that long reads as a hang. The word the operator now sees is "activated"
-                    rather than "armed" — same state, plainer language. */}
-                {phase === 'activating' && (
-                  <span className="pg-rail__trigger-state">trigger activating…</span>
-                )}
-                {phase === 'activated' && (
-                  <span className="pg-rail__trigger-state">trigger activated</span>
-                )}
-              </button>
-              <TriggerNote message={messages[s.id]} />
-            </li>
-          );
-        })}
-        <li className="pg-triggers__row">
-          <button
-            type="button"
-            className="pg-rail__item pg-rail__item--trigger pg-rail__item--reset"
-            onClick={onReset}
-            title="Restore every setting the triggers changed"
-          >
-            <span className="pg-rail__trigger-label">Reset all</span>
-            {busy === RESET_KEY && <span className="pg-rail__trigger-state">resetting…</span>}
-          </button>
-          <TriggerNote message={messages[RESET_KEY]} />
-        </li>
-      </ul>
+                  {phase === 'activated' && (
+                    <span className="pg-rail__trigger-state">trigger activated</span>
+                  )}
+                </button>
+                <TriggerNote message={messages[s.id]} />
+              </li>
+            );
+          })}
+          <li className="pg-triggers__row">
+            <button
+              type="button"
+              className="pg-rail__item pg-rail__item--trigger pg-rail__item--reset"
+              onClick={onReset}
+              title="Restore every setting the triggers changed"
+            >
+              <span className="pg-rail__trigger-label">Reset all</span>
+              {busy === RESET_KEY && <span className="pg-rail__trigger-state">resetting…</span>}
+            </button>
+            <TriggerNote message={messages[RESET_KEY]} />
+          </li>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/hooks/useResizable.ts
+++ b/apps/dashboard/src/hooks/useResizable.ts
@@ -1,0 +1,282 @@
+/**
+ * Drag-to-resize, for the nav rail and the right-hand drawer.
+ *
+ * ONE HOOK FOR BOTH, because the two differ in exactly two ways — which custom property they drive
+ * and which side the handle sits on — and everything with a decision in it is shared: the clamp, the
+ * pointer capture, the keyboard fallback, and remembering the width. Two copies of that would drift,
+ * and the half that drifts is always the keyboard half.
+ *
+ * THE WIDTH IS WRITTEN TO A CUSTOM PROPERTY ON <html>, NOT AS AN INLINE `width` ON THE PANEL. Both
+ * targets already resolve theirs from a token and neither would obey an inline width correctly:
+ *
+ *   - the rail is a GRID COLUMN on `.pg-shell` (`grid-template-columns: var(--pg-rail-width) …`), so
+ *     a width on the rail element itself does nothing at all;
+ *   - `.pg-drawer` narrows to `min(var(--pg-drawer-width), 60vw)` under 1100px, and an inline width
+ *     would override that clamp and cover the grid on a 1024px laptop — defeating the reason it is a
+ *     drawer and not a modal.
+ *
+ * Overriding the variable leaves every existing rule, including the responsive one, in charge of how
+ * the number is used. Same arrangement as `data-theme` (`lib/theme.ts`): the only thing JS decides is
+ * a value, and CSS decides what it means.
+ *
+ * THE DEFAULT, MINIMUM AND MAXIMUM ARE ALSO TOKENS, read back off the document rather than written
+ * here. They are geometry, so §9 puts them in `tokens.css`; reading them is what makes the reset
+ * target unable to disagree with the width the page loads at, which is exactly the duplication that
+ * keeps going stale in this repo. The read is cached per property and taken during the FIRST render,
+ * before this hook has written anything — after that the computed value is our own override rather
+ * than the token, so a later read would return whatever the operator last dragged to.
+ *
+ * POINTER CAPTURE RATHER THAN WINDOW LISTENERS. `setPointerCapture` routes every later move to the
+ * handle even once the cursor has left it — which is the normal case while dragging — and the browser
+ * releases it implicitly on `pointerup`. Nothing is attached to `window`, so there is no listener to
+ * leak and no drag that can outlive the element it started on.
+ *
+ * A DRAG-ONLY CONTROL WOULD NOT MEET THE BAR (§7.3). The handle is a focusable `separator` — the ARIA
+ * window-splitter pattern, which is why this one control is not a `<button>` — and it answers the
+ * arrow keys, Home/End, and Enter/Space to reset, so both panels are resizable without a mouse.
+ *
+ * THE VARIABLE IS NEVER CLEANED UP ON UNMOUNT, DELIBERATELY. All three right-edge panels
+ * (`FindingDetail`, `HostDetail`, `ThresholdSettings`) are mutually exclusive by construction and
+ * share `--pg-drawer-width`, so the width has to survive one closing and the next opening. Each
+ * mount re-reads the same remembered value, so they cannot disagree.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent, PointerEvent } from 'react';
+
+/**
+ * Which edge of the panel the handle sits on, which is the same thing as the sign of a drag: a
+ * handle on the panel's own end grows it when the pointer moves right, one on its start shrinks it.
+ * Both keep "right widens the thing left of the separator", which is what a splitter means.
+ */
+export type ResizeEdge = 'start' | 'end';
+
+const SIGN: Record<ResizeEdge, number> = { start: -1, end: 1 };
+
+/** One press of an arrow key. `--pg-space-4`'s 16px, so a keyboard step lands on the 4px scale. */
+const STEP = 16;
+
+/** Shift + arrow, for crossing the whole range in a few presses rather than twenty. */
+const COARSE_STEP = 64;
+
+export interface UseResizableOptions {
+  /** The custom property this drives, e.g. `--pg-rail-width`. Its `-min`/`-max` siblings bound it. */
+  variable: string;
+  /** `localStorage` key the width is remembered under. */
+  storageKey: string;
+  edge: ResizeEdge;
+  /** The handle's accessible name — it is the only text this control has. */
+  label: string;
+}
+
+export interface Resizable {
+  /**
+   * False when a bound could not be read, in which case nothing is written and `ResizeHandle`
+   * renders nothing. A missing token is a mistake in `tokens.css`, and the honest response to one is
+   * a panel that does not resize rather than a panel `NaN` pixels wide.
+   */
+  enabled: boolean;
+  width: number;
+  min: number;
+  max: number;
+  label: string;
+  dragging: boolean;
+  onPointerDown: (event: PointerEvent<HTMLElement>) => void;
+  onPointerMove: (event: PointerEvent<HTMLElement>) => void;
+  onPointerUp: () => void;
+  onLostPointerCapture: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+  onDoubleClick: () => void;
+}
+
+interface Bounds {
+  fallback: number;
+  min: number;
+  max: number;
+}
+
+/**
+ * A px-valued custom property, read once and cached.
+ *
+ * CACHED BECAUSE THE FIRST READ IS THE ONLY HONEST ONE for the width itself — see the file comment.
+ * `--pg-rail-width-min` and `-max` are never overridden and would be safe to re-read, but they go
+ * through the same door so there is one rule rather than two.
+ */
+const TOKEN_PX = new Map<string, number>();
+
+function tokenPx(variable: string): number {
+  const cached = TOKEN_PX.get(variable);
+  if (cached !== undefined) return cached;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(variable);
+  const value = Number.parseFloat(raw);
+  if (!Number.isFinite(value)) {
+    console.warn(`[resize] ${variable} is not a px length; that panel will not be resizable`);
+  }
+  TOKEN_PX.set(variable, value);
+  return value;
+}
+
+function clamp(value: number, bounds: Bounds): number {
+  return Math.min(Math.max(Math.round(value), bounds.min), bounds.max);
+}
+
+/** Wrapped like `lib/theme.ts` and `api/lastGood.ts`: localStorage throws under `file://`. */
+function readStored(key: string): number | null {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return null;
+    const value = Number.parseFloat(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch (cause) {
+    console.warn(`[resize] could not read ${key}`, cause);
+    return null;
+  }
+}
+
+function storeWidth(key: string, width: number): void {
+  try {
+    window.localStorage.setItem(key, String(width));
+  } catch (cause) {
+    // The width still applies for this session; only its persistence is lost.
+    console.warn(`[resize] could not store ${key}`, cause);
+  }
+}
+
+export function useResizable({ variable, storageKey, edge, label }: UseResizableOptions): Resizable {
+  // Both initialisers run during the first render, in this order, which is what puts the token read
+  // ahead of the first write. `useState` rather than `useMemo` because these must be computed once
+  // and never recomputed — a `useMemo` is allowed to be dropped and re-run.
+  const [bounds] = useState<Bounds>(() => ({
+    fallback: tokenPx(variable),
+    min: tokenPx(`${variable}-min`),
+    max: tokenPx(`${variable}-max`),
+  }));
+  const enabled =
+    Number.isFinite(bounds.fallback) && Number.isFinite(bounds.min) && Number.isFinite(bounds.max);
+
+  const [width, setWidth] = useState<number>(() =>
+    enabled ? clamp(readStored(storageKey) ?? bounds.fallback, bounds) : bounds.fallback,
+  );
+  const [dragging, setDragging] = useState(false);
+
+  /** Where the drag started, in both axes of the problem. Null between drags. */
+  const origin = useRef<{ x: number; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    document.documentElement.style.setProperty(variable, `${width}px`);
+  }, [enabled, variable, width]);
+
+  /*
+   * Persisted when the width SETTLES, not on every pointermove — a drag produces a write per frame
+   * otherwise. `dragging` gating it means the keyboard path, where every change is already discrete,
+   * persists immediately and needs no separate branch. It also runs once on mount, writing back the
+   * value it just read, which is harmless and cheaper than a ref to suppress.
+   */
+  useEffect(() => {
+    if (!enabled || dragging) return;
+    storeWidth(storageKey, width);
+  }, [enabled, dragging, storageKey, width]);
+
+  /*
+   * A page-wide attribute for the duration of a drag, so the text under the cursor cannot be
+   * selected and the col-resize cursor does not flicker back to a caret over prose. On <html> rather
+   * than <body> to match `data-theme`, and removed by the cleanup so an unmount mid-drag cannot
+   * leave the page unselectable.
+   */
+  useEffect(() => {
+    if (!dragging) return;
+    document.documentElement.dataset.pgResizing = '';
+    return () => {
+      delete document.documentElement.dataset.pgResizing;
+    };
+  }, [dragging]);
+
+  const endDrag = useCallback(() => {
+    if (origin.current === null) return;
+    origin.current = null;
+    setDragging(false);
+  }, []);
+
+  const onPointerDown = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      // Primary button only. A right-click would otherwise start a drag that no pointerup ends.
+      if (!enabled || event.button !== 0) return;
+      // Suppresses the native selection and drag-image gestures, which would both fight the drag.
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      origin.current = { x: event.clientX, width };
+      setDragging(true);
+    },
+    [enabled, width],
+  );
+
+  const onPointerMove = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      const start = origin.current;
+      if (start === null) return;
+      // Measured from where the drag STARTED rather than accumulated per event, so a clamped edge
+      // does not eat the pointer's position: drag past the maximum and back, and the panel follows
+      // again from the same place the cursor is.
+      setWidth(clamp(start.width + (event.clientX - start.x) * SIGN[edge], bounds));
+    },
+    [bounds, edge],
+  );
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (!enabled) return;
+      const step = (event.shiftKey ? COARSE_STEP : STEP) * SIGN[edge];
+      let next: number;
+      switch (event.key) {
+        case 'ArrowRight':
+          next = width + step;
+          break;
+        case 'ArrowLeft':
+          next = width - step;
+          break;
+        // Home and End move the SEPARATOR to its extremes, which is the widest panel for one edge
+        // and the narrowest for the other. Keyed off the sign so neither reads as inverted.
+        case 'Home':
+          next = SIGN[edge] > 0 ? bounds.min : bounds.max;
+          break;
+        case 'End':
+          next = SIGN[edge] > 0 ? bounds.max : bounds.min;
+          break;
+        // Reset. The same thing double-clicking does, since a separator has no other obvious use
+        // for Enter, and a dragged-somewhere-odd panel otherwise needs pixel-accurate mousework.
+        case 'Enter':
+        case ' ':
+          next = bounds.fallback;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      setWidth(clamp(next, bounds));
+    },
+    [bounds, edge, enabled, width],
+  );
+
+  const onDoubleClick = useCallback(() => {
+    if (!enabled) return;
+    setWidth(clamp(bounds.fallback, bounds));
+  }, [bounds, enabled]);
+
+  return {
+    enabled,
+    width,
+    min: bounds.min,
+    max: bounds.max,
+    label,
+    dragging,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: endDrag,
+    // Capture can be lost without a pointerup — a touch cancelled by the browser, or the element
+    // being removed. Ending the drag here too means `dragging` cannot latch on.
+    onLostPointerCapture: endDrag,
+    onKeyDown,
+    onDoubleClick,
+  };
+}

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -72,6 +72,8 @@ button {
 
 .pg-rail {
   grid-area: rail;
+  /* The containing block for `.pg-resize--rail`, which straddles the rail's right edge. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--pg-space-5);
@@ -785,6 +787,77 @@ button {
   cursor: default;
 }
 
+/* ── Drag-to-resize handles ────────────────────────────────────────────────────
+   Geometry only. Every decision — the clamp, the persistence, the keyboard path — is
+   in `hooks/useResizable.ts`, and the reason the width is written to a custom
+   property rather than to these elements is in that file's comment.
+
+   Placed between the shell and the drawer because it belongs to both.               */
+
+.pg-resize {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  /* Ten pixels of target for a two-pixel mark. A 1px seam is not something a trackpad
+     can hit, and the strip sits inside the panel's own horizontal padding — 12px on the
+     rail, 24px on the drawer — so it covers nothing clickable. */
+  width: 10px;
+  z-index: 30;
+  cursor: col-resize;
+  /* Otherwise a touch drag scrolls the page instead of producing pointermove. */
+  touch-action: none;
+}
+
+/* The mark itself: invisible until the pointer or the keyboard is on it, because a
+   permanent line here would read as a border and the rail already has one. */
+.pg-resize::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--pg-teal-500);
+  opacity: 0;
+}
+
+.pg-resize:hover::after,
+.pg-resize--dragging::after {
+  opacity: 0.9;
+}
+
+/* Focus is shown on the mark rather than as an outline around a 10px strip, which would
+   look like a stray box. Full opacity plus the shared ring, so it is unmistakably the
+   focused control while the arrow keys are moving it. */
+.pg-resize:focus-visible {
+  outline: none;
+}
+
+.pg-resize:focus-visible::after {
+  opacity: 1;
+  box-shadow: var(--pg-focus-ring);
+}
+
+/* On the rail's own right edge. */
+.pg-resize--rail {
+  right: 0;
+}
+
+/* On the drawer's LEFT edge, so it tracks the rendered width including the `min(…, 60vw)`
+   narrowing below. */
+.pg-resize--drawer {
+  left: 0;
+}
+
+/* Set on <html> for the duration of a drag. Without it the pointer selects the prose it
+   passes over and the cursor flickers between col-resize and a caret. Inherited, so no
+   universal selector is needed. */
+html[data-pg-resizing] {
+  cursor: col-resize;
+  user-select: none;
+}
+
 /* ── Finding detail drawer ─────────────────────────────────────────────────── */
 
 /* Fixed rather than a grid column: the operator must keep seeing the grid behind
@@ -1006,10 +1079,28 @@ button {
     justify-content: center;
   }
 
+  /* `justify-content: center` above cannot centre anything while this margin is still
+     absorbing the free space — the label is zero-width here, but its auto margin is not. */
+  .pg-triggers__toggle-label {
+    margin-right: 0;
+  }
+
   /* At 1024px a 420px drawer would cover most of the grid, defeating the reason
-     it is a drawer and not a modal. Narrower, so the grid stays visible beside it. */
+     it is a drawer and not a modal. Narrower, so the grid stays visible beside it.
+
+     THIS CLAMP OUTRANKS A DRAG, deliberately. `--pg-drawer-width-max` is 720px, so on a
+     1024px viewport the last stretch of a drag has no visible effect — 60vw is 614px and
+     wins. That is the right way round: the reason the drawer is not a modal does not stop
+     applying because someone pulled its edge. */
   .pg-drawer {
     width: min(var(--pg-drawer-width), 60vw);
+  }
+
+  /* The rail is pinned to an icon strip above, so its width token is not being read here
+     and dragging it would appear to do nothing at all. An absent handle says that; an
+     inert one invites the drag and then reports nothing. */
+  .pg-resize--rail {
+    display: none;
   }
 }
 
@@ -1105,10 +1196,66 @@ button {
 
 /* Evidence list. Each row carries its own provenance, so the source label sits on
    the same line as the label rather than under the detail. */
+/* The disclosure row above the evidence list. A real <button>, since it is the control that
+   reveals the list, and full-width so the whole row is the target rather than the word.
+   Deliberately quieter than a heading: the thing it hides is supporting material, and the
+   recommended action below it is what an operator is looking for when it is closed. */
+.pg-disclose {
+  display: flex;
+  align-items: center;
+  gap: var(--pg-space-2);
+  width: 100%;
+  margin-top: var(--pg-space-3);
+  padding: var(--pg-space-2) 0;
+  border: 0;
+  background: none;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: left;
+  color: var(--pg-text);
+  cursor: pointer;
+}
+
+.pg-disclose:hover {
+  color: var(--pg-info);
+}
+
+.pg-disclose:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: 2px;
+  border-radius: var(--pg-radius);
+}
+
+/* The count and how much of it was measured rather than asserted. Right-aligned and in the
+   muted tone, because it is a fact about the list rather than part of the label — but never
+   hidden, since it is the only provenance visible while the list is closed. */
+.pg-disclose__count {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--pg-text-muted);
+}
+
+.pg-disclose__chevron {
+  flex-shrink: 0;
+  color: var(--pg-text-muted);
+}
+
+.pg-disclose__chevron--open {
+  transform: rotate(90deg);
+}
+
 .pg-evidence {
   margin: var(--pg-space-3) 0 0;
   padding: 0;
   list-style: none;
+}
+
+/* The toggle already supplies the gap. Scoped to the adjacency so `ActivityChat`, which reuses
+   `.pg-evidence` without a disclosure, keeps its own spacing. */
+.pg-disclose + .pg-evidence {
+  margin-top: 0;
 }
 
 .pg-evidence__item {
@@ -1523,11 +1670,15 @@ button {
 
 /* ── Demo triggers in the rail (opt-in, see TriggerRail.tsx) ─────────────────── */
 
-/* Pushed to the bottom of the rail and separated by a rule, because this is scaffolding
-   rather than product: an audience should read the navigation above it first. `margin-top:
-   auto` works because .pg-rail is already a flex column. */
+/* DIRECTLY UNDER THE PRODUCT'S OWN GROUP, not pushed to the bottom of the rail
+   (@Ari-Glikman, 2026-09-02). This carried `margin-top: auto` — .pg-rail is a flex column,
+   so that pinned it to the bottom — because an audience should read the navigation above it
+   first. That reasoning is unchanged and is now served by the group being COLLAPSED by
+   default (see TriggerRail.tsx) rather than by distance, which is the stronger version of
+   it: absent beats merely lower down, and it also stops four destructive buttons being the
+   tallest thing in the rail. The rule and the heading, which did the other half of the
+   separating, stay exactly as they were. */
 .pg-triggers {
-  margin-top: auto;
   padding-top: var(--pg-space-4);
   border-top: 1px solid rgb(255 255 255 / 12%);
 }
@@ -1539,6 +1690,69 @@ button {
   align-items: center;
   gap: var(--pg-space-2);
   color: var(--pg-warning);
+}
+
+/* The heading doubles as the disclosure button, so this only resets button chrome and adds
+   the row layout. Deliberately does NOT restate font-size, weight or colour: those come from
+   `.pg-rail__brand` and `--triggers` above, and a second copy here is what would drift if the
+   rail's type changed. `font-family` alone, because that is the one property a <button> does
+   not inherit. */
+.pg-triggers__toggle {
+  width: 100%;
+  /* Overrides `.pg-rail__brand`'s `0 var(--pg-space-3)`: this one is pressed, so it needs a
+     row of target rather than a line of text, and the hover fill needs somewhere to sit. */
+  padding: var(--pg-space-1) var(--pg-space-3);
+  border: 0;
+  border-radius: var(--pg-radius);
+  background: none;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+/* The same hover pair as the trigger buttons below it, so the group reads as one thing.
+   `--pg-text-invert` rather than a warning tint: the warning tones are backgrounds elsewhere
+   and a primitive used as both ink and fill cannot be themed (§7.1). */
+.pg-triggers__toggle:hover {
+  background: var(--pg-rail-hover);
+  color: var(--pg-text-invert);
+}
+
+.pg-triggers__toggle:focus-visible {
+  outline: 2px solid var(--pg-teal-500);
+  outline-offset: -2px;
+}
+
+/* Pushes the summary and the chevron to the right edge. On the label rather than as
+   `margin-left: auto` on both, which would split the free space between them and leave a gap
+   whose size depended on whether a scenario happened to be armed. */
+.pg-triggers__toggle-label {
+  margin-right: auto;
+}
+
+/* What the collapsed heading says about a live scenario — the count and the phase word. Kept
+   readable rather than decorative: `pool_bottleneck` sits in `activating` for ~75s, and this is
+   the only place that state is visible while the list is closed. */
+.pg-triggers__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--pg-space-1);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: rgb(255 255 255 / 70%);
+}
+
+/* Rotated by a class, not by an `[aria-expanded='true']` selector, which would match any
+   expandable control added to the rail later — the same choice AppShell makes for the
+   Thresholds button. */
+.pg-triggers__chevron {
+  flex-shrink: 0;
+  color: rgb(255 255 255 / 55%);
+}
+
+.pg-triggers__chevron--open {
+  transform: rotate(90deg);
 }
 
 .pg-triggers__caption {

--- a/apps/dashboard/src/styles/tokens.css
+++ b/apps/dashboard/src/styles/tokens.css
@@ -76,11 +76,26 @@
   --pg-shadow-card: 0 1px 2px rgb(20 33 56 / 6%), 0 2px 8px rgb(20 33 56 / 4%);
   --pg-shadow-drawer: -8px 0 24px rgb(20 33 56 / 12%);
 
-  /* Layout — added here rather than inlined, per §9 */
+  /* Layout — added here rather than inlined, per §9.
+
+     THE TWO WIDTHS ARE OVERRIDDEN AT RUNTIME. `hooks/useResizable.ts` writes them on <html> when the
+     operator drags a panel's edge, and reads the three values below back as that panel's default,
+     minimum and maximum. So a `-min`/`-max` pair is not decoration: dropping one disables resizing
+     for that panel (loudly, in the console), and the plain value is both the initial width and what
+     a double-click resets to. Retune the range here rather than in the hook.
+
+     The bounds are chosen against what the panels have to keep legible, not by eye: the rail's 160px
+     is about where the longest trigger label stops wrapping mid-word, and the drawer's 320px is
+     where the evidence rows' label-and-provenance line stops colliding. The maxima are simply
+     "generous, but still leaving a dashboard behind the drawer". */
   --pg-rail-width: 208px;
+  --pg-rail-width-min: 160px;
+  --pg-rail-width-max: 420px;
   --pg-header-height: 60px;
   --pg-content-max: 1600px;
   --pg-drawer-width: 420px;
+  --pg-drawer-width-min: 320px;
+  --pg-drawer-width-max: 720px;
   --pg-focus-ring: 0 0 0 3px rgb(0 168 135 / 45%);
 }
 


### PR DESCRIPTION
Closes #239.

Four display-only changes in `apps/dashboard/`, all from driving the pool-bottleneck demo (@Ari-Glikman, 2026-09-02):

1. **Demo triggers move up the rail**, to directly under Production Guardian › Thresholds.
2. **The trigger list collapses behind an arrow**, closed by default.
3. **The rail and the right-hand panel drag by their inner edge.**
4. **The evidence list on a finding collapses**, so the recommended fix is readable without it.

The ask on 3 was explicitly a drag, not a toggle — *"I'd prefer if it could be dragged left/right with the mouse"* — and on 4, *"the evidence itself should be hidden if retracted and not shown below."*

## Files

| File | |
|---|---|
| `hooks/useResizable.ts` | **new** — clamp, persistence, pointer capture, keyboard, reset |
| `components/ResizeHandle.tsx` | **new** — presentational `role="separator"`, renders `null` when disabled |
| `components/DrawerResizeHandle.tsx` | **new** — the drawer's hook + handle, so three panels name one key |
| `AppShell.tsx` | the rail's handle, one inline hook call |
| `FindingDetail.tsx`, `HostDetail.tsx`, `ThresholdSettings.tsx` | `<DrawerResizeHandle />` as each `<aside>`'s first child |
| `TriggerRail.tsx` | heading becomes a disclosure button carrying a phase summary |
| `InvestigationPanel.tsx` | evidence behind a disclosure carrying the counts |
| `styles/tokens.css` | `--pg-rail-width-min/-max`, `--pg-drawer-width-min/-max` |
| `styles/app.css` | `.pg-resize*`, `.pg-triggers__toggle*`, `.pg-disclose*`; `.pg-triggers` loses `margin-top: auto` |

## Review notes — the decisions, not the diff

**The width is a custom property on `<html>`, not an inline `width`.** Neither target would obey an inline width correctly. The rail is a *grid column* on `.pg-shell` (`grid-template-columns: var(--pg-rail-width) minmax(0,1fr)`), so a width on the rail element does nothing at all. And `.pg-drawer` narrows to `min(var(--pg-drawer-width), 60vw)` under 1100px — an inline width would outrank that clamp and cover the grid on a 1024px laptop, the exact viewport §7.3 sets as the floor. Same split as `data-theme` in `lib/theme.ts`: JS picks a value, CSS decides what it means.

**Default, min and max are tokens, read back off the document** rather than written in TS, per §9's no-magic-numbers rule. That is what makes the double-click reset target unable to disagree with the width the page loads at. `tokenPx()` caches per property in a module `Map`, and the read happens during the **first render, before the hook has written anything** — after that the computed value is our own override, so a later read would return whatever was last dragged to. If a `-min`/`-max` token is ever dropped, `enabled` goes false, the handle stops rendering and a `console.warn` names the property: resizing disappears loudly rather than clamping to `NaN`.

**Pointer capture, not window listeners.** `setPointerCapture` routes subsequent moves to the handle and the browser releases implicitly on `pointerup`, so nothing is attached to `window` — no listener to leak, no drag that outlives its element. `onLostPointerCapture` also ends the drag so `dragging` cannot latch if capture is stolen. Deltas are measured from the drag **origin** rather than accumulated per event, so hitting a clamp edge does not desync the handle from the pointer.

**`role="separator"` is the one documented exception to §7.3's "a real `<button>` for anything clickable."** This is the ARIA window-splitter pattern (`aria-orientation`, `aria-valuenow/min/max`, `tabIndex={0}`); a button would announce the wrong role and have no way to report a width. Arrow keys move by `--pg-space-4` so a keyboard step lands on the 4px scale, Shift moves by 64, Home/End jump to the bounds with the sign keyed off which edge the handle is on, and Enter/Space or a double-click resets. A drag-only control would not clear the bar.

**All three right-edge panels share one width.** `FindingDetail`, `HostDetail` and `ThresholdSettings` are mutually exclusive by construction — `App` clears the other two selections on each — so `DrawerResizeHandle` exists to keep three call sites from naming three storage keys. The custom property is deliberately **never** cleaned up on unmount, so switching between them keeps the width.

**The `min(…, 60vw)` clamp outranks a drag, on purpose.** On a narrow viewport the last stretch of a drag has no visible effect. The reason the drawer is not a modal — the operator should keep seeing the grid — does not stop applying because someone pulled its edge. And the **rail handle is hidden under 1100px**, where the media query pins the rail to an icon strip and the width token is not being read: an absent handle says that, where an inert one would invite the drag and report nothing.

**Collapsing must not hide state — twice.** `pool_bottleneck` reads `trigger activating…` for ~75s, the longest wait in the demo and the entire reason the middle phase exists (#135); the closed heading therefore carries the count and the phase word with the same dot the buttons use. And on the evidence side, `InvestigationPanel`'s point 3 is that provenance is part of the evidence — so the closed control states the item count *and* how many were **read from IRIS** rather than asserted by the model, and the badge row above it (live-vs-canned, model, tool count, confidence) is never collapsed. A disclosure that hid the count would let a canned narrative and a governed one look identical while closed.

**Closed-by-default is the load-bearing choice for the evidence.** It sits *between* the root cause and the recommended action, deliberately, because it is what the recommendation rests on — and four to six bullets is enough to push Approve below the fold of a 420px drawer, which is the complaint being fixed. Expand-by-default would leave it exactly where it was. Neither disclosure state is persisted, unlike the widths: a remembered "expanded" would put the scaffolding, or the below-the-fold fix, back for whoever opens the dashboard next.

**Both lists use `hidden`, not unmounting.** `TriggerNote`'s live regions are marked ALWAYS MOUNTED so a phase change announces, and `aria-controls` has to point at an element that exists.

**`.pg-evidence`'s base rule is untouched** because `ActivityChat` renders it too; the spacing fix is scoped as `.pg-disclose + .pg-evidence`. The chevron rotates on an explicit `--open` class rather than an `[aria-expanded='true']` selector, matching AppShell's stated preference — the attribute selector would catch any expandable control added here later.

## Verification

- `node node_modules/typescript/bin/tsc --noEmit` — clean, exit 0. (`npx tsc` cannot run here: `node_modules/.bin` has no `tsc` symlink.)
- `node tools/validate-architecture.mjs` — `ok (8 labels and 12 paths, no overlaps, all within the viewBox)`; `validate-fixtures` and `validate-fixture-claims` exit 0.
- **`docker compose up -d --build dashboard`** — the build that ships (§6.1), which runs the real `tsc && validate-architecture && vite build`. Succeeds; `http://localhost:5173/` serves 200; all four containers up.
- The shipped bundle contains `pg-resize--rail`, `pg-resize--drawer`, `data-pg-resizing`, `pg-triggers__toggle`, `pg-triggers__chevron`, `pg-disclose__count`, `read from IRIS`, `--pg-rail-width-min`, `--pg-drawer-width-max`, and **zero** occurrences of `margin-top:auto`.
- `npm run build` on the host still fails on `@rollup/rollup-win32-x64-msvc` — pre-existing half-installed `node_modules` on this machine (npm/cli#4828), unrelated.

**Not verifiable from here:** the interaction itself. Dragging both edges and the two arrows need a human on `http://localhost:5173/`; there is no headless browser in this environment, and saying otherwise would be the green-claim-over-a-red-build failure §6 names.

## Not in scope

No engine, `contracts/` or `iris/**` change. No new dependency. No host name or count in `src/` (§9). No colour or spacing literal — the four new geometry values are tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
