### PR TITLE
fix(dashboard): the host and Thresholds panels ignored the width their handle drives

### DIFF
--- a/apps/dashboard/src/components/InvestigationPanel.tsx
+++ b/apps/dashboard/src/components/InvestigationPanel.tsx
@@ -108,8 +108,8 @@ export function InvestigationPanel({
    * COLLAPSED IS THE INITIAL STATE, and that is the load-bearing half of the request rather than a
    * default picked for tidiness. The evidence sits BETWEEN the root cause and the recommended action
    * in this panel — deliberately, because it is what the recommendation rests on — and four to six
-   * bullets is enough to push Approve below the fold of a 420px drawer. An expand-by-default toggle
-   * would leave that complaint exactly where it was.
+   * bullets is enough to push Approve below the fold at any width the drawer opens at. An
+   * expand-by-default toggle would leave that complaint exactly where it was.
    *
    * WHAT MUST NOT BE HIDEABLE IS PROVENANCE, so two things stay outside the collapse: the badge row
    * above (live-vs-canned, model, tool count, confidence) is never collapsed, and the closed toggle

--- a/apps/dashboard/src/styles/app.css
+++ b/apps/dashboard/src/styles/app.css
@@ -1085,7 +1085,7 @@ html[data-pg-resizing] {
     margin-right: 0;
   }
 
-  /* At 1024px a 420px drawer would cover most of the grid, defeating the reason
+  /* At 1024px a drawer at its default width covers most of the grid, defeating the reason
      it is a drawer and not a modal. Narrower, so the grid stays visible beside it.
 
      THIS CLAMP OUTRANKS A DRAG, deliberately. `--pg-drawer-width-max` is 720px, so on a
@@ -2307,13 +2307,22 @@ html[data-pg-resizing] {
 
 /* The two panels are mutually exclusive in `App`, so this shares the drawer's z-index
    rather than stacking above it -- if it ever needed a stacking order, that would mean two
-   were open at once, which is the defect the exclusivity prevents. */
-.pg-drawer--host {
-  /* A slightly wider surface than the finding drawer: three charts plus six metric rows do
-     not read at 420px, and the charts are the reason the panel exists. Still `min()` against
-     the viewport so the grid stays visible beside it, which is why this is a drawer. */
-  width: min(480px, 92vw);
-}
+   were open at once, which is the defect the exclusivity prevents.
+
+   THERE IS DELIBERATELY NO `.pg-drawer--host` RULE, and the absence is the fix for #241.
+   It used to carry `width: min(480px, 92vw)` -- wider than the finding drawer because three
+   charts and six metric rows did not read at the finding drawer's then-420px, which was a good
+   reason. But it is the
+   same specificity as `.pg-drawer` and later in this file, so source order made it the
+   winning rule, and it therefore ignored BOTH the width the resize handle drives and the
+   `min(..., 60vw)` narrowing below 1100px. The panel an operator most wants wider was the
+   one that could not be dragged at all.
+
+   The 480px was right, so it moved to `--pg-drawer-width` in `tokens.css` and all three
+   panels now start there. The 92vw did not move: at 1024px it resolves to 942px, which is
+   very nearly the whole viewport and exactly what `.pg-drawer` says a drawer exists not to
+   cover. A per-panel width cannot survive here anyway -- the three share one remembered
+   width by design, so a variant could only ever change what they start at. */
 
 .pg-host-detail__status {
   display: flex;
@@ -2517,12 +2526,12 @@ html[data-pg-resizing] {
    things unique to a FORM are declared here, since nothing else in this file styles a
    labelled numeric input. All colours, spacing and radii come from tokens (§7.1). */
 
-.pg-drawer--settings {
-  /* Wider than the finding drawer: each row carries a label, an input, two lines of
-     prose and the two reference values, and at 420px the blast-radius sentence wrapped
-     to four lines and buried the number it describes. */
-  width: min(480px, 92vw);
-}
+/* NO `.pg-drawer--settings` RULE EITHER, for the same reason as `.pg-drawer--host` above
+   (#241). It carried the same `width: min(480px, 92vw)`, for its own good reason -- each row
+   is a label, an input, two lines of prose and two reference values, and at the then-420px the
+   blast-radius sentence wrapped to four lines and buried the number it describes. That is now
+   the shared default rather than an override, so the sentence still fits and the panel is
+   draggable. */
 
 .pg-settings__status {
   margin: 0;

--- a/apps/dashboard/src/styles/tokens.css
+++ b/apps/dashboard/src/styles/tokens.css
@@ -87,13 +87,21 @@
      The bounds are chosen against what the panels have to keep legible, not by eye: the rail's 160px
      is about where the longest trigger label stops wrapping mid-word, and the drawer's 320px is
      where the evidence rows' label-and-provenance line stops colliding. The maxima are simply
-     "generous, but still leaving a dashboard behind the drawer". */
+     "generous, but still leaving a dashboard behind the drawer".
+
+     THE DRAWER'S 480px DEFAULT IS NOT A NEW NUMBER -- it is the width `.pg-drawer--host` and
+     `.pg-drawer--settings` each hardcoded until #241, where two of the three panels needed it
+     (charts and metric rows; a form row with prose and two reference values) and the finding
+     drawer loses nothing at it. Those two overrides had to go: they were the same specificity as
+     `.pg-drawer` and later in `app.css`, so they won, and a panel that wins on `width` cannot be
+     resized. A variant width is not a thing this token supports -- the three panels share one
+     remembered width by design -- so anything that wants a different default changes it here. */
   --pg-rail-width: 208px;
   --pg-rail-width-min: 160px;
   --pg-rail-width-max: 420px;
   --pg-header-height: 60px;
   --pg-content-max: 1600px;
-  --pg-drawer-width: 420px;
+  --pg-drawer-width: 480px;
   --pg-drawer-width-min: 320px;
   --pg-drawer-width-max: 720px;
   --pg-focus-ring: 0 0 0 3px rgb(0 168 135 / 45%);


### PR DESCRIPTION
Closes #241. Reported from the live demo: *"the right panel cannot be moved when i click on a host."*

Confirmed, and it affected the Thresholds panel too. The finding drawer was fine, which is why #240 shipped with it.

## Root cause — CSS precedence, not the handle

The handle and `useResizable` were doing their job; `--pg-drawer-width` updates on every pointermove. Two rules override the property it drives. From the bundle that was actually running, in source order:

```css
.pg-drawer{ … width:var(--pg-drawer-width) … }        /* what the handle drives */
.pg-drawer{ width:min(var(--pg-drawer-width),60vw) }  /* the <1100px narrowing */
.pg-drawer--host{ width:min(480px,92vw) }             /* last, and wins */
.pg-drawer--settings{ width:min(480px,92vw) }
```

`.pg-drawer--host` and `.pg-drawer--settings` are **one class each — the same specificity as `.pg-drawer`** — and sit at `app.css:2311` and `:2520` against `:871`. Source order decides, so the variants win and nothing in those two panels ever reads the variable.

Both overrides predate the resize handle by a long way and each had a stated, good reason. Neither could have anticipated a rule needing to set that width from outside.

**A second defect falls out of the same win, and it is not new.** Those two panels also outranked the `@media (max-width: 1100px)` rule, so they have been using `92vw` rather than `60vw` throughout. At 1024px that is 942px — very nearly the whole viewport, and precisely what `.pg-drawer`'s own comment says a drawer exists *not* to do. Fixed here because it is the same deletion.

## The fix

Delete both `width` declarations; the two rules had nothing else in them, so both are now comment-only blocks recording what was there and why it had to go.

- **`--pg-drawer-width: 420px → 480px`.** Not a new number — it is the one both variants hardcoded, and it was right for two of the three panels (charts and six metric rows; a form row with prose and two reference values). The finding drawer loses nothing at 480, and 420 is now a drag away, which is what the feature is for.
- `-min: 320px` / `-max: 720px` unchanged; 480 sits inside them.
- All three panels now clamp to `min(…, 60vw)` under 1100px.

A per-panel default was never really on the table: the three share one storage key by design (#239 — they are mutually exclusive in `App`), so after the first drag they are identical anyway. The token is only what they *start* at.

Also dropped three now-stale `420px` mentions in comments rather than re-pointing them at 480 — a width copied into prose is the value that goes stale next.

## Why #240's review missed it

Worth writing down, because the miss is more reusable than the bug. The self-review checked that `.pg-drawer` reads the variable. It does. It never asked whether a **later rule re-declares the same property at equal specificity**. And the bundle verification grepped for the presence of every new class and token — all present. *Presence is not precedence.* The grep that actually found this was "what else sets `width` on `.pg-drawer`", which is one line and now the one I'd run first.

## Verification — in the shipped bundle, since that is where it was proven

```
$ grep -o "\.pg-drawer[^{,]*{[^}]*width[^}]*}" index.html
.pg-drawer{ … width:var(--pg-drawer-width) … }
.pg-drawer{width:min(var(--pg-drawer-width),60vw)}
```

Only two, and both read the token. Also: `--pg-drawer-width: 480px`, `92vw` appears **zero** times, and both `pg-resize--drawer` occurrences are intact.

`node node_modules/typescript/bin/tsc --noEmit` clean · `validate-architecture` ok · `docker compose up -d --build dashboard` builds and serves 200 on `:5173`.

**Still needs eyes:** that the host panel now actually drags. The mechanism is proven from the CSS; the gesture needs a human, same caveat as #240.

## Follow-up not bundled here

Nothing in CI can catch a CSS precedence bug. The durable guard is a lint over `app.css` — *no rule may re-declare a property a resize handle drives* — filed separately so the fix the demo needs is not gated on designing a checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
